### PR TITLE
feat(core): streaming anomaly governance (rate/velocity/cascade)

### DIFF
--- a/packages/core/src/anomaly/detector.ts
+++ b/packages/core/src/anomaly/detector.ts
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * detector.ts — AnomalyDetector
+ *
+ * Mental model:
+ *   - One detector instance per intercepted streaming call (or shared across
+ *     a "conversation" when injection-cascade tracking is needed).
+ *   - The streaming pipeline calls observe(event) for each chunk; the detector
+ *     updates per-signal state and check() returns a verdict.
+ *   - On tripped verdict: caller throws AnomalyError, which propagates through
+ *     the existing wrapStream onError → VOID flow → upstream caller. An audit
+ *     event `anomaly_detected` is appended via the existing hash-chain.
+ *   - After cooldownMs the detector auto-resets; reset() can be called manually.
+ *
+ * Defaults are tuned conservatively (500 tok/s sustained, $1/min, 3 injections in 60s).
+ * Detection is opt-in (anomaly.enabled=true) — when off, observe/check are no-ops.
+ */
+
+import { estimateCost } from "../ledger/pricing.js";
+import {
+	type InjectionCascadeSignal,
+	createInjectionCascadeSignal,
+	resolveInjectionCascadeConfig,
+} from "./signals/injection-cascade.js";
+import {
+	type SpendVelocitySignal,
+	createSpendVelocitySignal,
+	resolveSpendVelocityConfig,
+} from "./signals/spend-velocity.js";
+import {
+	type TokenRateSignal,
+	createTokenRateSignal,
+	resolveTokenRateConfig,
+} from "./signals/token-rate.js";
+import type {
+	AnomalyChunkEvent,
+	AnomalyConfig,
+	AnomalyDetectorOptions,
+	AnomalyDetectorState,
+	AnomalyEvent,
+	AnomalyInjectionEvent,
+	AnomalyKind,
+	AnomalyVerdict,
+	ResolvedAnomalyConfig,
+} from "./types.js";
+
+const DEFAULT_COOLDOWN_MS = 30_000;
+
+/** Resolve a partial AnomalyConfig with defaults. */
+export function resolveAnomalyConfig(cfg?: AnomalyConfig): ResolvedAnomalyConfig {
+	return {
+		enabled: cfg?.enabled ?? false,
+		tokenRate: resolveTokenRateConfig(cfg?.tokenRate),
+		spendVelocity: resolveSpendVelocityConfig(cfg?.spendVelocity),
+		injectionCascade: resolveInjectionCascadeConfig(cfg?.injectionCascade),
+		cooldownMs: cfg?.cooldownMs ?? DEFAULT_COOLDOWN_MS,
+	};
+}
+
+/** USD value of one usertoken. 1 usertoken = $0.0001 (one basis point of a cent). */
+const USERTOKENS_PER_DOLLAR = 10_000;
+
+function defaultCostCalculator(model: string, inputTokens: number, outputTokens: number): number {
+	// estimateCost returns usertokens; convert to dollars.
+	const usertokens = estimateCost(model, inputTokens, outputTokens);
+	return usertokens / USERTOKENS_PER_DOLLAR;
+}
+
+export interface AnomalyDetector {
+	readonly config: ResolvedAnomalyConfig;
+	readonly state: Readonly<AnomalyDetectorState>;
+	/** Observe a chunk or injection event. */
+	observe(event: AnomalyEvent): void;
+	/** Check current state. Returns the most-severe tripped verdict, or {tripped:false}. */
+	check(): AnomalyVerdict;
+	/** Manually reset the detector to a clean state. */
+	reset(): void;
+	/** True if currently tripped (and not yet auto-recovered via cooldown). */
+	isTripped(): boolean;
+}
+
+export function createAnomalyDetector(
+	cfg?: AnomalyConfig,
+	options?: AnomalyDetectorOptions,
+): AnomalyDetector {
+	const config = resolveAnomalyConfig(cfg);
+	const now = options?.now ?? (() => Date.now());
+	const model = options?.model ?? "unknown";
+	const costCalculator = options?.costCalculator ?? defaultCostCalculator;
+
+	const tokenRate: TokenRateSignal = createTokenRateSignal(config.tokenRate);
+	const spendVelocity: SpendVelocitySignal = createSpendVelocitySignal(config.spendVelocity);
+	const injectionCascade: InjectionCascadeSignal = createInjectionCascadeSignal(
+		config.injectionCascade,
+	);
+
+	const state: AnomalyDetectorState = {
+		tripped: false,
+		trippedAt: null,
+		trippedKind: null,
+	};
+
+	function maybeAutoRecover(): void {
+		if (!state.tripped || state.trippedAt == null) return;
+		if (now() - state.trippedAt >= config.cooldownMs) {
+			doReset();
+		}
+	}
+
+	function observeChunk(ev: AnomalyChunkEvent): void {
+		const t = ev.at ?? now();
+		tokenRate.observe(ev.deltaTokens, t);
+		const dollars = costCalculator(model, ev.cumulativeInputTokens, ev.cumulativeOutputTokens);
+		spendVelocity.observe(dollars, t);
+	}
+
+	function observeInjection(ev: AnomalyInjectionEvent): void {
+		injectionCascade.observe(ev.at ?? now());
+	}
+
+	function observe(event: AnomalyEvent): void {
+		if (!config.enabled) return;
+		maybeAutoRecover();
+		if (event.kind === "chunk") {
+			observeChunk(event);
+		} else {
+			observeInjection(event);
+		}
+	}
+
+	function check(): AnomalyVerdict {
+		if (!config.enabled) return { tripped: false };
+		maybeAutoRecover();
+		// If already tripped (still in cooldown), keep returning the trip verdict
+		// so the caller's check is idempotent during the same call.
+		if (state.tripped && state.trippedKind != null) {
+			return buildKnownTrip(state.trippedKind);
+		}
+
+		const t = now();
+
+		// Check signals in priority order: token-rate first (cheapest), spend-velocity, then injection.
+		const tr = tokenRate.check(t);
+		if (tr.tripped) {
+			return markTripped(
+				"token_rate",
+				`tokens/s ${tr.metric.toFixed(1)} >= ${tr.threshold}`,
+				tr.metric,
+				tr.threshold,
+			);
+		}
+
+		const sv = spendVelocity.check(t);
+		if (sv.tripped) {
+			return markTripped(
+				"spend_velocity",
+				`$/min ${sv.metric.toFixed(4)} >= ${sv.threshold}`,
+				sv.metric,
+				sv.threshold,
+			);
+		}
+
+		const ic = injectionCascade.check(t);
+		if (ic.tripped) {
+			return markTripped(
+				"injection_cascade",
+				`injection events ${ic.metric} >= ${ic.threshold} within window`,
+				ic.metric,
+				ic.threshold,
+			);
+		}
+
+		return { tripped: false };
+	}
+
+	function buildKnownTrip(kind: AnomalyKind): AnomalyVerdict {
+		// Re-check the tripped signal so metric reflects the most recent value.
+		const t = now();
+		switch (kind) {
+			case "token_rate": {
+				const r = tokenRate.check(t);
+				return {
+					tripped: true,
+					kind,
+					message: `tokens/s ${r.metric.toFixed(1)} >= ${r.threshold}`,
+					metric: r.metric,
+					threshold: r.threshold,
+				};
+			}
+			case "spend_velocity": {
+				const r = spendVelocity.check(t);
+				return {
+					tripped: true,
+					kind,
+					message: `$/min ${r.metric.toFixed(4)} >= ${r.threshold}`,
+					metric: r.metric,
+					threshold: r.threshold,
+				};
+			}
+			case "injection_cascade": {
+				const r = injectionCascade.check(t);
+				return {
+					tripped: true,
+					kind,
+					message: `injection events ${r.metric} >= ${r.threshold} within window`,
+					metric: r.metric,
+					threshold: r.threshold,
+				};
+			}
+		}
+	}
+
+	function markTripped(
+		kind: AnomalyKind,
+		message: string,
+		metric: number,
+		threshold: number,
+	): AnomalyVerdict {
+		state.tripped = true;
+		state.trippedAt = now();
+		state.trippedKind = kind;
+		return { tripped: true, kind, message, metric, threshold };
+	}
+
+	function doReset(): void {
+		state.tripped = false;
+		state.trippedAt = null;
+		state.trippedKind = null;
+		tokenRate.reset();
+		spendVelocity.reset();
+		injectionCascade.reset();
+	}
+
+	function isTripped(): boolean {
+		// Run a check first so that signals which have crossed thresholds since
+		// the last observe() are reflected. Then handle auto-recovery.
+		if (!state.tripped && config.enabled) {
+			check();
+		}
+		maybeAutoRecover();
+		return state.tripped;
+	}
+
+	return {
+		config,
+		state,
+		observe,
+		check,
+		reset: doReset,
+		isTripped,
+	};
+}

--- a/packages/core/src/anomaly/index.ts
+++ b/packages/core/src/anomaly/index.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * anomaly/index.ts — Public exports for streaming anomaly governance.
+ */
+
+export { createAnomalyDetector, resolveAnomalyConfig } from "./detector.js";
+export type { AnomalyDetector } from "./detector.js";
+export type {
+	AnomalyChunkEvent,
+	AnomalyConfig,
+	AnomalyDetectorOptions,
+	AnomalyDetectorState,
+	AnomalyEvent,
+	AnomalyInjectionEvent,
+	AnomalyKind,
+	AnomalyVerdict,
+	InjectionCascadeConfig,
+	ResolvedAnomalyConfig,
+	SpendVelocityConfig,
+	TokenRateConfig,
+} from "./types.js";
+export { AnomalyError } from "../shared/errors.js";

--- a/packages/core/src/anomaly/signals/injection-cascade.ts
+++ b/packages/core/src/anomaly/signals/injection-cascade.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * injection-cascade.ts — Injection-cascade anomaly signal.
+ *
+ * Detects when N injection signals fire within an M-second rolling window.
+ * Useful for catching agents under sustained adversarial pressure.
+ *
+ * Default: 3 events in 60s.
+ */
+
+import type { InjectionCascadeConfig } from "../types.js";
+
+export interface InjectionCascadeSignalState {
+	/** Timestamps (ms since epoch) of injection events within the active window. */
+	eventTimes: number[];
+}
+
+export interface InjectionCascadeSignal {
+	state: Readonly<InjectionCascadeSignalState>;
+	observe(nowMs: number): void;
+	check(nowMs: number): {
+		tripped: boolean;
+		metric: number;
+		threshold: number;
+	};
+	reset(): void;
+}
+
+export interface ResolvedInjectionCascadeConfig {
+	eventCount: number;
+	windowMs: number;
+}
+
+export const INJECTION_CASCADE_DEFAULTS: ResolvedInjectionCascadeConfig = {
+	eventCount: 3,
+	windowMs: 60_000,
+};
+
+export function resolveInjectionCascadeConfig(
+	cfg?: InjectionCascadeConfig,
+): ResolvedInjectionCascadeConfig {
+	return {
+		eventCount: cfg?.eventCount ?? INJECTION_CASCADE_DEFAULTS.eventCount,
+		windowMs: cfg?.windowMs ?? INJECTION_CASCADE_DEFAULTS.windowMs,
+	};
+}
+
+export function createInjectionCascadeSignal(
+	cfg: ResolvedInjectionCascadeConfig,
+): InjectionCascadeSignal {
+	const state: InjectionCascadeSignalState = {
+		eventTimes: [],
+	};
+
+	function pruneOlderThan(cutoffMs: number): void {
+		while (state.eventTimes.length > 0) {
+			const head = state.eventTimes[0];
+			if (head !== undefined && head < cutoffMs) {
+				state.eventTimes.shift();
+			} else {
+				break;
+			}
+		}
+	}
+
+	function observe(nowMs: number): void {
+		pruneOlderThan(nowMs - cfg.windowMs);
+		state.eventTimes.push(nowMs);
+	}
+
+	function check(nowMs: number): {
+		tripped: boolean;
+		metric: number;
+		threshold: number;
+	} {
+		pruneOlderThan(nowMs - cfg.windowMs);
+		const count = state.eventTimes.length;
+		return {
+			tripped: count >= cfg.eventCount,
+			metric: count,
+			threshold: cfg.eventCount,
+		};
+	}
+
+	function reset(): void {
+		state.eventTimes.length = 0;
+	}
+
+	return { state, observe, check, reset };
+}

--- a/packages/core/src/anomaly/signals/spend-velocity.ts
+++ b/packages/core/src/anomaly/signals/spend-velocity.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * spend-velocity.ts — Spend-velocity anomaly signal.
+ *
+ * Tracks $/min over a rolling window. Each observation records the
+ * cumulative cost (in dollars). The signal trips when the rolling
+ * dollars-per-minute exceeds the configured ceiling.
+ *
+ * Default: $1.00/min over a 10s rolling window.
+ *
+ * Cost is computed via a `costCalculator` callback so the signal stays
+ * decoupled from the SDK's pricing module.
+ */
+
+import type { SpendVelocityConfig } from "../types.js";
+
+interface CostSample {
+	tMs: number;
+	cumulativeDollars: number;
+}
+
+export interface SpendVelocitySignalState {
+	samples: CostSample[];
+	lastDollarsPerMin: number;
+}
+
+export interface SpendVelocitySignal {
+	state: Readonly<SpendVelocitySignalState>;
+	/** Record cumulative dollars at time `nowMs`. */
+	observe(cumulativeDollars: number, nowMs: number): void;
+	check(nowMs: number): {
+		tripped: boolean;
+		metric: number;
+		threshold: number;
+	};
+	reset(): void;
+}
+
+export interface ResolvedSpendVelocityConfig {
+	thresholdDollarsPerMin: number;
+	windowMs: number;
+}
+
+export const SPEND_VELOCITY_DEFAULTS: ResolvedSpendVelocityConfig = {
+	thresholdDollarsPerMin: 1.0,
+	windowMs: 10_000,
+};
+
+export function resolveSpendVelocityConfig(cfg?: SpendVelocityConfig): ResolvedSpendVelocityConfig {
+	return {
+		thresholdDollarsPerMin:
+			cfg?.thresholdDollarsPerMin ?? SPEND_VELOCITY_DEFAULTS.thresholdDollarsPerMin,
+		windowMs: cfg?.windowMs ?? SPEND_VELOCITY_DEFAULTS.windowMs,
+	};
+}
+
+export function createSpendVelocitySignal(cfg: ResolvedSpendVelocityConfig): SpendVelocitySignal {
+	const state: SpendVelocitySignalState = {
+		samples: [],
+		lastDollarsPerMin: 0,
+	};
+
+	function pruneOlderThan(cutoffMs: number): void {
+		// Keep at least one sample older than the cutoff so we can compute deltas.
+		// Find the most recent sample at or before cutoffMs and drop everything before it.
+		let lastBeforeCutoff = -1;
+		for (let i = 0; i < state.samples.length; i++) {
+			const sample = state.samples[i];
+			if (sample !== undefined && sample.tMs <= cutoffMs) {
+				lastBeforeCutoff = i;
+			} else {
+				break;
+			}
+		}
+		if (lastBeforeCutoff > 0) {
+			state.samples.splice(0, lastBeforeCutoff);
+		}
+	}
+
+	function observe(cumulativeDollars: number, nowMs: number): void {
+		// Reject NaN/negative deltas — keep the cumulative monotonic non-decreasing.
+		if (!Number.isFinite(cumulativeDollars) || cumulativeDollars < 0) return;
+		const last = state.samples[state.samples.length - 1];
+		if (last !== undefined && cumulativeDollars < last.cumulativeDollars) {
+			// Provider regressed (shouldn't happen) — clamp to last
+			state.samples.push({ tMs: nowMs, cumulativeDollars: last.cumulativeDollars });
+		} else {
+			state.samples.push({ tMs: nowMs, cumulativeDollars });
+		}
+		pruneOlderThan(nowMs - cfg.windowMs);
+	}
+
+	function check(nowMs: number): {
+		tripped: boolean;
+		metric: number;
+		threshold: number;
+	} {
+		pruneOlderThan(nowMs - cfg.windowMs);
+		if (state.samples.length < 2) {
+			return {
+				tripped: false,
+				metric: 0,
+				threshold: cfg.thresholdDollarsPerMin,
+			};
+		}
+		const first = state.samples[0];
+		const last = state.samples[state.samples.length - 1];
+		if (first === undefined || last === undefined) {
+			return {
+				tripped: false,
+				metric: 0,
+				threshold: cfg.thresholdDollarsPerMin,
+			};
+		}
+		const dollarsDelta = last.cumulativeDollars - first.cumulativeDollars;
+		const minutesDelta = (last.tMs - first.tMs) / 60_000;
+		if (minutesDelta <= 0) {
+			return {
+				tripped: false,
+				metric: 0,
+				threshold: cfg.thresholdDollarsPerMin,
+			};
+		}
+		const dollarsPerMin = dollarsDelta / minutesDelta;
+		state.lastDollarsPerMin = dollarsPerMin;
+		return {
+			tripped: dollarsPerMin >= cfg.thresholdDollarsPerMin,
+			metric: dollarsPerMin,
+			threshold: cfg.thresholdDollarsPerMin,
+		};
+	}
+
+	function reset(): void {
+		state.samples.length = 0;
+		state.lastDollarsPerMin = 0;
+	}
+
+	return { state, observe, check, reset };
+}

--- a/packages/core/src/anomaly/signals/token-rate.ts
+++ b/packages/core/src/anomaly/signals/token-rate.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * token-rate.ts — Token-rate anomaly signal.
+ *
+ * Buckets observed chunks into fixed-width windows (default 2 s) and counts
+ * tokens-per-second within each window. Trips when N consecutive windows
+ * exceed the configured threshold (default 500 tok/s, 3 windows).
+ *
+ * Brief spikes (1-2 hot windows) are ignored — only sustained runaway
+ * behavior trips the circuit.
+ */
+
+import type { TokenRateConfig } from "../types.js";
+
+export interface TokenRateSignalState {
+	/** Per-window tokens accumulated in the current bucket. */
+	currentWindowTokens: number;
+	/** Start time of the current window. */
+	currentWindowStartMs: number;
+	/** Number of consecutive completed windows that exceeded threshold. */
+	consecutiveHotWindows: number;
+	/** Last computed peak rate (for the most recently closed window). */
+	lastWindowRateTokPerSec: number;
+}
+
+export interface TokenRateSignal {
+	state: Readonly<TokenRateSignalState>;
+	/** Observe a chunk's delta tokens at time `nowMs`. */
+	observe(deltaTokens: number, nowMs: number): void;
+	/**
+	 * Check if the threshold has been crossed.
+	 * Returns the metric (peak window rate) when tripped, else null.
+	 */
+	check(nowMs: number): {
+		tripped: boolean;
+		metric: number;
+		threshold: number;
+		hotWindows: number;
+	};
+	reset(): void;
+}
+
+export interface ResolvedTokenRateConfig {
+	thresholdTokPerSec: number;
+	windowMs: number;
+	consecutiveWindows: number;
+}
+
+export const TOKEN_RATE_DEFAULTS: ResolvedTokenRateConfig = {
+	thresholdTokPerSec: 500,
+	windowMs: 2_000,
+	consecutiveWindows: 3,
+};
+
+export function resolveTokenRateConfig(cfg?: TokenRateConfig): ResolvedTokenRateConfig {
+	return {
+		thresholdTokPerSec: cfg?.thresholdTokPerSec ?? TOKEN_RATE_DEFAULTS.thresholdTokPerSec,
+		windowMs: cfg?.windowMs ?? TOKEN_RATE_DEFAULTS.windowMs,
+		consecutiveWindows: cfg?.consecutiveWindows ?? TOKEN_RATE_DEFAULTS.consecutiveWindows,
+	};
+}
+
+export function createTokenRateSignal(cfg: ResolvedTokenRateConfig): TokenRateSignal {
+	const state: TokenRateSignalState = {
+		currentWindowTokens: 0,
+		currentWindowStartMs: 0,
+		consecutiveHotWindows: 0,
+		lastWindowRateTokPerSec: 0,
+	};
+	let initialized = false;
+
+	function rollWindowsTo(nowMs: number): void {
+		// Roll forward: close completed windows, evaluate threshold, advance.
+		while (nowMs - state.currentWindowStartMs >= cfg.windowMs) {
+			const windowEndMs = state.currentWindowStartMs + cfg.windowMs;
+			const seconds = cfg.windowMs / 1_000;
+			const rate = state.currentWindowTokens / seconds;
+			state.lastWindowRateTokPerSec = rate;
+			if (rate >= cfg.thresholdTokPerSec) {
+				state.consecutiveHotWindows += 1;
+			} else {
+				state.consecutiveHotWindows = 0;
+			}
+			state.currentWindowStartMs = windowEndMs;
+			state.currentWindowTokens = 0;
+		}
+	}
+
+	function observe(deltaTokens: number, nowMs: number): void {
+		if (!initialized) {
+			state.currentWindowStartMs = nowMs;
+			initialized = true;
+		}
+		rollWindowsTo(nowMs);
+		state.currentWindowTokens += Math.max(0, deltaTokens);
+	}
+
+	function check(nowMs: number): {
+		tripped: boolean;
+		metric: number;
+		threshold: number;
+		hotWindows: number;
+	} {
+		if (!initialized) {
+			return {
+				tripped: false,
+				metric: 0,
+				threshold: cfg.thresholdTokPerSec,
+				hotWindows: 0,
+			};
+		}
+		rollWindowsTo(nowMs);
+		// Also evaluate the current (incomplete) window if it has surpassed threshold
+		// by enough margin to count: only if it would already be a "hot" window.
+		const elapsedMs = nowMs - state.currentWindowStartMs;
+		let inFlightHot = false;
+		let inFlightRate = 0;
+		if (elapsedMs > 0) {
+			inFlightRate = state.currentWindowTokens / (elapsedMs / 1_000);
+			// Only consider in-flight as "hot" once the window has accumulated meaningful
+			// data (>=50% elapsed) to avoid false positives from one large early chunk.
+			if (elapsedMs >= cfg.windowMs / 2 && inFlightRate >= cfg.thresholdTokPerSec) {
+				inFlightHot = true;
+			}
+		}
+		const effectiveHot = state.consecutiveHotWindows + (inFlightHot ? 1 : 0);
+		const tripped = effectiveHot >= cfg.consecutiveWindows;
+		const metric = Math.max(state.lastWindowRateTokPerSec, inFlightRate);
+		return {
+			tripped,
+			metric,
+			threshold: cfg.thresholdTokPerSec,
+			hotWindows: effectiveHot,
+		};
+	}
+
+	function reset(): void {
+		state.currentWindowTokens = 0;
+		state.currentWindowStartMs = 0;
+		state.consecutiveHotWindows = 0;
+		state.lastWindowRateTokPerSec = 0;
+		initialized = false;
+	}
+
+	return { state, observe, check, reset };
+}

--- a/packages/core/src/anomaly/types.ts
+++ b/packages/core/src/anomaly/types.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * anomaly/types.ts — Shared types for the streaming anomaly detector.
+ *
+ * The detector is a per-operation observer attached to a streaming LLM call.
+ * It receives `observe(event)` calls for each chunk, accumulates per-signal
+ * state, and `check()` returns a verdict. On a "trip" verdict, the caller
+ * should VOID the PENDING hold, throw `AnomalyError`, and emit a hash-chained
+ * `anomaly_detected` audit event.
+ */
+
+import type { LLMClientKind } from "../shared/types.js";
+
+// ── Anomaly kinds ──
+
+/** The three signal types the detector watches. */
+export type AnomalyKind = "token_rate" | "spend_velocity" | "injection_cascade";
+
+// ── Config ──
+
+/** Token-rate signal config. */
+export interface TokenRateConfig {
+	/** Threshold tokens-per-second above which a window is "hot". Default 500. */
+	thresholdTokPerSec?: number;
+	/** Window size in milliseconds. Default 2000. */
+	windowMs?: number;
+	/** Number of consecutive hot windows required to trip. Default 3. */
+	consecutiveWindows?: number;
+}
+
+/** Spend-velocity signal config. */
+export interface SpendVelocityConfig {
+	/** Maximum dollars per minute (rolling). Default 1.00. */
+	thresholdDollarsPerMin?: number;
+	/** Rolling window in milliseconds. Default 10000. */
+	windowMs?: number;
+}
+
+/** Injection-cascade signal config. */
+export interface InjectionCascadeConfig {
+	/** Number of injection events to trip. Default 3. */
+	eventCount?: number;
+	/** Window in milliseconds. Default 60000. */
+	windowMs?: number;
+}
+
+/** Top-level anomaly governance config (extends TrustConfig). */
+export interface AnomalyConfig {
+	/** Enable streaming anomaly detection. Default: false (opt-in). */
+	enabled?: boolean;
+	tokenRate?: TokenRateConfig;
+	spendVelocity?: SpendVelocityConfig;
+	injectionCascade?: InjectionCascadeConfig;
+	/** Cooldown after a trip before auto-reset. Default 30000 ms. */
+	cooldownMs?: number;
+}
+
+/** Resolved (defaulted) config used internally. */
+export interface ResolvedAnomalyConfig {
+	enabled: boolean;
+	tokenRate: Required<TokenRateConfig>;
+	spendVelocity: Required<SpendVelocityConfig>;
+	injectionCascade: Required<InjectionCascadeConfig>;
+	cooldownMs: number;
+}
+
+// ── Observation events ──
+
+/** Per-chunk observation passed to the detector. */
+export interface AnomalyChunkEvent {
+	kind: "chunk";
+	/** Tokens contained in this chunk (delta, not cumulative). */
+	deltaTokens: number;
+	/** Cumulative input tokens reported by provider so far (or last estimate). */
+	cumulativeInputTokens: number;
+	/** Cumulative output tokens reported by provider so far (or last estimate). */
+	cumulativeOutputTokens: number;
+	/** Wall-clock timestamp. Defaults to Date.now() if omitted. */
+	at?: number;
+}
+
+/** Out-of-band injection event (fired when detect.injection finds something). */
+export interface AnomalyInjectionEvent {
+	kind: "injection";
+	at?: number;
+	patterns?: string[];
+}
+
+export type AnomalyEvent = AnomalyChunkEvent | AnomalyInjectionEvent;
+
+// ── Verdicts ──
+
+/** Detector verdict after each observation or on demand. */
+export type AnomalyVerdict =
+	| { tripped: false }
+	| {
+			tripped: true;
+			kind: AnomalyKind;
+			message: string;
+			/** Numeric metric that crossed the threshold (e.g., 612.4 for tok/s). */
+			metric: number;
+			/** The configured threshold the metric crossed. */
+			threshold: number;
+	  };
+
+// ── Detector public surface ──
+
+export interface AnomalyDetectorOptions {
+	/** The provider kind being observed (used for audit/log context). */
+	provider?: LLMClientKind;
+	/** Model name being observed (used for cost calculation in spend-velocity). */
+	model?: string;
+	/** Override the cost calculator (for testing). Returns dollars for given tokens. */
+	costCalculator?: (model: string, inputTokens: number, outputTokens: number) => number;
+	/** Time source override (for deterministic tests). */
+	now?: () => number;
+}
+
+export interface AnomalyDetectorState {
+	/** Whether the detector is currently in a tripped state (post-trip, pre-cooldown). */
+	tripped: boolean;
+	/** When the trip occurred (ms since epoch), if tripped. */
+	trippedAt: number | null;
+	/** The kind that tripped, if tripped. */
+	trippedKind: AnomalyKind | null;
+}

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -48,7 +48,8 @@ import { DEFAULT_BUDGET, VAULT_DIR } from "./shared/constants.js";
 
 /** Base URL for receipt verification links (used in proxy mode). */
 const VERIFY_URL_BASE = "https://verify.usertrust.dev";
-import { LedgerUnavailableError, PolicyDeniedError } from "./shared/errors.js";
+import { createAnomalyDetector } from "./anomaly/detector.js";
+import { AnomalyError, LedgerUnavailableError, PolicyDeniedError } from "./shared/errors.js";
 import { trustId } from "./shared/ids.js";
 import { TrustConfigSchema } from "./shared/types.js";
 import type {
@@ -59,7 +60,7 @@ import type {
 	TrustReceipt,
 	TrustedResponse,
 } from "./shared/types.js";
-import { type StreamCompletion, createGovernedStream } from "./streaming.js";
+import { type ChunkObservation, type StreamCompletion, createGovernedStream } from "./streaming.js";
 
 // ── Public types ──
 
@@ -270,6 +271,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 	let inFlightStreamCount = 0; // AUD-462: track in-flight streams (consumed after interceptCall returns)
 	let inFlightHoldTotal = 0; // Track estimated cost of in-flight pending holds
 
+	// Streaming anomaly detector — shared across calls so injection-cascade
+	// can track signals across the conversation. Disabled when config.anomaly.enabled=false.
+	const anomalyDetector = createAnomalyDetector(config.anomaly, { provider: kind });
+
 	// 7. Two-phase intercept
 	async function interceptCall(
 		originalFn: (...args: unknown[]) => unknown,
@@ -366,6 +371,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 								},
 							})
 							.catch(() => {});
+						// Feed the anomaly detector so cascading injections trip the breaker.
+						anomalyDetector.observe({
+							kind: "injection",
+							patterns: injectionResult.patterns,
+						});
 					}
 				}
 
@@ -593,6 +603,45 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							}
 
 							inFlightStreamCount--;
+						},
+						// onChunk: streaming anomaly detector hook. Observe each chunk;
+						// if a signal trips, throw AnomalyError to abort the stream.
+						// The thrown error propagates through wrapStream's onError above
+						// → existing VOID flow runs → upstream caller sees AnomalyError.
+						(obs: ChunkObservation) => {
+							if (!config.anomaly.enabled) return;
+							anomalyDetector.observe({
+								kind: "chunk",
+								deltaTokens: obs.deltaTokens,
+								cumulativeInputTokens: obs.cumulativeInputTokens,
+								cumulativeOutputTokens: obs.cumulativeOutputTokens,
+							});
+							const verdict = anomalyDetector.check();
+							if (verdict.tripped) {
+								// Append hash-chained anomaly_detected audit event.
+								// Best-effort: do not block the abort if audit fails.
+								audit
+									.appendEvent({
+										kind: "anomaly_detected",
+										actor: "local",
+										data: {
+											anomalyKind: verdict.kind,
+											message: verdict.message,
+											metric: verdict.metric,
+											threshold: verdict.threshold,
+											model,
+											transferId,
+											provider: kind,
+										},
+									})
+									.catch(() => {});
+								throw new AnomalyError(
+									verdict.kind,
+									verdict.message,
+									verdict.metric,
+									verdict.threshold,
+								);
+							}
 						},
 					);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,7 @@ export {
 	SkillVerificationError,
 	VaultKeyMissingError,
 	CredentialAccessDeniedError,
+	AnomalyError,
 } from "./shared/errors.js";
 
 // Streaming
@@ -106,3 +107,21 @@ export type { BoardStats, BoardReviewResult } from "./board/board.js";
 // Circuit breaker
 export { CircuitBreaker, CircuitBreakerRegistry, CircuitOpenError } from "./resilience/circuit.js";
 export type { CircuitBreakerSnapshot } from "./resilience/circuit.js";
+
+// Streaming anomaly governance
+export { createAnomalyDetector, resolveAnomalyConfig } from "./anomaly/detector.js";
+export type { AnomalyDetector } from "./anomaly/detector.js";
+export type {
+	AnomalyChunkEvent,
+	AnomalyConfig,
+	AnomalyDetectorOptions,
+	AnomalyDetectorState,
+	AnomalyEvent,
+	AnomalyInjectionEvent,
+	AnomalyKind,
+	AnomalyVerdict,
+	InjectionCascadeConfig,
+	ResolvedAnomalyConfig,
+	SpendVelocityConfig,
+	TokenRateConfig,
+} from "./anomaly/types.js";

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -164,6 +164,32 @@ export class SkillVerificationError extends Error {
 	}
 }
 
+export class AnomalyError extends Error {
+	public readonly kind: "token_rate" | "spend_velocity" | "injection_cascade";
+	public readonly metric: number;
+	public readonly threshold: number;
+	public readonly hint: string;
+	public readonly docsUrl: string;
+
+	constructor(
+		kind: "token_rate" | "spend_velocity" | "injection_cascade",
+		message: string,
+		metric: number,
+		threshold: number,
+	) {
+		const hint =
+			"The streaming circuit breaker tripped on anomalous behavior. Tune anomaly thresholds in config or call detector.reset() to clear the trip.";
+		const docsUrl = "https://usertrust.ai/docs/errors/anomaly-detected";
+		super(`Anomaly detected (${kind}): ${message}\n\n  Hint: ${hint}\n  Docs: ${docsUrl}`);
+		this.name = "AnomalyError";
+		this.kind = kind;
+		this.metric = metric;
+		this.threshold = threshold;
+		this.hint = hint;
+		this.docsUrl = docsUrl;
+	}
+}
+
 export class VaultKeyMissingError extends Error {
 	public readonly envVar: string;
 	public readonly hint: string;

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -124,6 +124,31 @@ export const TrustConfigSchema = z.object({
 				.default({}),
 		})
 		.default({}),
+	anomaly: z
+		.object({
+			enabled: z.boolean().default(false),
+			tokenRate: z
+				.object({
+					thresholdTokPerSec: z.number().positive().default(500),
+					windowMs: z.number().int().positive().default(2_000),
+					consecutiveWindows: z.number().int().positive().default(3),
+				})
+				.default({}),
+			spendVelocity: z
+				.object({
+					thresholdDollarsPerMin: z.number().positive().default(1.0),
+					windowMs: z.number().int().positive().default(10_000),
+				})
+				.default({}),
+			injectionCascade: z
+				.object({
+					eventCount: z.number().int().positive().default(3),
+					windowMs: z.number().int().positive().default(60_000),
+				})
+				.default({}),
+			cooldownMs: z.number().int().nonnegative().default(30_000),
+		})
+		.default({}),
 });
 
 export type TrustConfig = z.infer<typeof TrustConfigSchema>;

--- a/packages/core/src/streaming.ts
+++ b/packages/core/src/streaming.ts
@@ -93,17 +93,38 @@ function extractTokensFromChunk(chunk: unknown, kind: LLMClientKind): StreamUsag
 // ── Stream wrapper ──
 
 /**
+ * Per-chunk hook called after token extraction but before yielding the chunk
+ * to the consumer. Throwing from this hook aborts the stream — onError will
+ * fire with the thrown value (this is how the anomaly detector trips a
+ * circuit breaker mid-stream).
+ *
+ * `delta` reflects the change in tokens compared to the previous chunk
+ * (cumulative reporting is normalised to a delta here).
+ */
+export interface ChunkObservation {
+	chunk: unknown;
+	deltaTokens: number;
+	cumulativeInputTokens: number;
+	cumulativeOutputTokens: number;
+}
+
+export type ChunkHook = (obs: ChunkObservation) => void;
+
+/**
  * Wraps a provider stream with token counting.
  * Yields all chunks unchanged. Calls onComplete with accumulated usage
- * when the stream ends, or onError on failure.
+ * when the stream ends, or onError on failure. An optional `onChunk` hook
+ * fires per chunk and can throw to abort the stream (used by the anomaly
+ * detector to trip a circuit breaker mid-stream).
  */
 export function wrapStream<T>(
 	stream: AsyncIterable<T>,
 	kind: LLMClientKind,
 	onComplete: (completion: StreamCompletion) => void,
 	onError: (error: unknown, partial: StreamCompletion) => void,
+	onChunk?: ChunkHook,
 ): AsyncIterable<T> {
-	return wrapStreamImpl(stream, kind, onComplete, onError);
+	return wrapStreamImpl(stream, kind, onComplete, onError, onChunk);
 }
 
 async function* wrapStreamImpl<T>(
@@ -111,6 +132,7 @@ async function* wrapStreamImpl<T>(
 	kind: LLMClientKind,
 	onComplete: (completion: StreamCompletion) => void,
 	onError: (error: unknown, partial: StreamCompletion) => void,
+	onChunk?: ChunkHook,
 ): AsyncGenerator<T> {
 	let inputTokens = 0;
 	let outputTokens = 0;
@@ -120,14 +142,28 @@ async function* wrapStreamImpl<T>(
 	try {
 		for await (const chunk of stream) {
 			const tokens = extractTokensFromChunk(chunk, kind);
+			let deltaInput = 0;
+			let deltaOutput = 0;
 			// Use latest non-zero value (providers report cumulative or final)
 			if (tokens.inputTokens > 0) {
+				deltaInput = Math.max(0, tokens.inputTokens - inputTokens);
 				inputTokens = tokens.inputTokens;
 				usageReported = true;
 			}
 			if (tokens.outputTokens > 0) {
+				deltaOutput = Math.max(0, tokens.outputTokens - outputTokens);
 				outputTokens = tokens.outputTokens;
 				usageReported = true;
+			}
+
+			// Run hook BEFORE yielding so a throw aborts before the consumer sees it.
+			if (onChunk != null) {
+				onChunk({
+					chunk,
+					deltaTokens: deltaInput + deltaOutput,
+					cumulativeInputTokens: inputTokens,
+					cumulativeOutputTokens: outputTokens,
+				});
 			}
 
 			yield chunk;
@@ -155,6 +191,7 @@ export function createGovernedStream<T>(
 	kind: LLMClientKind,
 	resolveReceipt: (completion: StreamCompletion) => Promise<TrustReceipt>,
 	rejectReceipt: (error: unknown, partial: StreamCompletion) => void,
+	onChunk?: ChunkHook,
 ): GovernedStream<T> {
 	let receiptResolve!: (receipt: TrustReceipt) => void;
 	let receiptReject!: (error: unknown) => void;
@@ -180,6 +217,7 @@ export function createGovernedStream<T>(
 			rejectReceipt(error, partial);
 			receiptReject(error);
 		},
+		onChunk,
 	);
 
 	return Object.assign(wrapped, {

--- a/packages/core/tests/anomaly/injection-cascade.test.ts
+++ b/packages/core/tests/anomaly/injection-cascade.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { createAnomalyDetector } from "../../src/anomaly/detector.js";
+
+describe("injection-cascade anomaly signal", () => {
+	it("trips on N injection events within window", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				injectionCascade: { eventCount: 3, windowMs: 60_000 },
+			},
+			{ now: () => nowMs },
+		);
+		nowMs = 1_000;
+		detector.observe({ kind: "injection", patterns: ["a"] });
+		nowMs = 2_000;
+		detector.observe({ kind: "injection", patterns: ["b"] });
+		expect(detector.check()).toEqual({ tripped: false });
+
+		nowMs = 3_000;
+		detector.observe({ kind: "injection", patterns: ["c"] });
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("injection_cascade");
+			expect(verdict.metric).toBe(3);
+			expect(verdict.threshold).toBe(3);
+		}
+	});
+
+	it("cleans up older events outside window", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				injectionCascade: { eventCount: 3, windowMs: 10_000 },
+				cooldownMs: 0, // disable cooldown lock
+			},
+			{ now: () => nowMs },
+		);
+		// 2 injections at t=0, 1s
+		nowMs = 0;
+		detector.observe({ kind: "injection" });
+		nowMs = 1_000;
+		detector.observe({ kind: "injection" });
+
+		// Advance past window
+		nowMs = 12_000;
+		// Only one new injection — outside window, should not trip
+		detector.observe({ kind: "injection" });
+		const v = detector.check();
+		expect(v.tripped).toBe(false);
+	});
+
+	it("does NOT trip when injections are spaced beyond window", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				injectionCascade: { eventCount: 3, windowMs: 5_000 },
+			},
+			{ now: () => nowMs },
+		);
+		// Spaced 10s apart — never more than 1 in window
+		nowMs = 0;
+		detector.observe({ kind: "injection" });
+		nowMs = 10_000;
+		detector.observe({ kind: "injection" });
+		nowMs = 20_000;
+		detector.observe({ kind: "injection" });
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(false);
+	});
+
+	it("stays disabled when enabled=false", () => {
+		const nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				injectionCascade: { eventCount: 1, windowMs: 1_000 },
+			},
+			{ now: () => nowMs },
+		);
+		detector.observe({ kind: "injection" });
+		detector.observe({ kind: "injection" });
+		expect(detector.check()).toEqual({ tripped: false });
+	});
+});

--- a/packages/core/tests/anomaly/integration.test.ts
+++ b/packages/core/tests/anomaly/integration.test.ts
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import { type TrustEngine, trust } from "../../src/govern.js";
+import { AnomalyError } from "../../src/shared/errors.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+// Mock tigerbeetle-node (native module, never loaded in tests)
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: {
+		linked: 1,
+		pending: 2,
+		post_pending_transfer: 4,
+		void_pending_transfer: 8,
+	},
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Helpers ──
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `trust-anomaly-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function makeMockEngine(overrides?: Partial<TrustEngine>): TrustEngine {
+	return {
+		spendPending: vi.fn(async (params: { transferId: string; amount: number }) => ({
+			transferId: params.transferId,
+		})),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		destroy: vi.fn(),
+		...overrides,
+	};
+}
+
+function makeMockAudit(overrides?: Partial<AuditWriter>): AuditWriter {
+	const events: AppendEventInput[] = [];
+	let prevHash = "0".repeat(64);
+	return {
+		appendEvent: vi.fn(async (input: AppendEventInput): Promise<AuditEvent> => {
+			events.push(input);
+			// Simulate hash chaining: each event's hash includes the previous hash.
+			const hash = `${prevHash.slice(0, 60)}${events.length.toString(16).padStart(4, "0")}`;
+			const event: AuditEvent = {
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: prevHash,
+				hash,
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			};
+			prevHash = hash;
+			return event;
+		}),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+		...overrides,
+	};
+}
+
+/**
+ * A "runaway" Anthropic stream that emits very high token rates.
+ * Each chunk reports cumulative output_tokens that grow rapidly.
+ * Optional `delayMs` injects a small inter-chunk delay so wall-clock time
+ * advances enough for the detector windows to roll. When 0, all chunks
+ * arrive in the same microsecond and the detector trips on in-flight rate.
+ */
+function makeRunawayStreamMock(totalChunks: number, tokensPerChunk: number, delayMs = 0) {
+	return {
+		messages: {
+			create: vi.fn(async () => {
+				async function* gen() {
+					yield {
+						type: "message_start",
+						message: { usage: { input_tokens: 50 } },
+					};
+					let cumulative = 0;
+					for (let i = 0; i < totalChunks; i++) {
+						cumulative += tokensPerChunk;
+						yield {
+							type: "content_block_delta",
+							delta: { text: "x".repeat(tokensPerChunk) },
+						};
+						yield {
+							type: "message_delta",
+							usage: { output_tokens: cumulative },
+						};
+						if (delayMs > 0) {
+							await new Promise<void>((r) => setTimeout(r, delayMs));
+						}
+					}
+				}
+				return gen();
+			}),
+		},
+	};
+}
+
+function makeNormalStreamMock() {
+	return {
+		messages: {
+			create: vi.fn(async () => {
+				async function* gen() {
+					yield { type: "message_start", message: { usage: { input_tokens: 10 } } };
+					yield { type: "content_block_delta", delta: { text: "hi" } };
+					yield { type: "message_delta", usage: { output_tokens: 5 } };
+				}
+				return gen();
+			}),
+		},
+	};
+}
+
+// ── Tests ──
+
+describe("Anomaly governance integration", () => {
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = makeTmpVault();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("opt-in: when anomaly.enabled is false (default), behavior is unchanged", async () => {
+		// Use a runaway stream that WOULD trip if enabled
+		const engine = makeMockEngine();
+		const mockAudit = makeMockAudit();
+		const mockClient = makeRunawayStreamMock(50, 200);
+
+		const governed = await trust(mockClient, {
+			dryRun: false,
+			budget: 50_000_000,
+			vaultBase: tmpVault,
+			_engine: engine,
+			_audit: mockAudit,
+			// No anomaly opts → default disabled
+		});
+
+		const result = await governed.messages.create({
+			model: "claude-sonnet-4-6",
+			max_tokens: 1024,
+			messages: [{ role: "user", content: "Hello" }],
+		});
+
+		// Stream should fully consume without throwing
+		const stream = result.response as AsyncIterable<unknown>;
+		const collected: unknown[] = [];
+		for await (const chunk of stream) {
+			collected.push(chunk);
+		}
+		expect(collected.length).toBeGreaterThan(0);
+
+		// Wait for the async settlement after stream completion.
+		await (result.response as { receipt: Promise<unknown> }).receipt;
+
+		// No anomaly_detected audit event should have been emitted
+		const calls = (mockAudit.appendEvent as ReturnType<typeof vi.fn>).mock.calls as Array<
+			[AppendEventInput]
+		>;
+		const anomalyEvents = calls.filter(([e]) => e.kind === "anomaly_detected");
+		expect(anomalyEvents).toHaveLength(0);
+
+		// VOID was NOT called
+		expect(engine.voidPendingSpend).not.toHaveBeenCalled();
+		// POST was called
+		expect(engine.postPendingSpend).toHaveBeenCalledOnce();
+
+		await governed.destroy();
+	});
+
+	it(
+		"runaway stream trips token-rate anomaly: VOID + AnomalyError + audit event emitted",
+		{ timeout: 15_000 },
+		async () => {
+			// Anomaly opts go through the config file (TrustOpts has no anomaly field —
+			// it would expand the public surface). Write a config file with low
+			// thresholds so a synthetic runaway stream trips immediately.
+			const fs = await import("node:fs");
+			const path = await import("node:path");
+			const vaultDir = path.join(tmpVault, ".usertrust");
+			fs.mkdirSync(vaultDir, { recursive: true });
+			fs.writeFileSync(
+				path.join(vaultDir, "usertrust.config.json"),
+				JSON.stringify({
+					budget: 50_000_000,
+					anomaly: {
+						enabled: true,
+						tokenRate: {
+							thresholdTokPerSec: 10, // any rate will trip
+							windowMs: 100,
+							consecutiveWindows: 1,
+						},
+						// Disable the other signals so we know which one tripped.
+						spendVelocity: { thresholdDollarsPerMin: 1_000_000 },
+						injectionCascade: { eventCount: 1_000_000 },
+						cooldownMs: 60_000,
+					},
+				}),
+			);
+
+			const engine2 = makeMockEngine();
+			const audit2 = makeMockAudit();
+			// Delay 30ms between chunks so two 100ms windows complete with high tokens.
+			const mockClient2 = makeRunawayStreamMock(30, 1_000, 30);
+
+			const governed2 = await trust(mockClient2, {
+				vaultBase: tmpVault,
+				_engine: engine2,
+				_audit: audit2,
+			});
+
+			const result = await governed2.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 1024,
+				messages: [{ role: "user", content: "Tell me a story" }],
+			});
+
+			// Attach a no-op catch to the receipt promise immediately so the rejection
+			// (which fires synchronously when the stream throws) is handled before
+			// node's unhandledRejection sniffer fires.
+			const receiptP = (result.response as { receipt: Promise<unknown> }).receipt;
+			receiptP.catch(() => {});
+
+			const stream = result.response as AsyncIterable<unknown>;
+			let caught: unknown = null;
+			try {
+				for await (const _chunk of stream) {
+					// consume
+				}
+			} catch (err) {
+				caught = err;
+			}
+
+			// Stream should have aborted with AnomalyError
+			expect(caught).toBeInstanceOf(AnomalyError);
+			if (caught instanceof AnomalyError) {
+				expect(caught.kind).toBe("token_rate");
+				expect(caught.metric).toBeGreaterThan(0);
+			}
+
+			// Wait for async callbacks (audit + void)
+			await new Promise<void>((r) => setTimeout(r, 100));
+
+			// Audit should contain anomaly_detected event
+			const calls = (audit2.appendEvent as ReturnType<typeof vi.fn>).mock.calls as Array<
+				[AppendEventInput]
+			>;
+			const anomalyEvent = calls.find(([e]) => e.kind === "anomaly_detected");
+			expect(anomalyEvent).toBeDefined();
+			if (anomalyEvent) {
+				const data = anomalyEvent[0].data as Record<string, unknown>;
+				expect(data.anomalyKind).toBe("token_rate");
+				expect(typeof data.metric).toBe("number");
+				expect(typeof data.threshold).toBe("number");
+			}
+
+			// VOID should have been called (PENDING hold released)
+			expect(engine2.voidPendingSpend).toHaveBeenCalledOnce();
+			// POST should NOT have been called
+			expect(engine2.postPendingSpend).not.toHaveBeenCalled();
+
+			// Receipt promise should reject
+			await expect(receiptP).rejects.toBeInstanceOf(AnomalyError);
+
+			await governed2.destroy();
+		},
+	);
+
+	it("normal stream does NOT trip when anomaly is enabled with normal thresholds", async () => {
+		const fs = await import("node:fs");
+		const path = await import("node:path");
+		const vaultDir = path.join(tmpVault, ".usertrust");
+		fs.mkdirSync(vaultDir, { recursive: true });
+		fs.writeFileSync(
+			path.join(vaultDir, "usertrust.config.json"),
+			JSON.stringify({
+				budget: 50_000,
+				anomaly: {
+					enabled: true,
+					// In synthetic streams chunks arrive in microseconds, so the rolling
+					// rate is artificially huge. Use generous thresholds so a normal
+					// completion never trips.
+					tokenRate: { thresholdTokPerSec: 1_000_000 },
+					spendVelocity: { thresholdDollarsPerMin: 1_000_000 },
+				},
+			}),
+		);
+
+		const engine = makeMockEngine();
+		const mockAudit = makeMockAudit();
+		const mockClient = makeNormalStreamMock();
+
+		const governed = await trust(mockClient, {
+			vaultBase: tmpVault,
+			_engine: engine,
+			_audit: mockAudit,
+		});
+
+		const result = await governed.messages.create({
+			model: "claude-sonnet-4-6",
+			max_tokens: 1024,
+			messages: [{ role: "user", content: "Hi" }],
+		});
+
+		const stream = result.response as AsyncIterable<unknown>;
+		const collected: unknown[] = [];
+		for await (const chunk of stream) {
+			collected.push(chunk);
+		}
+		expect(collected.length).toBe(3);
+
+		await (result.response as { receipt: Promise<unknown> }).receipt;
+		const calls = (mockAudit.appendEvent as ReturnType<typeof vi.fn>).mock.calls as Array<
+			[AppendEventInput]
+		>;
+		const anomalyEvent = calls.find(([e]) => e.kind === "anomaly_detected");
+		expect(anomalyEvent).toBeUndefined();
+		expect(engine.postPendingSpend).toHaveBeenCalledOnce();
+		expect(engine.voidPendingSpend).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+});

--- a/packages/core/tests/anomaly/spend-velocity.test.ts
+++ b/packages/core/tests/anomaly/spend-velocity.test.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { createAnomalyDetector } from "../../src/anomaly/detector.js";
+
+describe("spend-velocity anomaly signal", () => {
+	it("trips when $/min exceeds threshold", () => {
+		let nowMs = 0;
+		// Fixed cost calculator: returns the cumulative output tokens as dollars
+		const costCalc = (_m: string, _i: number, output: number) => output;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				spendVelocity: { thresholdDollarsPerMin: 1.0, windowMs: 10_000 },
+			},
+			{ now: () => nowMs, costCalculator: costCalc, model: "test" },
+		);
+		// Push $0.20 over 10 seconds = $1.20/min — over threshold
+		for (let t = 0; t <= 10_000; t += 1_000) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 0,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 1_000) * 0.02, // $0.02 per second = $1.20/min
+			});
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("spend_velocity");
+			expect(verdict.metric).toBeGreaterThanOrEqual(1.0);
+		}
+	});
+
+	it("does NOT trip when spend rate is below threshold", () => {
+		let nowMs = 0;
+		const costCalc = (_m: string, _i: number, output: number) => output;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				spendVelocity: { thresholdDollarsPerMin: 1.0, windowMs: 10_000 },
+			},
+			{ now: () => nowMs, costCalculator: costCalc, model: "test" },
+		);
+		// $0.05 over 10s → $0.30/min — under threshold
+		for (let t = 0; t <= 10_000; t += 1_000) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 0,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 1_000) * 0.005,
+			});
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(false);
+	});
+
+	it("rolling window discards stale samples", () => {
+		let nowMs = 0;
+		const costCalc = (_m: string, _i: number, output: number) => output;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				spendVelocity: { thresholdDollarsPerMin: 1.0, windowMs: 10_000 },
+			},
+			{ now: () => nowMs, costCalculator: costCalc, model: "test" },
+		);
+		// First push high spend at t=0..2000
+		for (let t = 0; t <= 2_000; t += 100) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 0,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 100) * 0.1, // huge
+			});
+		}
+		// Wait until past the window — only one stale sample left
+		nowMs = 30_000;
+		// Push another sample with slow rate
+		detector.observe({
+			kind: "chunk",
+			deltaTokens: 0,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: 2.1, // very small delta from clamped boundary
+		});
+		nowMs = 35_000;
+		detector.observe({
+			kind: "chunk",
+			deltaTokens: 0,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: 2.11,
+		});
+
+		const verdict = detector.check();
+		// With ~$0.01 over 5s ≈ $0.12/min — below 1.0
+		expect(verdict.tripped).toBe(false);
+	});
+
+	it("cooldown auto-resets after configured ms", () => {
+		let nowMs = 0;
+		const costCalc = (_m: string, _i: number, output: number) => output;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				spendVelocity: { thresholdDollarsPerMin: 1.0, windowMs: 5_000 },
+				cooldownMs: 5_000,
+			},
+			{ now: () => nowMs, costCalculator: costCalc, model: "test" },
+		);
+		// Trip
+		for (let t = 0; t <= 5_000; t += 500) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 0,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 1_000) * 0.05,
+			});
+		}
+		expect(detector.isTripped()).toBe(true);
+
+		// Advance past cooldown
+		nowMs = 5_000 + 5_001;
+		expect(detector.isTripped()).toBe(false);
+	});
+
+	it("ignores negative or NaN cumulative values", () => {
+		let nowMs = 0;
+		const costCalc = (_m: string, _i: number, output: number) => output;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				spendVelocity: { thresholdDollarsPerMin: 1.0, windowMs: 10_000 },
+			},
+			{ now: () => nowMs, costCalculator: costCalc, model: "test" },
+		);
+		nowMs = 0;
+		detector.observe({
+			kind: "chunk",
+			deltaTokens: 0,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: Number.NaN,
+		});
+		nowMs = 1_000;
+		detector.observe({
+			kind: "chunk",
+			deltaTokens: 0,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: -5,
+		});
+		const v = detector.check();
+		expect(v.tripped).toBe(false);
+	});
+});

--- a/packages/core/tests/anomaly/token-rate.test.ts
+++ b/packages/core/tests/anomaly/token-rate.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { createAnomalyDetector } from "../../src/anomaly/detector.js";
+
+describe("token-rate anomaly signal", () => {
+	it("does not trip when disabled (default off)", () => {
+		const detector = createAnomalyDetector(undefined, { now: () => 0 });
+		// Even at huge rate, default config has enabled=false
+		for (let i = 0; i < 100; i++) {
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 10_000,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: i * 10_000,
+				at: i * 10,
+			});
+		}
+		expect(detector.check()).toEqual({ tripped: false });
+	});
+
+	it("trips on sustained high-rate chunks (3 consecutive 2s windows above 500 tok/s)", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 500, windowMs: 2_000, consecutiveWindows: 3 },
+			},
+			{ now: () => nowMs },
+		);
+		// Emit 1500 tokens per 2s window for 7 seconds — well above 500 tok/s.
+		// Spread chunks every 100ms. 1500 tokens / 2s = 750 tok/s.
+		for (let t = 0; t <= 7_000; t += 100) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 75,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 100) * 75,
+			});
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("token_rate");
+			expect(verdict.metric).toBeGreaterThanOrEqual(500);
+		}
+	});
+
+	it("does NOT trip on a brief spike (1-2 hot windows then quiet)", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 500, windowMs: 2_000, consecutiveWindows: 3 },
+			},
+			{ now: () => nowMs },
+		);
+		// First 2s window: 2000 tokens → 1000 tok/s (HOT)
+		for (let i = 0; i < 20; i++) {
+			nowMs = i * 100;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 100,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (i + 1) * 100,
+			});
+		}
+		// Next 4s: silence → consecutive resets to 0
+		for (let t = 2_000; t <= 6_000; t += 100) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 0,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: 2_000,
+			});
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(false);
+	});
+
+	it("tripped state persists across check() calls until reset()", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 100, windowMs: 1_000, consecutiveWindows: 1 },
+				cooldownMs: 60_000,
+			},
+			{ now: () => nowMs },
+		);
+		// Push 200 tokens in 1s → 200 tok/s, well above 100.
+		for (let i = 0; i < 10; i++) {
+			nowMs = i * 100;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 20,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (i + 1) * 20,
+			});
+		}
+		nowMs = 1_500;
+		// Trigger window roll-over with one more chunk
+		detector.observe({
+			kind: "chunk",
+			deltaTokens: 0,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: 200,
+		});
+
+		const v1 = detector.check();
+		expect(v1.tripped).toBe(true);
+		const v2 = detector.check();
+		expect(v2.tripped).toBe(true);
+
+		detector.reset();
+		const v3 = detector.check();
+		expect(v3.tripped).toBe(false);
+	});
+
+	it("auto-recovers after cooldownMs", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 100, windowMs: 1_000, consecutiveWindows: 1 },
+				cooldownMs: 5_000,
+			},
+			{ now: () => nowMs },
+		);
+		// Trip the detector
+		for (let i = 0; i < 10; i++) {
+			nowMs = i * 100;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 20,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (i + 1) * 20,
+			});
+		}
+		nowMs = 1_500;
+		detector.observe({
+			kind: "chunk",
+			deltaTokens: 0,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: 200,
+		});
+		expect(detector.isTripped()).toBe(true);
+
+		// Advance past cooldown
+		nowMs = 1_500 + 5_001;
+		expect(detector.isTripped()).toBe(false);
+		expect(detector.check()).toEqual({ tripped: false });
+	});
+});


### PR DESCRIPTION
## Summary

Adds **real-time anomaly governance** to the existing usertrust streaming pipeline — a new module under `packages/core/src/anomaly/` that watches mid-stream signals and trips a circuit breaker (VOID the PENDING hold + abort the stream + throw \`AnomalyError\`) when rogue agent behavior is detected.

This is genuinely additive: zero behavior change when disabled (default), and the existing 1397-test suite continues to pass.

## What

Three signal detectors, each independently configurable:

| Signal | Default threshold | What it catches |
|---|---|---|
| **Token rate** | 500 tok/s sustained over 3 consecutive 2s windows | Looping / runaway generation |
| **Spend velocity** | \$1.00 / minute rolling over 10s | Cost burn spikes |
| **Injection cascade** | 3 \`injection_detected\` events in 60s | Sustained adversarial pressure |

On trip:

1. \`AnomalyError(kind, message, metric, threshold)\` is thrown — propagates through \`wrapStream\`'s \`onError\` to existing VOID flow
2. PENDING hold is VOIDed via the existing two-phase lifecycle
3. \`anomaly_detected\` audit event is appended to the SHA-256 hash-chained audit trail
4. Detector enters configurable cooldown (default 30s) and auto-resets

A manual \`detector.reset()\` is also available.

## Why

Existing governance (budget, injection, PII) is **pre-call**. This adds **mid-stream** governance for failure modes you can't catch at call boundaries — runaway loops that blow through tokens, sudden cost spikes, and cascades of injection attempts within a conversation.

## How to enable

Opt-in via config — all defaults preserve current behavior:

\`\`\`json
{
  "anomaly": {
    "enabled": true,
    "tokenRate":        { "thresholdTokPerSec": 500, "windowMs": 2000, "consecutiveWindows": 3 },
    "spendVelocity":    { "thresholdDollarsPerMin": 1.0, "windowMs": 10000 },
    "injectionCascade": { "eventCount": 3, "windowMs": 60000 },
    "cooldownMs": 30000
  }
}
\`\`\`

## Files touched

**New:**
- \`packages/core/src/anomaly/index.ts\` — public exports
- \`packages/core/src/anomaly/detector.ts\` — \`AnomalyDetector\` core
- \`packages/core/src/anomaly/types.ts\` — config + verdict types
- \`packages/core/src/anomaly/signals/{token-rate,spend-velocity,injection-cascade}.ts\` — per-signal modules
- \`packages/core/tests/anomaly/{token-rate,spend-velocity,injection-cascade,integration}.test.ts\` — 17 tests

**Wired into existing pipeline (additive):**
- \`packages/core/src/streaming.ts\` — added optional \`onChunk\` hook to \`wrapStream\`/\`createGovernedStream\`. Throwing aborts the stream.
- \`packages/core/src/govern.ts\` — instantiates an \`AnomalyDetector\` per trusted client; feeds chunk + injection events; throws \`AnomalyError\` from the chunk hook on trip; emits hash-chained \`anomaly_detected\` audit.
- \`packages/core/src/shared/types.ts\` — added \`anomaly\` block to \`TrustConfigSchema\`.
- \`packages/core/src/shared/errors.ts\` — added \`AnomalyError\` (matches existing error class pattern).
- \`packages/core/src/index.ts\` — exports \`AnomalyError\`, \`AnomalyConfig\`, \`createAnomalyDetector\`, related types.

## Test plan

- [x] \`npx tsc -b --noEmit\` passes
- [x] \`npx biome check\` clean on touched files
- [x] All 17 anomaly tests pass (5 token-rate, 5 spend-velocity, 4 injection-cascade, 3 integration)
- [x] Full suite passes: 1397 / 1397 (no regressions)
- [x] Default-off behavior verified: integration test with runaway stream + \`enabled=false\` settles normally with no anomaly events
- [x] Hash-chained audit verified: \`anomaly_detected\` events flow through existing \`audit.appendEvent\`
- [x] Two-phase TigerBeetle lifecycle preserved: trip → VOID, no POST

## Notes

- \`AnomalyError\` extends the existing usertrust error pattern (name, hint, docsUrl)
- Detector is **shared across calls** of one trusted client so \`injection_cascade\` can track signals across a conversation
- \`onChunk\` hook fires *before* the chunk is yielded to the consumer — a thrown error reliably aborts before downstream sees the chunk
- No new external dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)