### PR TITLE
chore: OSS hardening — security policy, CoC, DCO enforcement

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,30 @@
+name: DCO
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check DCO sign-off
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: 'Signed-off-by: .+ <.+>'
+          error: |
+            All commits must include a DCO sign-off line:
+              Signed-off-by: Your Name <your@email.com>
+
+            Add it with: git commit -s --amend
+            See CONTRIBUTING.md for details.
+          excludeTitle: true
+          excludeDescription: true
+          checkAllCommitMessages: true
+          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+This project adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct. All contributors, maintainers, and participants are expected to uphold these standards.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it by emailing **conduct@usertrust.ai**. All reports will be reviewed and investigated promptly and confidentially.
+
+## Enforcement
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by the project leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,4 +35,4 @@ All contributions are made under the [Apache License 2.0](./LICENSE). By submitt
 
 ## Code of conduct
 
-Be respectful. Be constructive. We are building something together.
+This project follows the [Contributor Covenant v2.1](./CODE_OF_CONDUCT.md). By participating, you agree to uphold these standards.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,95 @@
+# Security Policy
+
+The usertrust project takes security seriously. As a financial governance SDK,
+we hold ourselves to a high standard for protecting the integrity of the
+software and the safety of our users.
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.2.x   | Yes                |
+| 1.1.x   | Security fixes only |
+| 1.0.x   | No                 |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report vulnerabilities by email to:
+
+**security@usertrust.ai**
+
+### What to Include
+
+To help us triage and respond quickly, please include as much of the following
+as possible:
+
+- A clear description of the vulnerability and its potential impact.
+- Step-by-step instructions to reproduce the issue.
+- The affected package(s) and version(s).
+- Any proof-of-concept code or logs.
+- Your assessment of severity (e.g., low, medium, high, critical).
+- Whether you believe the issue is being actively exploited.
+
+### Response Timeline
+
+- **Acknowledgment:** We will acknowledge receipt of your report within
+  **48 hours**.
+- **Initial assessment:** We will provide an initial severity assessment and
+  next steps within **5 business days**.
+- **Disclosure window:** We follow a **90-day coordinated disclosure** window.
+  We will work with you to coordinate public disclosure after a fix is
+  available, or after 90 days, whichever comes first.
+
+If we need more time to develop a fix, we will communicate that to you and
+request a mutually agreed-upon extension.
+
+## Scope
+
+### In Scope
+
+- `usertrust` (core SDK)
+- `usertrust-verify` (verification package)
+- `usertrust-openclaw` (OpenClaw integration)
+- The usertrust CLI
+- All code in the [usertrust repository](https://github.com/usertools-ai/usertrust)
+
+### Out of Scope
+
+- The documentation website and marketing site
+- Third-party dependencies (please report these to the upstream maintainer,
+  though we appreciate a heads-up)
+- Social engineering attacks against maintainers or users
+
+## Safe Harbor
+
+We consider security research conducted in good faith to be authorized and
+welcome it. We will not pursue legal action against researchers who:
+
+- Make a good-faith effort to avoid privacy violations, data destruction, and
+  disruption of service.
+- Only interact with accounts they own or with explicit permission from the
+  account holder.
+- Report vulnerabilities through the process described above.
+- Allow us a reasonable timeframe to address the issue before public disclosure.
+
+We ask that you do not:
+
+- Access, modify, or delete data belonging to other users.
+- Perform denial-of-service attacks.
+- Conduct testing against production systems in a way that could impact other
+  users.
+
+## Acknowledgments
+
+We are grateful to the security researchers who help keep usertrust and its
+users safe. With your permission, we will acknowledge your contribution in
+our release notes.
+
+## Contact
+
+For security-related inquiries: **security@usertrust.ai**
+
+For general questions, use [GitHub Issues](https://github.com/usertools-ai/usertrust/issues)
+or [GitHub Discussions](https://github.com/usertools-ai/usertrust/discussions).


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with coordinated vulnerability disclosure policy (48h ack, 90-day window, safe harbor)
- Add `CODE_OF_CONDUCT.md` adopting Contributor Covenant v2.1
- Add `.github/workflows/dco.yml` to enforce DCO sign-off on all PR commits
- Update `CONTRIBUTING.md` to reference Code of Conduct

Also applied via GitHub API (not in this diff):
- Enabled secret scanning + push protection
- Enabled Dependabot security updates
- Disabled unused wiki
- Branch protection on `master`: no force push, no deletion, linear history required, conversation resolution required
- Repo settings: auto-delete branches on merge, allow update branch, allow auto-merge

## Test plan

- [ ] Verify SECURITY.md renders correctly on GitHub
- [ ] Verify CODE_OF_CONDUCT.md renders correctly on GitHub
- [ ] Verify DCO workflow triggers on PRs without sign-off
- [ ] Verify branch protection allows solo-dev merges (no required reviews)

🤖 Generated with [Claude Code](https://claude.com/claude-code)