### PR TITLE
fix(ci): biome --write after npm version in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,12 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "### Release v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
 
+      # ── Re-format package.json after bump (biome) ──
+      # npm version produces multi-line keywords/files arrays that fail biome.
+      # Auto-format so master stays lint-clean after release.
+      - name: Format package.json after bump
+        run: npx biome check . --write
+
       # ── Build ──
       - name: Build usertrust
         run: cd packages/core && npx tsc


### PR DESCRIPTION
## Summary
- Adds a `Format package.json after bump` step to `.github/workflows/publish.yml`
- Runs `npx biome check . --write` between version bump and build steps
- Stops the recurring biome lint failure on every PR after release

## Why
`npm version` rewrites `keywords` and `files` arrays as multi-line. Biome wants single-line. After each release commit, master is lint-broken until the next PR fixes it. Seen on v1.2.5, v1.3.0.

## Test plan
- [ ] Trigger Release workflow in dry-run mode: `gh workflow run Release -f version=patch -f dry_run=true` and confirm the new step succeeds
- [ ] Next real release: verify package.json arrays stay single-line in the resulting commit

## Files changed
- `.github/workflows/publish.yml` (+5/-0)