### PR TITLE
feat(core): add governAction() for non-LLM action governance

### DIFF
--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -764,13 +764,14 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 
 			try {
 				// c. Policy gate — action fields available in context
+				// AUD-467: Caller params spread FIRST so governance fields cannot be shadowed
 				const policyResult = evaluatePolicy(policyRules, {
+					...(action.params ?? {}),
 					action_kind: action.kind,
 					action_name: action.name,
 					estimated_cost: action.cost,
 					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
 					tier: config.tier,
-					...(action.params ?? {}),
 				});
 				if (policyResult.decision === "deny") {
 					const reason =
@@ -896,7 +897,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					});
 					auditHash = auditEvent.hash;
 				} catch {
+					// Failure mode 15.3: Audit degraded — do not fail the response
 					callAuditDegraded = true;
+					process.stderr.write(
+						`[usertrust] audit degraded: failed to write ${action.kind} event for ${transferId}\n`,
+					);
 				}
 
 				// j. Daily-rotated receipt

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -49,7 +49,14 @@ const VERIFY_URL_BASE = "https://verify.usertrust.dev";
 import { LedgerUnavailableError, PolicyDeniedError } from "./shared/errors.js";
 import { trustId } from "./shared/ids.js";
 import { TrustConfigSchema } from "./shared/types.js";
-import type { LLMClientKind, TrustConfig, TrustReceipt, TrustedResponse } from "./shared/types.js";
+import type {
+	ActionDescriptor,
+	GovernedActionResult,
+	LLMClientKind,
+	TrustConfig,
+	TrustReceipt,
+	TrustedResponse,
+} from "./shared/types.js";
 import { type StreamCompletion, createGovernedStream } from "./streaming.js";
 
 // ── Public types ──
@@ -98,8 +105,14 @@ export interface TrustEngine {
 	destroy?(): void;
 }
 
-/** The trusted client: original client shape + `destroy()`. */
-export type TrustedClient<T> = T & { destroy(): Promise<void> };
+/** The trusted client: original client shape + governance methods. */
+export type TrustedClient<T> = T & {
+	destroy(): Promise<void>;
+	governAction<R>(
+		action: ActionDescriptor,
+		execute: () => Promise<R>,
+	): Promise<GovernedActionResult<R>>;
+};
 
 // ── AUD-453: Async mutex for budget atomicity ──
 // Prevents concurrent interceptCall invocations from racing through
@@ -718,6 +731,258 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		}
 	}
 
+	// 7b. Action governance — simplified pipeline for non-LLM actions
+	async function governActionImpl<R>(
+		action: ActionDescriptor,
+		execute: () => Promise<R>,
+	): Promise<GovernedActionResult<R>> {
+		if (destroyed) {
+			throw new Error("TrustedClient has been destroyed");
+		}
+
+		// AUD-466: Validate cost to prevent budget inflation via negative values
+		if (!Number.isFinite(action.cost) || action.cost < 0) {
+			throw new Error(
+				`action.cost must be a non-negative finite number, got ${String(action.cost)}`,
+			);
+		}
+
+		inFlightCount++;
+		let callAuditDegraded = false;
+
+		try {
+			const actor = action.actor ?? "local";
+			const transferId = trustId("tx");
+
+			// a. Circuit breaker check (keyed by action kind)
+			const cb = breaker.get(action.kind as unknown as LLMClientKind);
+			cb.allowRequest();
+
+			// b. Acquire mutex for budget atomicity
+			const releaseBudgetLock = await budgetMutex.acquire();
+			let proxyTransferId: string | undefined;
+
+			try {
+				// c. Policy gate — action fields available in context
+				const policyResult = evaluatePolicy(policyRules, {
+					action_kind: action.kind,
+					action_name: action.name,
+					estimated_cost: action.cost,
+					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
+					tier: config.tier,
+					...(action.params ?? {}),
+				});
+				if (policyResult.decision === "deny") {
+					const reason =
+						policyResult.reasons.length > 0 ? policyResult.reasons.join("; ") : "Policy denied";
+					throw new PolicyDeniedError(reason);
+				}
+
+				// d. PII check on action params
+				if (config.pii !== "off" && action.params != null) {
+					const piiResult = detectPII(action.params);
+					if (piiResult.found && config.pii === "block") {
+						throw new PolicyDeniedError(
+							`PII detected in action params: ${piiResult.types.join(", ")}`,
+						);
+					}
+				}
+
+				// e. PENDING hold
+				if (proxyConn != null && !isDryRun) {
+					try {
+						const proxyResult = await proxyConn.spend({
+							model: action.name,
+							estimatedCost: action.cost,
+							actor,
+						});
+						proxyTransferId = proxyResult.transferId;
+					} catch (holdErr) {
+						throw new LedgerUnavailableError(
+							holdErr instanceof Error ? holdErr.message : String(holdErr),
+						);
+					}
+				} else if (engine != null && !isDryRun) {
+					try {
+						await engine.spendPending({
+							transferId,
+							amount: action.cost,
+						});
+					} catch (holdErr) {
+						throw new LedgerUnavailableError(
+							holdErr instanceof Error ? holdErr.message : String(holdErr),
+						);
+					}
+				}
+
+				inFlightHoldTotal += action.cost;
+			} finally {
+				releaseBudgetLock();
+			}
+
+			// f. Execute the action
+			// Guard against double-decrement of inFlightHoldTotal (AUD-465)
+			let holdReleased = false;
+			function releaseHold(): void {
+				if (!holdReleased) {
+					holdReleased = true;
+					inFlightHoldTotal -= action.cost;
+				}
+			}
+
+			try {
+				const result = await execute();
+
+				// Release in-flight hold
+				releaseHold();
+
+				// Track budget
+				budgetSpent += action.cost;
+				await persistSpendLedger(vaultBase, budgetSpent);
+
+				// g. Circuit breaker: record success
+				cb.recordSuccess();
+
+				// h. POST settlement
+				let settled = true;
+				if (engine != null && !isDryRun) {
+					try {
+						await engine.postPendingSpend(transferId);
+					} catch (postErr) {
+						settled = false;
+						await audit
+							.appendEvent({
+								kind: "settlement_ambiguous",
+								actor,
+								data: {
+									actionKind: action.kind,
+									actionName: action.name,
+									cost: action.cost,
+									transferId,
+									error:
+										postErr instanceof Error
+											? postErr.message.slice(0, 200)
+											: String(postErr).slice(0, 200),
+								},
+							})
+							.catch(() => {
+								callAuditDegraded = true;
+							});
+					}
+				}
+
+				if (proxyConn != null && !isDryRun) {
+					try {
+						await proxyConn.settle(proxyTransferId ?? transferId, action.cost);
+					} catch {
+						settled = false;
+					}
+				}
+
+				// i. Audit event
+				const syntheticHash = createHash("sha256").update(transferId).digest("hex");
+				let auditHash = syntheticHash;
+				try {
+					const auditEvent = await audit.appendEvent({
+						kind: action.kind,
+						actor,
+						data: {
+							actionName: action.name,
+							cost: action.cost,
+							settled,
+							transferId,
+							...(action.params != null ? { params: action.params } : {}),
+						},
+					});
+					auditHash = auditEvent.hash;
+				} catch {
+					callAuditDegraded = true;
+				}
+
+				// j. Daily-rotated receipt
+				if (config.audit.rotation !== "none") {
+					writeReceipt(
+						vaultPath,
+						{
+							kind: action.kind,
+							subsystem: "trust",
+							actor,
+							data: {
+								actionName: action.name,
+								cost: action.cost,
+								settled,
+								transferId,
+							},
+						},
+						config.audit.indexLimit,
+					);
+				}
+
+				const budgetRemaining = config.budget - budgetSpent - inFlightHoldTotal;
+
+				const receipt: TrustReceipt = {
+					transferId,
+					cost: action.cost,
+					budgetRemaining,
+					auditHash,
+					chainPath: join(VAULT_DIR, "audit"),
+					receiptUrl: opts?.proxy != null ? `${VERIFY_URL_BASE}/${transferId}` : null,
+					settled,
+					model: action.name,
+					provider: action.kind,
+					timestamp: new Date().toISOString(),
+					actionKind: action.kind,
+					...(callAuditDegraded ? { auditDegraded: true as const } : {}),
+					...(proxyConn != null ? { proxyStub: true as const } : {}),
+				};
+
+				return { result, receipt };
+			} catch (err) {
+				// Release in-flight hold (AUD-465: guard prevents double-decrement)
+				releaseHold();
+
+				// Circuit breaker: record failure
+				cb.recordFailure();
+
+				// VOID the pending hold
+				if (engine != null && !isDryRun) {
+					try {
+						await engine.voidPendingSpend(transferId);
+					} catch {
+						// Best-effort void
+					}
+				}
+
+				if (proxyConn != null && !isDryRun) {
+					try {
+						await proxyConn.void(proxyTransferId ?? transferId);
+					} catch {
+						// Best-effort void
+					}
+				}
+
+				// Audit the failure
+				await audit
+					.appendEvent({
+						kind: `${action.kind}_failed`,
+						actor,
+						data: {
+							actionName: action.name,
+							error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+							transferId,
+						},
+					})
+					.catch(() => {
+						callAuditDegraded = true;
+					});
+
+				throw err;
+			}
+		} finally {
+			inFlightCount--;
+		}
+	}
+
 	// 8. Safety net: clean up on process exit if destroy() was never called
 	let beforeExitHandler: (() => void) | null = null;
 
@@ -765,13 +1030,13 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		};
 
 		if (kind === "anthropic") {
-			return buildAnthropicProxy(client, interceptCall, destroyFn);
+			return buildAnthropicProxy(client, interceptCall, destroyFn, governActionImpl);
 		}
 		if (kind === "openai") {
-			return buildOpenAIProxy(client, interceptCall, destroyFn);
+			return buildOpenAIProxy(client, interceptCall, destroyFn, governActionImpl);
 		}
 		// google
-		return buildGoogleProxy(client, interceptCall, destroyFn);
+		return buildGoogleProxy(client, interceptCall, destroyFn, governActionImpl);
 	}
 
 	const governedClient = createClientProxy();
@@ -877,10 +1142,16 @@ type InterceptFn = (
 	args: unknown[],
 ) => Promise<TrustedResponse<unknown>>;
 
+type GovernActionFn = <R>(
+	action: ActionDescriptor,
+	execute: () => Promise<R>,
+) => Promise<GovernedActionResult<R>>;
+
 function buildAnthropicProxy<T>(
 	client: T,
 	intercept: InterceptFn,
 	destroy: () => Promise<void>,
+	governAction: GovernActionFn,
 ): TrustedClient<T> {
 	const original = client as Record<string, unknown>;
 	const messages = original.messages as Record<string, unknown>;
@@ -901,6 +1172,7 @@ function buildAnthropicProxy<T>(
 		get(target, prop, receiver) {
 			if (prop === "messages") return messagesProxy;
 			if (prop === "destroy") return destroy;
+			if (prop === "governAction") return governAction;
 			return Reflect.get(target, prop, receiver);
 		},
 	});
@@ -912,6 +1184,7 @@ function buildOpenAIProxy<T>(
 	client: T,
 	intercept: InterceptFn,
 	destroy: () => Promise<void>,
+	governAction: GovernActionFn,
 ): TrustedClient<T> {
 	const original = client as Record<string, unknown>;
 	const chat = original.chat as Record<string, unknown>;
@@ -938,6 +1211,7 @@ function buildOpenAIProxy<T>(
 		get(target, prop, receiver) {
 			if (prop === "chat") return chatProxy;
 			if (prop === "destroy") return destroy;
+			if (prop === "governAction") return governAction;
 			return Reflect.get(target, prop, receiver);
 		},
 	});
@@ -949,6 +1223,7 @@ function buildGoogleProxy<T>(
 	client: T,
 	intercept: InterceptFn,
 	destroy: () => Promise<void>,
+	governAction: GovernActionFn,
 ): TrustedClient<T> {
 	const original = client as Record<string, unknown>;
 	const models = original.models as Record<string, unknown>;
@@ -967,6 +1242,7 @@ function buildGoogleProxy<T>(
 		get(target, prop, receiver) {
 			if (prop === "models") return modelsProxy;
 			if (prop === "destroy") return destroy;
+			if (prop === "governAction") return governAction;
 			return Reflect.get(target, prop, receiver);
 		},
 	});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,9 @@ export type {
 	BoardDecision,
 	AuditEvent,
 	LLMClientKind,
+	ActionKind,
+	ActionDescriptor,
+	GovernedActionResult,
 } from "./shared/types.js";
 
 // Errors

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -21,6 +21,8 @@ export interface TrustReceipt {
 	usageSource?: "provider" | "estimated";
 	/** Number of chunks delivered to the consumer (streaming calls only). */
 	chunksDelivered?: number;
+	/** Action kind for governed non-LLM actions. Absent for LLM calls (backward compat). */
+	actionKind?: ActionKind;
 }
 
 // ── TrustedResponse — returned by every governed LLM call ──
@@ -128,3 +130,28 @@ export type DirectorVote = "approve" | "veto" | "abstain";
 
 // ── LLM Client detection ──
 export type LLMClientKind = "anthropic" | "openai" | "google";
+
+// ── Action Governance types ──
+
+/** Extensible union for governed action types. */
+export type ActionKind = "llm_call" | "tool_use" | "file_access" | "shell_command" | "api_request";
+
+/** Descriptor for a governed action. */
+export interface ActionDescriptor {
+	/** The kind of action being governed. */
+	kind: ActionKind;
+	/** Human-readable name (e.g., "file_read", "curl", tool name). */
+	name: string;
+	/** Estimated cost in usertokens. Required for budget enforcement. */
+	cost: number;
+	/** Arbitrary parameters for policy evaluation and audit logging. */
+	params?: Record<string, unknown>;
+	/** Actor identity (defaults to "local"). */
+	actor?: string;
+}
+
+/** Result wrapper for governed actions. */
+export interface GovernedActionResult<T> {
+	result: T;
+	receipt: TrustReceipt;
+}

--- a/packages/core/tests/e2e/action-governance-e2e.test.ts
+++ b/packages/core/tests/e2e/action-governance-e2e.test.ts
@@ -1,0 +1,412 @@
+/**
+ * End-to-end integration test for action governance.
+ *
+ * Exercises the governAction() method alongside LLM calls to verify that
+ * both share the same budget, audit chain, policy engine, and circuit
+ * breaker. Uses dryRun: true to avoid needing TigerBeetle.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Usertools, Inc.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trust } from "../../src/govern.js";
+import { GENESIS_HASH, VAULT_DIR } from "../../src/shared/constants.js";
+import { PolicyDeniedError } from "../../src/shared/errors.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+// ── Mock tigerbeetle-node at module level (native module, never loaded in tests) ──
+
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: {
+		linked: 1,
+		pending: 2,
+		post_pending_transfer: 4,
+		void_pending_transfer: 8,
+	},
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Shared helpers ──
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `action-e2e-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function makeAnthropicMock(response?: Record<string, unknown>) {
+	const defaultResponse = {
+		id: "msg_e2e_act",
+		type: "message",
+		role: "assistant",
+		content: [{ type: "text", text: "Hello from Claude" }],
+		model: "claude-sonnet-4-6",
+		usage: { input_tokens: 100, output_tokens: 50 },
+	};
+	return {
+		messages: {
+			create: vi.fn(async () => response ?? defaultResponse),
+		},
+	};
+}
+
+function writeVaultConfig(vaultBase: string, config: Record<string, unknown>): void {
+	const configDir = join(vaultBase, VAULT_DIR);
+	mkdirSync(configDir, { recursive: true });
+	writeFileSync(join(configDir, "usertrust.config.json"), JSON.stringify(config));
+}
+
+function writePolicyFile(vaultBase: string, relativePath: string, rules: unknown[]): void {
+	const fullDir = join(vaultBase, relativePath.replace(/\/[^/]+$/, ""));
+	mkdirSync(fullDir, { recursive: true });
+	writeFileSync(join(vaultBase, relativePath), JSON.stringify({ rules }));
+}
+
+// ── E2E Test Suite ──
+
+describe("Action governance — E2E integration", () => {
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = makeTmpVault();
+	});
+
+	afterEach(async () => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// Cleanup best-effort
+		}
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 1. Mixed LLM + action governance lifecycle
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("1. Mixed LLM + action governance lifecycle", () => {
+		it("both LLM calls and governed actions return valid receipts sharing budget", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 50_000,
+				vaultBase: tmpVault,
+			});
+
+			// LLM call
+			const llmResult = await governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "Explain governance" }],
+			});
+
+			// Verify LLM receipt
+			expect(llmResult.receipt.transferId).toMatch(/^tx_/);
+			expect(llmResult.receipt.cost).toBeGreaterThan(0);
+			expect(llmResult.receipt.settled).toBe(true);
+			expect(llmResult.receipt.model).toBe("claude-sonnet-4-6");
+			expect(llmResult.receipt.provider).toBe("anthropic");
+			expect(llmResult.receipt.budgetRemaining).toBeLessThan(50_000);
+
+			const budgetAfterLlm = llmResult.receipt.budgetRemaining;
+
+			// Action call
+			const actionResult = await governed.governAction(
+				{
+					kind: "tool_use",
+					name: "file_read",
+					cost: 50,
+					params: { path: "/etc/hosts" },
+				},
+				async () => ({ content: "127.0.0.1 localhost" }),
+			);
+
+			// Verify action receipt
+			expect(actionResult.receipt.transferId).toMatch(/^tx_/);
+			expect(actionResult.receipt.cost).toBe(50);
+			expect(actionResult.receipt.settled).toBe(true);
+			expect(actionResult.receipt.actionKind).toBe("tool_use");
+			expect(actionResult.receipt.model).toBe("file_read");
+			expect(actionResult.receipt.provider).toBe("tool_use");
+
+			// Budget is deducted by both
+			expect(actionResult.receipt.budgetRemaining).toBeLessThan(budgetAfterLlm);
+			expect(actionResult.receipt.budgetRemaining).toBe(budgetAfterLlm - 50);
+
+			// Action result is returned
+			expect(actionResult.result).toEqual({ content: "127.0.0.1 localhost" });
+
+			// Audit chain has events for both
+			const auditPath = join(tmpVault, VAULT_DIR, "audit", "events.jsonl");
+			expect(existsSync(auditPath)).toBe(true);
+
+			const events = readFileSync(auditPath, "utf-8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line) as AuditEvent);
+
+			expect(events.length).toBe(2);
+			expect(events[0]?.kind).toBe("llm_call");
+			expect(events[1]?.kind).toBe("tool_use");
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 2. Shared budget enforcement
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("2. Shared budget enforcement", () => {
+		it("action fails when LLM call exhausts the shared budget", async () => {
+			// Write a policy with the budget-exhausted rule so the gate
+			// denies when budget_remaining drops to zero or below.
+			writePolicyFile(tmpVault, ".usertrust/policies/default.yml", [
+				{
+					name: "block-budget-exhausted",
+					effect: "deny",
+					enforcement: "hard",
+					conditions: [{ field: "budget_remaining", operator: "lte", value: 0 }],
+				},
+			]);
+			writeVaultConfig(tmpVault, {
+				budget: 500,
+				policies: "./policies/default.yml",
+			});
+
+			// Use a mock with high token usage so the LLM call costs >= budget.
+			// Sonnet pricing: input 30/1k, output 150/1k.
+			// 10000 input + 2000 output → (10000/1000)*30 + (2000/1000)*150 = 300 + 300 = 600.
+			const expensiveMock = makeAnthropicMock({
+				id: "msg_expensive",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "Expensive reply" }],
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10_000, output_tokens: 2_000 },
+			});
+
+			const governed = await trust(expensiveMock, {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			// LLM call succeeds (budget_remaining = 500 > 0 at pre-call check)
+			const llmResult = await governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 4096,
+				messages: [{ role: "user", content: "Write a long essay" }],
+			});
+
+			// LLM cost should be 600, exhausting the budget of 500
+			expect(llmResult.receipt.cost).toBe(600);
+			expect(llmResult.receipt.budgetRemaining).toBeLessThan(0);
+
+			// Governed action should fail — budget_remaining is now <= 0
+			await expect(
+				governed.governAction({ kind: "tool_use", name: "curl", cost: 300 }, async () => ({
+					ok: true,
+				})),
+			).rejects.toThrow(PolicyDeniedError);
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 3. Audit chain integrity across mixed calls
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("3. Audit chain integrity across mixed calls", () => {
+		it("produces an unbroken hash chain with all 4 events", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 100_000,
+				vaultBase: tmpVault,
+			});
+
+			// Interleave: LLM, action, LLM, action
+			await governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 512,
+				messages: [{ role: "user", content: "Call 1" }],
+			});
+
+			await governed.governAction(
+				{ kind: "tool_use", name: "file_read", cost: 10, params: { path: "/tmp/a" } },
+				async () => "file-content-a",
+			);
+
+			await governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 512,
+				messages: [{ role: "user", content: "Call 2" }],
+			});
+
+			await governed.governAction(
+				{ kind: "shell_command", name: "ls", cost: 5, params: { args: ["-la"] } },
+				async () => "total 42\ndrwxr-xr-x ...",
+			);
+
+			await governed.destroy();
+
+			// Read the audit chain JSONL
+			const auditPath = join(tmpVault, VAULT_DIR, "audit", "events.jsonl");
+			expect(existsSync(auditPath)).toBe(true);
+
+			const events = readFileSync(auditPath, "utf-8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line) as AuditEvent & { sequence: number });
+
+			// (a) All 4 events are present
+			expect(events.length).toBe(4);
+
+			// (b) Hash chain is unbroken
+			expect(events[0]?.previousHash).toBe(GENESIS_HASH);
+			for (let i = 1; i < events.length; i++) {
+				expect(events[i]?.previousHash).toBe(events[i - 1]?.hash);
+			}
+
+			// Every event has a unique, non-empty 64-char hex hash
+			const hashes = events.map((e) => e.hash);
+			expect(new Set(hashes).size).toBe(hashes.length);
+			for (const h of hashes) {
+				expect(h).toMatch(/^[a-f0-9]{64}$/);
+			}
+
+			// Sequences are monotonically increasing
+			for (let i = 0; i < events.length; i++) {
+				expect(events[i]?.sequence).toBe(i + 1);
+			}
+
+			// (c) Action events have actionName in data
+			const kinds = events.map((e) => e.kind);
+			expect(kinds).toEqual(["llm_call", "tool_use", "llm_call", "shell_command"]);
+
+			const actionEvents = events.filter(
+				(e) => e.kind === "tool_use" || e.kind === "shell_command",
+			);
+			for (const ae of actionEvents) {
+				expect(ae.data.actionName).toBeDefined();
+				expect(typeof ae.data.actionName).toBe("string");
+			}
+
+			// LLM events have model in data
+			const llmEvents = events.filter((e) => e.kind === "llm_call");
+			for (const le of llmEvents) {
+				expect(le.data.model).toBe("claude-sonnet-4-6");
+			}
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 4. Action receipt shape
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("4. Action receipt shape", () => {
+		it("returns a well-formed receipt matching ActionDescriptor fields", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			const actionResult = await governed.governAction(
+				{
+					kind: "file_access",
+					name: "file_write",
+					cost: 25,
+					params: { path: "/tmp/output.txt", bytes: 1024 },
+				},
+				async () => ({ written: true, bytes: 1024 }),
+			);
+
+			const receipt = actionResult.receipt;
+
+			// transferId starts with "tx_"
+			expect(receipt.transferId).toMatch(/^tx_/);
+
+			// cost matches input
+			expect(receipt.cost).toBe(25);
+
+			// settled is true
+			expect(receipt.settled).toBe(true);
+
+			// actionKind equals action.kind
+			expect(receipt.actionKind).toBe("file_access");
+
+			// model equals action.name
+			expect(receipt.model).toBe("file_write");
+
+			// provider equals action.kind
+			expect(receipt.provider).toBe("file_access");
+
+			// auditHash is 64-char hex
+			expect(receipt.auditHash).toMatch(/^[a-f0-9]{64}$/);
+
+			// budgetRemaining is correct
+			expect(receipt.budgetRemaining).toBe(10_000 - 25);
+
+			// timestamp is valid ISO
+			expect(receipt.timestamp).toBeTruthy();
+			expect(new Date(receipt.timestamp).getTime()).not.toBeNaN();
+
+			// receiptUrl is null in local mode (no proxy)
+			expect(receipt.receiptUrl).toBeNull();
+
+			// Result is passed through
+			expect(actionResult.result).toEqual({ written: true, bytes: 1024 });
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 5. Destroy cleans up mixed state
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("5. Destroy cleans up mixed state", () => {
+		it("completes without timeout after mixed LLM + action usage", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 50_000,
+				vaultBase: tmpVault,
+			});
+
+			// LLM call
+			await governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "Hello" }],
+			});
+
+			// Action call
+			await governed.governAction(
+				{ kind: "api_request", name: "fetch_weather", cost: 15 },
+				async () => ({ temp: 72, unit: "F" }),
+			);
+
+			// Destroy should complete without hanging
+			await governed.destroy();
+
+			// Further calls should throw after destroy
+			await expect(
+				governed.governAction({ kind: "tool_use", name: "noop", cost: 1 }, async () => null),
+			).rejects.toThrow("TrustedClient has been destroyed");
+		});
+	});
+});

--- a/packages/core/tests/govern/action-governance.test.ts
+++ b/packages/core/tests/govern/action-governance.test.ts
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Tests for governAction() — the action governance pipeline.
+ *
+ * Exercises: successful governance, policy denial, budget enforcement,
+ * PII detection, execution failure, audit trail, multiple action kinds,
+ * budget tracking across calls, custom actor, and destroyed-client rejection.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trust } from "../../src/govern.js";
+import { PolicyDeniedError } from "../../src/shared/errors.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+// ── Mock tigerbeetle-node at module level (native module, never loaded in tests) ──
+
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: {
+		linked: 1,
+		pending: 2,
+		post_pending_transfer: 4,
+		void_pending_transfer: 8,
+	},
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Shared helpers ──
+
+const VAULT_DIR = ".usertrust";
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `action-gov-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function makeAnthropicMock() {
+	return {
+		messages: {
+			create: vi.fn(async () => ({
+				id: "msg_test",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "Hello" }],
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			})),
+		},
+	};
+}
+
+function writeVaultConfig(vaultBase: string, config: Record<string, unknown>): void {
+	const configDir = join(vaultBase, VAULT_DIR);
+	mkdirSync(configDir, { recursive: true });
+	writeFileSync(join(configDir, "usertrust.config.json"), JSON.stringify(config));
+}
+
+function writePolicyFile(vaultBase: string, relativePath: string, rules: unknown[]): void {
+	const fullDir = join(vaultBase, relativePath.replace(/\/[^/]+$/, ""));
+	mkdirSync(fullDir, { recursive: true });
+	writeFileSync(join(vaultBase, relativePath), JSON.stringify({ rules }));
+}
+
+function readAuditEvents(vaultBase: string): AuditEvent[] {
+	const auditPath = join(vaultBase, VAULT_DIR, "audit", "events.jsonl");
+	if (!existsSync(auditPath)) return [];
+	const lines = readFileSync(auditPath, "utf-8").trim().split("\n");
+	return lines.filter((l) => l.length > 0).map((line) => JSON.parse(line) as AuditEvent);
+}
+
+// ── Test Suite ──
+
+describe("governAction() — action governance pipeline", () => {
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = makeTmpVault();
+	});
+
+	afterEach(async () => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// Cleanup best-effort
+		}
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 1. Successful tool_use governance
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("1. Successful tool_use governance", () => {
+		it("returns result and receipt with correct shape", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			const { result, receipt } = await governed.governAction(
+				{ kind: "tool_use", name: "file_read", cost: 50 },
+				async () => "file contents here",
+			);
+
+			// Verify result
+			expect(result).toBe("file contents here");
+
+			// Verify receipt shape
+			expect(receipt.transferId).toMatch(/^tx_/);
+			expect(receipt.cost).toBe(50);
+			expect(receipt.settled).toBe(true);
+			expect(receipt.actionKind).toBe("tool_use");
+			expect(receipt.model).toBe("file_read");
+			expect(receipt.provider).toBe("tool_use");
+			expect(receipt.auditHash).toMatch(/^[a-f0-9]{64}$/);
+			expect(receipt.timestamp).toBeTruthy();
+			expect(new Date(receipt.timestamp).getTime()).not.toBeNaN();
+			expect(receipt.budgetRemaining).toBeLessThan(10_000);
+			expect(receipt.receiptUrl).toBeNull(); // local mode
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 2. Policy denial on action
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("2. Policy denial on action", () => {
+		it("denies shell_command when policy rule matches action_kind", async () => {
+			writePolicyFile(tmpVault, ".usertrust/policies/default.yml", [
+				{
+					name: "block-shell",
+					effect: "deny",
+					enforcement: "hard",
+					conditions: [{ field: "action_kind", operator: "eq", value: "shell_command" }],
+				},
+			]);
+			writeVaultConfig(tmpVault, {
+				budget: 10_000,
+				policies: "./policies/default.yml",
+			});
+
+			const executeFn = vi.fn(async () => "should not run");
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			await expect(
+				governed.governAction({ kind: "shell_command", name: "rm -rf", cost: 10 }, executeFn),
+			).rejects.toThrow(PolicyDeniedError);
+
+			expect(executeFn).not.toHaveBeenCalled();
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 3. Budget enforcement
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("3. Budget enforcement", () => {
+		it("rejects action when budget is exhausted", async () => {
+			// Write a policy with the budget-exhausted rule
+			writePolicyFile(tmpVault, ".usertrust/policies/default.yml", [
+				{
+					name: "block-budget-exhausted",
+					effect: "deny",
+					enforcement: "hard",
+					conditions: [{ field: "budget_remaining", operator: "lte", value: 0 }],
+				},
+			]);
+			writeVaultConfig(tmpVault, {
+				budget: 100,
+				policies: "./policies/default.yml",
+			});
+
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			// First call — exhausts entire budget (budget_remaining becomes 0)
+			await governed.governAction({ kind: "tool_use", name: "first", cost: 100 }, async () => "ok");
+
+			// Second call — budget_remaining is 0, rule denies
+			await expect(
+				governed.governAction(
+					{ kind: "tool_use", name: "second", cost: 50 },
+					async () => "should not run",
+				),
+			).rejects.toThrow(PolicyDeniedError);
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 4. PII detection in action params
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("4. PII detection in action params", () => {
+		it("blocks action with SSN in params when pii is block", async () => {
+			writeVaultConfig(tmpVault, { budget: 10_000, pii: "block" });
+
+			const executeFn = vi.fn(async () => "should not run");
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			await expect(
+				governed.governAction(
+					{
+						kind: "tool_use",
+						name: "send_data",
+						cost: 10,
+						params: { ssn: "My social security number is 123-45-6789" },
+					},
+					executeFn,
+				),
+			).rejects.toThrow("PII detected");
+
+			expect(executeFn).not.toHaveBeenCalled();
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 5. Action execution failure
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("5. Action execution failure", () => {
+		it("propagates error from execute function without returning a receipt", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			const execError = new Error("Tool crashed unexpectedly");
+			await expect(
+				governed.governAction({ kind: "tool_use", name: "broken_tool", cost: 50 }, async () => {
+					throw execError;
+				}),
+			).rejects.toThrow("Tool crashed unexpectedly");
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 6. Audit trail includes action events
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("6. Audit trail includes action events", () => {
+		it("writes audit event with correct kind and data", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			await governed.governAction(
+				{ kind: "tool_use", name: "search_db", cost: 25, params: { query: "users" } },
+				async () => ({ rows: 42 }),
+			);
+
+			await governed.destroy();
+
+			const events = readAuditEvents(tmpVault);
+			expect(events.length).toBeGreaterThanOrEqual(1);
+
+			const actionEvent = events.find((e) => e.kind === "tool_use");
+			expect(actionEvent).toBeDefined();
+			const ae = actionEvent as AuditEvent;
+			expect(ae.data.actionName).toBe("search_db");
+			expect(ae.data.cost).toBe(25);
+			expect(ae.data.settled).toBe(true);
+			expect(ae.data.transferId).toMatch(/^tx_/);
+			expect(ae.data.params).toEqual({ query: "users" });
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 7. Multiple action kinds
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("7. Multiple action kinds", () => {
+		it("governs tool_use, file_access, and api_request in sequence", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 50_000,
+				vaultBase: tmpVault,
+			});
+
+			const r1 = await governed.governAction(
+				{ kind: "tool_use", name: "grep", cost: 10 },
+				async () => "match found",
+			);
+
+			const r2 = await governed.governAction(
+				{ kind: "file_access", name: "read_config", cost: 20 },
+				async () => ({ key: "value" }),
+			);
+
+			const r3 = await governed.governAction(
+				{ kind: "api_request", name: "fetch_users", cost: 30 },
+				async () => [{ id: 1 }],
+			);
+
+			// All succeed with correct results
+			expect(r1.result).toBe("match found");
+			expect(r2.result).toEqual({ key: "value" });
+			expect(r3.result).toEqual([{ id: 1 }]);
+
+			// Receipts have correct action kinds
+			expect(r1.receipt.actionKind).toBe("tool_use");
+			expect(r2.receipt.actionKind).toBe("file_access");
+			expect(r3.receipt.actionKind).toBe("api_request");
+
+			// Provider maps to action kind
+			expect(r1.receipt.provider).toBe("tool_use");
+			expect(r2.receipt.provider).toBe("file_access");
+			expect(r3.receipt.provider).toBe("api_request");
+
+			// Model maps to action name
+			expect(r1.receipt.model).toBe("grep");
+			expect(r2.receipt.model).toBe("read_config");
+			expect(r3.receipt.model).toBe("fetch_users");
+
+			// Budget decreases with each call
+			expect(r1.receipt.budgetRemaining).toBeLessThan(50_000);
+			expect(r2.receipt.budgetRemaining).toBeLessThan(r1.receipt.budgetRemaining);
+			expect(r3.receipt.budgetRemaining).toBeLessThan(r2.receipt.budgetRemaining);
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 8. Budget tracking across multiple actions
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("8. Budget tracking across multiple actions", () => {
+		it("allows first two actions but rejects when budget exhausted", async () => {
+			// Write a policy with the budget-exhausted rule
+			writePolicyFile(tmpVault, ".usertrust/policies/default.yml", [
+				{
+					name: "block-budget-exhausted",
+					effect: "deny",
+					enforcement: "hard",
+					conditions: [{ field: "budget_remaining", operator: "lte", value: 0 }],
+				},
+			]);
+			writeVaultConfig(tmpVault, {
+				budget: 250,
+				policies: "./policies/default.yml",
+			});
+
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			// First action: cost 100, remaining 150
+			const r1 = await governed.governAction(
+				{ kind: "tool_use", name: "action_1", cost: 100 },
+				async () => "a",
+			);
+			expect(r1.receipt.budgetRemaining).toBe(150);
+
+			// Second action: cost 100, remaining 50
+			const r2 = await governed.governAction(
+				{ kind: "tool_use", name: "action_2", cost: 100 },
+				async () => "b",
+			);
+			expect(r2.receipt.budgetRemaining).toBe(50);
+
+			// Third action: cost 50, remaining 0 (exactly exhausted)
+			const r3 = await governed.governAction(
+				{ kind: "tool_use", name: "action_3", cost: 50 },
+				async () => "c",
+			);
+			expect(r3.receipt.budgetRemaining).toBe(0);
+
+			// Fourth action — budget_remaining is 0, rule denies
+			await expect(
+				governed.governAction(
+					{ kind: "tool_use", name: "action_4", cost: 100 },
+					async () => "should not run",
+				),
+			).rejects.toThrow(PolicyDeniedError);
+
+			await governed.destroy();
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 9. Custom actor
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("9. Custom actor", () => {
+		it("records the specified actor in the audit event", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			await governed.governAction(
+				{ kind: "tool_use", name: "custom_tool", cost: 10, actor: "agent-1" },
+				async () => "done",
+			);
+
+			await governed.destroy();
+
+			const events = readAuditEvents(tmpVault);
+			const actionEvent = events.find((e) => e.kind === "tool_use");
+			expect(actionEvent).toBeDefined();
+			expect((actionEvent as AuditEvent).actor).toBe("agent-1");
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 10. Destroyed client rejects actions
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("10. Destroyed client rejects actions", () => {
+		it("throws after destroy() is called", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			await governed.destroy();
+
+			await expect(
+				governed.governAction(
+					{ kind: "tool_use", name: "late_call", cost: 10 },
+					async () => "should not run",
+				),
+			).rejects.toThrow("TrustedClient has been destroyed");
+		});
+	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 11. AUD-466: Negative cost validation
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("11. Negative cost validation (AUD-466)", () => {
+		it("rejects negative cost to prevent budget inflation", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			await expect(
+				governed.governAction(
+					{ kind: "tool_use", name: "exploit", cost: -500 },
+					async () => "should not run",
+				),
+			).rejects.toThrow("action.cost must be a non-negative finite number");
+
+			await governed.destroy();
+		});
+
+		it("rejects NaN cost", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			await expect(
+				governed.governAction(
+					{ kind: "tool_use", name: "exploit", cost: Number.NaN },
+					async () => "should not run",
+				),
+			).rejects.toThrow("action.cost must be a non-negative finite number");
+
+			await governed.destroy();
+		});
+
+		it("rejects Infinity cost", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			await expect(
+				governed.governAction(
+					{ kind: "tool_use", name: "exploit", cost: Number.POSITIVE_INFINITY },
+					async () => "should not run",
+				),
+			).rejects.toThrow("action.cost must be a non-negative finite number");
+
+			await governed.destroy();
+		});
+
+		it("allows zero cost", async () => {
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 10_000,
+				vaultBase: tmpVault,
+			});
+
+			const { result, receipt } = await governed.governAction(
+				{ kind: "tool_use", name: "free_action", cost: 0 },
+				async () => "free",
+			);
+
+			expect(result).toBe("free");
+			expect(receipt.cost).toBe(0);
+			expect(receipt.budgetRemaining).toBe(10_000);
+
+			await governed.destroy();
+		});
+	});
+});

--- a/packages/core/tests/govern/action-governance.test.ts
+++ b/packages/core/tests/govern/action-governance.test.ts
@@ -539,4 +539,52 @@ describe("governAction() — action governance pipeline", () => {
 			await governed.destroy();
 		});
 	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 12. AUD-467: Policy context field shadowing prevention
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("12. Policy context field shadowing (AUD-467)", () => {
+		it("governance fields cannot be overridden by action.params", async () => {
+			writePolicyFile(tmpVault, ".usertrust/policies/default.yml", [
+				{
+					name: "block-budget-exhausted",
+					effect: "deny",
+					enforcement: "hard",
+					conditions: [{ field: "budget_remaining", operator: "lte", value: 0 }],
+				},
+			]);
+			writeVaultConfig(tmpVault, {
+				budget: 100,
+				policies: "./policies/default.yml",
+			});
+
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				budget: 100,
+				vaultBase: tmpVault,
+			});
+
+			// First call exhausts budget
+			await governed.governAction(
+				{ kind: "tool_use", name: "normal", cost: 100 },
+				async () => "ok",
+			);
+
+			// Second call tries to shadow budget_remaining with a large value
+			await expect(
+				governed.governAction(
+					{
+						kind: "tool_use",
+						name: "exploit",
+						cost: 50,
+						params: { budget_remaining: 999999 },
+					},
+					async () => "should not run",
+				),
+			).rejects.toThrow("Policy denied");
+
+			await governed.destroy();
+		});
+	});
 });


### PR DESCRIPTION
## Summary

- Add `governAction<R>()` method to `TrustedClient` — governs arbitrary agent actions (tool use, file access, shell commands, API requests) through the same pipeline as LLM calls
- New types: `ActionKind`, `ActionDescriptor`, `GovernedActionResult` — exported from `usertrust`
- `TrustReceipt` gains optional `actionKind` field (backward compatible)
- Security: AUD-466 validates `action.cost >= 0` to prevent budget inflation via negative values
- Safety: AUD-465 uses `holdReleased` guard to prevent double-decrement of in-flight hold tracking

## API

```typescript
const client = await trust(new Anthropic(), { budget: 50_000 });

// LLM calls still work exactly as before
const { response, receipt } = await client.messages.create({ ... });

// NEW: Govern any agent action through the same pipeline
const { result, receipt: actionReceipt } = await client.governAction(
  { kind: "tool_use", name: "file_read", cost: 10, params: { path: "/data" } },
  async () => fs.readFile("/data", "utf-8"),
);
```

## Governance pipeline for actions

`mutex → circuit breaker → policy gate → PII check → PENDING hold → execute → POST/VOID → audit → receipt`

## Test plan

- [x] 14 unit tests: policy denial, budget enforcement, PII detection, audit trail, multiple action kinds, budget tracking, custom actor, destroyed client, negative/NaN/Infinity cost rejection, zero cost
- [x] 5 E2E tests: mixed LLM+action lifecycle, shared budget enforcement, audit chain integrity across mixed calls, action receipt shape, destroy cleanup
- [x] All 1084 tests pass (46 test files)
- [x] TypeScript: clean
- [x] Biome: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)