### PR TITLE
feat(openclaw): complete plugin + stream governor + demo

### DIFF
--- a/packages/openclaw/demo/README.md
+++ b/packages/openclaw/demo/README.md
@@ -1,0 +1,69 @@
+# usertrust × OpenClaw — runaway agent demo
+
+A runnable demo showing usertrust governance cutting off a buggy agent
+loop the moment the budget is exhausted.
+
+## Run
+
+```sh
+pnpm --filter usertrust-openclaw demo
+```
+
+Or directly:
+
+```sh
+npx tsx packages/openclaw/demo/runaway-agent.ts
+```
+
+## What it shows
+
+- A `createUsertrustPlugin` instance is built with a tiny $0.50 budget.
+- A mock `streamFn` simulates a runaway agent burning ~250 usertokens per call.
+- The plugin's `wrapStreamFn` middleware authorizes → forwards → settles each call.
+- After ~5 calls the budget is exhausted and the next call is denied with a clear
+  `budget exhausted` error. The audit ledger reflects every settled call.
+
+Expected output (truncated):
+
+```
+  budget:        1,200 usertokens (~$0.50)
+  agent model:   claude-sonnet-4-6
+  agent:         buggy loop, ~250 usertokens per call
+
+  call # 1  OK     chunks=29  → call settled
+  call # 2  OK     chunks=29  → call settled
+  call # 3  OK     chunks=29  → call settled
+  call # 4  OK     chunks=29  → call settled
+  call # 5  OK     chunks=29  → call settled
+  call # 6  BLOCK  usertrust: budget exhausted (0 remaining); call denied
+
+  --- final ledger ----------------------------------------
+  successful calls:  5
+  cut off at:        call #6
+  budget exhausted:  yes — governance enforced
+  ---------------------------------------------------------
+```
+
+## How OpenClaw users wire this
+
+```sh
+openclaw plugin add usertrust
+```
+
+Then in `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "usertrust": {
+        "enabled": true,
+        "config": { "budget": 100000, "dryRun": true }
+      }
+    }
+  }
+}
+```
+
+That's it — every LLM call routed through OpenClaw's `pi-ai` layer is
+now governed: budget, audit, policy gates.

--- a/packages/openclaw/demo/runaway-agent.ts
+++ b/packages/openclaw/demo/runaway-agent.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * runaway-agent.ts — usertrust governance cuts off a runaway LLM agent.
+ *
+ * Scenario: a buggy agent is in a loop, burning tokens. Without governance
+ * it would happily exhaust the entire budget. With usertrust wrapping
+ * the OpenClaw stream function, it gets cut off mid-stream the moment
+ * the budget is exhausted.
+ *
+ * Run:
+ *   pnpm --filter usertrust-openclaw demo
+ *
+ * (or: npx tsx packages/openclaw/demo/runaway-agent.ts)
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createUsertrustPlugin } from "../src/index.js";
+import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+
+// ── 1. Tiny budget — 1,200 usertokens (~$0.50 at typical rates) ──
+const BUDGET = 1_200;
+const vaultBase = mkdtempSync(join(tmpdir(), "usertrust-runaway-"));
+
+console.log("\n  usertrust × OpenClaw — runaway agent demo");
+console.log("  -------------------------------------------");
+console.log(`  budget:        ${BUDGET.toLocaleString()} usertokens (~$0.50)`);
+console.log("  agent model:   claude-sonnet-4-6");
+console.log("  agent:         buggy loop, ~250 usertokens per call");
+console.log("");
+
+// ── 2. The "runaway" mock streamFn — pretends to be a real LLM stream ──
+const runawayStreamFn: StreamFn = async function* (_model, _ctx) {
+	yield { type: "start" } as StreamEvent;
+	yield { type: "text_start" } as StreamEvent;
+	for (let i = 0; i < 25; i++) {
+		yield { type: "text_delta", text: `tok-${i} ` } as StreamEvent;
+	}
+	yield { type: "text_end" } as StreamEvent;
+	yield {
+		type: "done",
+		stopReason: "stop",
+		usage: { inputTokens: 500, outputTokens: 1500 }, // ~240 usertokens / call
+	} as StreamEvent;
+};
+
+// ── 3. Wire the governance plugin ──
+const plugin = createUsertrustPlugin({ budget: BUDGET, dryRun: true, vaultBase });
+const governedStream = plugin.wrapStreamFn?.(runawayStreamFn);
+if (!governedStream) throw new Error("plugin missing wrapStreamFn");
+
+// ── 4. Run the agent loop. Each iteration costs ~$0.10 — it gets ~5 calls. ──
+const ctx: StreamContext = {
+	messages: [{ role: "user", content: "do the thing forever" }],
+	model: "claude-sonnet-4-6",
+};
+
+let call = 0;
+let cutoff = false;
+while (!cutoff && call < 40) {
+	call += 1;
+	try {
+		let chunks = 0;
+		for await (const _e of governedStream("claude-sonnet-4-6", ctx)) {
+			chunks += 1;
+		}
+		console.log(`  call #${String(call).padStart(2)}  OK     chunks=${chunks}  → call settled`);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.log(`  call #${String(call).padStart(2)}  BLOCK  ${msg.split("\n")[0]}`);
+		cutoff = true;
+	}
+}
+
+console.log("");
+console.log("  --- final ledger ----------------------------------------");
+console.log(`  successful calls:  ${call - 1}`);
+console.log(`  cut off at:        call #${call}`);
+console.log(`  budget exhausted:  ${cutoff ? "yes — governance enforced" : "no"}`);
+console.log("  ---------------------------------------------------------");
+console.log("  Without usertrust, the buggy loop would have run forever.");
+console.log("");
+
+// cleanup
+const { shutdown } = await import("../src/index.js");
+await shutdown();
+try {
+	rmSync(vaultBase, { recursive: true, force: true });
+} catch {
+	// best effort
+}

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -23,7 +23,8 @@
 	},
 	"scripts": {
 		"build": "tsc",
-		"prepublishOnly": "tsc"
+		"prepublishOnly": "tsc",
+		"demo": "tsx demo/runaway-agent.ts"
 	},
 	"files": ["dist", "openclaw.plugin.json"],
 	"dependencies": {

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -37,6 +37,7 @@ import type { Governor } from "usertrust";
 import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "./stream-governor.js";
 import type {
 	OpenClawPluginApi,
+	ProviderPlugin,
 	StreamContext,
 	StreamEvent,
 	StreamFn,
@@ -45,7 +46,12 @@ import type {
 
 // Re-export for consumers
 export { wrapStreamWithGovernance, wrapCompleteWithGovernance } from "./stream-governor.js";
-export { createAccumulator, extractUsageFromEvent } from "./token-extractor.js";
+export {
+	createAccumulator,
+	extractUsageFromEvent,
+	extractUsageFromProviderChunk,
+	extractTextDeltaLength,
+} from "./token-extractor.js";
 export type {
 	StreamEvent,
 	StreamFn,
@@ -53,6 +59,7 @@ export type {
 	StreamUsage,
 	UsertrustPluginConfig,
 	GovernedStreamMeta,
+	ProviderPlugin,
 } from "./types.js";
 
 /** Active governor instance — singleton per plugin lifecycle. */
@@ -93,13 +100,46 @@ export default function register(api: OpenClawPluginApi): void {
 }
 
 /**
+ * Factory: build an OpenClaw `ProviderPlugin` bound to a usertrust config.
+ *
+ * Use this when programmatically wiring usertrust into an OpenClaw runtime
+ * (rather than going through the auto-discovery `register()` default).
+ * The returned plugin's `wrapStreamFn` follows OpenClaw's middleware shape:
+ * `(next: StreamFn) => StreamFn`.
+ *
+ * Init is lazy — the governor is created on the first wrapped call, not
+ * at plugin construction time. This matches OpenClaw's lifecycle (plugins
+ * register synchronously; governance needs async init).
+ *
+ * ```ts
+ * import { createUsertrustPlugin } from "usertrust-openclaw";
+ *
+ * const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true });
+ * const wrapped = plugin.wrapStreamFn!(rawStreamFn);
+ * for await (const event of wrapped(model, context)) { ... }
+ * ```
+ */
+export function createUsertrustPlugin(config: UsertrustPluginConfig): ProviderPlugin {
+	const getGovernor = lazyGovernor(config);
+
+	return {
+		id: "usertrust",
+		label: "usertrust Governance",
+		wrapStreamFn(next: StreamFn): StreamFn {
+			return (model, context, options) =>
+				governedStreamLazy(getGovernor, next, model, context, options);
+		},
+	};
+}
+
+/**
  * Programmatic API for non-OpenClaw usage.
  *
  * Use this when integrating usertrust governance into a custom
  * pi-ai setup without the full OpenClaw plugin system.
  *
  * ```ts
- * import { createGovernedStreamFn } from "@usertrust/openclaw";
+ * import { createGovernedStreamFn } from "usertrust-openclaw";
  *
  * const governed = await createGovernedStreamFn(myStreamFn, {
  *   budget: 100_000,
@@ -159,6 +199,7 @@ function initGovernor(config: UsertrustPluginConfig): Promise<Governor> {
 			...(config.configPath != null ? { configPath: config.configPath } : {}),
 			...(config.proxy != null ? { proxy: config.proxy } : {}),
 			...(config.proxyKey != null ? { key: config.proxyKey } : {}),
+			...(config.vaultBase != null ? { vaultBase: config.vaultBase } : {}),
 		}).then((gov) => {
 			governor = gov;
 			return gov;

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -47,7 +47,17 @@ async function* governedStream(
 	context: StreamContext,
 	options?: Record<string, unknown>,
 ): AsyncGenerator<StreamEvent> {
-	// 1. Authorize — budget check, policy gate, PENDING hold
+	// 1a. Pre-flight budget check.
+	// In dry-run mode (no TigerBeetle) the engine cannot enforce balance,
+	// so we explicitly refuse calls when budget_remaining ≤ 0. This matches
+	// the behaviour users expect from a "budget" config: hit zero, get cut off.
+	if (governor.budgetRemaining() <= 0) {
+		throw new Error(
+			`usertrust: budget exhausted (${governor.budgetRemaining()} remaining); call denied`,
+		);
+	}
+
+	// 1b. Authorize — policy gate, PENDING hold
 	const auth: Authorization = await governor.authorize({
 		model,
 		messages: context.messages,
@@ -106,7 +116,14 @@ export function wrapCompleteWithGovernance<
 		context: StreamContext,
 		options?: Record<string, unknown>,
 	): Promise<T> => {
-		// 1. Authorize
+		// 1a. Pre-flight budget check (see governedStream for rationale).
+		if (governor.budgetRemaining() <= 0) {
+			throw new Error(
+				`usertrust: budget exhausted (${governor.budgetRemaining()} remaining); call denied`,
+			);
+		}
+
+		// 1b. Authorize
 		const auth = await governor.authorize({
 			model,
 			messages: context.messages,

--- a/packages/openclaw/src/token-extractor.ts
+++ b/packages/openclaw/src/token-extractor.ts
@@ -2,11 +2,13 @@
 // Copyright 2026 Usertools, Inc.
 
 /**
- * token-extractor.ts — pi-ai Stream Token Extraction
+ * token-extractor.ts — Stream Token Extraction
  *
- * Extracts token usage from pi-ai's normalized stream events.
- * pi-ai reports usage on `done` and `error` events, unlike provider
- * SDKs which scatter it across multiple event types.
+ * Extracts token usage from pi-ai's normalized stream events AND from
+ * raw provider chunk shapes (Anthropic, OpenAI, Gemini) via duck-typing.
+ *
+ * pi-ai reports usage on `done` / `error` events. Raw provider chunks
+ * scatter usage across multiple shapes — we duck-type each one.
  */
 
 import type { StreamEvent, StreamUsage } from "./types.js";
@@ -19,17 +21,159 @@ export interface AccumulatedUsage {
 	usageReported: boolean;
 }
 
-/**
- * Extract token usage from a pi-ai stream event.
- * Returns non-zero usage only for `done` and `error` events.
- */
 /** Max tokens to accept from a provider (prevents Infinity/overflow in cost math). */
 const MAX_TOKENS = 2_000_000;
 
 function clampTokens(n: number): number {
-	return Math.min(Math.max(0, n), MAX_TOKENS);
+	if (!Number.isFinite(n)) return 0;
+	return Math.min(Math.max(0, Math.trunc(n)), MAX_TOKENS);
 }
 
+/**
+ * Duck-type chunks from raw provider streams. We support:
+ *
+ *   Anthropic:
+ *     { type: "message_start", message: { usage: { input_tokens, output_tokens } } }
+ *     { type: "message_delta", usage: { output_tokens } }
+ *     { type: "content_block_delta", delta: { text } }
+ *
+ *   OpenAI:
+ *     { choices: [{ delta: { content } }], usage: { prompt_tokens, completion_tokens } }
+ *
+ *   Gemini:
+ *     { candidates: [{ content: { parts: [...] } }], usageMetadata: { promptTokenCount, candidatesTokenCount } }
+ *
+ * Returns null if the chunk is not a recognized usage-bearing shape.
+ */
+export function extractUsageFromProviderChunk(chunk: unknown): StreamUsage | null {
+	if (chunk == null || typeof chunk !== "object") return null;
+	const c = chunk as Record<string, unknown>;
+
+	// ── Anthropic message_start ──
+	if (c.type === "message_start" && typeof c.message === "object" && c.message != null) {
+		const msg = c.message as Record<string, unknown>;
+		const usage = msg.usage as Record<string, unknown> | undefined;
+		if (usage != null) {
+			const input = readNum(usage.input_tokens);
+			const output = readNum(usage.output_tokens);
+			if (input != null || output != null) {
+				return {
+					inputTokens: clampTokens(input ?? 0),
+					outputTokens: clampTokens(output ?? 0),
+					...(typeof usage.cache_read_input_tokens === "number"
+						? { cacheReadTokens: clampTokens(usage.cache_read_input_tokens) }
+						: {}),
+					...(typeof usage.cache_creation_input_tokens === "number"
+						? { cacheWriteTokens: clampTokens(usage.cache_creation_input_tokens) }
+						: {}),
+				};
+			}
+		}
+	}
+
+	// ── Anthropic message_delta (final usage) ──
+	if (c.type === "message_delta" && typeof c.usage === "object" && c.usage != null) {
+		const usage = c.usage as Record<string, unknown>;
+		const output = readNum(usage.output_tokens);
+		const input = readNum(usage.input_tokens);
+		if (output != null || input != null) {
+			return {
+				inputTokens: clampTokens(input ?? 0),
+				outputTokens: clampTokens(output ?? 0),
+			};
+		}
+	}
+
+	// ── OpenAI usage (final chunk on stream_options.include_usage=true) ──
+	if (typeof c.usage === "object" && c.usage != null && Array.isArray(c.choices)) {
+		const usage = c.usage as Record<string, unknown>;
+		const prompt = readNum(usage.prompt_tokens);
+		const completion = readNum(usage.completion_tokens);
+		if (prompt != null || completion != null) {
+			return {
+				inputTokens: clampTokens(prompt ?? 0),
+				outputTokens: clampTokens(completion ?? 0),
+			};
+		}
+	}
+
+	// ── Gemini usageMetadata ──
+	if (typeof c.usageMetadata === "object" && c.usageMetadata != null) {
+		const meta = c.usageMetadata as Record<string, unknown>;
+		const prompt = readNum(meta.promptTokenCount);
+		const candidates = readNum(meta.candidatesTokenCount);
+		if (prompt != null || candidates != null) {
+			return {
+				inputTokens: clampTokens(prompt ?? 0),
+				outputTokens: clampTokens(candidates ?? 0),
+				...(typeof meta.cachedContentTokenCount === "number"
+					? { cacheReadTokens: clampTokens(meta.cachedContentTokenCount) }
+					: {}),
+			};
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Estimate output tokens from a streaming chunk's text delta.
+ * Used as a fallback when usage isn't reported. ~4 chars per token.
+ *
+ * Duck-types each provider's text delta shape:
+ *   Anthropic: chunk.delta.text                    (content_block_delta)
+ *   OpenAI:    chunk.choices[0].delta.content
+ *   Gemini:    chunk.candidates[0].content.parts[0].text
+ *   pi-ai:     chunk.text  (text_delta event)
+ */
+export function extractTextDeltaLength(chunk: unknown): number {
+	if (chunk == null || typeof chunk !== "object") return 0;
+	const c = chunk as Record<string, unknown>;
+
+	// pi-ai text_delta
+	if (c.type === "text_delta" && typeof c.text === "string") {
+		return c.text.length;
+	}
+
+	// Anthropic content_block_delta
+	if (c.type === "content_block_delta" && typeof c.delta === "object" && c.delta != null) {
+		const delta = c.delta as Record<string, unknown>;
+		if (typeof delta.text === "string") return delta.text.length;
+	}
+
+	// OpenAI choices[].delta.content
+	if (Array.isArray(c.choices) && c.choices.length > 0) {
+		const first = c.choices[0] as Record<string, unknown> | undefined;
+		const delta = first?.delta as Record<string, unknown> | undefined;
+		if (typeof delta?.content === "string") return delta.content.length;
+	}
+
+	// Gemini candidates[].content.parts[].text
+	if (Array.isArray(c.candidates) && c.candidates.length > 0) {
+		const first = c.candidates[0] as Record<string, unknown> | undefined;
+		const content = first?.content as Record<string, unknown> | undefined;
+		const parts = content?.parts;
+		if (Array.isArray(parts)) {
+			let len = 0;
+			for (const part of parts) {
+				const p = part as Record<string, unknown> | undefined;
+				if (typeof p?.text === "string") len += p.text.length;
+			}
+			return len;
+		}
+	}
+
+	return 0;
+}
+
+function readNum(v: unknown): number | null {
+	return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Extract token usage from a pi-ai stream event.
+ * Returns non-zero usage only for `done` and `error` events.
+ */
 export function extractUsageFromEvent(event: StreamEvent): StreamUsage | null {
 	if (event.type === "done" && event.usage != null) {
 		return {

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -106,6 +106,8 @@ export interface UsertrustPluginConfig {
 	configPath?: string;
 	proxy?: string;
 	proxyKey?: string;
+	/** Vault directory (audit chain, spend ledger). Defaults to cwd. */
+	vaultBase?: string;
 }
 
 // ── Stream Function Types ──
@@ -129,4 +131,25 @@ export interface GovernedStreamMeta {
 	transferId: string;
 	estimatedCost: number;
 	model: string;
+}
+
+// ── OpenClaw ProviderPlugin shape ──
+
+/**
+ * The plugin shape that OpenClaw's plugin loader expects.
+ *
+ * Mirrors `ProviderPlugin` from openclaw/src/plugins/types.ts. The two
+ * primary integration hooks are `wrapStreamFn` (middleware-style wrap of
+ * an existing stream function) and `createStreamFn` (custom factory).
+ *
+ * We only implement `wrapStreamFn` — middleware is the path of least
+ * surprise for governance: budget check → forward → settle.
+ */
+export interface ProviderPlugin {
+	id: string;
+	label: string;
+	/** Middleware: receives an existing stream fn, returns a wrapped one. */
+	wrapStreamFn?: (next: StreamFn) => StreamFn;
+	/** Optional: provide a fully custom stream fn. We do not use this. */
+	createStreamFn?: () => StreamFn;
 }

--- a/packages/openclaw/tests/integration.test.ts
+++ b/packages/openclaw/tests/integration.test.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * integration.test.ts — End-to-end shape + behaviour for createUsertrustPlugin.
+ *
+ * Verifies the public factory returns an OpenClaw-compatible ProviderPlugin,
+ * lazily initializes the governor on first call, and correctly wraps a mock
+ * streamFn through the budget → forward → settle lifecycle.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock tigerbeetle-node so the test never touches a real ledger
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: {
+		linked: 1,
+		pending: 2,
+		post_pending_transfer: 4,
+		void_pending_transfer: 8,
+	},
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+import { createUsertrustPlugin } from "../src/index.js";
+import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `openclaw-integration-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+describe("createUsertrustPlugin (factory)", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		// Reset module-level governor between tests
+		const mod = await import("../src/index.js");
+		await mod.shutdown();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup
+		}
+	});
+
+	it("returns a valid OpenClaw ProviderPlugin shape", () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+
+		expect(plugin.id).toBe("usertrust");
+		expect(plugin.label).toBe("usertrust Governance");
+		expect(typeof plugin.wrapStreamFn).toBe("function");
+	});
+
+	it("wrapStreamFn(next) returns a callable stream function", () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+
+		const rawStreamFn: StreamFn = async function* () {
+			yield { type: "start" as const };
+		};
+
+		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		expect(typeof wrapped).toBe("function");
+	});
+
+	it("wrapped stream forwards all events from the inner streamFn", async () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+
+		const events: StreamEvent[] = [
+			{ type: "start" },
+			{ type: "text_start" },
+			{ type: "text_delta", text: "hello " },
+			{ type: "text_delta", text: "world" },
+			{ type: "text_end" },
+			{
+				type: "done",
+				stopReason: "stop",
+				usage: { inputTokens: 10, outputTokens: 5 },
+			},
+		];
+
+		const rawStreamFn: StreamFn = async function* () {
+			for (const e of events) yield e;
+		};
+
+		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		expect(wrapped).toBeDefined();
+
+		const ctx: StreamContext = {
+			messages: [{ role: "user", content: "hi" }],
+			model: "claude-sonnet-4-6",
+		};
+
+		const collected: StreamEvent[] = [];
+		// biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+		for await (const event of wrapped!("claude-sonnet-4-6", ctx)) {
+			collected.push(event);
+		}
+
+		expect(collected).toHaveLength(events.length);
+		expect(collected[0]?.type).toBe("start");
+		expect(collected[collected.length - 1]?.type).toBe("done");
+	});
+
+	it("lazy-init: governor is null until first call", async () => {
+		const { getGovernor } = await import("../src/index.js");
+
+		// Create plugin — should NOT initialize governor
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+		expect(getGovernor()).toBeNull();
+
+		// First call should trigger init
+		const rawStreamFn: StreamFn = async function* () {
+			yield { type: "start" as const };
+		};
+		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		const ctx: StreamContext = {
+			messages: [{ role: "user", content: "hi" }],
+			model: "claude-sonnet-4-6",
+		};
+
+		// biome-ignore lint/style/noNonNullAssertion: guarded above
+		for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+			// drain
+		}
+
+		expect(getGovernor()).not.toBeNull();
+	});
+
+	it("propagates errors from the inner streamFn and aborts the hold", async () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+
+		const rawStreamFn: StreamFn = async function* () {
+			yield { type: "start" as const };
+			throw new Error("upstream_failure");
+		};
+
+		// Trigger lazy init by calling once with a successful no-op — but
+		// we can't, since first call may also be the failing one. Instead,
+		// snapshot budget AFTER first authorize completes by routing through
+		// a separate channel: just compare delta within this test.
+		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		const ctx: StreamContext = {
+			messages: [{ role: "user", content: "hi" }],
+			model: "claude-sonnet-4-6",
+		};
+
+		const { getGovernor } = await import("../src/index.js");
+
+		await expect(async () => {
+			// biome-ignore lint/style/noNonNullAssertion: guarded above
+			for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+				// drain
+			}
+		}).rejects.toThrow("upstream_failure");
+
+		const gov = getGovernor();
+		expect(gov).not.toBeNull();
+		// After abort, budget should equal the configured starting budget
+		// (no spend should have been recorded for the failed call).
+		expect(gov?.budgetRemaining()).toBe(100_000);
+	});
+
+	it("denies further calls once the budget is exhausted", async () => {
+		// 240 usertokens per call (claude-sonnet-4-6 at 500/1500 tokens),
+		// budget 480 → exactly 2 calls then 0 remaining → 3rd call denied.
+		const plugin = createUsertrustPlugin({ budget: 480, dryRun: true, vaultBase });
+
+		const rawStreamFn: StreamFn = async function* () {
+			yield { type: "start" as const };
+			yield {
+				type: "done" as const,
+				stopReason: "stop" as const,
+				usage: { inputTokens: 500, outputTokens: 1500 },
+			};
+		};
+
+		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		const ctx: StreamContext = {
+			messages: [{ role: "user", content: "hi" }],
+			model: "claude-sonnet-4-6",
+		};
+
+		// First two calls should succeed
+		// biome-ignore lint/style/noNonNullAssertion: guarded above
+		for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+			// drain
+		}
+		// biome-ignore lint/style/noNonNullAssertion: guarded above
+		for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+			// drain
+		}
+
+		// Third should be cut off
+		await expect(async () => {
+			// biome-ignore lint/style/noNonNullAssertion: guarded above
+			for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+				// drain
+			}
+		}).rejects.toThrow(/budget exhausted/);
+	});
+
+	it("settles the hold on early consumer-side termination (break)", async () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+
+		// A stream that produces many chunks and never gets to `done`
+		const rawStreamFn: StreamFn = async function* () {
+			yield { type: "start" as const };
+			for (let i = 0; i < 100; i++) {
+				yield { type: "text_delta" as const, text: `chunk-${i}` };
+			}
+			yield {
+				type: "done" as const,
+				stopReason: "stop" as const,
+				usage: { inputTokens: 10, outputTokens: 100 },
+			};
+		};
+
+		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		const ctx: StreamContext = {
+			messages: [{ role: "user", content: "hi" }],
+			model: "claude-sonnet-4-6",
+		};
+
+		// biome-ignore lint/style/noNonNullAssertion: guarded above
+		const iter = wrapped!("claude-sonnet-4-6", ctx)[Symbol.asyncIterator]();
+		await iter.next(); // consume one chunk
+		// Caller drops the iterator without consuming `done`. The async
+		// generator's `return()` will run the finally block — abort path.
+		if (typeof iter.return === "function") {
+			await iter.return(undefined);
+		}
+		// We don't assert budget here — abort vs. settle on early-return is
+		// implementation-defined. We just assert it doesn't throw or hang.
+		expect(true).toBe(true);
+	});
+});

--- a/packages/openclaw/tests/token-extractor.test.ts
+++ b/packages/openclaw/tests/token-extractor.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { createAccumulator, extractUsageFromEvent } from "../src/token-extractor.js";
+import {
+	createAccumulator,
+	extractTextDeltaLength,
+	extractUsageFromEvent,
+	extractUsageFromProviderChunk,
+} from "../src/token-extractor.js";
 import type { DoneEvent, ErrorEvent, StreamEvent, TextDeltaEvent } from "../src/types.js";
 
 describe("extractUsageFromEvent", () => {
@@ -220,5 +225,191 @@ describe("createAccumulator", () => {
 		expect(result.outputTokens).toBe(25);
 		expect(result.chunksDelivered).toBe(2);
 		expect(result.usageReported).toBe(true);
+	});
+});
+
+// ── Multi-provider duck-typed parsing ──
+
+describe("extractUsageFromProviderChunk — Anthropic", () => {
+	it("parses message_start with input/output tokens", () => {
+		const chunk = {
+			type: "message_start",
+			message: {
+				id: "msg_01",
+				usage: { input_tokens: 120, output_tokens: 1 },
+			},
+		};
+		const usage = extractUsageFromProviderChunk(chunk);
+		expect(usage).not.toBeNull();
+		expect(usage?.inputTokens).toBe(120);
+		expect(usage?.outputTokens).toBe(1);
+	});
+
+	it("parses message_delta with final output tokens", () => {
+		const chunk = {
+			type: "message_delta",
+			delta: { stop_reason: "end_turn" },
+			usage: { output_tokens: 87 },
+		};
+		const usage = extractUsageFromProviderChunk(chunk);
+		expect(usage).not.toBeNull();
+		expect(usage?.outputTokens).toBe(87);
+	});
+
+	it("preserves cache token fields on Anthropic message_start", () => {
+		const chunk = {
+			type: "message_start",
+			message: {
+				usage: {
+					input_tokens: 50,
+					output_tokens: 1,
+					cache_read_input_tokens: 200,
+					cache_creation_input_tokens: 30,
+				},
+			},
+		};
+		const usage = extractUsageFromProviderChunk(chunk);
+		expect(usage?.cacheReadTokens).toBe(200);
+		expect(usage?.cacheWriteTokens).toBe(30);
+	});
+
+	it("returns null for content_block_delta (no usage)", () => {
+		const chunk = {
+			type: "content_block_delta",
+			delta: { type: "text_delta", text: "hello" },
+		};
+		expect(extractUsageFromProviderChunk(chunk)).toBeNull();
+	});
+});
+
+describe("extractUsageFromProviderChunk — OpenAI", () => {
+	it("parses final usage chunk on stream_options.include_usage", () => {
+		const chunk = {
+			id: "chatcmpl_01",
+			choices: [],
+			usage: {
+				prompt_tokens: 200,
+				completion_tokens: 87,
+				total_tokens: 287,
+			},
+		};
+		const usage = extractUsageFromProviderChunk(chunk);
+		expect(usage).not.toBeNull();
+		expect(usage?.inputTokens).toBe(200);
+		expect(usage?.outputTokens).toBe(87);
+	});
+
+	it("returns null for normal delta chunks (no usage)", () => {
+		const chunk = {
+			id: "chatcmpl_01",
+			choices: [{ index: 0, delta: { content: "hello" } }],
+		};
+		expect(extractUsageFromProviderChunk(chunk)).toBeNull();
+	});
+});
+
+describe("extractUsageFromProviderChunk — Gemini", () => {
+	it("parses usageMetadata block", () => {
+		const chunk = {
+			candidates: [{ content: { parts: [{ text: "hi" }] } }],
+			usageMetadata: {
+				promptTokenCount: 50,
+				candidatesTokenCount: 12,
+				totalTokenCount: 62,
+			},
+		};
+		const usage = extractUsageFromProviderChunk(chunk);
+		expect(usage).not.toBeNull();
+		expect(usage?.inputTokens).toBe(50);
+		expect(usage?.outputTokens).toBe(12);
+	});
+
+	it("captures cachedContentTokenCount as cache reads", () => {
+		const chunk = {
+			usageMetadata: {
+				promptTokenCount: 100,
+				candidatesTokenCount: 20,
+				cachedContentTokenCount: 80,
+			},
+		};
+		const usage = extractUsageFromProviderChunk(chunk);
+		expect(usage?.cacheReadTokens).toBe(80);
+	});
+});
+
+describe("extractUsageFromProviderChunk — malformed/edge", () => {
+	it("returns null for null", () => {
+		expect(extractUsageFromProviderChunk(null)).toBeNull();
+	});
+
+	it("returns null for undefined", () => {
+		expect(extractUsageFromProviderChunk(undefined)).toBeNull();
+	});
+
+	it("returns null for primitive string", () => {
+		expect(extractUsageFromProviderChunk("not a chunk")).toBeNull();
+	});
+
+	it("returns null for empty object", () => {
+		expect(extractUsageFromProviderChunk({})).toBeNull();
+	});
+
+	it("returns null for unknown shape", () => {
+		expect(extractUsageFromProviderChunk({ foo: "bar" })).toBeNull();
+	});
+
+	it("ignores Infinity / NaN tokens", () => {
+		const chunk = {
+			usageMetadata: {
+				promptTokenCount: Number.POSITIVE_INFINITY,
+				candidatesTokenCount: Number.NaN,
+			},
+		};
+		// readNum filters non-finite, so usageMetadata yields no usable nums
+		expect(extractUsageFromProviderChunk(chunk)).toBeNull();
+	});
+});
+
+describe("extractTextDeltaLength", () => {
+	it("returns 0 for null/undefined chunks", () => {
+		expect(extractTextDeltaLength(null)).toBe(0);
+		expect(extractTextDeltaLength(undefined)).toBe(0);
+	});
+
+	it("counts pi-ai text_delta length", () => {
+		expect(extractTextDeltaLength({ type: "text_delta", text: "hello" })).toBe(5);
+	});
+
+	it("counts Anthropic content_block_delta length", () => {
+		const chunk = {
+			type: "content_block_delta",
+			delta: { type: "text_delta", text: "world!" },
+		};
+		expect(extractTextDeltaLength(chunk)).toBe(6);
+	});
+
+	it("counts OpenAI choices[0].delta.content length", () => {
+		const chunk = {
+			choices: [{ index: 0, delta: { content: "abcdef" } }],
+		};
+		expect(extractTextDeltaLength(chunk)).toBe(6);
+	});
+
+	it("counts Gemini candidates[0].content.parts[*].text length (sums parts)", () => {
+		const chunk = {
+			candidates: [
+				{
+					content: {
+						parts: [{ text: "foo" }, { text: "bar" }],
+					},
+				},
+			],
+		};
+		expect(extractTextDeltaLength(chunk)).toBe(6);
+	});
+
+	it("returns 0 for chunks with no text content", () => {
+		expect(extractTextDeltaLength({ type: "start" })).toBe(0);
+		expect(extractTextDeltaLength({ choices: [] })).toBe(0);
 	});
 });


### PR DESCRIPTION
## Summary

Completes the `usertrust-openclaw` plugin so OpenClaw users can install
governance with a single command (`openclaw plugin add usertrust`) and
get budget enforcement + audit + policy gates on every LLM call —
zero code changes.

- **`createUsertrustPlugin(config)`** factory — returns an OpenClaw
  `ProviderPlugin` shape with lazy governor init on first wrapped call
- **stream-governor** — pre-flight budget check + `authorize → forward → settle`
  lifecycle, abort on stream error (releases the PENDING hold), explicit
  budget-exhaustion deny so dry-run users get the same enforcement as
  TigerBeetle-backed runs
- **token-extractor** — duck-typed multi-provider parsing for raw chunk
  shapes (Anthropic `message_start`/`message_delta`/`content_block_delta`,
  OpenAI `choices[].delta` + final `usage`, Gemini
  `candidates[].content.parts` + `usageMetadata`); existing pi-ai event
  parsing retained
- **demo** — `demo/runaway-agent.ts` shows a buggy agent with a $0.50
  budget getting cut off mid-run after exactly 5 calls

## Test plan

```sh
npx tsc -b --noEmit                 # pass
npx vitest run packages/openclaw    # 65 / 65 pass (4 files)
npx biome check packages/openclaw   # clean
pnpm --filter usertrust-openclaw demo  # cuts off at call #6
```

Test coverage:
- `tests/integration.test.ts` (7) — factory shape, lazy init, event
  forwarding, error → abort, budget-exhausted denial, early termination
- `tests/token-extractor.test.ts` (33) — pi-ai events, multi-provider
  duck-typing, malformed/edge cases, text-delta length sums
- `tests/stream-governor.test.ts` (10) — happy path, abort, concurrent
  streams, completion variant
- `tests/index.test.ts` (15) — register, createGovernedStreamFn,
  shutdown idempotency, end-to-end

## Demo

```sh
pnpm --filter usertrust-openclaw demo
```

Output (15 lines):

```
  budget:        1,200 usertokens (~$0.50)
  agent model:   claude-sonnet-4-6
  agent:         buggy loop, ~250 usertokens per call

  call # 1  OK     chunks=29  → call settled
  ... (4 more)
  call # 6  BLOCK  usertrust: budget exhausted (0 remaining); call denied

  --- final ledger ----------------------------------------
  successful calls:  5
  cut off at:        call #6
  budget exhausted:  yes — governance enforced
```

## Integration path for OpenClaw users

```sh
openclaw plugin add usertrust
```

In `openclaw.json`:

```json
{
  "plugins": {
    "entries": {
      "usertrust": {
        "enabled": true,
        "config": { "budget": 100000, "dryRun": true }
      }
    }
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)