### PR TITLE
feat(site): dynamic OG image + AI financial governance meta

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,9 +57,7 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"peerDependencies": {
 		"@anthropic-ai/sdk": ">=0.30.0",
 		"openai": ">=4.70.0"

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -11,16 +11,7 @@
 		"directory": "packages/openclaw"
 	},
 	"bugs": "https://github.com/usertools-ai/usertrust/issues",
-	"keywords": [
-		"openclaw",
-		"usertrust",
-		"ai",
-		"governance",
-		"budget",
-		"audit",
-		"llm",
-		"plugin"
-	],
+	"keywords": ["openclaw", "usertrust", "ai", "governance", "budget", "audit", "llm", "plugin"],
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -34,10 +25,7 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc"
 	},
-	"files": [
-		"dist",
-		"openclaw.plugin.json"
-	],
+	"files": ["dist", "openclaw.plugin.json"],
 	"dependencies": {
 		"usertrust": "*"
 	},

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -11,14 +11,7 @@
 		"directory": "packages/verify"
 	},
 	"bugs": "https://github.com/usertools-ai/usertrust/issues",
-	"keywords": [
-		"ai",
-		"governance",
-		"audit",
-		"verify",
-		"hash-chain",
-		"merkle"
-	],
+	"keywords": ["ai", "governance", "audit", "verify", "hash-chain", "merkle"],
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -35,8 +28,6 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"dependencies": {}
 }

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -24,7 +24,7 @@ const jetbrainsMono = localFont({
 });
 
 export const metadata: Metadata = {
-	title: "usertrust — Financial governance in 30 seconds",
+	title: "usertrust — AI financial governance in 30 seconds",
 	description:
 		"One-line SDK wrapper that turns every AI agent LLM call into an auditable, budget-enforced financial transaction. Open source.",
 	keywords: [
@@ -43,20 +43,20 @@ export const metadata: Metadata = {
 	metadataBase: new URL("https://usertrust.ai"),
 	alternates: { canonical: "/" },
 	openGraph: {
-		title: "usertrust — Financial governance in 30 seconds",
+		title: "usertrust — AI financial governance in 30 seconds",
 		description:
 			"One-line SDK wrapper that turns every AI agent LLM call into an auditable, budget-enforced financial transaction. Open source.",
 		url: "https://usertrust.ai",
 		siteName: "UserTrust",
-		images: [{ url: "/og.png" }],
+		images: [{ url: "/og", width: 1200, height: 630, type: "image/png" }],
 		type: "website",
 	},
 	twitter: {
 		card: "summary_large_image",
-		title: "usertrust — Financial governance in 30 seconds",
+		title: "usertrust — AI financial governance in 30 seconds",
 		description:
 			"One-line SDK wrapper that turns every AI agent LLM call into an auditable, budget-enforced financial transaction. Open source.",
-		images: ["/og.png"],
+		images: [{ url: "/og", width: 1200, height: 630 }],
 	},
 	icons: { icon: "/favicon.svg" },
 };
@@ -70,7 +70,8 @@ const jsonLd = {
 	offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
 	author: { "@type": "Organization", name: "Usertools Inc" },
 	url: "https://usertrust.ai",
-	description: "Budget holds, audit trails, and spend limits for every LLM call.",
+	description:
+		"AI financial governance in 30 seconds. Budget holds, audit trails, and spend limits for every LLM call.",
 };
 
 export default function RootLayout({

--- a/site/app/og/route.tsx
+++ b/site/app/og/route.tsx
@@ -1,0 +1,126 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+
+export async function GET() {
+	return new ImageResponse(
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				alignItems: "center",
+				justifyContent: "center",
+				background: "#0a0a1a",
+				position: "relative",
+			}}
+		>
+			{/* Bliss-like gradient background */}
+			<div
+				style={{
+					position: "absolute",
+					bottom: 0,
+					left: 0,
+					right: 0,
+					height: "45%",
+					background:
+						"linear-gradient(180deg, #0a0a1a 0%, #0f2a1a 30%, #1a4a2a 50%, #2d6b3a 70%, #1a4a2a 85%, #0a0a1a 100%)",
+				}}
+			/>
+			{/* Sky gradient */}
+			<div
+				style={{
+					position: "absolute",
+					top: 0,
+					left: 0,
+					right: 0,
+					height: "60%",
+					background: "linear-gradient(180deg, #0a1a3a 0%, #0f2a4a 40%, #1a3a5a 70%, #0a0a1a 100%)",
+				}}
+			/>
+
+			{/* Content */}
+			<div
+				style={{
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					justifyContent: "center",
+					gap: "16px",
+					position: "relative",
+					zIndex: 1,
+				}}
+			>
+				{/* Open source badge */}
+				<div
+					style={{
+						display: "flex",
+						padding: "6px 16px",
+						borderRadius: "999px",
+						border: "1px solid rgba(52,211,153,0.3)",
+						fontSize: "14px",
+						color: "rgba(52,211,153,0.8)",
+						letterSpacing: "0.05em",
+					}}
+				>
+					Open source · Apache 2.0
+				</div>
+
+				{/* Main title */}
+				<div
+					style={{
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						gap: "4px",
+					}}
+				>
+					<span
+						style={{
+							fontSize: "72px",
+							fontWeight: 700,
+							color: "#34d399",
+							fontFamily: "monospace",
+							letterSpacing: "-0.02em",
+						}}
+					>
+						trust()
+					</span>
+					<span
+						style={{
+							fontSize: "56px",
+							fontWeight: 700,
+							color: "#ffffff",
+							letterSpacing: "-0.01em",
+						}}
+					>
+						your AI spend
+					</span>
+				</div>
+
+				{/* Install command */}
+				<div
+					style={{
+						display: "flex",
+						padding: "10px 24px",
+						borderRadius: "12px",
+						border: "1px solid rgba(255,255,255,0.1)",
+						background: "rgba(255,255,255,0.04)",
+						fontSize: "18px",
+						fontFamily: "monospace",
+						color: "rgba(255,255,255,0.6)",
+						letterSpacing: "0.02em",
+					}}
+				>
+					<span style={{ color: "rgba(52,211,153,0.6)" }}>$</span>
+					<span style={{ marginLeft: "8px" }}>npm install usertrust</span>
+				</div>
+			</div>
+		</div>,
+		{
+			width: 1200,
+			height: 630,
+		},
+	);
+}


### PR DESCRIPTION
## Summary

- Replace static `og.png` with dynamic `next/og` ImageResponse at `/og`
- OG image renders branded card: `trust()` title, sky/ground gradients, install command
- Meta title updated to "AI financial governance in 30 seconds" (page, OG, Twitter)
- JSON-LD description leads with "AI financial governance in 30 seconds"

## Test plan

- [ ] Visit `/og` directly — should render 1200x630 PNG
- [ ] Share link on Slack/iMessage — preview should show dynamic image with big title
- [ ] `<title>` tag reads "usertrust — AI financial governance in 30 seconds"

🤖 Generated with [Claude Code](https://claude.com/claude-code)