### PR TITLE
fix(core): resolve 6 deferred security/correctness findings

### DIFF
--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -38,8 +38,9 @@ import { detectClientKind } from "./detect.js";
 import { TrustTBClient, XFER_SPEND } from "./ledger/client.js";
 import { estimateCost, estimateInputTokens } from "./ledger/pricing.js";
 import { recordPattern } from "./memory/patterns.js";
+import { DEFAULT_RULES } from "./policy/default-rules.js";
 import { type GateRule, evaluatePolicy, loadPolicies } from "./policy/gate.js";
-import { detectPII } from "./policy/pii.js";
+import { detectPII, redactPII } from "./policy/pii.js";
 import { type ProxyConnection, connectProxy } from "./proxy.js";
 import { CircuitBreakerRegistry } from "./resilience/circuit.js";
 import { DEFAULT_BUDGET, VAULT_DIR } from "./shared/constants.js";
@@ -216,7 +217,8 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 	const audit: AuditWriter = (isTestEnv ? opts?._audit : undefined) ?? createAuditWriter(vaultPath);
 
 	const policiesPath = join(vaultPath, VAULT_DIR, config.policies);
-	const policyRules: GateRule[] = existsSync(policiesPath) ? loadPolicies(policiesPath) : [];
+	const loadedRules = existsSync(policiesPath) ? loadPolicies(policiesPath) : [];
+	const policyRules: GateRule[] = loadedRules.length > 0 ? loadedRules : DEFAULT_RULES;
 
 	const breaker = new CircuitBreakerRegistry({
 		failureThreshold: config.circuitBreaker.failureThreshold,
@@ -387,10 +389,13 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 								usageSource = "estimated";
 							}
 
-							// Release in-flight hold
-							inFlightHoldTotal -= estimatedCost;
-
-							budgetSpent += streamCost;
+							// Release in-flight hold and commit budget under mutex
+							{
+								const releaseLock = await budgetMutex.acquire();
+								inFlightHoldTotal -= estimatedCost;
+								budgetSpent += streamCost;
+								releaseLock();
+							}
 							// AUD-457: Persist cumulative spend to disk
 							await persistSpendLedger(vaultBase, budgetSpent);
 							cb.recordSuccess();
@@ -447,17 +452,25 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							const syntheticHash = createHash("sha256").update(transferId).digest("hex");
 							let auditHash = syntheticHash;
 							try {
+								const auditEventData: Record<string, unknown> = {
+									model,
+									cost: streamCost,
+									settled,
+									transferId,
+									usageSource,
+									chunksDelivered: completion.chunksDelivered,
+								};
+								if (config.pii === "warn" || config.pii === "redact") {
+									const piiResult = redactPII(messages);
+									if (piiResult.detection.found) {
+										auditEventData.piiDetected = piiResult.detection.types;
+										auditEventData.piiPaths = piiResult.detection.paths;
+									}
+								}
 								const auditEvent = await audit.appendEvent({
 									kind: "llm_call",
 									actor: "local",
-									data: {
-										model,
-										cost: streamCost,
-										settled,
-										transferId,
-										usageSource,
-										chunksDelivered: completion.chunksDelivered,
-									},
+									data: auditEventData,
 								});
 								auditHash = auditEvent.hash;
 							} catch {
@@ -468,7 +481,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 								transferId,
 								cost: streamCost,
 								budgetRemaining: config.budget - budgetSpent - inFlightHoldTotal,
-								auditHash,
+								auditHash: callAuditDegraded ? "AUDIT_DEGRADED" : auditHash,
 								chainPath: join(VAULT_DIR, "audit"),
 								receiptUrl: opts?.proxy != null ? `${VERIFY_URL_BASE}/${transferId}` : null,
 								settled,
@@ -484,9 +497,13 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							inFlightStreamCount--;
 							return streamReceipt;
 						},
-						(error: unknown, partial: StreamCompletion) => {
-							// Release in-flight hold
-							inFlightHoldTotal -= estimatedCost;
+						async (error: unknown, partial: StreamCompletion) => {
+							// Release in-flight hold under mutex
+							{
+								const releaseLock = await budgetMutex.acquire();
+								inFlightHoldTotal -= estimatedCost;
+								releaseLock();
+							}
 
 							cb.recordFailure();
 
@@ -502,10 +519,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 										partialInputTokens: partial.usage.inputTokens,
 										partialOutputTokens: partial.usage.outputTokens,
 										usageReported: partial.usageReported,
-										error:
-											error instanceof Error
-												? error.message.slice(0, 200)
-												: String(error).slice(0, 200),
+										error: (() => {
+											const raw = error instanceof Error ? error.message : String(error);
+											return config.pii === "warn" || config.pii === "redact"
+												? (redactPII(raw).data as string).slice(0, 200)
+												: raw.slice(0, 200);
+										})(),
 									},
 								})
 								.catch(() => {});
@@ -524,12 +543,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					// AUD-454: For streaming responses, settlement has NOT happened yet.
 					// Set settled: false — the real settlement status will be on
 					// governedStream.receipt after the stream is fully consumed.
-					const auditHash = createHash("sha256").update(transferId).digest("hex");
+					const streamEstimateHash = createHash("sha256").update(transferId).digest("hex");
 					const estimatedReceipt: TrustReceipt = {
 						transferId,
 						cost: estimatedCost,
 						budgetRemaining: config.budget - budgetSpent - inFlightHoldTotal,
-						auditHash,
+						auditHash: callAuditDegraded ? "AUDIT_DEGRADED" : streamEstimateHash,
 						chainPath: join(VAULT_DIR, "audit"),
 						receiptUrl: opts?.proxy != null ? `${VERIFY_URL_BASE}/${transferId}` : null,
 						settled: false, // AUD-454: not settled yet — stream hasn't been consumed
@@ -565,11 +584,13 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					}
 				}
 
-				// Release in-flight hold (non-streaming success)
-				inFlightHoldTotal -= estimatedCost;
-
-				// Track budget (cumulative)
-				budgetSpent += actualCost;
+				// Release in-flight hold and commit budget under mutex
+				{
+					const releaseLock = await budgetMutex.acquire();
+					inFlightHoldTotal -= estimatedCost;
+					budgetSpent += actualCost;
+					releaseLock();
+				}
 				// AUD-457: Persist cumulative spend to disk
 				await persistSpendLedger(vaultBase, budgetSpent);
 
@@ -606,8 +627,25 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					try {
 						// AUD-460: Use the proxy's transferId for settlement
 						await proxyConn.settle(proxyTransferId ?? transferId, actualCost);
-					} catch {
+					} catch (postErr) {
 						settled = false;
+						await audit
+							.appendEvent({
+								kind: "settlement_ambiguous",
+								actor: "local",
+								data: {
+									model,
+									cost: actualCost,
+									transferId,
+									error:
+										postErr instanceof Error
+											? postErr.message.slice(0, 200)
+											: String(postErr).slice(0, 200),
+								},
+							})
+							.catch(() => {
+								callAuditDegraded = true;
+							});
 					}
 				}
 
@@ -615,15 +653,23 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				const syntheticHash = createHash("sha256").update(transferId).digest("hex");
 				let auditHash = syntheticHash;
 				try {
+					const auditData: Record<string, unknown> = {
+						model,
+						cost: actualCost,
+						settled,
+						transferId,
+					};
+					if (config.pii === "warn" || config.pii === "redact") {
+						const piiResult = redactPII(messages);
+						if (piiResult.detection.found) {
+							auditData.piiDetected = piiResult.detection.types;
+							auditData.piiPaths = piiResult.detection.paths;
+						}
+					}
 					const auditEvent = await audit.appendEvent({
 						kind: "llm_call",
 						actor: "local",
-						data: {
-							model,
-							cost: actualCost,
-							settled,
-							transferId,
-						},
+						data: auditData,
 					});
 					auditHash = auditEvent.hash;
 				} catch {
@@ -665,7 +711,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					transferId,
 					cost: actualCost,
 					budgetRemaining,
-					auditHash,
+					auditHash: callAuditDegraded ? "AUDIT_DEGRADED" : auditHash,
 					chainPath: join(VAULT_DIR, "audit"),
 					receiptUrl: opts?.proxy != null ? `${VERIFY_URL_BASE}/${transferId}` : null,
 					settled,
@@ -679,8 +725,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 
 				return { response, receipt };
 			} catch (err) {
-				// Release in-flight hold (non-streaming failure)
-				inFlightHoldTotal -= estimatedCost;
+				// Release in-flight hold under mutex (non-streaming failure)
+				{
+					const releaseLock = await budgetMutex.acquire();
+					inFlightHoldTotal -= estimatedCost;
+					releaseLock();
+				}
 
 				// j. Circuit breaker: record failure
 				cb.recordFailure();
@@ -709,7 +759,14 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					.appendEvent({
 						kind: "llm_call_failed",
 						actor: "local",
-						data: { model, error: String(err), transferId },
+						data: {
+							model,
+							error:
+								config.pii === "warn" || config.pii === "redact"
+									? (redactPII(String(err)).data as string).slice(0, 200)
+									: String(err),
+							transferId,
+						},
 					})
 					.catch(() => {
 						callAuditDegraded = true;
@@ -827,21 +884,23 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			// f. Execute the action
 			// Guard against double-decrement of inFlightHoldTotal (AUD-465)
 			let holdReleased = false;
-			function releaseHold(): void {
+			async function releaseHoldAndCommit(cost?: number): Promise<void> {
 				if (!holdReleased) {
 					holdReleased = true;
+					const releaseLock = await budgetMutex.acquire();
 					inFlightHoldTotal -= action.cost;
+					if (cost !== undefined) {
+						budgetSpent += cost;
+					}
+					releaseLock();
 				}
 			}
 
 			try {
 				const result = await execute();
 
-				// Release in-flight hold
-				releaseHold();
-
-				// Track budget
-				budgetSpent += action.cost;
+				// Release in-flight hold and commit budget under mutex
+				await releaseHoldAndCommit(action.cost);
 				await persistSpendLedger(vaultBase, budgetSpent);
 
 				// g. Circuit breaker: record success
@@ -878,12 +937,41 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (proxyConn != null && !isDryRun) {
 					try {
 						await proxyConn.settle(proxyTransferId ?? transferId, action.cost);
-					} catch {
+					} catch (postErr) {
 						settled = false;
+						await audit
+							.appendEvent({
+								kind: "settlement_ambiguous",
+								actor,
+								data: {
+									actionKind: action.kind,
+									actionName: action.name,
+									cost: action.cost,
+									transferId,
+									error:
+										postErr instanceof Error
+											? postErr.message.slice(0, 200)
+											: String(postErr).slice(0, 200),
+								},
+							})
+							.catch(() => {
+								callAuditDegraded = true;
+							});
 					}
 				}
 
-				// i. Audit event
+				// i. Prepare params for audit — redact PII if configured
+				let auditParams: Record<string, unknown> | undefined;
+				if (action.params != null) {
+					if (config.pii === "warn" || config.pii === "redact") {
+						const redacted = redactPII(action.params);
+						auditParams = redacted.data as Record<string, unknown>;
+					} else {
+						auditParams = action.params;
+					}
+				}
+
+				// i2. Audit event
 				const syntheticHash = createHash("sha256").update(transferId).digest("hex");
 				let auditHash = syntheticHash;
 				try {
@@ -895,7 +983,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							cost: action.cost,
 							settled,
 							transferId,
-							...(action.params != null ? { params: action.params } : {}),
+							...(auditParams != null ? { params: auditParams } : {}),
 						},
 					});
 					auditHash = auditEvent.hash;
@@ -920,6 +1008,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 								cost: action.cost,
 								settled,
 								transferId,
+								...(auditParams != null ? { params: auditParams } : {}),
 							},
 						},
 						config.audit.indexLimit,
@@ -932,7 +1021,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					transferId,
 					cost: action.cost,
 					budgetRemaining,
-					auditHash,
+					auditHash: callAuditDegraded ? "AUDIT_DEGRADED" : auditHash,
 					chainPath: join(VAULT_DIR, "audit"),
 					receiptUrl: opts?.proxy != null ? `${VERIFY_URL_BASE}/${transferId}` : null,
 					settled,
@@ -947,7 +1036,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				return { result, receipt };
 			} catch (err) {
 				// Release in-flight hold (AUD-465: guard prevents double-decrement)
-				releaseHold();
+				await releaseHoldAndCommit();
 
 				// Circuit breaker: record failure
 				cb.recordFailure();
@@ -976,7 +1065,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						actor,
 						data: {
 							actionName: action.name,
-							error: err instanceof Error ? err.message.slice(0, 200) : String(err).slice(0, 200),
+							error: (() => {
+								const raw = err instanceof Error ? err.message : String(err);
+								return config.pii === "warn" || config.pii === "redact"
+									? (redactPII(raw).data as string).slice(0, 200)
+									: raw.slice(0, 200);
+							})(),
 							transferId,
 						},
 					})

--- a/packages/core/src/policy/pii.ts
+++ b/packages/core/src/policy/pii.ts
@@ -10,7 +10,8 @@
  *
  * Pure module — no side effects, no network calls.
  *
- * Detects: email, phone, SSN, credit card (Luhn-validated), IPv4.
+ * Detects: email, phone, SSN, credit card (Luhn-validated), IPv4,
+ * API keys, AWS keys, GitHub tokens, bearer tokens, generic secrets.
  */
 
 // ---------------------------------------------------------------------------
@@ -93,12 +94,66 @@ function luhnCheck(digits: string): boolean {
 	return sum % 10 === 0;
 }
 
+/** API key: sk-... (OpenAI/Anthropic) or sk_live_/sk_test_ (Stripe) */
+function isApiKey(value: string): boolean {
+	return /\b(?:sk-|sk_(?:live|test)_)[a-zA-Z0-9_-]{20,}\b/.test(value);
+}
+
+/** AWS access key: AKIA followed by 16 uppercase alphanumeric chars */
+function isAwsKey(value: string): boolean {
+	return /\bAKIA[0-9A-Z]{16}\b/.test(value);
+}
+
+/** GitHub token: ghp_, gho_, ghs_, ghr_, github_pat_ followed by 22+ alphanumeric chars */
+function isGithubToken(value: string): boolean {
+	return /\b(?:ghp_|gho_|ghs_|ghr_|github_pat_)[a-zA-Z0-9]{22,}\b/.test(value);
+}
+
+/** Bearer token: Authorization header with 20+ char token */
+function isBearerToken(value: string): boolean {
+	return /\bBearer\s+\S{20,}/.test(value);
+}
+
+/** JWT token: eyJ... header.payload.signature */
+function isJwt(value: string): boolean {
+	return /\beyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\b/.test(value);
+}
+
+/** PEM-encoded private key */
+function isPrivateKey(value: string): boolean {
+	return /-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(value);
+}
+
+/** Generic secret: known prefixes (xox, SG., glpat-, npm_) or long hex strings (64+ chars) */
+function isGenericSecret(value: string): boolean {
+	// Note: sk- and sk_ prefixes handled by isApiKey — not duplicated here
+	if (
+		/\b(?:xox[bpars]-[a-zA-Z0-9-]+|SG\.[a-zA-Z0-9_-]{20,}|glpat-[a-zA-Z0-9_-]{20,}|npm_[a-zA-Z0-9]{36,})\b/.test(
+			value,
+		)
+	) {
+		return true;
+	}
+	// Long hex strings — require at least one digit and one letter to avoid false positives
+	const hexMatch = value.match(/\b[0-9a-fA-F]{64,}\b/);
+	if (!hexMatch) return false;
+	const hex = hexMatch[0];
+	return /[0-9]/.test(hex) && /[a-fA-F]/.test(hex);
+}
+
 const PII_PATTERNS: PIIPattern[] = [
 	{ type: "email", test: isEmail },
 	{ type: "phone", test: isPhoneNumber },
 	{ type: "ssn", test: isSSN },
 	{ type: "credit_card", test: isCreditCard },
 	{ type: "ipv4", test: isIPv4 },
+	{ type: "api_key", test: isApiKey },
+	{ type: "aws_key", test: isAwsKey },
+	{ type: "github_token", test: isGithubToken },
+	{ type: "bearer_token", test: isBearerToken },
+	{ type: "jwt", test: isJwt },
+	{ type: "private_key", test: isPrivateKey },
+	{ type: "generic_secret", test: isGenericSecret },
 ];
 
 // ---------------------------------------------------------------------------
@@ -153,4 +208,65 @@ function scanString(value: string, currentPath: string, types: Set<string>, path
 			paths.push(currentPath ? `${currentPath}(${pattern.type})` : `(${pattern.type})`);
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+export interface RedactedData {
+	/** The data with PII values replaced by placeholders */
+	data: unknown;
+	/** The detection result (same as detectPII) */
+	detection: PIIDetection;
+}
+
+/**
+ * Deep-clone data and replace detected PII values with redacted placeholders.
+ * Returns both the redacted data and the detection metadata.
+ */
+export function redactPII(data: unknown): RedactedData {
+	const detection = detectPII(data);
+	if (!detection.found) {
+		return { data, detection };
+	}
+	const redacted = redactValue(data);
+	return { data: redacted, detection };
+}
+
+/** Return matched PII type names for a string value. */
+function matchedTypes(value: string): string[] {
+	const matched: string[] = [];
+	for (const pattern of PII_PATTERNS) {
+		if (pattern.test(value)) {
+			matched.push(pattern.type);
+		}
+	}
+	return matched;
+}
+
+/** Recursively traverse data and replace PII strings with redacted placeholders. */
+function redactValue(value: unknown): unknown {
+	if (typeof value === "string") {
+		const types = matchedTypes(value);
+		if (types.length > 0) {
+			return `[REDACTED:${types.join(",")}]`;
+		}
+		return value;
+	}
+
+	if (Array.isArray(value)) {
+		return value.map((item) => redactValue(item));
+	}
+
+	if (value !== null && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		const result: Record<string, unknown> = {};
+		for (const key of Object.keys(record)) {
+			result[key] = redactValue(record[key]);
+		}
+		return result;
+	}
+
+	return value;
 }

--- a/packages/core/tests/govern/action-governance.test.ts
+++ b/packages/core/tests/govern/action-governance.test.ts
@@ -587,4 +587,100 @@ describe("governAction() — action governance pipeline", () => {
 			await governed.destroy();
 		});
 	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// 13. PII redaction in audit writes
+	// ─────────────────────────────────────────────────────────────────────
+
+	describe("13. PII redaction in audit writes", () => {
+		it("redacts PII in action params for audit in warn mode", async () => {
+			writeVaultConfig(tmpVault, { budget: 10_000, pii: "warn" });
+
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			await governed.governAction(
+				{
+					kind: "tool_use",
+					name: "send_data",
+					cost: 10,
+					params: { userEmail: "test@example.com", safeField: "hello" },
+				},
+				async () => "ok",
+			);
+
+			await governed.destroy();
+
+			const events = readAuditEvents(tmpVault);
+			const actionEvent = events.find((e) => e.kind === "tool_use");
+			expect(actionEvent).toBeDefined();
+
+			const ae = actionEvent as AuditEvent;
+			const params = ae.data.params as Record<string, unknown>;
+			expect(params.userEmail).toBe("[REDACTED:email]");
+			expect(params.safeField).toBe("hello");
+		});
+
+		it("redacts PII in action params for audit in redact mode", async () => {
+			writeVaultConfig(tmpVault, { budget: 10_000, pii: "redact" });
+
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			await governed.governAction(
+				{
+					kind: "tool_use",
+					name: "send_data",
+					cost: 10,
+					params: { ssn: "My SSN is 123-45-6789", safeField: "world" },
+				},
+				async () => "ok",
+			);
+
+			await governed.destroy();
+
+			const events = readAuditEvents(tmpVault);
+			const actionEvent = events.find((e) => e.kind === "tool_use");
+			expect(actionEvent).toBeDefined();
+
+			const ae = actionEvent as AuditEvent;
+			const params = ae.data.params as Record<string, unknown>;
+			expect(params.ssn).toBe("[REDACTED:ssn]");
+			expect(params.safeField).toBe("world");
+		});
+
+		it("does NOT redact params when pii is off", async () => {
+			writeVaultConfig(tmpVault, { budget: 10_000, pii: "off" });
+
+			const governed = await trust(makeAnthropicMock(), {
+				dryRun: true,
+				vaultBase: tmpVault,
+			});
+
+			await governed.governAction(
+				{
+					kind: "tool_use",
+					name: "send_data",
+					cost: 10,
+					params: { userEmail: "test@example.com", safeField: "hello" },
+				},
+				async () => "ok",
+			);
+
+			await governed.destroy();
+
+			const events = readAuditEvents(tmpVault);
+			const actionEvent = events.find((e) => e.kind === "tool_use");
+			expect(actionEvent).toBeDefined();
+
+			const ae = actionEvent as AuditEvent;
+			const params = ae.data.params as Record<string, unknown>;
+			expect(params.userEmail).toBe("test@example.com");
+			expect(params.safeField).toBe("hello");
+		});
+	});
 });

--- a/packages/core/tests/govern/failure-modes.test.ts
+++ b/packages/core/tests/govern/failure-modes.test.ts
@@ -5,8 +5,30 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
 import { type TrustEngine, trust } from "../../src/govern.js";
+import type { ProxyConnection } from "../../src/proxy.js";
 import { LedgerUnavailableError } from "../../src/shared/errors.js";
 import type { AuditEvent } from "../../src/shared/types.js";
+
+// Hoist mock proxy so it's available in vi.mock factory
+const { mockConnectProxy } = vi.hoisted(() => {
+	return {
+		mockConnectProxy: vi.fn(),
+	};
+});
+
+// Mock proxy module so we can control settle() behavior
+vi.mock("../../src/proxy.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/proxy.js")>();
+	return {
+		...actual,
+		connectProxy: (...args: unknown[]) => {
+			if (mockConnectProxy.getMockImplementation()) {
+				return mockConnectProxy(...args);
+			}
+			return actual.connectProxy(args[0] as string, args[1] as string | undefined);
+		},
+	};
+});
 
 // Mock tigerbeetle-node (native module, never loaded in tests)
 vi.mock("tigerbeetle-node", () => ({
@@ -481,6 +503,77 @@ describe("Failure mode 15.5: Multiple failures combine gracefully", () => {
 
 		expect(result.response).toBeDefined();
 		expect(result.receipt.settled).toBe(false);
+
+		await governed.destroy();
+	});
+});
+
+describe("Proxy settlement failure writes settlement_ambiguous audit event", () => {
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = makeTmpVault();
+	});
+
+	afterEach(() => {
+		mockConnectProxy.mockReset();
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+	});
+
+	it("logs settlement_ambiguous when proxy settle() throws", async () => {
+		// Create a mock proxy where settle() throws
+		const mockProxy: ProxyConnection = {
+			url: "https://proxy.usertools.ai",
+			key: "pk_test",
+			spend: vi.fn(async () => ({
+				transferId: "proxy_test_123",
+				estimatedCost: 100,
+			})),
+			settle: vi.fn(async () => {
+				throw new Error("Proxy settlement network error");
+			}),
+			void: vi.fn(async () => {}),
+			destroy: vi.fn(),
+		};
+
+		mockConnectProxy.mockImplementation(() => mockProxy);
+
+		const mockAudit = makeMockAudit();
+		const mockClient = makeAnthropicMock();
+
+		const governed = await trust(mockClient, {
+			dryRun: false,
+			budget: 50_000,
+			vaultBase: tmpVault,
+			proxy: "https://proxy.usertools.ai",
+			_engine: null,
+			_audit: mockAudit,
+		});
+
+		const result = await governed.messages.create({
+			model: "claude-sonnet-4-6",
+			max_tokens: 1024,
+			messages: [{ role: "user", content: "Hello" }],
+		});
+
+		// LLM call succeeded but settlement failed
+		expect(result.response).toBeDefined();
+		expect(result.receipt.settled).toBe(false);
+
+		// Verify settlement_ambiguous audit event was written
+		const appendCalls = (mockAudit.appendEvent as ReturnType<typeof vi.fn>).mock.calls;
+		const ambiguousCall = appendCalls.find(
+			(call: unknown[]) => (call[0] as AppendEventInput).kind === "settlement_ambiguous",
+		);
+		expect(ambiguousCall).toBeDefined();
+		const ambiguousData = (ambiguousCall?.[0] as AppendEventInput).data;
+		expect(ambiguousData.error).toContain("Proxy settlement network error");
+		expect(ambiguousData.model).toBe("claude-sonnet-4-6");
+		expect(ambiguousData.transferId).toMatch(/^tx_/);
 
 		await governed.destroy();
 	});

--- a/packages/core/tests/govern/govern.test.ts
+++ b/packages/core/tests/govern/govern.test.ts
@@ -3,7 +3,10 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
 import { type TrustedClient, trust } from "../../src/govern.js";
+import { PolicyDeniedError } from "../../src/shared/errors.js";
+import type { AuditEvent } from "../../src/shared/types.js";
 
 // Mock tigerbeetle-node at module level (native module, never loaded in tests)
 vi.mock("tigerbeetle-node", () => ({
@@ -839,6 +842,85 @@ describe("trust()", () => {
 			});
 
 			expect(result.receipt.cost).toBeGreaterThan(0);
+
+			await governed.destroy();
+		});
+	});
+
+	// ─── DEFAULT_RULES fallback ───
+
+	describe("DEFAULT_RULES fallback", () => {
+		it("denies second call when budget exhausted and no policy file (block-budget-exhausted default rule)", async () => {
+			// budget=1 is the minimum allowed. First call succeeds and exhausts the budget.
+			// Second call is denied by the block-budget-exhausted default rule.
+			const createFn = vi.fn(async () => ({
+				id: "msg_123",
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			}));
+			const mockClient = { messages: { create: createFn } };
+
+			const governed = await trust(mockClient, {
+				dryRun: true,
+				budget: 1,
+				vaultBase: tmpVault,
+			});
+
+			// First call succeeds (budget_remaining=1 passes policy)
+			const r1 = await governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "Hello" }],
+			});
+			expect(r1.response).toBeDefined();
+			expect(r1.receipt.budgetRemaining).toBeLessThanOrEqual(0);
+
+			// Second call denied by DEFAULT_RULES block-budget-exhausted
+			await expect(
+				governed.messages.create({
+					model: "claude-sonnet-4-6",
+					messages: [{ role: "user", content: "Hello again" }],
+				}),
+			).rejects.toThrow(PolicyDeniedError);
+
+			// The original create was called only once (first call)
+			expect(createFn).toHaveBeenCalledOnce();
+
+			await governed.destroy();
+		});
+	});
+
+	// ─── auditHash AUDIT_DEGRADED sentinel ───
+
+	describe("auditHash AUDIT_DEGRADED sentinel", () => {
+		it("sets auditHash to AUDIT_DEGRADED when audit writer throws", async () => {
+			const mockAudit: AuditWriter = {
+				appendEvent: vi.fn(async () => {
+					throw new Error("Audit disk full");
+				}),
+				getWriteFailures: vi.fn(() => 0),
+				isDegraded: vi.fn(() => false),
+				flush: vi.fn(async () => {}),
+				release: vi.fn(),
+			};
+
+			const mockClient = makeAnthropicMock();
+
+			const governed = await trust(mockClient, {
+				dryRun: true,
+				budget: 50_000,
+				vaultBase: tmpVault,
+				_audit: mockAudit,
+			});
+
+			const result = await governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "Hello" }],
+			});
+
+			expect(result.receipt.auditHash).toBe("AUDIT_DEGRADED");
+			expect(result.receipt.auditDegraded).toBe(true);
 
 			await governed.destroy();
 		});

--- a/packages/core/tests/policy/pii.test.ts
+++ b/packages/core/tests/policy/pii.test.ts
@@ -7,7 +7,12 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { type PIIDetection, detectPII } from "../../src/policy/pii.js";
+import {
+	type PIIDetection,
+	type RedactedData,
+	detectPII,
+	redactPII,
+} from "../../src/policy/pii.js";
 
 // ===========================================================================
 // Part A: Individual PII patterns
@@ -456,5 +461,250 @@ describe("detectPII — empty structures", () => {
 	it("handles empty string", () => {
 		const result = detectPII("");
 		expect(result.found).toBe(false);
+	});
+});
+
+// ===========================================================================
+// Part E: Secret pattern detection
+// ===========================================================================
+
+describe("detectPII — api_key", () => {
+	it("detects OpenAI-style sk- key", () => {
+		const result = detectPII({ key: "sk-proj-abc123def456ghi789jkl" });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("api_key");
+	});
+
+	it("detects Anthropic-style sk-ant- key", () => {
+		const result = detectPII({ key: "sk-ant-api03-abc123def456ghi789jklmno" });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("api_key");
+	});
+
+	it("does not detect short sk- strings", () => {
+		const result = detectPII({ key: "sk-short" });
+		expect(result.types).not.toContain("api_key");
+	});
+});
+
+describe("detectPII — aws_key", () => {
+	it("detects a standard AWS access key", () => {
+		const result = detectPII({ key: "AKIAIOSFODNN7EXAMPLE" });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("aws_key");
+	});
+
+	it("does not detect AKIA alone", () => {
+		const result = detectPII({ key: "AKIA" });
+		expect(result.types).not.toContain("aws_key");
+	});
+});
+
+describe("detectPII — github_token", () => {
+	it("detects ghp_ personal access token", () => {
+		const result = detectPII({ token: "ghp_ABCDEFghijklmnopqrstuv1234" });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("github_token");
+	});
+
+	it("detects github_pat_ fine-grained token", () => {
+		const result = detectPII({ token: "github_pat_ABCDEFghijklmnopqrstuv1234" });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("github_token");
+	});
+
+	it("does not detect short ghp_ strings", () => {
+		const result = detectPII({ token: "ghp_short" });
+		expect(result.types).not.toContain("github_token");
+	});
+});
+
+describe("detectPII — api_key (Stripe-style underscore prefix)", () => {
+	// Construct test keys programmatically to avoid GitHub push protection
+	const livePrefix = ["sk", "live", ""].join("_");
+	const testPrefix = ["sk", "test", ""].join("_");
+
+	it("detects Stripe-style live secret key", () => {
+		const result = detectPII({ key: `${livePrefix}xxxxxxxxxxxxxxxxxxxxxxxxxxx` });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("api_key");
+	});
+
+	it("detects Stripe-style test secret key", () => {
+		const result = detectPII({ key: `${testPrefix}xxxxxxxxxxxxxxxxxxxxxxxxxxx` });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("api_key");
+	});
+});
+
+describe("detectPII — jwt", () => {
+	it("detects a raw JWT token", () => {
+		const result = detectPII({
+			token:
+				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+		});
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("jwt");
+	});
+
+	it("does not detect a short JWT-like string", () => {
+		const result = detectPII({ token: "eyJhbGci.short.x" });
+		expect(result.types).not.toContain("jwt");
+	});
+});
+
+describe("detectPII — private_key", () => {
+	it("detects a PEM RSA private key header", () => {
+		const result = detectPII({
+			key: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAK...",
+		});
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("private_key");
+	});
+
+	it("detects a generic PEM private key header", () => {
+		const result = detectPII({
+			key: "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADA...",
+		});
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("private_key");
+	});
+
+	it("does not detect PEM public key", () => {
+		const result = detectPII({
+			key: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBg...",
+		});
+		expect(result.types).not.toContain("private_key");
+	});
+});
+
+describe("detectPII — generic_secret (npm token)", () => {
+	it("detects npm token", () => {
+		const result = detectPII({
+			token: "npm_abcdefghijklmnopqrstuvwxyz0123456789",
+		});
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("generic_secret");
+	});
+});
+
+describe("detectPII — api_key does not double-fire with generic_secret", () => {
+	it("sk- key tagged as api_key only, not generic_secret", () => {
+		const result = detectPII({ key: "sk-proj-abc123def456ghi789jkl" });
+		expect(result.types).toContain("api_key");
+		expect(result.types).not.toContain("generic_secret");
+	});
+});
+
+describe("detectPII — bearer_token", () => {
+	it("detects Bearer JWT token", () => {
+		const result = detectPII({
+			header: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc123",
+		});
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("bearer_token");
+	});
+
+	it("does not detect Bearer with short token", () => {
+		const result = detectPII({ header: "Bearer short" });
+		expect(result.types).not.toContain("bearer_token");
+	});
+});
+
+describe("detectPII — generic_secret", () => {
+	it("detects GitLab personal access token", () => {
+		const result = detectPII({ token: "glpat-xxxxxxxxxxxxxxxxxxxx" });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("generic_secret");
+	});
+
+	it("detects Slack bot token", () => {
+		const result = detectPII({ token: "xoxb-12345-67890-abcdef" });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("generic_secret");
+	});
+
+	it("detects long hex string (64+ chars)", () => {
+		const hex = "a1b2c3d4e5f6".repeat(6);
+		const result = detectPII({ secret: hex });
+		expect(result.found).toBe(true);
+		expect(result.types).toContain("generic_secret");
+	});
+
+	it("does not detect short random strings", () => {
+		const result = detectPII({ value: "hello-world-123" });
+		expect(result.types).not.toContain("generic_secret");
+	});
+});
+
+// ===========================================================================
+// Part F: redactPII
+// ===========================================================================
+
+describe("redactPII", () => {
+	it("returns unchanged data when no PII is found", () => {
+		const input = { name: "John", age: 30, active: true };
+		const result = redactPII(input);
+		expect(result.data).toEqual(input);
+		expect(result.detection.found).toBe(false);
+	});
+
+	it("redacts an email address", () => {
+		const result = redactPII({ email: "user@example.com" });
+		expect((result.data as Record<string, unknown>).email).toBe("[REDACTED:email]");
+		expect(result.detection.found).toBe(true);
+		expect(result.detection.types).toContain("email");
+	});
+
+	it("redacts nested objects", () => {
+		const result = redactPII({
+			user: {
+				profile: {
+					email: "user@example.com",
+				},
+			},
+		});
+		const data = result.data as Record<string, Record<string, Record<string, unknown>>>;
+		expect(data.user.profile.email).toBe("[REDACTED:email]");
+	});
+
+	it("redacts values inside arrays", () => {
+		const result = redactPII({
+			emails: ["user@example.com", "admin@test.org"],
+		});
+		const data = result.data as Record<string, string[]>;
+		expect(data.emails[0]).toBe("[REDACTED:email]");
+		expect(data.emails[1]).toBe("[REDACTED:email]");
+	});
+
+	it("lists multiple PII types in one redaction placeholder", () => {
+		const result = redactPII({
+			note: "Call 234-567-8901 or email user@example.com",
+		});
+		const data = result.data as Record<string, string>;
+		expect(data.note).toContain("REDACTED:");
+		expect(data.note).toContain("email");
+		expect(data.note).toContain("phone");
+	});
+
+	it("redacts API keys", () => {
+		const result = redactPII({ key: "sk-proj-abc123def456ghi789jkl" });
+		const data = result.data as Record<string, string>;
+		expect(data.key).toContain("REDACTED:");
+		expect(data.key).toContain("api_key");
+	});
+
+	it("passes through non-string values unchanged", () => {
+		const result = redactPII({
+			count: 42,
+			flag: true,
+			empty: null,
+			email: "user@example.com",
+		});
+		const data = result.data as Record<string, unknown>;
+		expect(data.count).toBe(42);
+		expect(data.flag).toBe(true);
+		expect(data.empty).toBe(null);
+		expect(data.email).toBe("[REDACTED:email]");
 	});
 });


### PR DESCRIPTION
## Summary

Fixes all 6 deferred findings from the code review and security review of #10 (governAction). These are pre-existing issues in the `interceptCall()` LLM path that apply to both old and new governance paths.

### Critical
- **DEFAULT_RULES dead code** — `DEFAULT_RULES` (block-zero-budget, block-budget-exhausted, warn-high-cost) now used as fallback when no policy file exists OR when the file is empty/corrupt. Previously, `policyRules` defaulted to `[]`, meaning zero budget enforcement in dry-run mode.

### High
- **PII in warn mode logged verbatim** — Audit writes now redact PII in `warn`/`redact` mode before writing to the append-only chain. Applied to success paths, failure paths (error strings that may echo request content), and action params.
- **Secret pattern detection** — PII scanner extended with: API keys (OpenAI `sk-`, Anthropic `sk-ant-`, Stripe `sk_live_`/`sk_test_`), AWS keys (`AKIA`), GitHub tokens (`ghp_`/`gho_`/`ghs_`/`ghr_`/`github_pat_`), Bearer tokens, JWTs, PEM private keys, npm tokens, and generic secrets (Slack `xox`, SendGrid `SG.`, GitLab `glpat-`, long hex).
- **TOCTOU budget commit gap** — `inFlightHoldTotal` and `budgetSpent` mutations now re-acquire the async mutex, preventing transient budget miscalculation under concurrent calls. Applied to all 5 budget mutation sites (streaming success, streaming error, non-streaming success, non-streaming failure, governActionImpl).

### Medium
- **Proxy settlement failure not audited** — Proxy settle catch blocks now emit `settlement_ambiguous` audit events (matching the TigerBeetle path). Applied to both `interceptCall` and `governActionImpl`.
- **Synthetic auditHash misleading** — Degraded audit receipts now return `"AUDIT_DEGRADED"` sentinel instead of a synthetic SHA-256 hash. Applied to all 4 receipt construction sites including the streaming estimated receipt.

### Also includes (from internal review remediation)
- `redactPII()` utility for deep-cloning data with PII replaced by `[REDACTED:<type>]` placeholders
- Error strings in `llm_call_failed` and `stream_partial_delivery` audit events now redacted when PII mode is active
- `isGenericSecret` no longer double-fires with `isApiKey` on `sk-` prefixed keys

## Test plan
- [ ] `npx vitest run` — 1146/1155 pass (9 pre-existing `@clack/prompts` CLI failures)
- [ ] Verify DEFAULT_RULES fallback: trust client with budget=1 and no policy file denies second call
- [ ] Verify PII redaction: audit events contain `[REDACTED:email]` not raw emails in warn mode
- [ ] Verify secret detection: `sk-`, `AKIA`, `ghp_`, `Bearer`, JWT, PEM all detected
- [ ] Verify proxy settle audit: `settlement_ambiguous` event emitted when proxy settle fails
- [ ] Verify AUDIT_DEGRADED sentinel: receipt.auditHash === "AUDIT_DEGRADED" when audit writer throws
- [ ] Verify no double-fire: `sk-` key tagged as `api_key` only, not `generic_secret`

## Files changed (6 files, +785/-54)
| File | Changes |
|------|---------|
| `packages/core/src/govern.ts` | DEFAULT_RULES fallback, TOCTOU mutex, proxy audit events, AUDIT_DEGRADED sentinel, PII redaction in audit writes |
| `packages/core/src/policy/pii.ts` | 7 new secret patterns, `redactPII()` function, JWT/PEM/npm detection |
| `packages/core/tests/govern/govern.test.ts` | DEFAULT_RULES + AUDIT_DEGRADED tests |
| `packages/core/tests/govern/failure-modes.test.ts` | Proxy settlement audit test |
| `packages/core/tests/govern/action-governance.test.ts` | PII redaction in audit tests (warn, redact, off modes) |
| `packages/core/tests/policy/pii.test.ts` | 28 new tests for secret patterns, redactPII, Stripe, JWT, PEM, npm, no-double-fire |

🤖 Generated with [Claude Code](https://claude.com/claude-code)