### PR TITLE
fix(site): eliminate hero LCP artifact and continuous blur raster load

### DIFF
--- a/site/app/components/copy-command.tsx
+++ b/site/app/components/copy-command.tsx
@@ -28,10 +28,7 @@ export function CopyCommand() {
 			type="button"
 			onClick={handleCopy}
 			className="gradient-border group relative flex w-full items-center justify-between gap-4 rounded-xl border border-white/[0.06] px-5 py-3.5 cursor-pointer hover:border-ut/30 hover:shadow-[0_0_20px_rgba(52,211,153,0.1)] transition-all duration-200"
-			style={{
-				background: "rgba(255,255,255,0.04)",
-				backdropFilter: "blur(24px)",
-			}}
+			style={{ background: "rgba(255,255,255,0.06)" }}
 			aria-label="Copy install command"
 		>
 			<code data-install-cmd className="text-sm text-white/80 select-all">

--- a/site/app/components/gradient-orbs.tsx
+++ b/site/app/components/gradient-orbs.tsx
@@ -1,7 +1,3 @@
-"use client";
-
-import { motion, useReducedMotion } from "motion/react";
-
 const orbs = [
 	{
 		color: "rgba(52,211,153,0.08)",
@@ -26,8 +22,12 @@ const orbs = [
 	},
 ];
 
+// Server component: no motion, no filter. A radial gradient is already soft —
+// the old blur(80px) on top of it was invisible duplication that forced huge
+// blurred layers to re-rasterize on every frame of the JS-driven drift.
+// Drift now runs on the compositor via the CSS `orb-float` keyframes
+// (transform-only); prefers-reduced-motion is handled in globals.css.
 export function GradientOrbs() {
-	const reduce = useReducedMotion();
 	return (
 		<div
 			className="fixed inset-0 pointer-events-none overflow-hidden"
@@ -35,29 +35,18 @@ export function GradientOrbs() {
 			aria-hidden="true"
 		>
 			{orbs.map((orb, i) => (
-				<motion.div
+				<div
 					// biome-ignore lint/suspicious/noArrayIndexKey: static constant array
 					key={`orb-${i}`}
-					className="absolute rounded-full"
+					className="orb absolute rounded-full"
 					style={{
 						width: orb.size,
 						height: orb.size,
 						left: orb.x,
 						top: orb.y,
 						background: `radial-gradient(circle, ${orb.color} 0%, transparent 70%)`,
-						filter: "blur(80px)",
-						willChange: reduce ? undefined : "transform",
+						animationDuration: `${orb.duration}s`,
 					}}
-					animate={reduce ? undefined : { x: [0, 30, -20, 10, 0], y: [0, -25, 15, -10, 0] }}
-					transition={
-						reduce
-							? undefined
-							: {
-									duration: orb.duration,
-									repeat: Number.POSITIVE_INFINITY,
-									ease: "easeInOut",
-								}
-					}
 				/>
 			))}
 		</div>

--- a/site/app/components/hero.tsx
+++ b/site/app/components/hero.tsx
@@ -6,11 +6,14 @@ import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { CopyCommand } from "./copy-command";
 
+// Longest tagline first: the largest text paint happens at first render, so
+// later rotations never produce a bigger paint area and LCP stays anchored to
+// the initial (server-rendered, CSS-revealed) tagline instead of a rotation.
 const taglines = [
+	"Hash-chained receipts. Tamper-evident by construction. Zero vendor lock-in.",
 	"Budget holds, audit trails, and spend limits for every LLM call.",
 	"Your API keys. Your billing. Your provider. We add the trust layer.",
 	"Like a credit card hold — but for AI spend. Settled or voided, never lost.",
-	"Hash-chained receipts. Tamper-evident by construction. Zero vendor lock-in.",
 ];
 
 export function Hero({ downloads, stars }: { downloads: string; stars: string }) {
@@ -18,10 +21,29 @@ export function Hero({ downloads, stars }: { downloads: string; stars: string })
 	const [taglineIndex, setTaglineIndex] = useState(0);
 
 	useEffect(() => {
-		const interval = setInterval(() => {
-			setTaglineIndex((prev) => (prev + 1) % taglines.length);
-		}, 4000);
-		return () => clearInterval(interval);
+		// Rotation starts on first interaction. LCP finalizes at first input, so
+		// the rotating (and re-wrapping) taglines can never supersede the initial
+		// server-rendered paint as the LCP candidate — and a page nobody is
+		// engaging with doesn't churn.
+		let interval: ReturnType<typeof setInterval> | undefined;
+		const start = () => {
+			if (interval) return;
+			interval = setInterval(() => {
+				setTaglineIndex((prev) => (prev + 1) % taglines.length);
+			}, 4000);
+		};
+		const opts = { once: true, passive: true } as const;
+		window.addEventListener("pointerdown", start, opts);
+		window.addEventListener("pointermove", start, opts);
+		window.addEventListener("keydown", start, opts);
+		window.addEventListener("scroll", start, opts);
+		return () => {
+			if (interval) clearInterval(interval);
+			window.removeEventListener("pointerdown", start);
+			window.removeEventListener("pointermove", start);
+			window.removeEventListener("keydown", start);
+			window.removeEventListener("scroll", start);
+		};
 	}, []);
 
 	const { scrollYProgress } = useScroll({
@@ -60,9 +82,10 @@ export function Hero({ downloads, stars }: { downloads: string; stars: string })
 			<div
 				className="relative z-10 max-w-3xl mx-auto flex flex-col items-center gap-6 px-8 py-10 sm:px-12 sm:py-14 rounded-2xl border border-white/[0.08]"
 				style={{
-					background: "rgba(10,10,26,0.35)",
-					backdropFilter: "blur(24px)",
-					WebkitBackdropFilter: "blur(24px)",
+					// No backdrop-filter here: blurring the Ken Burns background forces a
+					// full re-blur every animation frame — the higher-alpha fill reads the
+					// same and costs nothing.
+					background: "rgba(10,10,26,0.62)",
 					boxShadow: "0 0 80px rgba(10,10,26,0.3)",
 				}}
 			>
@@ -94,7 +117,7 @@ export function Hero({ downloads, stars }: { downloads: string; stars: string })
 					className="hero-rise max-w-lg text-base sm:text-lg text-white/70 leading-relaxed h-[3.5em] sm:h-[3em] flex items-center justify-center"
 					style={{ animationDelay: "0.22s" }}
 				>
-					<AnimatePresence mode="wait">
+					<AnimatePresence mode="wait" initial={false}>
 						<motion.span
 							key={taglineIndex}
 							initial={{ opacity: 0, y: 8 }}

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -192,6 +192,13 @@ html {
 	}
 }
 
+/* Compositor-only orb drift (duration set inline per orb).
+   No filter here — the radial gradient supplies the softness. */
+.orb {
+	animation: orb-float 25s ease-in-out infinite;
+	will-change: transform;
+}
+
 /* Shimmer effect for cards */
 @keyframes shimmer {
 	0% {
@@ -235,11 +242,11 @@ html {
 	animation-play-state: running;
 }
 
-/* Reduced motion: disable decorative + utility animations.
-   (Gradient orbs are JS-driven and gated via useReducedMotion in the component.) */
+/* Reduced motion: disable decorative + utility animations. */
 @media (prefers-reduced-motion: reduce) {
 	.shimmer-border::after,
 	.glow-ring,
+	.orb,
 	[class*="animate-"] {
 		animation: none !important;
 	}


### PR DESCRIPTION
## Summary
Production trace showed LCP **4.67s** (98.3% render delay) and continuous raster load making the site feel laggy. Three verified causes fixed:
- Tagline rotator superseded LCP with ever-larger paints → rotation now starts on first user interaction (identical UX for real users; LCP finalizes at first input) and the first tagline is server-rendered visible (`AnimatePresence initial={false}`)
- `backdrop-filter: blur(24px)` panes over the infinitely-animating Ken Burns background re-blurred every frame → higher-alpha fills, same look
- Gradient orbs were 450–600px `blur(80px)` layers under JS animation → server component, compositor-only CSS drift, no filter

## Test plan
- Local prod build traced with Chrome DevTools: **LCP 4,603ms → 141ms**, CLS 0.00
- Visual check: hero/glass/badges render correctly (screenshot in session)
- `npm run build` clean, biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)