### PR TITLE
feat(cli): interactive onboarding wizard with API keys, budget, and pricing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -274,6 +274,25 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@clack/core": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.1.0.tgz",
+			"integrity": "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA==",
+			"license": "MIT",
+			"dependencies": {
+				"sisteransi": "^1.0.5"
+			}
+		},
+		"node_modules/@clack/prompts": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.1.0.tgz",
+			"integrity": "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g==",
+			"license": "MIT",
+			"dependencies": {
+				"@clack/core": "1.1.0",
+				"sisteransi": "^1.0.5"
+			}
+		},
 		"node_modules/@emnapi/core": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
@@ -2021,6 +2040,12 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"license": "MIT"
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2382,6 +2407,7 @@
 			"version": "1.0.0",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@clack/prompts": "^1.1.0",
 				"minimatch": "^10.2.4",
 				"picocolors": "^1.1.1",
 				"tigerbeetle-node": "^0.16.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,9 +49,7 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"peerDependencies": {
 		"@anthropic-ai/sdk": ">=0.30.0",
 		"openai": ">=4.70.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
 		}
 	},
 	"dependencies": {
+		"@clack/prompts": "^1.1.0",
 		"minimatch": "^10.2.4",
 		"picocolors": "^1.1.1",
 		"tigerbeetle-node": "^0.16.0",
@@ -48,7 +49,9 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc"
 	},
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"peerDependencies": {
 		"@anthropic-ai/sdk": ">=0.30.0",
 		"openai": ">=4.70.0"

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -230,6 +230,11 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 			const model = (modelResult as string).trim();
 			if (model === "") break;
 
+			if (!/^[a-z0-9][a-z0-9._-]{0,127}$/i.test(model)) {
+				clack.log.warn("Invalid model name.");
+				continue;
+			}
+
 			const inputResult = await clack.text({
 				message: `${model} input rate ($/1M tokens):`,
 			});
@@ -328,9 +333,10 @@ function createVault(vaultPath: string, data: VaultData): void {
 
 	// Write .env with API keys
 	if (data.keys && Object.keys(data.keys).length > 0) {
-		const envLines = Object.entries(data.keys).map(
-			([provider, key]) => `${envVarName(provider)}=${key}`,
-		);
+		const envLines = Object.entries(data.keys).map(([provider, key]) => {
+			const escaped = key.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+			return `${envVarName(provider)}="${escaped}"`;
+		});
 		writeFileSync(join(vaultPath, ".env"), `${envLines.join("\n")}\n`, {
 			encoding: "utf-8",
 			mode: 0o600,

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -2,30 +2,31 @@
 // Copyright 2026 Usertools, Inc.
 
 /**
- * CLI: usertrust init — Initialize trust vault
+ * CLI: usertrust init — Interactive onboarding wizard
  *
- * Creates the .usertrust/ directory structure with default config,
- * policy, and .gitignore. Sets permissions to 700 (owner only).
+ * Walks the user through API key setup, budget configuration,
+ * and pricing selection. Creates the .usertrust/ vault with
+ * config, .env, policy, and .gitignore.
  */
 
 import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import pc from "picocolors";
+import * as clack from "@clack/prompts";
+import { PRICING_TABLE, PRICING_TABLE_VERSION, modelsForProvider } from "../ledger/pricing.js";
+import type { ModelRates } from "../ledger/pricing.js";
 import { VAULT_DIR } from "../shared/constants.js";
+import { detectProvider, maskKey, validateKey } from "./validate-key.js";
 
 export interface CliOptions {
 	json?: boolean;
+	skipVerify?: boolean;
+	reconfigure?: boolean;
 }
 
-const DEFAULT_CONFIG = {
-	budget: 50000,
-	tier: "mini",
-	policies: "./policies/default.yml",
-	pii: "warn",
-	board: { enabled: false, vetoThreshold: "high" },
-	circuitBreaker: { failureThreshold: 5, resetTimeout: 60000 },
-	patterns: { enabled: true, feedProxy: false },
-	audit: { rotation: "daily", indexLimit: 10000 },
+const ENV_VAR_MAP: Record<string, string> = {
+	anthropic: "ANTHROPIC_API_KEY",
+	openai: "OPENAI_API_KEY",
+	google: "GOOGLE_API_KEY",
 };
 
 const DEFAULT_POLICY = `rules:
@@ -46,19 +47,19 @@ const DEFAULT_POLICY = `rules:
         value: 1000
 `;
 
-const GITIGNORE = `tigerbeetle/
-*.tigerbeetle
-dlq/
-`;
-
 const SUBDIRS = ["audit", "policies", "patterns", "snapshots", "board", "dlq"] as const;
+
+function envVarName(provider: string): string {
+	return ENV_VAR_MAP[provider] ?? `${provider.toUpperCase()}_API_KEY`;
+}
 
 export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 	const root = rootDir ?? process.cwd();
 	const vaultPath = join(root, VAULT_DIR);
 	const json = opts?.json === true;
 
-	if (existsSync(vaultPath)) {
+	// ── Check existing vault ──
+	if (existsSync(vaultPath) && !opts?.reconfigure) {
 		if (json) {
 			console.log(
 				JSON.stringify({
@@ -68,34 +69,19 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 				}),
 			);
 		} else {
-			console.log(pc.yellow(`Vault already exists at ${vaultPath}`));
+			clack.log.warn(`Vault already exists at ${vaultPath}`);
 		}
 		return;
 	}
 
-	// Create directory structure
-	mkdirSync(vaultPath, { recursive: true });
-	for (const sub of SUBDIRS) {
-		mkdirSync(join(vaultPath, sub), { recursive: true });
-	}
-
-	// Write default config
-	writeFileSync(
-		join(vaultPath, "usertrust.config.json"),
-		JSON.stringify(DEFAULT_CONFIG, null, "\t"),
-		"utf-8",
-	);
-
-	// Write default policy
-	writeFileSync(join(vaultPath, "policies", "default.yml"), DEFAULT_POLICY, "utf-8");
-
-	// Write .gitignore
-	writeFileSync(join(vaultPath, ".gitignore"), GITIGNORE, "utf-8");
-
-	// Set vault permissions to 700 (owner only)
-	chmodSync(vaultPath, 0o700);
-
+	// ── Non-interactive (--json) mode ──
 	if (json) {
+		createVault(vaultPath, {
+			budget: 50_000,
+			providers: [],
+			pricing: "recommended",
+			keys: {},
+		});
 		console.log(
 			JSON.stringify({
 				command: "init",
@@ -108,10 +94,244 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 				},
 			}),
 		);
-	} else {
-		console.log(pc.green(`Initialized trust vault at ${vaultPath}`));
-		console.log(pc.dim("  Created: audit/, policies/, patterns/, snapshots/, board/, dlq/"));
-		console.log(pc.dim("  Config:  usertrust.config.json"));
-		console.log(pc.dim("  Policy:  policies/default.yml"));
+		return;
 	}
+
+	// ── Interactive wizard ──
+	clack.intro("usertrust init");
+
+	// Step 1: API key loop
+	const keys: Record<string, string> = {};
+	const providers: Array<{ name: string; models: string[] }> = [];
+
+	// biome-ignore lint/correctness/noConstantCondition: intentional loop
+	while (true) {
+		const keyResult = await clack.text({
+			message:
+				Object.keys(keys).length === 0
+					? "Paste your API key:"
+					: "Paste another API key (empty = done):",
+			placeholder: "sk-...",
+		});
+
+		if (clack.isCancel(keyResult)) {
+			clack.log.warn("Setup cancelled.");
+			return;
+		}
+
+		const key = (keyResult as string).trim();
+		if (key === "") break;
+
+		let provider = detectProvider(key);
+
+		if (provider === null) {
+			const providerResult = await clack.text({
+				message: "Could not detect provider. Enter provider name:",
+				placeholder: "e.g. mistral, deepseek",
+			});
+
+			if (clack.isCancel(providerResult)) {
+				clack.log.warn("Setup cancelled.");
+				return;
+			}
+
+			provider = (providerResult as string).trim().toLowerCase();
+		}
+
+		// Validate key unless --skip-verify
+		if (!opts?.skipVerify) {
+			const s = clack.spinner();
+			s.start(`Validating ${provider} key...`);
+			const result = await validateKey(key, provider);
+			if (result.valid) {
+				s.stop(`${provider} key valid (${maskKey(key)})`);
+			} else {
+				s.stop(`${provider} key validation failed: ${result.error}`);
+				clack.log.warn("Key added anyway — you can fix it later in .usertrust/.env");
+			}
+		} else {
+			clack.log.info(`Added ${provider} key (${maskKey(key)})`);
+		}
+
+		keys[provider] = key;
+		const models = modelsForProvider(provider);
+		providers.push({ name: provider, models });
+	}
+
+	// Step 2: Budget
+	const budgetResult = await clack.text({
+		message: "Monthly budget: $",
+		placeholder: "50",
+		validate: (value) => {
+			const cleaned = value.replace(/[$,]/g, "");
+			if (Number.isNaN(Number(cleaned)) || Number(cleaned) <= 0) {
+				return "Enter a positive number";
+			}
+		},
+	});
+
+	if (clack.isCancel(budgetResult)) {
+		clack.log.warn("Setup cancelled.");
+		return;
+	}
+
+	const dollars = Number((budgetResult as string).replace(/[$,]/g, ""));
+	const budgetUsertokens = Math.round(dollars * 10_000);
+
+	// Step 3: Rates
+	let pricing: "recommended" | "custom" = "recommended";
+	let customRates: Record<string, ModelRates> | undefined;
+
+	const useRecommended = await clack.confirm({
+		message: `Use recommended rates? (verified ${PRICING_TABLE_VERSION})`,
+		initialValue: true,
+	});
+
+	if (clack.isCancel(useRecommended)) {
+		clack.log.warn("Setup cancelled.");
+		return;
+	}
+
+	if (!useRecommended) {
+		pricing = "custom";
+		customRates = {};
+
+		// Show rate card for configured providers
+		for (const p of providers) {
+			const models = modelsForProvider(p.name);
+			if (models.length === 0) continue;
+
+			clack.log.info(`\n${p.name} models:`);
+			for (const model of models) {
+				const rates = PRICING_TABLE[model];
+				if (!rates) continue;
+				clack.log.step(
+					`  ${model}: input=${rates.inputPer1k}/1k, output=${rates.outputPer1k}/1k`,
+				);
+			}
+		}
+
+		// Allow editing individual models
+		// biome-ignore lint/correctness/noConstantCondition: intentional loop
+		while (true) {
+			const modelResult = await clack.text({
+				message: "Model to edit (empty = accept all):",
+				placeholder: "e.g. claude-sonnet-4-6",
+			});
+
+			if (clack.isCancel(modelResult)) {
+				clack.log.warn("Setup cancelled.");
+				return;
+			}
+
+			const model = (modelResult as string).trim();
+			if (model === "") break;
+
+			const inputResult = await clack.text({
+				message: `${model} input rate ($/1M tokens):`,
+			});
+
+			if (clack.isCancel(inputResult)) {
+				clack.log.warn("Setup cancelled.");
+				return;
+			}
+
+			const outputResult = await clack.text({
+				message: `${model} output rate ($/1M tokens):`,
+			});
+
+			if (clack.isCancel(outputResult)) {
+				clack.log.warn("Setup cancelled.");
+				return;
+			}
+
+			const inputPerM = Number(inputResult);
+			const outputPerM = Number(outputResult);
+
+			// Convert $/1M to usertokens/1K: $X per 1M = X*10 usertokens per 1K
+			customRates[model] = {
+				inputPer1k: inputPerM * 10,
+				outputPer1k: outputPerM * 10,
+			};
+
+			clack.log.success(`Updated ${model}`);
+		}
+	}
+
+	// Step 4: Create vault
+	createVault(vaultPath, {
+		budget: budgetUsertokens,
+		providers,
+		pricing,
+		customRates,
+		keys,
+	});
+
+	clack.outro(`Vault created at ${vaultPath}`);
+}
+
+interface VaultData {
+	budget: number;
+	providers: Array<{ name: string; models: string[] }>;
+	pricing: "recommended" | "custom";
+	customRates?: Record<string, ModelRates>;
+	keys?: Record<string, string>;
+}
+
+function createVault(vaultPath: string, data: VaultData): void {
+	// Create directory structure
+	mkdirSync(vaultPath, { recursive: true });
+	for (const sub of SUBDIRS) {
+		mkdirSync(join(vaultPath, sub), { recursive: true });
+	}
+
+	// Build config
+	const config: Record<string, unknown> = {
+		budget: data.budget,
+		tier: "mini",
+		policies: "./policies/default.yml",
+		pii: "warn",
+		board: { enabled: false, vetoThreshold: "high" },
+		circuitBreaker: { failureThreshold: 5, resetTimeout: 60000 },
+		patterns: { enabled: true, feedProxy: false },
+		audit: { rotation: "daily", indexLimit: 10000 },
+		providers: data.providers,
+		pricing: data.pricing,
+	};
+
+	if (data.customRates && Object.keys(data.customRates).length > 0) {
+		config.customRates = data.customRates;
+	}
+
+	// Write config
+	writeFileSync(
+		join(vaultPath, "usertrust.config.json"),
+		JSON.stringify(config, null, "\t"),
+		"utf-8",
+	);
+
+	// Write default policy
+	writeFileSync(join(vaultPath, "policies", "default.yml"), DEFAULT_POLICY, "utf-8");
+
+	// Write .env with API keys
+	if (data.keys && Object.keys(data.keys).length > 0) {
+		const envLines = Object.entries(data.keys).map(
+			([provider, key]) => `${envVarName(provider)}=${key}`,
+		);
+		writeFileSync(join(vaultPath, ".env"), envLines.join("\n") + "\n", {
+			encoding: "utf-8",
+			mode: 0o600,
+		});
+	}
+
+	// Write .gitignore
+	const gitignoreContent = `tigerbeetle/
+*.tigerbeetle
+dlq/
+.env
+`;
+	writeFileSync(join(vaultPath, ".gitignore"), gitignoreContent, "utf-8");
+
+	// Set vault permissions to 700 (owner only)
+	chmodSync(vaultPath, 0o700);
 }

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -136,6 +136,10 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 			}
 
 			provider = (providerResult as string).trim().toLowerCase();
+			if (!/^[a-z][a-z0-9-]{0,31}$/.test(provider)) {
+				clack.log.warn("Provider name must be lowercase alphanumeric (max 32 chars).");
+				continue;
+			}
 		}
 
 		// Validate key unless --skip-verify
@@ -163,6 +167,7 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 		message: "Monthly budget: $",
 		placeholder: "50",
 		validate: (value) => {
+			if (!value) return "Enter a positive number";
 			const cleaned = value.replace(/[$,]/g, "");
 			if (Number.isNaN(Number(cleaned)) || Number(cleaned) <= 0) {
 				return "Enter a positive number";
@@ -205,9 +210,7 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 			for (const model of models) {
 				const rates = PRICING_TABLE[model];
 				if (!rates) continue;
-				clack.log.step(
-					`  ${model}: input=${rates.inputPer1k}/1k, output=${rates.outputPer1k}/1k`,
-				);
+				clack.log.step(`  ${model}: input=${rates.inputPer1k}/1k, output=${rates.outputPer1k}/1k`);
 			}
 		}
 
@@ -248,6 +251,16 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 			const inputPerM = Number(inputResult);
 			const outputPerM = Number(outputResult);
 
+			if (
+				!Number.isFinite(inputPerM) ||
+				inputPerM < 0 ||
+				!Number.isFinite(outputPerM) ||
+				outputPerM < 0
+			) {
+				clack.log.warn("Rates must be non-negative numbers. Skipping.");
+				continue;
+			}
+
 			// Convert $/1M to usertokens/1K: $X per 1M = X*10 usertokens per 1K
 			customRates[model] = {
 				inputPer1k: inputPerM * 10,
@@ -263,7 +276,7 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 		budget: budgetUsertokens,
 		providers,
 		pricing,
-		customRates,
+		...(customRates !== undefined ? { customRates } : {}),
 		keys,
 	});
 
@@ -318,7 +331,7 @@ function createVault(vaultPath: string, data: VaultData): void {
 		const envLines = Object.entries(data.keys).map(
 			([provider, key]) => `${envVarName(provider)}=${key}`,
 		);
-		writeFileSync(join(vaultPath, ".env"), envLines.join("\n") + "\n", {
+		writeFileSync(join(vaultPath, ".env"), `${envLines.join("\n")}\n`, {
 			encoding: "utf-8",
 			mode: 0o600,
 		});

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Usertools, Inc.
 
-const COMMANDS = ["init", "inspect", "health", "verify", "snapshot", "tb", "completions"] as const;
+const COMMANDS = ["init", "inspect", "health", "verify", "snapshot", "tb", "pricing", "completions"] as const;
 
 const argv = process.argv.slice(2);
 const jsonFlag = argv.includes("--json");
-const positional = argv.filter((a) => a !== "--json");
+const skipVerify = argv.includes("--skip-verify");
+const reconfigure = argv.includes("--reconfigure");
+const positional = argv.filter((a) => a !== "--json" && a !== "--skip-verify" && a !== "--reconfigure");
 const command = positional[0];
 
 /** Simple Levenshtein distance — two-row DP, no dependency needed. */
@@ -52,7 +54,9 @@ export { levenshtein, suggestCommand, COMMANDS };
 
 switch (command) {
 	case "init":
-		await import("./init.js").then((m) => m.run(undefined, { json: jsonFlag }));
+		await import("./init.js").then((m) =>
+			m.run(undefined, { json: jsonFlag, skipVerify, reconfigure }),
+		);
 		break;
 	case "inspect":
 		await import("./inspect.js").then((m) => m.run(undefined, { json: jsonFlag }));
@@ -68,6 +72,9 @@ switch (command) {
 		break;
 	case "tb":
 		await import("./tb.js").then((m) => m.run({ json: jsonFlag }));
+		break;
+	case "pricing":
+		await import("./pricing.js").then((m) => m.run(undefined, { json: jsonFlag }));
 		break;
 	case "completions":
 		await import("./completions.js").then((m) => m.run(positional[1], { json: jsonFlag }));
@@ -90,6 +97,7 @@ Commands:
   verify        Verify audit chain integrity
   snapshot      Create/restore vault snapshots
   tb            Manage TigerBeetle process
+  pricing       Show current rate configuration
   completions   Output shell completion scripts
 
 Options:

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -2,13 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Usertools, Inc.
 
-const COMMANDS = ["init", "inspect", "health", "verify", "snapshot", "tb", "pricing", "completions"] as const;
+const COMMANDS = [
+	"init",
+	"inspect",
+	"health",
+	"verify",
+	"snapshot",
+	"tb",
+	"pricing",
+	"completions",
+] as const;
 
 const argv = process.argv.slice(2);
 const jsonFlag = argv.includes("--json");
 const skipVerify = argv.includes("--skip-verify");
 const reconfigure = argv.includes("--reconfigure");
-const positional = argv.filter((a) => a !== "--json" && a !== "--skip-verify" && a !== "--reconfigure");
+const positional = argv.filter(
+	(a) => a !== "--json" && a !== "--skip-verify" && a !== "--reconfigure",
+);
 const command = positional[0];
 
 /** Simple Levenshtein distance — two-row DP, no dependency needed. */

--- a/packages/core/src/cli/pricing.ts
+++ b/packages/core/src/cli/pricing.ts
@@ -9,8 +9,8 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import pc from "picocolors";
-import { VAULT_DIR } from "../shared/constants.js";
 import { PRICING_TABLE, PRICING_TABLE_VERSION, modelsForProvider } from "../ledger/pricing.js";
+import { VAULT_DIR } from "../shared/constants.js";
 import type { TrustConfig } from "../shared/types.js";
 import { TrustConfigSchema } from "../shared/types.js";
 
@@ -76,7 +76,5 @@ export async function run(rootDir?: string, opts?: PricingOpts): Promise<void> {
 		);
 	}
 
-	console.log(
-		pc.dim(`\n  Mode: ${pricing} | Run \`usertrust init --reconfigure\` to change\n`),
-	);
+	console.log(pc.dim(`\n  Mode: ${pricing} | Run \`usertrust init --reconfigure\` to change\n`));
 }

--- a/packages/core/src/cli/pricing.ts
+++ b/packages/core/src/cli/pricing.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * CLI: usertrust pricing — Display current rate configuration
+ */
+
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import pc from "picocolors";
+import { VAULT_DIR } from "../shared/constants.js";
+import { PRICING_TABLE, PRICING_TABLE_VERSION, modelsForProvider } from "../ledger/pricing.js";
+import type { TrustConfig } from "../shared/types.js";
+import { TrustConfigSchema } from "../shared/types.js";
+
+export interface PricingOpts {
+	json: boolean;
+}
+
+export async function run(rootDir?: string, opts?: PricingOpts): Promise<void> {
+	const root = rootDir ?? process.cwd();
+	const configPath = join(root, VAULT_DIR, "usertrust.config.json");
+	const json = opts?.json === true;
+
+	let config: TrustConfig | null = null;
+	if (existsSync(configPath)) {
+		const raw = JSON.parse(await readFile(configPath, "utf-8"));
+		config = TrustConfigSchema.parse(raw);
+	}
+
+	const pricing = config?.pricing ?? "recommended";
+	const customRates = config?.customRates;
+	const providers = config?.providers ?? [];
+
+	// Determine which models to show
+	const modelKeys =
+		providers.length > 0
+			? providers.flatMap((p) => modelsForProvider(p.name))
+			: Object.keys(PRICING_TABLE);
+
+	if (json) {
+		const rates: Record<string, { inputPerM: number; outputPerM: number; source: string }> = {};
+		for (const model of modelKeys) {
+			const custom = customRates?.[model];
+			const base = PRICING_TABLE[model];
+			const source = custom ? "custom" : "recommended";
+			const r = custom ?? base;
+			if (r) {
+				rates[model] = {
+					inputPerM: r.inputPer1k / 10,
+					outputPerM: r.outputPer1k / 10,
+					source,
+				};
+			}
+		}
+		console.log(
+			JSON.stringify({ command: "pricing", pricing, version: PRICING_TABLE_VERSION, rates }),
+		);
+		return;
+	}
+
+	console.log(pc.bold(`\n  Rates (${pricing}, verified ${PRICING_TABLE_VERSION})\n`));
+
+	for (const model of modelKeys) {
+		const custom = customRates?.[model];
+		const base = PRICING_TABLE[model];
+		const r = custom ?? base;
+		if (!r) continue;
+
+		const inputPerM = (r.inputPer1k / 10).toFixed(2);
+		const outputPerM = (r.outputPer1k / 10).toFixed(2);
+		const tag = custom ? pc.yellow(" (custom)") : "";
+		console.log(
+			`  ${pc.cyan(model.padEnd(24))} $${inputPerM} / $${outputPerM} per 1M tokens${tag}`,
+		);
+	}
+
+	console.log(
+		pc.dim(`\n  Mode: ${pricing} | Run \`usertrust init --reconfigure\` to change\n`),
+	);
+}

--- a/packages/core/src/cli/validate-key.ts
+++ b/packages/core/src/cli/validate-key.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * CLI: API key duck-typing and validation.
+ *
+ * Detects provider from key prefix, validates by hitting
+ * a lightweight provider endpoint (3s timeout).
+ */
+
+export interface KeyValidationResult {
+	valid: boolean;
+	error?: string;
+}
+
+const PROVIDER_ENDPOINTS: Record<
+	string,
+	{ url: string; headers: (key: string) => Record<string, string> }
+> = {
+	anthropic: {
+		url: "https://api.anthropic.com/v1/models",
+		headers: (key) => ({
+			"x-api-key": key,
+			"anthropic-version": "2023-06-01",
+		}),
+	},
+	openai: {
+		url: "https://api.openai.com/v1/models",
+		headers: (key) => ({ Authorization: `Bearer ${key}` }),
+	},
+	google: {
+		url: "https://generativelanguage.googleapis.com/v1/models",
+		headers: () => ({}),
+	},
+};
+
+/** Detect provider from API key prefix. Returns null if unrecognized. */
+export function detectProvider(key: string): string | null {
+	if (key.startsWith("sk-ant-")) return "anthropic";
+	if (key.startsWith("sk-")) return "openai";
+	if (key.startsWith("AIza")) return "google";
+	return null;
+}
+
+/** Validate an API key against the provider's models endpoint. */
+export async function validateKey(
+	key: string,
+	provider: string,
+): Promise<KeyValidationResult> {
+	const endpoint = PROVIDER_ENDPOINTS[provider];
+	if (!endpoint) return { valid: true };
+
+	try {
+		const url =
+			provider === "google" ? `${endpoint.url}?key=${key}` : endpoint.url;
+		const resp = await fetch(url, {
+			method: "GET",
+			headers: endpoint.headers(key),
+			signal: AbortSignal.timeout(3000),
+		});
+		if (resp.ok) return { valid: true };
+		return { valid: false, error: `HTTP ${resp.status}` };
+	} catch (err) {
+		return {
+			valid: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
+
+/** Mask an API key for display: show prefix + dots. */
+export function maskKey(key: string): string {
+	if (key.length <= 8) return "••••••••";
+	return `${key.slice(0, 8)}••••••••`;
+}

--- a/packages/core/src/cli/validate-key.ts
+++ b/packages/core/src/cli/validate-key.ts
@@ -30,7 +30,7 @@ const PROVIDER_ENDPOINTS: Record<
 	},
 	google: {
 		url: "https://generativelanguage.googleapis.com/v1/models",
-		headers: () => ({}),
+		headers: (key) => ({ "x-goog-api-key": key }),
 	},
 };
 
@@ -43,17 +43,12 @@ export function detectProvider(key: string): string | null {
 }
 
 /** Validate an API key against the provider's models endpoint. */
-export async function validateKey(
-	key: string,
-	provider: string,
-): Promise<KeyValidationResult> {
+export async function validateKey(key: string, provider: string): Promise<KeyValidationResult> {
 	const endpoint = PROVIDER_ENDPOINTS[provider];
 	if (!endpoint) return { valid: true };
 
 	try {
-		const url =
-			provider === "google" ? `${endpoint.url}?key=${key}` : endpoint.url;
-		const resp = await fetch(url, {
+		const resp = await fetch(endpoint.url, {
 			method: "GET",
 			headers: endpoint.headers(key),
 			signal: AbortSignal.timeout(3000),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -8,6 +8,21 @@ import { VAULT_DIR } from "./shared/constants.js";
 import { TrustConfigSchema } from "./shared/types.js";
 import type { TrustConfig } from "./shared/types.js";
 
+/** Parse a simple KEY=VALUE .env file. Only sets vars not already in process.env. */
+function loadEnvFile(content: string): void {
+	for (const line of content.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed === "" || trimmed.startsWith("#")) continue;
+		const eqIdx = trimmed.indexOf("=");
+		if (eqIdx === -1) continue;
+		const key = trimmed.slice(0, eqIdx);
+		const value = trimmed.slice(eqIdx + 1);
+		if (process.env[key] === undefined) {
+			process.env[key] = value;
+		}
+	}
+}
+
 /**
  * Load trust config from `.usertrust/usertrust.config.json`, merged with
  * optional runtime overrides. Returns a validated TrustConfig.
@@ -20,6 +35,14 @@ export async function loadConfig(
 	vaultBase?: string,
 ): Promise<TrustConfig> {
 	const base = vaultBase ?? process.cwd();
+
+	// Load .usertrust/.env if it exists (API keys from init wizard)
+	const envPath = join(base, VAULT_DIR, ".env");
+	if (existsSync(envPath)) {
+		const envContent = await readFile(envPath, "utf-8");
+		loadEnvFile(envContent);
+	}
+
 	const configPath = join(base, VAULT_DIR, "usertrust.config.json");
 	let raw: Record<string, unknown> = {};
 	if (existsSync(configPath)) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -8,6 +8,9 @@ import { VAULT_DIR } from "./shared/constants.js";
 import { TrustConfigSchema } from "./shared/types.js";
 import type { TrustConfig } from "./shared/types.js";
 
+/** Valid env var name: starts with letter or underscore, alphanumeric + underscore only. */
+const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /** Parse a simple KEY=VALUE .env file. Only sets vars not already in process.env. */
 function loadEnvFile(content: string): void {
 	for (const line of content.split("\n")) {
@@ -16,7 +19,15 @@ function loadEnvFile(content: string): void {
 		const eqIdx = trimmed.indexOf("=");
 		if (eqIdx === -1) continue;
 		const key = trimmed.slice(0, eqIdx);
-		const value = trimmed.slice(eqIdx + 1);
+		if (!ENV_KEY_RE.test(key)) continue;
+		let value = trimmed.slice(eqIdx + 1);
+		// Strip surrounding quotes (single or double)
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
 		if (process.env[key] === undefined) {
 			process.env[key] = value;
 		}

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -190,6 +190,8 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		});
 	}
 
+	const customRates = config.pricing === "custom" ? config.customRates : undefined;
+
 	const isDryRun = opts?.dryRun ?? process.env.USERTRUST_DRY_RUN === "true";
 
 	// AUD-470: Only accept injected _engine/_audit in test environments.
@@ -269,7 +271,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			const transferId = trustId("tx");
 			const estimatedInputTokens = estimateInputTokens(messages);
 			const maxOutputTokens = (params.max_tokens as number) ?? 4096;
-			const estimatedCost = estimateCost(model, estimatedInputTokens, maxOutputTokens);
+			const estimatedCost = estimateCost(model, estimatedInputTokens, maxOutputTokens, customRates);
 
 			// AUD-453: Acquire mutex to serialise budget-check + PENDING hold.
 			// This prevents concurrent calls from both passing the budget check
@@ -364,6 +366,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									model,
 									completion.usage.inputTokens,
 									completion.usage.outputTokens,
+									customRates,
 								);
 								usageSource = "provider";
 							} else {
@@ -545,7 +548,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							(usage.output_tokens as number | undefined) ??
 							(usage.completion_tokens as number | undefined) ??
 							0;
-						actualCost = estimateCost(model, inputTokens, outputTokens);
+						actualCost = estimateCost(model, inputTokens, outputTokens, customRates);
 					}
 				}
 

--- a/packages/core/src/ledger/pricing.ts
+++ b/packages/core/src/ledger/pricing.ts
@@ -90,19 +90,14 @@ const PROVIDER_MODEL_MAP: Record<string, string[]> = {
 export function modelsForProvider(provider: string): string[] {
 	const prefixes = PROVIDER_MODEL_MAP[provider];
 	if (!prefixes) return [];
-	return Object.keys(PRICING_TABLE).filter((model) =>
-		prefixes.some((p) => model.startsWith(p)),
-	);
+	return Object.keys(PRICING_TABLE).filter((model) => prefixes.some((p) => model.startsWith(p)));
 }
 
 /**
  * Look up rates by model string. Falls back to prefix matching,
  * then FALLBACK_RATE for unknown models.
  */
-export function getModelRates(
-	model: string,
-	customRates?: Record<string, ModelRates>,
-): ModelRates {
+export function getModelRates(model: string, customRates?: Record<string, ModelRates>): ModelRates {
 	if (customRates) {
 		const custom = customRates[model];
 		if (custom) return custom;

--- a/packages/core/src/ledger/pricing.ts
+++ b/packages/core/src/ledger/pricing.ts
@@ -62,17 +62,52 @@ export const PRICING_TABLE: Record<string, ModelRates> = {
 	"nova-pro": { inputPer1k: 8, outputPer1k: 32 },
 };
 
+/** Date the PRICING_TABLE rates were last verified against provider pricing pages. */
+export const PRICING_TABLE_VERSION = "2026-03-29";
+
 /** Pre-sorted entries for prefix matching (longest key first). */
 const SORTED_TABLE = Object.entries(PRICING_TABLE).sort((a, b) => b[0].length - a[0].length);
 
 /** Fallback rate for unknown models (sonnet-class pricing). */
 export const FALLBACK_RATE: ModelRates = { inputPer1k: 30, outputPer1k: 150 };
 
+/** Maps provider names to their model key prefixes in PRICING_TABLE. */
+const PROVIDER_MODEL_MAP: Record<string, string[]> = {
+	anthropic: ["claude-"],
+	openai: ["gpt-", "o3", "o4-"],
+	google: ["gemini-"],
+	mistral: ["mistral-"],
+	deepseek: ["deepseek-"],
+	xai: ["grok-"],
+	meta: ["llama-"],
+	cohere: ["command-"],
+	perplexity: ["sonar-"],
+	alibaba: ["qwen-"],
+	amazon: ["nova-"],
+};
+
+/** Return all PRICING_TABLE model keys that belong to a given provider. */
+export function modelsForProvider(provider: string): string[] {
+	const prefixes = PROVIDER_MODEL_MAP[provider];
+	if (!prefixes) return [];
+	return Object.keys(PRICING_TABLE).filter((model) =>
+		prefixes.some((p) => model.startsWith(p)),
+	);
+}
+
 /**
  * Look up rates by model string. Falls back to prefix matching,
  * then FALLBACK_RATE for unknown models.
  */
-export function getModelRates(model: string): ModelRates {
+export function getModelRates(
+	model: string,
+	customRates?: Record<string, ModelRates>,
+): ModelRates {
+	if (customRates) {
+		const custom = customRates[model];
+		if (custom) return custom;
+	}
+
 	const exact = PRICING_TABLE[model];
 	if (exact) return exact;
 
@@ -88,8 +123,13 @@ export function getModelRates(model: string): ModelRates {
  * Estimate cost in usertokens for a model call.
  * Returns at least 1 (floor to prevent zero-amount transfers).
  */
-export function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
-	const rates = getModelRates(model);
+export function estimateCost(
+	model: string,
+	inputTokens: number,
+	outputTokens: number,
+	customRates?: Record<string, ModelRates>,
+): number {
+	const rates = getModelRates(model, customRates);
 	const inputCost = (inputTokens / 1000) * rates.inputPer1k;
 	const outputCost = (outputTokens / 1000) * rates.outputPer1k;
 	return Math.max(1, Math.ceil(inputCost + outputCost));

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -80,8 +80,8 @@ export const TrustConfigSchema = z.object({
 		.record(
 			z.string(),
 			z.object({
-				inputPer1k: z.number(),
-				outputPer1k: z.number(),
+				inputPer1k: z.number().finite().nonnegative(),
+				outputPer1k: z.number().finite().nonnegative(),
 			}),
 		)
 		.optional(),

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -67,6 +67,24 @@ export const TrustConfigSchema = z.object({
 			clusterId: z.number().int().nonnegative().default(0),
 		})
 		.default({}),
+	providers: z
+		.array(
+			z.object({
+				name: z.string(),
+				models: z.array(z.string()).default([]),
+			}),
+		)
+		.default([]),
+	pricing: z.enum(["recommended", "custom"]).default("recommended"),
+	customRates: z
+		.record(
+			z.string(),
+			z.object({
+				inputPer1k: z.number(),
+				outputPer1k: z.number(),
+			}),
+		)
+		.optional(),
 });
 
 export type TrustConfig = z.infer<typeof TrustConfigSchema>;

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -80,8 +80,8 @@ describe("usertrust init (interactive)", () => {
 		expect(existsSync(envPath)).toBe(true);
 
 		const envContent = readFileSync(envPath, "utf-8");
-		expect(envContent).toContain("ANTHROPIC_API_KEY=sk-ant-api03-testkey123");
-		expect(envContent).toContain("OPENAI_API_KEY=sk-proj-openai-key456");
+		expect(envContent).toContain('ANTHROPIC_API_KEY="sk-ant-api03-testkey123"');
+		expect(envContent).toContain('OPENAI_API_KEY="sk-proj-openai-key456"');
 	});
 
 	it("writes .gitignore with .env entry", async () => {

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -2,14 +2,37 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @clack/prompts before importing init
+vi.mock("@clack/prompts", () => ({
+	intro: vi.fn(),
+	outro: vi.fn(),
+	text: vi.fn(),
+	confirm: vi.fn(),
+	log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), step: vi.fn(), message: vi.fn() },
+	spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+	isCancel: vi.fn(() => false),
+}));
+
+// Mock key validation to avoid network calls
+vi.mock("../../src/cli/validate-key.js", () => ({
+	detectProvider: vi.fn((key: string) => {
+		if (key.startsWith("sk-ant-")) return "anthropic";
+		if (key.startsWith("sk-")) return "openai";
+		return null;
+	}),
+	validateKey: vi.fn().mockResolvedValue({ valid: true }),
+	maskKey: vi.fn((key: string) => `${key.slice(0, 8)}••••••••`),
+}));
+
+import * as clack from "@clack/prompts";
 import { run } from "../../src/cli/init.js";
 
-describe("usertrust init", () => {
+describe("usertrust init (interactive)", () => {
 	let tempDir: string;
 
 	beforeEach(() => {
 		tempDir = mkdtempSync(join(tmpdir(), "trust-init-"));
-		vi.spyOn(console, "log").mockImplementation(() => {});
 	});
 
 	afterEach(() => {
@@ -17,89 +40,106 @@ describe("usertrust init", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("creates the .usertrust directory structure", async () => {
-		await run(tempDir);
+	it("creates vault with one API key and recommended rates", async () => {
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-testkey123") // first key
+			.mockResolvedValueOnce("")                         // empty = done
+			.mockResolvedValueOnce("50");                      // budget
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);  // recommended rates
 
-		const vaultPath = join(tempDir, ".usertrust");
-		expect(existsSync(vaultPath)).toBe(true);
-		expect(existsSync(join(vaultPath, "audit"))).toBe(true);
-		expect(existsSync(join(vaultPath, "policies"))).toBe(true);
-		expect(existsSync(join(vaultPath, "patterns"))).toBe(true);
-		expect(existsSync(join(vaultPath, "snapshots"))).toBe(true);
-		expect(existsSync(join(vaultPath, "board"))).toBe(true);
-		expect(existsSync(join(vaultPath, "dlq"))).toBe(true);
-	});
-
-	it("writes default usertrust.config.json", async () => {
 		await run(tempDir);
 
 		const configPath = join(tempDir, ".usertrust", "usertrust.config.json");
 		expect(existsSync(configPath)).toBe(true);
 
 		const config = JSON.parse(readFileSync(configPath, "utf-8"));
-		expect(config.budget).toBe(50000);
-		expect(config.tier).toBe("mini");
-		expect(config.pii).toBe("warn");
-		expect(config.board.enabled).toBe(false);
-		expect(config.board.vetoThreshold).toBe("high");
-		expect(config.circuitBreaker.failureThreshold).toBe(5);
-		expect(config.circuitBreaker.resetTimeout).toBe(60000);
-		expect(config.patterns.enabled).toBe(true);
-		expect(config.patterns.feedProxy).toBe(false);
-		expect(config.audit.rotation).toBe("daily");
-		expect(config.audit.indexLimit).toBe(10000);
+		expect(config.budget).toBe(500_000); // $50 × 10,000
+		expect(config.providers).toHaveLength(1);
+		expect(config.providers[0].name).toBe("anthropic");
+		expect(config.pricing).toBe("recommended");
 	});
 
-	it("writes default policies/default.yml", async () => {
+	it("creates .env with API keys", async () => {
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-testkey123")
+			.mockResolvedValueOnce("sk-proj-openai-key456")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("100");
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);
+
 		await run(tempDir);
 
-		const policyPath = join(tempDir, ".usertrust", "policies", "default.yml");
-		expect(existsSync(policyPath)).toBe(true);
+		const envPath = join(tempDir, ".usertrust", ".env");
+		expect(existsSync(envPath)).toBe(true);
 
-		const content = readFileSync(policyPath, "utf-8");
-		expect(content).toContain("block-zero-budget");
-		expect(content).toContain("warn-high-cost");
-		expect(content).toContain("effect: deny");
-		expect(content).toContain("effect: warn");
-		expect(content).toContain("budget_remaining");
-		expect(content).toContain("estimated_cost");
+		const envContent = readFileSync(envPath, "utf-8");
+		expect(envContent).toContain("ANTHROPIC_API_KEY=sk-ant-api03-testkey123");
+		expect(envContent).toContain("OPENAI_API_KEY=sk-proj-openai-key456");
 	});
 
-	it("writes .gitignore", async () => {
+	it("writes .gitignore with .env entry", async () => {
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-testkey123")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("50");
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);
+
 		await run(tempDir);
 
-		const gitignorePath = join(tempDir, ".usertrust", ".gitignore");
-		expect(existsSync(gitignorePath)).toBe(true);
-
-		const content = readFileSync(gitignorePath, "utf-8");
-		expect(content).toContain("tigerbeetle/");
-		expect(content).toContain("*.tigerbeetle");
-		expect(content).toContain("dlq/");
+		const gitignore = readFileSync(join(tempDir, ".usertrust", ".gitignore"), "utf-8");
+		expect(gitignore).toContain(".env");
 	});
 
 	it("sets vault permissions to 700", async () => {
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-testkey123")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("50");
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);
+
 		await run(tempDir);
 
-		const vaultPath = join(tempDir, ".usertrust");
-		const stats = statSync(vaultPath);
-		// 0o700 = owner read/write/execute only
-		const mode = stats.mode & 0o777;
-		expect(mode).toBe(0o700);
+		const stats = statSync(join(tempDir, ".usertrust"));
+		expect(stats.mode & 0o777).toBe(0o700);
 	});
 
-	it("prints success message", async () => {
+	it("does not overwrite existing vault without --reconfigure", async () => {
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-testkey123")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("50");
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);
 		await run(tempDir);
 
-		expect(console.log).toHaveBeenCalledWith(expect.stringContaining("Initialized trust vault"));
+		// Second init — should warn
+		await run(tempDir);
+		expect(clack.log.warn).toHaveBeenCalled();
 	});
 
-	it("does not overwrite existing vault", async () => {
-		await run(tempDir);
-		vi.mocked(console.log).mockClear();
+	it("converts dollar budget to usertokens", async () => {
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-testkey123")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("100.50"); // $100.50
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);
 
-		// Run again — should detect existing vault
 		await run(tempDir);
 
-		expect(console.log).toHaveBeenCalledWith(expect.stringContaining("already exists"));
+		const config = JSON.parse(
+			readFileSync(join(tempDir, ".usertrust", "usertrust.config.json"), "utf-8"),
+		);
+		expect(config.budget).toBe(1_005_000); // $100.50 × 10,000
+	});
+
+	it("--json flag produces non-interactive output with defaults", async () => {
+		await run(tempDir, { json: true });
+
+		const configPath = join(tempDir, ".usertrust", "usertrust.config.json");
+		expect(existsSync(configPath)).toBe(true);
+
+		const config = JSON.parse(readFileSync(configPath, "utf-8"));
+		expect(config.budget).toBe(50_000); // default
+		expect(config.providers).toEqual([]);
+		expect(config.pricing).toBe("recommended");
 	});
 });

--- a/packages/core/tests/cli/init.test.ts
+++ b/packages/core/tests/cli/init.test.ts
@@ -9,7 +9,14 @@ vi.mock("@clack/prompts", () => ({
 	outro: vi.fn(),
 	text: vi.fn(),
 	confirm: vi.fn(),
-	log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), step: vi.fn(), message: vi.fn() },
+	log: {
+		info: vi.fn(),
+		success: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		step: vi.fn(),
+		message: vi.fn(),
+	},
 	spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
 	isCancel: vi.fn(() => false),
 }));
@@ -43,9 +50,9 @@ describe("usertrust init (interactive)", () => {
 	it("creates vault with one API key and recommended rates", async () => {
 		vi.mocked(clack.text)
 			.mockResolvedValueOnce("sk-ant-api03-testkey123") // first key
-			.mockResolvedValueOnce("")                         // empty = done
-			.mockResolvedValueOnce("50");                      // budget
-		vi.mocked(clack.confirm).mockResolvedValueOnce(true);  // recommended rates
+			.mockResolvedValueOnce("") // empty = done
+			.mockResolvedValueOnce("50"); // budget
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true); // recommended rates
 
 		await run(tempDir);
 
@@ -114,6 +121,29 @@ describe("usertrust init (interactive)", () => {
 		// Second init — should warn
 		await run(tempDir);
 		expect(clack.log.warn).toHaveBeenCalled();
+	});
+
+	it("--reconfigure overwrites existing vault", async () => {
+		// First init
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-testkey123")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("50");
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);
+		await run(tempDir);
+
+		// Reconfigure with different budget
+		vi.mocked(clack.text)
+			.mockResolvedValueOnce("sk-ant-api03-newkey456")
+			.mockResolvedValueOnce("")
+			.mockResolvedValueOnce("200");
+		vi.mocked(clack.confirm).mockResolvedValueOnce(true);
+		await run(tempDir, { reconfigure: true });
+
+		const config = JSON.parse(
+			readFileSync(join(tempDir, ".usertrust", "usertrust.config.json"), "utf-8"),
+		);
+		expect(config.budget).toBe(2_000_000); // $200 × 10,000
 	});
 
 	it("converts dollar budget to usertokens", async () => {

--- a/packages/core/tests/cli/pricing.test.ts
+++ b/packages/core/tests/cli/pricing.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { run } from "../../src/cli/pricing.js";
+
+describe("usertrust pricing", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "trust-pricing-"));
+		vi.spyOn(console, "log").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("displays recommended rates when no vault exists", async () => {
+		await run(tempDir, { json: false });
+
+		expect(console.log).toHaveBeenCalledWith(expect.stringContaining("recommended"));
+	});
+
+	it("displays custom rates when configured", async () => {
+		const vaultPath = join(tempDir, ".usertrust");
+		mkdirSync(vaultPath, { recursive: true });
+		writeFileSync(
+			join(vaultPath, "usertrust.config.json"),
+			JSON.stringify({
+				budget: 50_000,
+				pricing: "custom",
+				customRates: {
+					"claude-sonnet-4-6": { inputPer1k: 25, outputPer1k: 120 },
+				},
+				providers: [{ name: "anthropic", models: ["claude-sonnet-4-6"] }],
+			}),
+			"utf-8",
+		);
+
+		await run(tempDir, { json: false });
+
+		expect(console.log).toHaveBeenCalledWith(expect.stringContaining("custom"));
+	});
+
+	it("outputs JSON with --json flag", async () => {
+		await run(tempDir, { json: true });
+
+		const calls = vi.mocked(console.log).mock.calls;
+		const jsonCall = calls.find((c) => {
+			try {
+				JSON.parse(c[0] as string);
+				return true;
+			} catch {
+				return false;
+			}
+		});
+		expect(jsonCall).toBeDefined();
+	});
+});

--- a/packages/core/tests/cli/pricing.test.ts
+++ b/packages/core/tests/cli/pricing.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/core/tests/cli/security.test.ts
+++ b/packages/core/tests/cli/security.test.ts
@@ -53,7 +53,7 @@ describe("vault security", () => {
 	it("default config template contains no API key placeholders", async () => {
 		// Run the init command to create the vault
 		const { run } = await import("../../src/cli/init.js");
-		await run(tmpDir);
+		await run(tmpDir, { json: true });
 
 		const configPath = join(tmpDir, ".usertrust", "usertrust.config.json");
 		expect(existsSync(configPath)).toBe(true);
@@ -75,7 +75,7 @@ describe("vault security", () => {
 
 	it(".gitignore in vault excludes tigerbeetle/ but includes audit/", async () => {
 		const { run } = await import("../../src/cli/init.js");
-		await run(tmpDir);
+		await run(tmpDir, { json: true });
 
 		const gitignorePath = join(tmpDir, ".usertrust", ".gitignore");
 		expect(existsSync(gitignorePath)).toBe(true);
@@ -91,7 +91,7 @@ describe("vault security", () => {
 
 	it(".gitignore excludes dead-letter queue", async () => {
 		const { run } = await import("../../src/cli/init.js");
-		await run(tmpDir);
+		await run(tmpDir, { json: true });
 
 		const gitignorePath = join(tmpDir, ".usertrust", ".gitignore");
 		const gitignoreContent = readFileSync(gitignorePath, "utf-8");
@@ -102,7 +102,7 @@ describe("vault security", () => {
 
 	it("vault directory is created with 700 permissions (owner-only)", async () => {
 		const { run } = await import("../../src/cli/init.js");
-		await run(tmpDir);
+		await run(tmpDir, { json: true });
 
 		const vaultPath = join(tmpDir, ".usertrust");
 		const { statSync } = await import("node:fs");
@@ -115,7 +115,7 @@ describe("vault security", () => {
 
 	it("default policy file does not contain secrets", async () => {
 		const { run } = await import("../../src/cli/init.js");
-		await run(tmpDir);
+		await run(tmpDir, { json: true });
 
 		const policyPath = join(tmpDir, ".usertrust", "policies", "default.yml");
 		expect(existsSync(policyPath)).toBe(true);
@@ -133,7 +133,7 @@ describe("vault security", () => {
 		const { run } = await import("../../src/cli/init.js");
 
 		// First init
-		await run(tmpDir);
+		await run(tmpDir, { json: true });
 
 		// Modify the config to detect if it gets overwritten
 		const configPath = join(tmpDir, ".usertrust", "usertrust.config.json");
@@ -141,7 +141,7 @@ describe("vault security", () => {
 		writeFileSync(configPath, JSON.stringify({ budget: 99999, modified: true }));
 
 		// Second init — should NOT overwrite
-		await run(tmpDir);
+		await run(tmpDir, { json: true });
 
 		const content = readFileSync(configPath, "utf-8");
 		const parsed = JSON.parse(content) as Record<string, unknown>;

--- a/packages/core/tests/cli/validate-key.test.ts
+++ b/packages/core/tests/cli/validate-key.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { detectProvider, maskKey, validateKey } from "../../src/cli/validate-key.js";
+
+describe("detectProvider", () => {
+	it("detects Anthropic from sk-ant- prefix", () => {
+		expect(detectProvider("sk-ant-api03-abc123")).toBe("anthropic");
+	});
+
+	it("detects OpenAI from sk- prefix (not sk-ant-)", () => {
+		expect(detectProvider("sk-proj-abc123def456")).toBe("openai");
+	});
+
+	it("detects Google from AIza prefix", () => {
+		expect(detectProvider("AIzaSyAbcdef123456")).toBe("google");
+	});
+
+	it("returns null for unrecognized key", () => {
+		expect(detectProvider("some-random-key-format")).toBeNull();
+	});
+
+	it("returns null for empty string", () => {
+		expect(detectProvider("")).toBeNull();
+	});
+});
+
+describe("maskKey", () => {
+	it("masks key showing first 8 chars", () => {
+		expect(maskKey("sk-ant-api03-longkey123")).toBe("sk-ant-a••••••••");
+	});
+
+	it("masks short keys entirely", () => {
+		expect(maskKey("short")).toBe("••••••••");
+	});
+});
+
+describe("validateKey", () => {
+	it("returns success for valid Anthropic key", async () => {
+		global.fetch = vi.fn().mockResolvedValueOnce({ ok: true });
+		const result = await validateKey("sk-ant-api03-abc", "anthropic");
+		expect(result.valid).toBe(true);
+	});
+
+	it("returns failure for invalid Anthropic key", async () => {
+		global.fetch = vi.fn().mockResolvedValueOnce({ ok: false, status: 401 });
+		const result = await validateKey("sk-ant-api03-bad", "anthropic");
+		expect(result.valid).toBe(false);
+	});
+
+	it("returns failure on network error", async () => {
+		global.fetch = vi.fn().mockRejectedValueOnce(new Error("fetch failed"));
+		const result = await validateKey("sk-ant-api03-abc", "anthropic");
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("fetch failed");
+	});
+
+	it("returns success for valid OpenAI key", async () => {
+		global.fetch = vi.fn().mockResolvedValueOnce({ ok: true });
+		const result = await validateKey("sk-proj-abc", "openai");
+		expect(result.valid).toBe(true);
+	});
+
+	it("returns success for valid Google key", async () => {
+		global.fetch = vi.fn().mockResolvedValueOnce({ ok: true });
+		const result = await validateKey("AIzaSyAbc", "google");
+		expect(result.valid).toBe(true);
+	});
+
+	it("returns valid: true for unknown provider (skips validation)", async () => {
+		const result = await validateKey("some-key", "custom-provider");
+		expect(result.valid).toBe(true);
+	});
+});

--- a/packages/core/tests/ledger/pricing.test.ts
+++ b/packages/core/tests/ledger/pricing.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
 	FALLBACK_RATE,
 	PRICING_TABLE,
+	PRICING_TABLE_VERSION,
 	estimateCost,
 	estimateInputTokens,
 	getModelRates,
+	modelsForProvider,
 } from "../../src/ledger/pricing.js";
 
 describe("PRICING_TABLE", () => {
@@ -350,5 +352,77 @@ describe("estimateInputTokens", () => {
 		// fallback: JSON.stringify({ type: "empty_block" }) → some chars
 		const tokens = estimateInputTokens(messages);
 		expect(tokens).toBeGreaterThan(1);
+	});
+});
+
+describe("PRICING_TABLE_VERSION", () => {
+	it("is a date string", () => {
+		expect(PRICING_TABLE_VERSION).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+	});
+});
+
+describe("getModelRates with customRates", () => {
+	it("prefers custom rate over PRICING_TABLE", () => {
+		const custom = { "claude-sonnet-4-6": { inputPer1k: 25, outputPer1k: 120 } };
+		const rates = getModelRates("claude-sonnet-4-6", custom);
+		expect(rates.inputPer1k).toBe(25);
+		expect(rates.outputPer1k).toBe(120);
+	});
+
+	it("falls back to PRICING_TABLE when model not in customRates", () => {
+		const custom = { "claude-sonnet-4-6": { inputPer1k: 25, outputPer1k: 120 } };
+		const rates = getModelRates("gpt-4o", custom);
+		expect(rates.inputPer1k).toBe(25); // gpt-4o PRICING_TABLE rate
+		expect(rates.outputPer1k).toBe(100); // gpt-4o PRICING_TABLE rate
+	});
+
+	it("falls back to PRICING_TABLE when customRates is undefined", () => {
+		const rates = getModelRates("claude-sonnet-4-6", undefined);
+		expect(rates.inputPer1k).toBe(30);
+		expect(rates.outputPer1k).toBe(150);
+	});
+});
+
+describe("modelsForProvider", () => {
+	it("returns Anthropic models", () => {
+		const models = modelsForProvider("anthropic");
+		expect(models).toContain("claude-sonnet-4-6");
+		expect(models).toContain("claude-haiku-4-5");
+		expect(models).toContain("claude-opus-4-6");
+		expect(models).not.toContain("gpt-4o");
+	});
+
+	it("returns OpenAI models", () => {
+		const models = modelsForProvider("openai");
+		expect(models).toContain("gpt-4o");
+		expect(models).toContain("gpt-5.4");
+		expect(models).not.toContain("claude-sonnet-4-6");
+	});
+
+	it("returns Google models", () => {
+		const models = modelsForProvider("google");
+		expect(models).toContain("gemini-2.5-flash");
+		expect(models).not.toContain("gpt-4o");
+	});
+
+	it("returns empty array for unknown provider", () => {
+		const models = modelsForProvider("unknown-provider");
+		expect(models).toEqual([]);
+	});
+});
+
+describe("estimateCost with customRates", () => {
+	it("uses custom rates when provided", () => {
+		const custom = { "claude-sonnet-4-6": { inputPer1k: 25, outputPer1k: 120 } };
+		// 1000 input * 25/1k + 500 output * 120/1k = 25 + 60 = 85
+		const cost = estimateCost("claude-sonnet-4-6", 1000, 500, custom);
+		expect(cost).toBe(85);
+	});
+
+	it("falls back to PRICING_TABLE when no custom rate for model", () => {
+		const custom = { "gpt-4o": { inputPer1k: 20, outputPer1k: 80 } };
+		// claude-sonnet-4-6 not in custom, uses PRICING_TABLE: 30 + 75 = 105
+		const cost = estimateCost("claude-sonnet-4-6", 1000, 500, custom);
+		expect(cost).toBe(105);
 	});
 });

--- a/packages/core/tests/shared/config-schema.test.ts
+++ b/packages/core/tests/shared/config-schema.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { TrustConfigSchema } from "../../src/shared/types.js";
+
+describe("TrustConfigSchema — new onboarding fields", () => {
+	it("accepts providers array", () => {
+		const config = TrustConfigSchema.parse({
+			budget: 1_000_000,
+			providers: [{ name: "anthropic" }, { name: "openai" }],
+		});
+		expect(config.providers).toHaveLength(2);
+		expect(config.providers[0]?.name).toBe("anthropic");
+	});
+
+	it("defaults providers to empty array", () => {
+		const config = TrustConfigSchema.parse({ budget: 50_000 });
+		expect(config.providers).toEqual([]);
+	});
+
+	it("accepts pricing mode", () => {
+		const config = TrustConfigSchema.parse({
+			budget: 50_000,
+			pricing: "custom",
+		});
+		expect(config.pricing).toBe("custom");
+	});
+
+	it("defaults pricing to recommended", () => {
+		const config = TrustConfigSchema.parse({ budget: 50_000 });
+		expect(config.pricing).toBe("recommended");
+	});
+
+	it("accepts customRates", () => {
+		const config = TrustConfigSchema.parse({
+			budget: 50_000,
+			pricing: "custom",
+			customRates: {
+				"claude-sonnet-4-6": { inputPer1k: 25, outputPer1k: 120 },
+			},
+		});
+		expect(config.customRates?.["claude-sonnet-4-6"]?.inputPer1k).toBe(25);
+	});
+
+	it("defaults customRates to undefined when not provided", () => {
+		const config = TrustConfigSchema.parse({ budget: 50_000 });
+		expect(config.customRates).toBeUndefined();
+	});
+
+	it("existing configs without new fields still parse (backwards compat)", () => {
+		const config = TrustConfigSchema.parse({
+			budget: 50_000,
+			tier: "mini",
+			policies: "./policies/default.yml",
+			pii: "warn",
+		});
+		expect(config.budget).toBe(50_000);
+		expect(config.providers).toEqual([]);
+		expect(config.pricing).toBe("recommended");
+	});
+});


### PR DESCRIPTION
## Summary

- Rewrites `usertrust init` as an interactive wizard using `@clack/prompts`
- API key entry with duck-type detection (Anthropic/OpenAI/Google from prefix) and live validation
- Budget input in dollars, converted to usertokens internally
- Recommended rates (baked-in with version date) or custom per-model rate editing
- New `usertrust pricing` command to display current rate configuration
- Custom rates threaded through `estimateCost()` in governance pipeline for accurate POST settlement
- API keys stored in `.usertrust/.env` (0o600 perms, gitignored)
- `--json` flag preserves non-interactive behavior for CI
- `--skip-verify` to bypass API key validation
- `--reconfigure` to update existing vault settings

## Security review

- Google API key moved from URL query param to `x-goog-api-key` header
- `.env` parser strips quotes, validates key names against allowlist
- Provider names validated against `^[a-z][a-z0-9-]{0,31}$`
- Custom rates validated as finite non-negative before storing
- Zod schema tightened with `.finite().nonnegative()` on rate fields

## Test plan

- [ ] `npx vitest run` — 1098 tests passing
- [ ] `npx tsc -b --noEmit` — zero errors
- [ ] `npx biome check .` — zero errors
- [ ] Manual: `npx usertrust init` in a fresh directory
- [ ] Manual: `npx usertrust init --json` produces non-interactive output
- [ ] Manual: `npx usertrust pricing` displays rate table

🤖 Generated with [Claude Code](https://claude.com/claude-code)