### PR TITLE
feat(core): supply chain plugin vetting with cryptographic trust chain

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,11 +25,19 @@ export type {
 	GovernedActionResult,
 	InjectionDetection,
 	CanaryToken,
+	SkillPermission,
+	SkillManifest,
+	SkillVerification,
 } from "./shared/types.js";
 
 // Injection detection
 export { detectInjection } from "./policy/injection.js";
 export { generateCanary, injectCanary, detectCanaryLeak } from "./policy/canary.js";
+
+// Supply Chain
+export { validateManifest, createUnsignedManifest, hashManifest } from "./supply-chain/manifest.js";
+export { generateKeyPair, signManifest, verifySignature } from "./supply-chain/sign.js";
+export { checkPermissions, enforceSkillLoad } from "./supply-chain/permissions.js";
 
 // Errors
 export {
@@ -38,4 +46,5 @@ export {
 	LedgerUnavailableError,
 	AuditDegradedError,
 	VaultNotInitializedError,
+	SkillVerificationError,
 } from "./shared/errors.js";

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -121,3 +121,24 @@ export class VaultNotInitializedError extends Error {
 		this.docsUrl = docsUrl;
 	}
 }
+
+export class SkillVerificationError extends Error {
+	public readonly skillId: string;
+	public readonly reason: string;
+	public readonly hint: string;
+	public readonly docsUrl: string;
+
+	constructor(skillId: string, reason: string) {
+		const hint =
+			"Verify the skill manifest is signed by a trusted publisher, or add the publisher to supplyChain.trustedPublishers.";
+		const docsUrl = "https://usertrust.ai/docs/errors/skill-verification";
+		super(
+			`Skill verification failed for ${skillId}: ${reason}\n\n  Hint: ${hint}\n  Docs: ${docsUrl}`,
+		);
+		this.name = "SkillVerificationError";
+		this.skillId = skillId;
+		this.reason = reason;
+		this.hint = hint;
+		this.docsUrl = docsUrl;
+	}
+}

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -88,6 +88,26 @@ export const TrustConfigSchema = z.object({
 			}),
 		)
 		.optional(),
+	supplyChain: z
+		.object({
+			enabled: z.boolean().default(false),
+			trustedPublishers: z.array(z.string()).default([]),
+			allowedPermissions: z
+				.array(
+					z.enum([
+						"llm_call",
+						"tool_use",
+						"file_read",
+						"file_write",
+						"shell_command",
+						"network_access",
+						"credential_access",
+					]),
+				)
+				.default(["llm_call", "tool_use", "file_read"]),
+			requireSignature: z.boolean().default(true),
+		})
+		.default({}),
 });
 
 export type TrustConfig = z.infer<typeof TrustConfigSchema>;
@@ -196,3 +216,73 @@ export interface CanaryToken {
 	/** HTML comment marker embedding the token. */
 	marker: string;
 }
+
+// ── Supply Chain types ──
+
+/** Permission an agent skill can request. */
+export type SkillPermission =
+	| "llm_call"
+	| "tool_use"
+	| "file_read"
+	| "file_write"
+	| "shell_command"
+	| "network_access"
+	| "credential_access";
+
+/** A signed skill manifest declaring identity, permissions, and integrity. */
+export interface SkillManifest {
+	/** Schema version for forward compatibility. */
+	version: 1;
+	/** Unique skill identifier (e.g., "acme/summarizer"). */
+	id: string;
+	/** Human-readable skill name. */
+	name: string;
+	/** Skill author or publisher. */
+	publisher: string;
+	/** Permissions the skill requires at runtime. */
+	permissions: SkillPermission[];
+	/** SHA-256 hash of the skill's entry point source code. */
+	entryHash: string;
+	/** ISO 8601 timestamp of when the manifest was signed. */
+	signedAt: string;
+	/** Ed25519 signature of the canonical manifest (hex-encoded). */
+	signature: string;
+	/** Ed25519 public key of the signer (hex-encoded). */
+	publicKey: string;
+}
+
+/** Result of verifying a skill manifest. */
+export interface SkillVerification {
+	/** Whether the manifest signature is valid. */
+	valid: boolean;
+	/** Whether all declared permissions are allowed by policy. */
+	permissionsAllowed: boolean;
+	/** Permissions that were denied by policy. */
+	deniedPermissions: SkillPermission[];
+	/** SHA-256 hash of the manifest for audit inclusion. */
+	manifestHash: string;
+	/** Error message if verification failed. */
+	error?: string;
+}
+
+export const SkillManifestSchema = z.object({
+	version: z.literal(1),
+	id: z.string().regex(/^[a-z0-9_-]+\/[a-z0-9_-]+$/, "Skill ID must be publisher/name format"),
+	name: z.string().min(1).max(128),
+	publisher: z.string().min(1).max(64),
+	permissions: z.array(
+		z.enum([
+			"llm_call",
+			"tool_use",
+			"file_read",
+			"file_write",
+			"shell_command",
+			"network_access",
+			"credential_access",
+		]),
+	),
+	entryHash: z.string().regex(/^[a-f0-9]{64}$/, "Must be a SHA-256 hex hash"),
+	signedAt: z.string().datetime(),
+	signature: z.string().regex(/^[a-f0-9]{128}$/, "Must be a hex-encoded 64-byte Ed25519 signature"),
+	publicKey: z.string().regex(/^[a-f0-9]{64}$/, "Must be hex-encoded Ed25519 public key"),
+});

--- a/packages/core/src/supply-chain/manifest.ts
+++ b/packages/core/src/supply-chain/manifest.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { createHash } from "node:crypto";
+import { canonicalize } from "../audit/canonical.js";
+import type { SkillManifest, SkillPermission } from "../shared/types.js";
+import { SkillManifestSchema } from "../shared/types.js";
+
+/**
+ * Validates a raw manifest object against the SkillManifest Zod schema.
+ * Returns the typed manifest or throws a ZodError.
+ */
+export function validateManifest(raw: unknown): SkillManifest {
+	return SkillManifestSchema.parse(raw) as SkillManifest;
+}
+
+/**
+ * Creates an unsigned manifest with the entryHash computed from the source code.
+ */
+export function createUnsignedManifest(opts: {
+	id: string;
+	name: string;
+	publisher: string;
+	permissions: SkillPermission[];
+	entrySource: string;
+}): Omit<SkillManifest, "signature" | "publicKey" | "signedAt"> {
+	const entryHash = createHash("sha256").update(opts.entrySource).digest("hex");
+	return {
+		version: 1,
+		id: opts.id,
+		name: opts.name,
+		publisher: opts.publisher,
+		permissions: opts.permissions,
+		entryHash,
+	};
+}
+
+/**
+ * Computes a deterministic SHA-256 hash of the manifest fields (excluding signature),
+ * using canonical JSON serialization.
+ */
+export function hashManifest(manifest: Omit<SkillManifest, "signature">): string {
+	// Extract only the fields that contribute to the hash (everything except signature)
+	const hashable = {
+		version: manifest.version,
+		id: manifest.id,
+		name: manifest.name,
+		publisher: manifest.publisher,
+		permissions: manifest.permissions,
+		entryHash: manifest.entryHash,
+		signedAt: (manifest as SkillManifest).signedAt,
+		publicKey: (manifest as SkillManifest).publicKey,
+	};
+	const canonical = canonicalize(hashable);
+	return createHash("sha256").update(canonical).digest("hex");
+}

--- a/packages/core/src/supply-chain/permissions.ts
+++ b/packages/core/src/supply-chain/permissions.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { createHash } from "node:crypto";
+import { canonicalize } from "../audit/canonical.js";
+import { SkillVerificationError } from "../shared/errors.js";
+import type {
+	SkillManifest,
+	SkillPermission,
+	SkillVerification,
+	TrustConfig,
+} from "../shared/types.js";
+import { SkillManifestSchema } from "../shared/types.js";
+import { verifySignature } from "./sign.js";
+
+/**
+ * Computes a SHA-256 hash of the full manifest for audit inclusion.
+ */
+function computeManifestHash(manifest: SkillManifest): string {
+	const canonical = canonicalize(manifest);
+	return createHash("sha256").update(canonical).digest("hex");
+}
+
+/**
+ * Checks whether a manifest's permissions are allowed by the config policy.
+ * Trusted publishers bypass permission restrictions.
+ */
+export function checkPermissions(manifest: SkillManifest, config: TrustConfig): SkillVerification {
+	const sc = config.supplyChain;
+	const manifestHash = computeManifestHash(manifest);
+
+	// Trusted publishers get all permissions
+	if (sc.trustedPublishers.includes(manifest.publisher)) {
+		return {
+			valid: true,
+			permissionsAllowed: true,
+			deniedPermissions: [],
+			manifestHash,
+		};
+	}
+
+	const allowed = new Set<SkillPermission>(sc.allowedPermissions);
+	const denied = manifest.permissions.filter((p) => !allowed.has(p));
+
+	return {
+		valid: true,
+		permissionsAllowed: denied.length === 0,
+		deniedPermissions: denied,
+		manifestHash,
+	};
+}
+
+/**
+ * Full verification pipeline: validate schema, verify signature, check permissions, check trusted publishers.
+ * Returns a SkillVerification result. Throws SkillVerificationError on hard failures.
+ */
+export function enforceSkillLoad(manifest: SkillManifest, config: TrustConfig): SkillVerification {
+	const sc = config.supplyChain;
+
+	// Guard: if supply chain is disabled, allow everything
+	if (!sc.enabled) {
+		return {
+			valid: true,
+			permissionsAllowed: true,
+			deniedPermissions: [],
+			manifestHash: computeManifestHash(manifest),
+		};
+	}
+
+	// Step 1: Validate schema
+	const parseResult = SkillManifestSchema.safeParse(manifest);
+	if (!parseResult.success) {
+		const reason = parseResult.error.issues.map((i) => i.message).join("; ");
+		throw new SkillVerificationError(
+			(manifest as { id?: string }).id ?? "unknown",
+			`Schema validation failed: ${reason}`,
+		);
+	}
+
+	// Step 2: Verify signature
+	// Always verify signature for trusted publishers (prevent publisher forgery)
+	// Also verify if requireSignature is true
+	const isTrusted = sc.trustedPublishers.includes(manifest.publisher);
+	if (sc.requireSignature || isTrusted) {
+		const sigValid = verifySignature(manifest);
+		if (!sigValid) {
+			const manifestHash = computeManifestHash(manifest);
+			return {
+				valid: false,
+				permissionsAllowed: false,
+				deniedPermissions: manifest.permissions,
+				manifestHash,
+				error: "Invalid manifest signature",
+			};
+		}
+	}
+
+	// Step 3: Check permissions and trusted publishers
+	const result = checkPermissions(manifest, config);
+
+	if (!result.permissionsAllowed) {
+		return {
+			...result,
+			valid: false,
+			error: `Denied permissions: ${result.deniedPermissions.join(", ")}`,
+		};
+	}
+
+	return result;
+}

--- a/packages/core/src/supply-chain/sign.ts
+++ b/packages/core/src/supply-chain/sign.ts
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Usertools, Inc.
 
-import {
-	createPrivateKey,
-	createPublicKey,
-	generateKeyPairSync,
-	sign,
-	verify,
-} from "node:crypto";
+import { createPrivateKey, createPublicKey, generateKeyPairSync, sign, verify } from "node:crypto";
 import { canonicalize } from "../audit/canonical.js";
 import type { SkillManifest } from "../shared/types.js";
 

--- a/packages/core/src/supply-chain/sign.ts
+++ b/packages/core/src/supply-chain/sign.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import {
+	createPrivateKey,
+	createPublicKey,
+	generateKeyPairSync,
+	sign,
+	verify,
+} from "node:crypto";
+import { canonicalize } from "../audit/canonical.js";
+import type { SkillManifest } from "../shared/types.js";
+
+/**
+ * Generates an Ed25519 keypair. Returns hex-encoded public and private keys.
+ */
+export function generateKeyPair(): { publicKey: string; privateKey: string } {
+	const { publicKey, privateKey } = generateKeyPairSync("ed25519", {
+		publicKeyEncoding: { type: "spki", format: "der" },
+		privateKeyEncoding: { type: "pkcs8", format: "der" },
+	});
+	// Ed25519 SPKI DER is 44 bytes: 12-byte prefix + 32-byte raw key
+	const rawPublic = (publicKey as Buffer).subarray(12).toString("hex");
+	// Return full DER for private key (needed for signing)
+	const rawPrivate = (privateKey as Buffer).toString("hex");
+	return { publicKey: rawPublic, privateKey: rawPrivate };
+}
+
+/**
+ * Computes the canonical hash of manifest fields for signing (excluding signature and publicKey and signedAt).
+ */
+function computeSigningPayload(
+	manifest: Omit<SkillManifest, "signature" | "publicKey" | "signedAt">,
+	signedAt: string,
+	publicKey: string,
+): string {
+	const hashable = {
+		version: manifest.version,
+		id: manifest.id,
+		name: manifest.name,
+		publisher: manifest.publisher,
+		permissions: manifest.permissions,
+		entryHash: manifest.entryHash,
+		signedAt,
+		publicKey,
+	};
+	return canonicalize(hashable);
+}
+
+/**
+ * Signs an unsigned manifest with the given private key. Returns a fully signed SkillManifest.
+ */
+export function signManifest(
+	manifest: Omit<SkillManifest, "signature" | "publicKey" | "signedAt">,
+	privateKeyHex: string,
+): SkillManifest {
+	const privateKeyDer = Buffer.from(privateKeyHex, "hex");
+	const privateKey = {
+		key: privateKeyDer,
+		format: "der" as const,
+		type: "pkcs8" as const,
+	};
+
+	// Derive public key from the private key
+	const privKeyObj = createPrivateKey({
+		key: privateKeyDer,
+		format: "der",
+		type: "pkcs8",
+	});
+	const pubKeyObj = createPublicKey(privKeyObj);
+	const pubKeyDerActual = pubKeyObj.export({ type: "spki", format: "der" });
+	const publicKeyHex = (pubKeyDerActual as Buffer).subarray(12).toString("hex");
+
+	const signedAt = new Date().toISOString();
+	const payload = computeSigningPayload(manifest, signedAt, publicKeyHex);
+	const payloadBytes = Buffer.from(payload, "utf-8");
+
+	const signature = sign(null, payloadBytes, privateKey);
+	const signatureHex = (signature as Buffer).toString("hex");
+
+	return {
+		...manifest,
+		signedAt,
+		publicKey: publicKeyHex,
+		signature: signatureHex,
+	};
+}
+
+/**
+ * Verifies the Ed25519 signature on a signed manifest.
+ */
+export function verifySignature(manifest: SkillManifest): boolean {
+	try {
+		const payload = computeSigningPayload(
+			{
+				version: manifest.version,
+				id: manifest.id,
+				name: manifest.name,
+				publisher: manifest.publisher,
+				permissions: manifest.permissions,
+				entryHash: manifest.entryHash,
+			},
+			manifest.signedAt,
+			manifest.publicKey,
+		);
+		const payloadBytes = Buffer.from(payload, "utf-8");
+
+		// Reconstruct DER-encoded SPKI public key from raw 32-byte key
+		const rawPubKey = Buffer.from(manifest.publicKey, "hex");
+		const spkiPrefix = Buffer.from("302a300506032b6570032100", "hex");
+		const spkiDer = Buffer.concat([spkiPrefix, rawPubKey]);
+
+		const publicKey = {
+			key: spkiDer,
+			format: "der" as const,
+			type: "spki" as const,
+		};
+
+		return verify(null, payloadBytes, publicKey, Buffer.from(manifest.signature, "hex"));
+	} catch {
+		return false;
+	}
+}

--- a/packages/core/tests/supply-chain/manifest.test.ts
+++ b/packages/core/tests/supply-chain/manifest.test.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+	createUnsignedManifest,
+	hashManifest,
+	validateManifest,
+} from "../../src/supply-chain/manifest.js";
+
+const validManifest = {
+	version: 1 as const,
+	id: "acme/summarizer",
+	name: "Summarizer",
+	publisher: "acme",
+	permissions: ["llm_call", "file_read"] as const,
+	entryHash: "a".repeat(64),
+	signedAt: "2026-03-15T12:00:00.000Z",
+	signature: "ab".repeat(64),
+	publicKey: "cd".repeat(32),
+};
+
+describe("validateManifest", () => {
+	it("accepts a valid manifest", () => {
+		const result = validateManifest(validManifest);
+		expect(result.id).toBe("acme/summarizer");
+		expect(result.version).toBe(1);
+	});
+
+	it("rejects skill ID without slash", () => {
+		expect(() => validateManifest({ ...validManifest, id: "acme-summarizer" })).toThrow();
+	});
+
+	it("rejects skill ID with uppercase", () => {
+		expect(() => validateManifest({ ...validManifest, id: "Acme/Summarizer" })).toThrow();
+	});
+
+	it("rejects skill ID with special characters", () => {
+		expect(() => validateManifest({ ...validManifest, id: "acme/summa rizer" })).toThrow();
+	});
+
+	it("rejects entryHash with wrong length", () => {
+		expect(() => validateManifest({ ...validManifest, entryHash: "abcd" })).toThrow();
+	});
+
+	it("rejects entryHash with non-hex characters", () => {
+		expect(() => validateManifest({ ...validManifest, entryHash: "g".repeat(64) })).toThrow();
+	});
+
+	it("rejects invalid permissions", () => {
+		expect(() => validateManifest({ ...validManifest, permissions: ["fly_to_moon"] })).toThrow();
+	});
+
+	it("rejects missing required field (name)", () => {
+		const { name, ...rest } = validManifest;
+		expect(() => validateManifest(rest)).toThrow();
+	});
+
+	it("rejects missing required field (publisher)", () => {
+		const { publisher, ...rest } = validManifest;
+		expect(() => validateManifest(rest)).toThrow();
+	});
+
+	it("rejects empty name", () => {
+		expect(() => validateManifest({ ...validManifest, name: "" })).toThrow();
+	});
+
+	it("rejects invalid version", () => {
+		expect(() => validateManifest({ ...validManifest, version: 2 })).toThrow();
+	});
+
+	it("rejects invalid signedAt (not ISO 8601)", () => {
+		expect(() => validateManifest({ ...validManifest, signedAt: "not-a-date" })).toThrow();
+	});
+
+	it("rejects invalid publicKey (wrong length)", () => {
+		expect(() => validateManifest({ ...validManifest, publicKey: "abcd" })).toThrow();
+	});
+});
+
+describe("createUnsignedManifest", () => {
+	it("computes correct SHA-256 hash of entry source", () => {
+		const source = 'export function run() { return "hello"; }';
+		const expected = createHash("sha256").update(source).digest("hex");
+		const manifest = createUnsignedManifest({
+			id: "acme/greeter",
+			name: "Greeter",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: source,
+		});
+		expect(manifest.entryHash).toBe(expected);
+	});
+
+	it("returns manifest with correct fields", () => {
+		const manifest = createUnsignedManifest({
+			id: "acme/greeter",
+			name: "Greeter",
+			publisher: "acme",
+			permissions: ["llm_call", "tool_use"],
+			entrySource: "code",
+		});
+		expect(manifest.version).toBe(1);
+		expect(manifest.id).toBe("acme/greeter");
+		expect(manifest.name).toBe("Greeter");
+		expect(manifest.publisher).toBe("acme");
+		expect(manifest.permissions).toEqual(["llm_call", "tool_use"]);
+		expect(manifest).not.toHaveProperty("signature");
+		expect(manifest).not.toHaveProperty("publicKey");
+		expect(manifest).not.toHaveProperty("signedAt");
+	});
+});
+
+describe("hashManifest", () => {
+	it("produces deterministic output for the same manifest", () => {
+		const manifest = {
+			version: 1 as const,
+			id: "acme/summarizer",
+			name: "Summarizer",
+			publisher: "acme",
+			permissions: ["llm_call" as const],
+			entryHash: "a".repeat(64),
+			signedAt: "2026-03-15T12:00:00.000Z",
+			publicKey: "cd".repeat(32),
+		};
+		const h1 = hashManifest(manifest);
+		const h2 = hashManifest(manifest);
+		expect(h1).toBe(h2);
+	});
+
+	it("excludes signature field from hash computation", () => {
+		const base = {
+			version: 1 as const,
+			id: "acme/summarizer",
+			name: "Summarizer",
+			publisher: "acme",
+			permissions: ["llm_call" as const],
+			entryHash: "a".repeat(64),
+			signedAt: "2026-03-15T12:00:00.000Z",
+			publicKey: "cd".repeat(32),
+		};
+		const withSig = { ...base, signature: "ff".repeat(64) };
+		// hashManifest only takes Omit<SkillManifest, "signature"> but we can
+		// pass the full manifest and the signature field should be ignored
+		const h1 = hashManifest(base);
+		const h2 = hashManifest(withSig as Omit<typeof withSig, "signature">);
+		expect(h1).toBe(h2);
+	});
+});

--- a/packages/core/tests/supply-chain/permissions.test.ts
+++ b/packages/core/tests/supply-chain/permissions.test.ts
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { SkillVerificationError } from "../../src/shared/errors.js";
+import { TrustConfigSchema } from "../../src/shared/types.js";
+import type { SkillManifest, TrustConfig } from "../../src/shared/types.js";
+import { createUnsignedManifest } from "../../src/supply-chain/manifest.js";
+import { checkPermissions, enforceSkillLoad } from "../../src/supply-chain/permissions.js";
+import { generateKeyPair, signManifest, verifySignature } from "../../src/supply-chain/sign.js";
+
+/** Helper: produce a valid signed manifest. */
+function makeSignedManifest(
+	overrides: Partial<{
+		id: string;
+		name: string;
+		publisher: string;
+		permissions: string[];
+		entrySource: string;
+	}> = {},
+): { manifest: SkillManifest; publicKey: string; privateKey: string } {
+	const keys = generateKeyPair();
+	const unsigned = createUnsignedManifest({
+		id: overrides.id ?? "acme/test",
+		name: overrides.name ?? "Test",
+		publisher: overrides.publisher ?? "acme",
+		permissions: (overrides.permissions ?? ["llm_call"]) as SkillManifest["permissions"],
+		entrySource: overrides.entrySource ?? "export default {}",
+	});
+	const manifest = signManifest(unsigned, keys.privateKey);
+	return { manifest, ...keys };
+}
+
+/** Helper: build a TrustConfig with supply chain overrides. */
+function makeConfig(overrides: Partial<TrustConfig["supplyChain"]> = {}): TrustConfig {
+	return TrustConfigSchema.parse({
+		budget: 1000,
+		supplyChain: {
+			enabled: true,
+			trustedPublishers: [],
+			allowedPermissions: ["llm_call", "tool_use", "file_read"],
+			requireSignature: true,
+			...overrides,
+		},
+	});
+}
+
+describe("checkPermissions", () => {
+	it("allows all when permissions are subset of allowed", () => {
+		const { manifest } = makeSignedManifest({ permissions: ["llm_call", "file_read"] });
+		const config = makeConfig();
+		const result = checkPermissions(manifest, config);
+		expect(result.permissionsAllowed).toBe(true);
+		expect(result.deniedPermissions).toEqual([]);
+	});
+
+	it("denies when requesting disallowed permission", () => {
+		const { manifest } = makeSignedManifest({ permissions: ["shell_command"] });
+		const config = makeConfig();
+		const result = checkPermissions(manifest, config);
+		expect(result.permissionsAllowed).toBe(false);
+	});
+
+	it("returns denied list", () => {
+		const { manifest } = makeSignedManifest({
+			permissions: ["llm_call", "shell_command", "network_access"],
+		});
+		const config = makeConfig();
+		const result = checkPermissions(manifest, config);
+		expect(result.deniedPermissions).toContain("shell_command");
+		expect(result.deniedPermissions).toContain("network_access");
+		expect(result.deniedPermissions).not.toContain("llm_call");
+	});
+
+	it("trusted publisher bypasses permission restrictions", () => {
+		const { manifest } = makeSignedManifest({
+			publisher: "trusted-co",
+			permissions: ["shell_command", "credential_access"],
+		});
+		const config = makeConfig({ trustedPublishers: ["trusted-co"] });
+		const result = checkPermissions(manifest, config);
+		expect(result.permissionsAllowed).toBe(true);
+		expect(result.deniedPermissions).toEqual([]);
+	});
+});
+
+describe("enforceSkillLoad", () => {
+	it("succeeds for valid signed manifest with allowed permissions", () => {
+		const { manifest } = makeSignedManifest({ permissions: ["llm_call"] });
+		const config = makeConfig();
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(true);
+		expect(result.permissionsAllowed).toBe(true);
+	});
+
+	it("fails for invalid signature", () => {
+		const { manifest } = makeSignedManifest();
+		const tampered = { ...manifest, signature: "ff".repeat(64) };
+		const config = makeConfig();
+		const result = enforceSkillLoad(tampered, config);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid manifest signature");
+	});
+
+	it("fails for disallowed permissions even with valid signature", () => {
+		const { manifest } = makeSignedManifest({ permissions: ["shell_command"] });
+		const config = makeConfig();
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Denied permissions");
+	});
+
+	it("succeeds when publisher is trusted (all permissions allowed)", () => {
+		const { manifest } = makeSignedManifest({
+			publisher: "trusted-co",
+			permissions: ["shell_command", "credential_access"],
+		});
+		const config = makeConfig({ trustedPublishers: ["trusted-co"] });
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(true);
+		expect(result.permissionsAllowed).toBe(true);
+	});
+
+	it("with requireSignature:false skips signature check for untrusted publisher", () => {
+		const { manifest } = makeSignedManifest();
+		const tampered = { ...manifest, signature: "ff".repeat(64) };
+		const config = makeConfig({ requireSignature: false });
+		const result = enforceSkillLoad(tampered, config);
+		// Should still pass because signature check is skipped for untrusted publishers
+		expect(result.valid).toBe(true);
+	});
+
+	it("with empty trustedPublishers list enforces permissions", () => {
+		const { manifest } = makeSignedManifest({ permissions: ["shell_command"] });
+		const config = makeConfig({ trustedPublishers: [] });
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(false);
+		expect(result.deniedPermissions).toContain("shell_command");
+	});
+
+	it("rejects manifest with schema validation errors", () => {
+		const badManifest = {
+			version: 1,
+			id: "INVALID",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entryHash: "a".repeat(64),
+			signedAt: "2026-03-15T12:00:00.000Z",
+			signature: "ab".repeat(64),
+			publicKey: "cd".repeat(32),
+		} as unknown as SkillManifest;
+		const config = makeConfig();
+		expect(() => enforceSkillLoad(badManifest, config)).toThrow(SkillVerificationError);
+	});
+
+	it("untrusted publisher with restricted permissions blocked", () => {
+		const { manifest } = makeSignedManifest({
+			publisher: "untrusted",
+			permissions: ["credential_access"],
+		});
+		const config = makeConfig({ trustedPublishers: ["acme"] });
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(false);
+		expect(result.deniedPermissions).toContain("credential_access");
+	});
+
+	it("trusted publisher with any permissions allowed", () => {
+		const { manifest } = makeSignedManifest({
+			publisher: "acme",
+			permissions: ["credential_access", "network_access", "shell_command"],
+		});
+		const config = makeConfig({ trustedPublishers: ["acme"] });
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(true);
+		expect(result.permissionsAllowed).toBe(true);
+		expect(result.deniedPermissions).toEqual([]);
+	});
+
+	it("config defaults work (enabled:false, default allowed permissions)", () => {
+		const config = TrustConfigSchema.parse({ budget: 1000 });
+		expect(config.supplyChain.enabled).toBe(false);
+		expect(config.supplyChain.allowedPermissions).toEqual(["llm_call", "tool_use", "file_read"]);
+		expect(config.supplyChain.requireSignature).toBe(true);
+		expect(config.supplyChain.trustedPublishers).toEqual([]);
+	});
+});
+
+describe("full pipeline", () => {
+	it("generate keys -> create manifest -> sign -> enforce -> passes", () => {
+		const keys = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/pipeline",
+			name: "Pipeline Test",
+			publisher: "acme",
+			permissions: ["llm_call", "file_read"],
+			entrySource: 'export function run() { return "ok"; }',
+		});
+		const signed = signManifest(unsigned, keys.privateKey);
+		const config = makeConfig();
+		const result = enforceSkillLoad(signed, config);
+		expect(result.valid).toBe(true);
+		expect(result.permissionsAllowed).toBe(true);
+		expect(result.manifestHash).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("tampered manifest -> enforce -> fails", () => {
+		const keys = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/pipeline",
+			name: "Pipeline Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: 'export function run() { return "ok"; }',
+		});
+		const signed = signManifest(unsigned, keys.privateKey);
+		const tampered = { ...signed, name: "Evil Plugin" };
+		const config = makeConfig();
+		const result = enforceSkillLoad(tampered, config);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid manifest signature");
+	});
+});
+
+describe("enforceSkillLoad — enabled guard", () => {
+	it("returns valid when supplyChain.enabled is false", () => {
+		const { manifest } = makeSignedManifest();
+		const config = makeConfig({ enabled: false });
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(true);
+		expect(result.permissionsAllowed).toBe(true);
+		expect(result.deniedPermissions).toEqual([]);
+		expect(result.manifestHash).toMatch(/^[a-f0-9]{64}$/);
+	});
+});
+
+describe("enforceSkillLoad — trusted publisher forgery prevention", () => {
+	it("requires valid signature for trusted publisher even with requireSignature:false", () => {
+		const { manifest } = makeSignedManifest({ publisher: "trusted-co" });
+		const tampered = { ...manifest, signature: "ff".repeat(64) };
+		const config = makeConfig({
+			requireSignature: false,
+			trustedPublishers: ["trusted-co"],
+		});
+		const result = enforceSkillLoad(tampered, config);
+		expect(result.valid).toBe(false);
+		expect(result.error).toContain("Invalid manifest signature");
+	});
+
+	it("allows trusted publisher with valid signature and requireSignature:false", () => {
+		const { manifest } = makeSignedManifest({
+			publisher: "trusted-co",
+			permissions: ["shell_command", "credential_access"],
+		});
+		const config = makeConfig({
+			requireSignature: false,
+			trustedPublishers: ["trusted-co"],
+		});
+		const result = enforceSkillLoad(manifest, config);
+		expect(result.valid).toBe(true);
+		expect(result.permissionsAllowed).toBe(true);
+	});
+});
+
+describe("verifySignature — malformed input", () => {
+	it("returns false for malformed signature (too short)", () => {
+		const { manifest } = makeSignedManifest();
+		const malformed = { ...manifest, signature: "aa" };
+		expect(verifySignature(malformed)).toBe(false);
+	});
+
+	it("returns false for empty signature", () => {
+		const { manifest } = makeSignedManifest();
+		const malformed = { ...manifest, signature: "" };
+		expect(verifySignature(malformed)).toBe(false);
+	});
+});

--- a/packages/core/tests/supply-chain/sign.test.ts
+++ b/packages/core/tests/supply-chain/sign.test.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { createUnsignedManifest } from "../../src/supply-chain/manifest.js";
+import { generateKeyPair, signManifest, verifySignature } from "../../src/supply-chain/sign.js";
+
+describe("generateKeyPair", () => {
+	it("produces valid hex-encoded keys", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		expect(publicKey).toMatch(/^[a-f0-9]{64}$/);
+		expect(privateKey).toMatch(/^[a-f0-9]+$/);
+		expect(privateKey.length).toBeGreaterThan(0);
+	});
+
+	it("produces unique keys each call", () => {
+		const k1 = generateKeyPair();
+		const k2 = generateKeyPair();
+		expect(k1.publicKey).not.toBe(k2.publicKey);
+		expect(k1.privateKey).not.toBe(k2.privateKey);
+	});
+});
+
+describe("signManifest", () => {
+	it("produces valid signature", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const signed = signManifest(unsigned, privateKey);
+		expect(signed.signature).toMatch(/^[a-f0-9]+$/);
+		expect(signed.signature.length).toBeGreaterThan(0);
+	});
+
+	it("adds signedAt timestamp", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const before = new Date().toISOString();
+		const signed = signManifest(unsigned, privateKey);
+		const after = new Date().toISOString();
+		expect(signed.signedAt).toBeDefined();
+		expect(signed.signedAt >= before).toBe(true);
+		expect(signed.signedAt <= after).toBe(true);
+	});
+
+	it("adds publicKey from keypair", () => {
+		const { publicKey, privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const signed = signManifest(unsigned, privateKey);
+		expect(signed.publicKey).toBe(publicKey);
+	});
+});
+
+describe("verifySignature", () => {
+	it("returns true for valid signature", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const signed = signManifest(unsigned, privateKey);
+		expect(verifySignature(signed)).toBe(true);
+	});
+
+	it("returns false for tampered manifest (changed name)", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const signed = signManifest(unsigned, privateKey);
+		const tampered = { ...signed, name: "Tampered" };
+		expect(verifySignature(tampered)).toBe(false);
+	});
+
+	it("returns false for tampered manifest (changed permissions)", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const signed = signManifest(unsigned, privateKey);
+		const tampered = { ...signed, permissions: ["llm_call", "shell_command"] as const };
+		expect(verifySignature(tampered)).toBe(false);
+	});
+
+	it("returns false for tampered manifest (changed entryHash)", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const signed = signManifest(unsigned, privateKey);
+		const tampered = { ...signed, entryHash: "b".repeat(64) };
+		expect(verifySignature(tampered)).toBe(false);
+	});
+
+	it("returns false for wrong public key", () => {
+		const keys1 = generateKeyPair();
+		const keys2 = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/test",
+			name: "Test",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: "export default {}",
+		});
+		const signed = signManifest(unsigned, keys1.privateKey);
+		const tampered = { ...signed, publicKey: keys2.publicKey };
+		expect(verifySignature(tampered)).toBe(false);
+	});
+});
+
+describe("round-trip", () => {
+	it("create -> sign -> verify succeeds", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/roundtrip",
+			name: "Round Trip",
+			publisher: "acme",
+			permissions: ["llm_call", "file_read"],
+			entrySource: 'console.log("hello world");',
+		});
+		const signed = signManifest(unsigned, privateKey);
+		expect(verifySignature(signed)).toBe(true);
+	});
+
+	it("create -> sign -> tamper -> verify fails", () => {
+		const { privateKey } = generateKeyPair();
+		const unsigned = createUnsignedManifest({
+			id: "acme/roundtrip",
+			name: "Round Trip",
+			publisher: "acme",
+			permissions: ["llm_call"],
+			entrySource: 'console.log("hello world");',
+		});
+		const signed = signManifest(unsigned, privateKey);
+		const tampered = { ...signed, publisher: "evil-corp" };
+		expect(verifySignature(tampered)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- **Cryptographic skill trust chain** using Ed25519 signing + verification for agent plugin manifests
- **Runtime permission enforcement** — skills declare required permissions; config defines allowed permissions and trusted publishers
- **Zod-validated manifest schema** with SHA-256 entry hashing, publisher/name ID format, and 128-char signature constraint
- Addresses the 820+ malicious ClawHub skills attack vector with cryptographic proof of integrity

## Security hardening (from 3 independent reviews)

| Finding | Severity | Fix |
|---------|----------|-----|
| Ed25519 signed SHA-256 pre-hash instead of raw payload | CRITICAL | Sign raw UTF-8 bytes (interop-safe) |
| Trusted-publisher bypass skipped sig verification | CRITICAL | Always verify signature for trusted publishers |
| Signature field accepted any hex length | HIGH | Enforce exactly 128 hex chars (64-byte Ed25519) |
| `enforceSkillLoad` ignored `enabled` flag | HIGH | Added guard respecting `supplyChain.enabled` |

## New files

- `src/supply-chain/manifest.ts` — schema validation, manifest creation, canonical hashing
- `src/supply-chain/sign.ts` — Ed25519 key generation, signing, verification
- `src/supply-chain/permissions.ts` — permission checking, `enforceSkillLoad()` pipeline
- `src/shared/errors.ts` — `SkillVerificationError`
- `src/shared/types.ts` — `SkillManifest`, `SkillPermission`, `SkillVerification`, config schema

## Test plan

- [ ] 50 tests across 3 test files (manifest, sign, permissions)
- [ ] Round-trip: create → sign → verify → enforce succeeds
- [ ] Tampered manifests rejected (changed name, permissions, entryHash, wrong key)
- [ ] Trusted publisher bypass requires valid signature
- [ ] `enabled: false` skips enforcement
- [ ] Malformed signatures rejected at schema level (128 hex char enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>