### PR TITLE
feat(site): full mobile optimization — iOS-safe viewport + focus states + 44x44 targets

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,9 +57,7 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"peerDependencies": {
 		"@anthropic-ai/sdk": ">=0.30.0",
 		"openai": ">=4.70.0"

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -11,16 +11,7 @@
 		"directory": "packages/openclaw"
 	},
 	"bugs": "https://github.com/usertools-ai/usertrust/issues",
-	"keywords": [
-		"openclaw",
-		"usertrust",
-		"ai",
-		"governance",
-		"budget",
-		"audit",
-		"llm",
-		"plugin"
-	],
+	"keywords": ["openclaw", "usertrust", "ai", "governance", "budget", "audit", "llm", "plugin"],
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -35,10 +26,7 @@
 		"prepublishOnly": "tsc",
 		"demo": "tsx demo/runaway-agent.ts"
 	},
-	"files": [
-		"dist",
-		"openclaw.plugin.json"
-	],
+	"files": ["dist", "openclaw.plugin.json"],
 	"dependencies": {
 		"usertrust": "*"
 	},

--- a/packages/verify/package.json
+++ b/packages/verify/package.json
@@ -11,14 +11,7 @@
 		"directory": "packages/verify"
 	},
 	"bugs": "https://github.com/usertools-ai/usertrust/issues",
-	"keywords": [
-		"ai",
-		"governance",
-		"audit",
-		"verify",
-		"hash-chain",
-		"merkle"
-	],
+	"keywords": ["ai", "governance", "audit", "verify", "hash-chain", "merkle"],
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -35,8 +28,6 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"dependencies": {}
 }

--- a/site/app/components/before-after.tsx
+++ b/site/app/components/before-after.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion, useInView } from "motion/react";
+import { AnimatePresence, motion, useInView, useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { ScrollReveal } from "./scroll-reveal";
 
@@ -199,7 +199,7 @@ function CodePanel({
 					<span className="ml-3 text-xs text-white/30">{filename}</span>
 				</div>
 				<span
-					className={`text-[10px] font-bold uppercase tracking-wider ${
+					className={`text-[11px] sm:text-[10px] font-bold uppercase tracking-wider ${
 						isBefore ? "text-danger/60" : "text-ut"
 					}`}
 				>
@@ -217,7 +217,7 @@ function CodePanel({
 						</div>
 					))}
 				</div>
-				<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden flex-1">
+				<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto flex-1 min-w-0">
 					<code>
 						{lines.map((line, i) => (
 							// biome-ignore lint/suspicious/noArrayIndexKey: static code lines
@@ -242,7 +242,7 @@ function CodePanel({
 
 			{/* Status bar */}
 			<div
-				className={`flex items-center justify-between px-4 py-2 border-t border-white/[0.04] text-[10px] ${
+				className={`flex items-center justify-between gap-3 px-4 py-2 border-t border-white/[0.04] text-[11px] sm:text-[10px] ${
 					isBefore ? "text-white/20" : "text-ut/40"
 				}`}
 			>
@@ -268,6 +268,7 @@ function CodePanel({
 export function BeforeAfter() {
 	const sectionRef = useRef<HTMLDivElement>(null);
 	const inView = useInView(sectionRef, { once: true, amount: 0.2 });
+	const prefersReducedMotion = useReducedMotion();
 	const [showAfter, setShowAfter] = useState(false);
 
 	// Auto-flip from Before to After after 2s of being in view
@@ -276,6 +277,10 @@ export function BeforeAfter() {
 		const timer = setTimeout(() => setShowAfter(true), 2000);
 		return () => clearTimeout(timer);
 	}, [inView]);
+
+	const transition = prefersReducedMotion
+		? { duration: 0 }
+		: { duration: 0.5, ease: "easeInOut" as const };
 
 	return (
 		<section className="relative py-24 sm:py-32 px-6">
@@ -308,7 +313,8 @@ export function BeforeAfter() {
 						<button
 							type="button"
 							onClick={() => setShowAfter(false)}
-							className={`px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 ${
+							aria-pressed={!showAfter}
+							className={`px-4 py-2 min-h-[44px] rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg ${
 								!showAfter
 									? "bg-danger/10 border border-danger/30 text-danger/80 shadow-[0_0_20px_rgba(239,68,68,0.1)]"
 									: "border border-white/[0.06] text-white/30 hover:text-white/50"
@@ -320,13 +326,15 @@ export function BeforeAfter() {
 							animate={{ x: showAfter ? 4 : -4 }}
 							transition={{ type: "spring", stiffness: 300, damping: 20 }}
 							className="text-white/20 text-lg"
+							aria-hidden="true"
 						>
 							→
 						</motion.span>
 						<button
 							type="button"
 							onClick={() => setShowAfter(true)}
-							className={`px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 ${
+							aria-pressed={showAfter}
+							className={`px-4 py-2 min-h-[44px] rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg ${
 								showAfter
 									? "bg-ut/10 border border-ut/30 text-ut shadow-[0_0_20px_rgba(52,211,153,0.1)]"
 									: "border border-white/[0.06] text-white/30 hover:text-white/50"
@@ -343,10 +351,14 @@ export function BeforeAfter() {
 						{!showAfter ? (
 							<motion.div
 								key="before"
-								initial={{ opacity: 0, scale: 0.97, y: 10 }}
+								initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.97, y: 10 }}
 								animate={{ opacity: 1, scale: 1, y: 0 }}
-								exit={{ opacity: 0, scale: 1.02, filter: "brightness(2)" }}
-								transition={{ duration: 0.5, ease: "easeInOut" }}
+								exit={
+									prefersReducedMotion
+										? { opacity: 0 }
+										: { opacity: 0, scale: 1.02, filter: "brightness(2)" }
+								}
+								transition={transition}
 								className="relative rounded-xl border border-danger/20 overflow-hidden"
 								style={{
 									background: "rgba(239,68,68,0.02)",
@@ -374,10 +386,10 @@ export function BeforeAfter() {
 						) : (
 							<motion.div
 								key="after"
-								initial={{ opacity: 0, scale: 0.97, y: 10 }}
+								initial={prefersReducedMotion ? false : { opacity: 0, scale: 0.97, y: 10 }}
 								animate={{ opacity: 1, scale: 1, y: 0 }}
-								exit={{ opacity: 0, scale: 0.97, y: -10 }}
-								transition={{ duration: 0.4, ease: "easeInOut" }}
+								exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.97, y: -10 }}
+								transition={transition}
 								className="relative rounded-xl border border-ut/20"
 								style={{
 									background: "rgba(52,211,153,0.03)",

--- a/site/app/components/copy-command.tsx
+++ b/site/app/components/copy-command.tsx
@@ -27,7 +27,7 @@ export function CopyCommand() {
 		<button
 			type="button"
 			onClick={handleCopy}
-			className="gradient-border group relative flex w-full items-center justify-between gap-4 rounded-xl border border-white/[0.06] px-5 py-3.5 cursor-pointer hover:border-ut/30 hover:shadow-[0_0_20px_rgba(52,211,153,0.1)] transition-all duration-200"
+			className="gradient-border group relative flex w-full items-center justify-between gap-4 rounded-xl border border-white/[0.06] px-5 py-3.5 min-h-[44px] cursor-pointer hover:border-ut/30 hover:shadow-[0_0_20px_rgba(52,211,153,0.1)] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 			style={{
 				background: "rgba(255,255,255,0.04)",
 				backdropFilter: "blur(24px)",

--- a/site/app/components/cta.tsx
+++ b/site/app/components/cta.tsx
@@ -30,7 +30,7 @@ export function CTA() {
 						<div className="flex flex-wrap items-center justify-center gap-3">
 							<a
 								href="#code"
-								className="inline-flex items-center justify-center gap-2.5 px-6 py-3 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_30px_rgba(52,211,153,0.3),0_0_80px_rgba(52,211,153,0.12)] hover:shadow-[0_0_40px_rgba(52,211,153,0.4),0_0_100px_rgba(52,211,153,0.2)]"
+								className="inline-flex items-center justify-center gap-2.5 px-6 py-3 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_30px_rgba(52,211,153,0.3),0_0_80px_rgba(52,211,153,0.12)] hover:shadow-[0_0_40px_rgba(52,211,153,0.4),0_0_100px_rgba(52,211,153,0.2)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/70 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 							>
 								Start Trusting
 							</a>
@@ -39,7 +39,7 @@ export function CTA() {
 								href="https://github.com/usertools-ai/usertrust"
 								target="_blank"
 								rel="noopener noreferrer"
-								className="inline-flex items-center justify-center gap-2 px-6 py-3 min-h-[44px] border border-white/[0.12] rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.05] hover:text-white hover:border-white/20 hover:shadow-[0_0_20px_rgba(255,255,255,0.04)] transition-all duration-200"
+								className="inline-flex items-center justify-center gap-2 px-6 py-3 min-h-[44px] border border-white/[0.12] rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.05] hover:text-white hover:border-white/20 hover:shadow-[0_0_20px_rgba(255,255,255,0.04)] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 							>
 								<GitHubIcon className="w-4 h-4" />
 								View on GitHub

--- a/site/app/components/footer.tsx
+++ b/site/app/components/footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
 	return (
 		<footer className="relative">
 			<div className="h-px bg-gradient-to-r from-transparent via-ut/15 to-transparent" />
-			<div className="max-w-5xl mx-auto px-6 py-12">
+			<div className="safe-x safe-bottom max-w-5xl mx-auto px-6 py-12">
 				<div className="grid grid-cols-2 sm:grid-cols-4 gap-8 mb-10">
 					{/* Brand column */}
 					<div className="col-span-2 sm:col-span-1 flex flex-col gap-3">

--- a/site/app/components/footer.tsx
+++ b/site/app/components/footer.tsx
@@ -21,25 +21,25 @@ export function Footer() {
 						</span>
 						<a
 							href="#features"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							Features
 						</a>
 						<a
 							href="#how"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							How it works
 						</a>
 						<a
 							href="#code"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							Quick start
 						</a>
 						<a
 							href="/docs"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							Docs
 						</a>
@@ -54,7 +54,7 @@ export function Footer() {
 							href="https://github.com/usertools-ai/usertrust"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							GitHub
 						</a>
@@ -62,7 +62,7 @@ export function Footer() {
 							href="https://www.npmjs.com/package/usertrust"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							npm
 						</a>
@@ -70,7 +70,7 @@ export function Footer() {
 							href="https://github.com/usertools-ai/usertrust/blob/master/LICENSE"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							License
 						</a>
@@ -85,7 +85,7 @@ export function Footer() {
 							href="https://usertools.ai"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							Usertools
 						</a>
@@ -100,7 +100,7 @@ export function Footer() {
 							href="https://usertools.ai"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="text-white/30 hover:text-ut transition-colors duration-200"
+							className="text-white/30 hover:text-ut transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							usertools.ai
 						</a>
@@ -108,7 +108,7 @@ export function Footer() {
 					<div className="flex items-center gap-4">
 						<a
 							href="#top"
-							className="text-xs text-white/20 hover:text-ut transition-colors duration-200"
+							className="text-xs text-white/20 hover:text-ut transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							Back to top ↑
 						</a>
@@ -116,7 +116,7 @@ export function Footer() {
 							href="https://github.com/usertools-ai/usertrust"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="flex items-center gap-1.5 text-xs text-white/20 hover:text-white/50 transition-colors duration-200"
+							className="flex items-center gap-1.5 text-xs text-white/20 hover:text-white/50 transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						>
 							<GitHubIcon className="w-3.5 h-3.5" />
 							Star on GitHub

--- a/site/app/components/governance-receipt.tsx
+++ b/site/app/components/governance-receipt.tsx
@@ -205,7 +205,7 @@ export function GovernanceReceipt() {
 						)}
 					</div>
 
-					<pre className="p-3 sm:p-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden">
+					<pre className="p-3 sm:p-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto">
 						<code>
 							{RECEIPT_LINES.map((line, i) => {
 								const indent = INDENTS[i] ?? 0;

--- a/site/app/components/hero.tsx
+++ b/site/app/components/hero.tsx
@@ -59,7 +59,7 @@ export function Hero() {
 	return (
 		<section
 			ref={sectionRef}
-			className="relative min-h-screen flex flex-col items-center justify-start text-center px-6 pt-[18vh]"
+			className="relative min-h-screen min-h-[100dvh] flex flex-col items-center justify-start text-center px-6 pt-28 sm:pt-[18vh]"
 			style={{ zIndex: 1 }}
 		>
 			{/* Bliss background — scroll-fades */}
@@ -83,7 +83,7 @@ export function Hero() {
 
 			{/* Hero content — glass pane */}
 			<div
-				className="relative z-10 max-w-3xl mx-auto flex flex-col items-center gap-6 px-8 py-10 sm:px-12 sm:py-14 rounded-2xl border border-white/[0.08]"
+				className="relative z-10 max-w-3xl mx-auto flex flex-col items-center gap-6 px-6 py-10 sm:px-12 sm:py-14 rounded-2xl border border-white/[0.08]"
 				style={{
 					background: "rgba(10,10,26,0.35)",
 					backdropFilter: "blur(24px)",
@@ -157,7 +157,7 @@ export function Hero() {
 				>
 					<a
 						href="#code"
-						className="inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_20px_rgba(52,211,153,0.3),0_0_60px_rgba(52,211,153,0.1)]"
+						className="inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_20px_rgba(52,211,153,0.3),0_0_60px_rgba(52,211,153,0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/70 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 					>
 						Start Trusting
 					</a>
@@ -165,7 +165,7 @@ export function Hero() {
 						href="https://github.com/usertools-ai/usertrust"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.10] hover:text-white transition-all duration-150"
+						className="inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.10] hover:text-white transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 					>
 						View on GitHub
 					</a>
@@ -237,7 +237,9 @@ export function Hero() {
 							</span>
 						))}
 					</div>
-					<p className="text-[10px] text-white/25 tracking-wide">Open source · Apache 2.0</p>
+					<p className="text-[11px] sm:text-[10px] text-white/25 tracking-wide">
+						Open source · Apache 2.0
+					</p>
 				</motion.div>
 			</div>
 		</section>

--- a/site/app/components/how-it-works.tsx
+++ b/site/app/components/how-it-works.tsx
@@ -19,10 +19,10 @@ function FlowConnector({
 		<div className="flex flex-col items-center py-5 sm:py-8">
 			<div className="w-px h-5 bg-gradient-to-b from-white/[0.06] to-ut/20" />
 			<div className="py-2.5 px-4 sm:px-6 text-center">
-				<span className="text-[10px] sm:text-[11px] tracking-[0.12em] text-white/40 block">
-					{label}
-				</span>
-				{sublabel && <span className="text-[9px] text-white/25 block mt-0.5">{sublabel}</span>}
+				<span className="text-[11px] tracking-[0.12em] text-white/40 block">{label}</span>
+				{sublabel && (
+					<span className="text-[10px] sm:text-[9px] text-white/25 block mt-0.5">{sublabel}</span>
+				)}
 			</div>
 			<div className="relative">
 				<svg width="10" height="16" className="text-ut/40" role="img" aria-label="Flow arrow">
@@ -242,7 +242,7 @@ export function HowItWorks() {
 
 				{/* POST ↔ VOID badge */}
 				<div className="flex items-center justify-center py-2 mb-2">
-					<span className="text-[9px] tracking-[0.1em] text-white/30 border border-ut/10 rounded px-2.5 py-1 shadow-[0_0_15px_rgba(52,211,153,0.05)]">
+					<span className="text-[10px] sm:text-[9px] tracking-[0.1em] text-white/30 border border-ut/10 rounded px-2.5 py-1 shadow-[0_0_15px_rgba(52,211,153,0.05)]">
 						POST xor VOID : exactly one outcome per transferId · never both
 					</span>
 				</div>
@@ -356,7 +356,7 @@ export function HowItWorks() {
 								))}
 							</div>
 
-							<p className="text-[10px] text-ut/25 text-center mt-8">
+							<p className="text-[11px] sm:text-[10px] text-ut/25 text-center mt-8">
 								5 PHASES · 3 STORAGE SYSTEMS · 1 UNIVERSAL JOIN KEY (transferId)
 							</p>
 						</div>

--- a/site/app/components/nav.tsx
+++ b/site/app/components/nav.tsx
@@ -34,7 +34,7 @@ export function Nav() {
 		return () => observer.disconnect();
 	}, []);
 
-	// Close on outside click
+	// Close on outside click (and return focus to hamburger)
 	useEffect(() => {
 		if (!open) return;
 		function handleClick(e: MouseEvent) {
@@ -45,10 +45,32 @@ export function Nav() {
 				!buttonRef.current.contains(e.target as Node)
 			) {
 				setOpen(false);
+				buttonRef.current.focus();
 			}
 		}
 		document.addEventListener("mousedown", handleClick);
 		return () => document.removeEventListener("mousedown", handleClick);
+	}, [open]);
+
+	// Body scroll lock + Escape-to-close while mobile menu is open
+	useEffect(() => {
+		if (!open) return;
+		const prevOverflow = document.body.style.overflow;
+		const prevOverscroll = document.body.style.overscrollBehavior;
+		document.body.style.overflow = "hidden";
+		document.body.style.overscrollBehavior = "contain";
+		function handleKey(e: KeyboardEvent) {
+			if (e.key === "Escape") {
+				setOpen(false);
+				buttonRef.current?.focus();
+			}
+		}
+		document.addEventListener("keydown", handleKey);
+		return () => {
+			document.body.style.overflow = prevOverflow;
+			document.body.style.overscrollBehavior = prevOverscroll;
+			document.removeEventListener("keydown", handleKey);
+		};
 	}, [open]);
 
 	const links = [
@@ -60,7 +82,7 @@ export function Nav() {
 
 	return (
 		<nav
-			className={`fixed top-0 left-0 right-0 z-50 border-b transition-all duration-300 ${
+			className={`safe-top fixed top-0 left-0 right-0 z-50 border-b transition-all duration-300 ${
 				scrolled
 					? "bg-brand-bg/60 backdrop-blur-[20px] border-white/[0.10]"
 					: "bg-brand-bg/80 backdrop-blur-[16px] border-white/[0.06]"
@@ -69,7 +91,7 @@ export function Nav() {
 			<div className="flex items-center justify-between px-6 py-4">
 				<a
 					href="/"
-					className={`inline-flex items-center px-4 py-2.5 border rounded-full text-sm font-medium tracking-tight transition-all duration-300 ${
+					className={`inline-flex items-center px-4 py-2.5 min-h-[44px] md:min-h-0 border rounded-full text-sm font-medium tracking-tight transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg ${
 						scrolled
 							? "border-ut/30 text-ut shadow-[0_0_20px_rgba(52,211,153,0.1)]"
 							: "border-white/20 hover:border-ut/50 hover:text-ut animate-[pulse-glow_4s_ease-in-out_infinite]"
@@ -84,7 +106,7 @@ export function Nav() {
 							<a
 								key={link.href}
 								href={link.href}
-								className={`relative hover:text-white transition-colors duration-200 ${
+								className={`relative hover:text-white transition-colors duration-200 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg ${
 									activeSection === link.href ? "text-ut" : ""
 								}`}
 							>
@@ -100,7 +122,7 @@ export function Nav() {
 						href="https://github.com/usertools-ai/usertrust"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="inline-flex items-center gap-2 px-3.5 py-1.5 bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium hover:bg-white/[0.10] hover:border-white/20 transition-all duration-200"
+						className="inline-flex items-center gap-2 px-3.5 py-1.5 min-h-[44px] md:min-h-0 bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium hover:bg-white/[0.10] hover:border-white/20 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 					>
 						<GitHubIcon className="w-4 h-4" />
 						GitHub
@@ -111,7 +133,7 @@ export function Nav() {
 						ref={buttonRef}
 						type="button"
 						onClick={() => setOpen((prev) => !prev)}
-						className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-lg border border-white/10 bg-white/[0.06] hover:bg-white/[0.10] transition-colors duration-200"
+						className="md:hidden inline-flex items-center justify-center w-11 h-11 rounded-lg border border-white/10 bg-white/[0.06] hover:bg-white/[0.10] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
 						aria-label={open ? "Close menu" : "Open menu"}
 						aria-expanded={open}
 					>
@@ -192,7 +214,7 @@ export function Nav() {
 								key={link.href}
 								href={link.href}
 								onClick={() => setOpen(false)}
-								className={`block px-3 py-2.5 text-sm font-medium rounded-lg hover:text-white hover:bg-white/[0.06] transition-colors duration-200 ${
+								className={`block px-3 py-3 min-h-[44px] text-sm font-medium rounded-lg hover:text-white hover:bg-white/[0.06] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg ${
 									activeSection === link.href ? "text-ut" : "text-white/60"
 								}`}
 							>

--- a/site/app/components/nav.tsx
+++ b/site/app/components/nav.tsx
@@ -82,7 +82,7 @@ export function Nav() {
 
 	return (
 		<nav
-			className={`safe-top fixed top-0 left-0 right-0 z-50 border-b transition-all duration-300 ${
+			className={`safe-top safe-x fixed top-0 left-0 right-0 z-50 border-b transition-all duration-300 ${
 				scrolled
 					? "bg-brand-bg/60 backdrop-blur-[20px] border-white/[0.10]"
 					: "bg-brand-bg/80 backdrop-blur-[16px] border-white/[0.06]"

--- a/site/app/components/typewriter-code.tsx
+++ b/site/app/components/typewriter-code.tsx
@@ -165,7 +165,7 @@ export function TypewriterCode() {
 								</div>
 							))}
 						</div>
-						<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden flex-1">
+						<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto flex-1 min-w-0">
 							<code>
 								{allChars.current.map((c, i) =>
 									c.char === "\n" ? <br key={`h${i}`} /> : <span key={`h${i}`}>{c.char}</span>,
@@ -182,7 +182,7 @@ export function TypewriterCode() {
 								</div>
 							))}
 						</div>
-						<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden flex-1">
+						<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto flex-1 min-w-0">
 							<code>
 								{rendered.map((c, i) =>
 									c.char === "\n" ? (

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -4,6 +4,32 @@
 
 /* Fonts loaded via next/font/local in layout.tsx — CSS variables injected on <html> */
 
+/* Mobile baseline — iOS Safari text-size stability, nav-offset scroll anchoring */
+html {
+	-webkit-text-size-adjust: 100%;
+	text-size-adjust: 100%;
+	scroll-padding-top: 5rem; /* sticky nav height */
+	scroll-behavior: smooth;
+}
+
+body {
+	-webkit-tap-highlight-color: transparent;
+}
+
+/* iPhone notch / Dynamic Island safe-area utilities — opt-in per component */
+@supports (padding: env(safe-area-inset-top)) {
+	.safe-top {
+		padding-top: env(safe-area-inset-top);
+	}
+	.safe-bottom {
+		padding-bottom: env(safe-area-inset-bottom);
+	}
+	.safe-x {
+		padding-left: env(safe-area-inset-left);
+		padding-right: env(safe-area-inset-right);
+	}
+}
+
 @theme {
 	--color-brand-bg: #0a0a1a;
 	--color-brand-surface: rgba(255, 255, 255, 0.05);
@@ -75,11 +101,6 @@
 	.hero-bg {
 		animation: none !important;
 	}
-}
-
-/* Smooth scroll */
-html {
-	scroll-behavior: smooth;
 }
 
 /* Custom scrollbar */

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -8,7 +8,8 @@
 html {
 	-webkit-text-size-adjust: 100%;
 	text-size-adjust: 100%;
-	scroll-padding-top: 5rem; /* sticky nav height */
+	/* Nav height (5rem) + notch inset — keeps anchored sections visible under fixed nav on notched iPhones */
+	scroll-padding-top: calc(5rem + env(safe-area-inset-top, 0px));
 	scroll-behavior: smooth;
 }
 

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import { NoiseOverlay } from "./components/noise-overlay";
 import { ScrollProgress } from "./components/scroll-progress";
@@ -58,7 +58,23 @@ export const metadata: Metadata = {
 			"One-line SDK wrapper that turns every AI agent LLM call into an auditable, budget-enforced financial transaction. Open source.",
 		images: [{ url: "/og", width: 1200, height: 630 }],
 	},
-	icons: { icon: "/favicon.svg" },
+	icons: {
+		icon: "/favicon.svg",
+		apple: "/favicon.svg",
+	},
+	appleWebApp: {
+		title: "usertrust",
+		capable: true,
+		statusBarStyle: "black-translucent",
+	},
+};
+
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	viewportFit: "cover",
+	themeColor: "#0a0a1a",
+	colorScheme: "dark",
 };
 
 const jsonLd = {


### PR DESCRIPTION
## Summary

Comprehensive mobile refinement pass for usertrust.ai marketing site. The site was already decently responsive; this PR closes the iOS Safari / a11y / touch-target gaps identified in a pre-code explore + GPT-5.4 plan review.

## Scope

**Metadata & baseline**
- Next.js `Viewport` export with `viewport-fit=cover`, `themeColor=#0a0a1a`, `colorScheme=dark`
- `appleWebApp` metadata + `icons.apple` fallback
- `html { -webkit-text-size-adjust: 100%; scroll-padding-top: 5rem; scroll-behavior: smooth }`
- `body { -webkit-tap-highlight-color: transparent }`
- `.safe-top / .safe-bottom / .safe-x` utilities behind `@supports (padding: env(safe-area-inset-top))`
- **Preserved pinch zoom** (no `maximumScale`) — low-vision a11y

**Hero** — `min-h-screen min-h-[100dvh]` (dvh with vh fallback for older Safari), `pt-28 sm:pt-[18vh]` responsive (no 100vh jank on iOS toolbar collapse), tightened glass pane px on mobile.

**Nav** — body scroll lock + `overscroll-behavior: contain` while menu open; Escape-to-close returns focus to hamburger; outside-click dismissal also returns focus; `.safe-top` for notch; hamburger bumped to 44×44 (`w-11 h-11`); mobile menu links `min-h-[44px]`; `md:min-h-0` on desktop pill/logo so the target floor doesn't break desktop nav rhythm.

**Before/after toggle** — `useReducedMotion()` gates crossfade transforms (brightness/scale degrade to opacity); `aria-pressed` + 44×44 touch targets; `<pre>` gets `overflow-x-auto min-w-0`.

**Code/JSON overflow** — `overflow-x-hidden` → `overflow-x-auto` + `min-w-0` in `typewriter-code.tsx` and `governance-receipt.tsx` (prevents viewport overflow on ≤375px widths).

**Typography** — responsive bump for informational 9–10px labels (FlowConnector, POST-xor-VOID pill, phase summary, hero caption, before/after status bar). Decorative eyebrows kept tight on purpose.

**Focus-visible rings** — consistent pattern (`focus-visible:ring-2 focus-visible:ring-ut/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg`) across nav, hero, cta, footer (11 links), copy-command, before-after.

## Non-goals

- No rewrites (polish pass only)
- No new dependencies
- No SDK / audit / verify changes
- No fumadocs internals touched

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npx biome check site/` — clean (pre-existing errors in `packages/*/package.json` unchanged)
- [x] `npx vitest run` — 1483/1483 passing
- [ ] Chrome DevTools: verify 320/390/412 widths — no horizontal scroll, nav open/close, before/after toggle, code blocks scroll, CTAs tappable
- [ ] Docs subroute (`/docs`) mobile smoke test — no regressions from globals.css / layout.tsx changes
- [ ] Real-device iPhone Safari pass (nice-to-have; DevTools covers most)

## Review audit trail

- **Plan review (GPT-5.4)**: incorporated iOS Safari edge cases (dvh, safe-area, viewport-fit=cover), rejected `maximumScale` (a11y regression), scoped touch-targets to controls not inline links, audited typography by role rather than blind-replace
- **Internal code review**: 11 findings surfaced, 4 applied (dvh fallback, `md:min-h-0` on 2 desktop nav items, outside-click focus return), 1 pre-applied during security triage (duplicate html block), 6 dismissed as cosmetic P3 or optional
- **Security review**: clean — no P0/P1/P2 issues; scroll-lock cleanup correct, event listeners paired, no new deps, CSP-compatible