### PR TITLE
fix(docs): fix README naming + add concepts landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ import Anthropic from "@anthropic-ai/sdk";
 // Audit chain and policy engine still run.
 const client = await trust(new Anthropic(), { dryRun: true, budget: 50_000 });
 
-const { response, governance } = await client.messages.create({
-  model: "claude-sonnet-4.6",
+const { response, receipt } = await client.messages.create({
+  model: "claude-sonnet-4-6",
   max_tokens: 1024,
   messages: [{ role: "user", content: "Analyze this contract" }],
 });
 
-console.log(governance);
+console.log(receipt);
 
 // REQUIRED — process hangs without this
 await client.destroy();
@@ -26,7 +26,7 @@ That's it. One function wraps any supported LLM client. Every call is metered, a
 
 ### Expected Output
 
-The `governance` receipt returned from every call:
+The `receipt` returned from every call:
 
 ```
 {
@@ -35,7 +35,7 @@ The `governance` receipt returned from every call:
   transferId: "tx_m4k7p2_a1b2c3",
   auditHash: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   settled: true,
-  model: "claude-sonnet-4.6",
+  model: "claude-sonnet-4-6",
   provider: "anthropic",
   inputTokens: 12,
   outputTokens: 28
@@ -61,11 +61,11 @@ import OpenAI from "openai";
 
 // Anthropic
 const anthropic = await trust(new Anthropic());
-const { response, governance } = await anthropic.messages.create({ ... });
+const { response, receipt } = await anthropic.messages.create({ ... });
 
 // OpenAI
 const openai = await trust(new OpenAI());
-const { response, governance } = await openai.chat.completions.create({ ... });
+const { response, receipt } = await openai.chat.completions.create({ ... });
 
 // With options (full mode — requires TigerBeetle)
 const client = await trust(new Anthropic(), {
@@ -73,7 +73,7 @@ const client = await trust(new Anthropic(), {
 });
 ```
 
-Every call returns `{ response, governance }` where `governance` is a receipt:
+Every call returns `{ response, receipt }`:
 
 ```typescript
 {
@@ -82,7 +82,7 @@ Every call returns `{ response, governance }` where `governance` is a receipt:
   budgetRemaining: 49_858,
   auditHash: "a3f8...",
   settled: true,
-  model: "claude-sonnet-4.6",
+  model: "claude-sonnet-4-6",
   provider: "anthropic",
   timestamp: "2026-03-16T12:00:00.000Z"
 }

--- a/site/content/docs/concepts/index.mdx
+++ b/site/content/docs/concepts/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Concepts
+description: How usertrust governs every LLM call — the banking patterns, cryptographic proofs, and policy engine under the hood.
+---
+
+usertrust combines financial accounting patterns with cryptographic verification to make every AI agent call auditable and budget-safe. These pages explain the core mechanisms.
+
+<Cards>
+  <Card title="Two-Phase Spend" description="Banking-style authorization holds for atomic budget enforcement" href="/docs/concepts/two-phase-spend" />
+  <Card title="Audit Trail" description="SHA-256 hash-chained, append-only log for every governed call" href="/docs/concepts/audit-trail" />
+  <Card title="Merkle Proofs" description="RFC 6962 inclusion and consistency proofs for public verifiability" href="/docs/concepts/merkle-proofs" />
+  <Card title="Board of Directors" description="Two-director democratic oversight with heuristic concern detection" href="/docs/concepts/board-of-directors" />
+  <Card title="Policy Engine" description="12 field operators, scope globs, and time windows for rule-based governance" href="/docs/concepts/policy-engine" />
+  <Card title="Pattern Memory" description="Cost-optimal model selection via SHA-256 prompt hash routing" href="/docs/concepts/pattern-memory" />
+  <Card title="Circuit Breaker" description="Per-provider failure isolation with automatic recovery" href="/docs/concepts/circuit-breaker" />
+</Cards>


### PR DESCRIPTION
## Summary

- **Fix `governance` → `receipt` in README.md** — all code examples now match source code (`govern.ts:751` returns `{ response, receipt }`)
- **Fix model string format** — `claude-sonnet-4.6` (period) → `claude-sonnet-4-6` (dash) in all README examples
- **Add concepts landing page** — `site/content/docs/concepts/index.mdx` with Cards linking to all 7 concept pages (was a 404)

## Test plan

- [ ] Verify README code examples show `{ response, receipt }` not `{ response, governance }`
- [ ] Verify `/docs/concepts` route renders the landing page with 7 cards
- [ ] Verify model strings use dashes not periods

## Files changed (2)

- `README.md` — naming + model string fixes
- `site/content/docs/concepts/index.mdx` — new landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)