### PR TITLE
feat(release): add usertrust-server and usertrust-acs-adapter to the npm lockstep

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,8 @@ jobs:
             cd packages/core && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
             cd packages/verify && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
             cd packages/openclaw && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
+            cd packages/server && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
+            cd packages/acs-adapter && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
           fi
           VERSION=$(node -p 'require("./packages/core/package.json").version')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -92,10 +94,16 @@ jobs:
       - name: Build usertrust-openclaw
         run: cd packages/openclaw && npx tsc
 
+      - name: Build usertrust-server
+        run: cd packages/server && npx tsc -b
+
+      - name: Build usertrust-acs-adapter
+        run: cd packages/acs-adapter && npx tsc -b
+
       # ── Verify builds ──
       - name: Verify dist directories exist
         run: |
-          for pkg in core verify openclaw; do
+          for pkg in core verify openclaw server acs-adapter; do
             if [ ! -d "packages/${pkg}/dist" ]; then
               echo "::error::packages/${pkg}/dist not found after build"
               exit 1
@@ -114,7 +122,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          for entry in core:usertrust verify:usertrust-verify openclaw:usertrust-openclaw; do
+          for entry in core:usertrust verify:usertrust-verify openclaw:usertrust-openclaw server:usertrust-server acs-adapter:usertrust-acs-adapter; do
             dir="${entry%%:*}"; pkg="${entry##*:}"
             version=$(node -p "require('./packages/${dir}/package.json').version")
             if [ -n "$(npm view "${pkg}@${version}" version 2>/dev/null || true)" ]; then
@@ -133,6 +141,8 @@ jobs:
           echo "- usertrust@${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- usertrust-verify@${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- usertrust-openclaw@${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- usertrust-server@${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- usertrust-acs-adapter@${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
 
       # ── Tag + commit version bump ──
       - name: Commit and tag

--- a/packages/acs-adapter/package.json
+++ b/packages/acs-adapter/package.json
@@ -1,11 +1,32 @@
 {
 	"name": "usertrust-acs-adapter",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "ACS/AGT composite-evaluator adapter: external policy decides, the usertrust ledger reserves",
 	"license": "Apache-2.0",
+	"author": "Usertools, Inc. <hello@usertools.ai> (https://usertrust.ai)",
+	"homepage": "https://usertrust.ai",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/usertools-ai/usertrust.git",
+		"directory": "packages/acs-adapter"
+	},
+	"bugs": "https://github.com/usertools-ai/usertrust/issues",
+	"keywords": ["ai", "governance", "agent", "acs", "agt", "policy", "adapter"],
 	"type": "module",
 	"main": "dist/index.js",
-	"exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-	"scripts": { "build": "tsc -b" },
-	"dependencies": { "usertrust": "*" }
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"scripts": {
+		"build": "tsc -b",
+		"prepublishOnly": "tsc -b"
+	},
+	"files": ["dist"],
+	"dependencies": {
+		"usertrust": "*"
+	}
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,12 +1,36 @@
 {
 	"name": "usertrust-server",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "Self-hostable HTTP control plane for the usertrust governance kernel",
 	"license": "Apache-2.0",
+	"author": "Usertools, Inc. <hello@usertools.ai> (https://usertrust.ai)",
+	"homepage": "https://usertrust.ai",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/usertools-ai/usertrust.git",
+		"directory": "packages/server"
+	},
+	"bugs": "https://github.com/usertools-ai/usertrust/issues",
+	"keywords": ["ai", "governance", "llm", "agent", "server", "self-hosted", "control-plane"],
 	"type": "module",
 	"main": "dist/index.js",
-	"bin": { "usertrust-server": "dist/cli/main.js" },
-	"exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } },
-	"scripts": { "build": "tsc -b" },
-	"dependencies": { "usertrust": "*", "zod": "^3.23.0" }
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"types": "./dist/index.d.ts"
+		}
+	},
+	"bin": {
+		"usertrust-server": "./dist/cli/main.js"
+	},
+	"scripts": {
+		"build": "tsc -b",
+		"prepublishOnly": "tsc -b"
+	},
+	"files": ["dist"],
+	"dependencies": {
+		"usertrust": "*",
+		"zod": "^3.23.0"
+	}
 }


### PR DESCRIPTION
## Summary

Prepares `usertrust-server` and `usertrust-acs-adapter` for their first npm publication and wires both into the lockstep Release workflow. Both names are confirmed free on the registry (npm view returns E404 / not found for each).

### package.json (server + acs-adapter)
Added the publish metadata the already-published packages (`core`, `verify`) carry and these two lacked, mirroring the existing conventions exactly:
- `author`, `homepage`, `repository` (with `directory`), `bugs`
- `keywords`
- top-level `types`
- `prepublishOnly` (mirrors each package's `build`, i.e. `tsc -b`)
- `files: ["dist"]` to scope the tarball to compiled output
- Bumped both `version` to **1.4.0** to join the current lockstep set (`core`/`verify` are at 1.4.0).

No `engines` field was added — neither `core` nor `verify` has one, so mirroring the convention means omitting it. `packages/claude-code-plugin` was left untouched (stays private).

### .github/workflows/publish.yml
`server` and `acs-adapter` added to every stage of the Release workflow:
- **Bump versions** loop
- **Build** steps — using `npx tsc -b` (not plain `tsc`) because both use TypeScript project references (`references: [{ path: "../core" }]`)
- **Verify dist directories exist** loop
- **Publish packages** loop (`server:usertrust-server acs-adapter:usertrust-acs-adapter`), ordered after `core` so the `usertrust` dependency is on-registry first
- **Dry run summary** list

## Test plan

Run from the worktree against this branch:

| Check | Result |
| --- | --- |
| `npm view usertrust-server` / `usertrust-acs-adapter` | E404 — both names free |
| `npx tsc -b` | exit 0 |
| `npx biome check .` | exit 0 (290 files) |
| `npx vitest run` | 1753 passed / 129 files, 0 failures |
| `npm pack --dry-run` (server) | 30 files: `README.md` + `dist/` + `package.json`; no `src/`/`tests/` |
| `npm pack --dry-run` (acs-adapter) | 22 files: `README.md` + `dist/` + `package.json`; no `src/`/`tests/` |

Neither tarball includes a LICENSE file, matching the existing `core`/`verify` convention (no package-level LICENSE exists; the root LICENSE is not pulled into a subdirectory package).

## Notes
- Draft — not for merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)