### PR TITLE
feat: first-class local-model governance (M2) — classify, meter nominally, govern honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Loopback/local endpoints now settle at nominal local rates instead of silently
+billing frontier fallback.** Before, a free `llama3.3:70b` call against
+`http://localhost:11434/v1` was priced like an unknown cloud model at
+sonnet-class `FALLBACK_RATE` — and a streamed call settled on the pre-call
+estimate (~615 usertokens of fake dollars per $0 stream). Local endpoints are
+now classified as their own settlement scope and meter at `local.defaultRate`
+(default `{0,0}` + the per-call `>=1` floor = exactly 1 nominal usertoken per
+call), so free inference stays **inside** budget, anomaly, and audit governance
+instead of being exempted from it.
+
+### Added
+
+- **First-class local-model governance (M2).** `classifyEndpoint()` labels every
+  governed call `local` or `cloud` from the client's `baseURL` (explicit
+  `endpoints[]` matchers, loopback autodetect, per-call override), and the
+  scoped `resolveRates()` resolver prices every costing site accordingly. Local
+  scope structurally cannot reach `FALLBACK_RATE`.
+- New config surface (all keys zod-defaulted — existing configs parse
+  unchanged): `endpoints[]` matchers (origin URL, `*.host` suffix, or bare
+  hostname), `local` block (`autoDetectLoopback`, `defaultRate`, `rateClass`
+  `"nominal" | "amortized-usd"` for GPU-amortized showback, per-model `models`
+  with trailing-`*` globs, `injectUsageOptions`), and `unknownModelPolicy`
+  (`"fallback" | "warn" | "deny"`, default `"warn"`) for cloud-scope models
+  missing from the pricing table — `"warn"` is cost-identical to the old silent
+  behavior but logs once per model and stamps the receipt.
+- Receipts carry `endpoint` (`class`/`runtime`) and `meter` (`costBasis`
+  `"usd-proxy" | "nominal"`, `rateSource`, optional `computeMs`) so the
+  settlement regime and rate provenance of every call are auditable.
+- Server-truth streaming usage for local endpoints:
+  `stream_options: { include_usage: true }` is auto-injected into local
+  OpenAI-compatible streams (gated by `local.injectUsageOptions`; the usage
+  chunk is forwarded to the consumer unmodified; one retry without the
+  injection if a server rejects it).
+- Local-calibrated anomaly governance: `tokenRate.localThresholdTokPerSec`
+  (default 5000), `tokenRate.perModel` glob overrides,
+  `spendVelocity.localThresholdUsertokensPerMin` (default 10000) — local
+  velocity verdicts are denominated in usertokens, never fake dollars; the
+  detector now prices events with the same scoped resolver as settlement.
+- Headless governor endpoint scope: `TrustOpts.endpoint` (governor default),
+  `AuthorizeParams.endpoint` (per-call override, captured at authorize),
+  `SettleParams.computeMs` → `receipt.meter.computeMs`.
+- OpenClaw: Ollama-native chunk extraction (`prompt_eval_count`/`eval_count`,
+  `eval_duration` → `computeMs`) alongside the OpenAI-compatible family.
+- OpenClaw: `UsertrustPluginConfig.endpoint` (`class`, optional `runtime`/
+  `baseURL`) declares the runtime's settlement scope — the headless path has no
+  client baseURL to classify, so operators set `{ class: "local" }` to meter
+  local models at local rates instead of cloud frontier fallback.
+- `usertrust init` "Local inference" wizard step: Ollama/LM Studio/vLLM
+  presets, optional `GET /v1/models` probe, writes `endpoints[]` +
+  `local.models` entries.
+- `examples/ollama-local-governance`: runnable before/after demo (`npx tsx
+  run.ts`), falls back to an inline mock OpenAI-compatible server when Ollama
+  is absent.
+
+### Changed
+
+- OpenAI and Google streaming usage accumulation is now replace-with-latest
+  (usage-bearing chunks carry cumulative snapshots — e.g. vLLM
+  `continuous_usage_stats` — which summing would multiply-count). Anthropic
+  stays additive (`message_start` + `message_delta` are genuinely incremental).
+
+### Security
+
+- Endpoint classification (config matchers, overrides, loopback autodetect) is
+  a **trusted-operator decision** — never wire it to end-user or request input.
+  In server/multi-tenant deployments set `local.autoDetectLoopback: false` and
+  classify via explicit `endpoints[]` config: loopback inside a container can
+  be a forwarding sidecar to a paid API. This is the same trust boundary as
+  `budget`/`customRates` — the config author already controls billing entirely.
+  Note that a compromised local server can under-report usage; receipts expose
+  `usageSource` and `meter.rateSource` precisely so that this is auditable.
+- `endpoints[]` matching never uses raw string prefixing: scheme entries match
+  by URL origin equality, killing `http://gpu-box:8000.evil.com` /
+  `...@evil.com` bypass shapes; malformed `baseURL`s classify as cloud
+  (fail-expensive).
+
 ## [1.0.0] - 2026-03-29
 
 First stable release.

--- a/examples/ollama-local-governance/README.md
+++ b/examples/ollama-local-governance/README.md
@@ -1,0 +1,113 @@
+# ollama-local-governance
+
+Before/after demo of **first-class local-model governance** (M2): loopback/local
+endpoints now settle at nominal local rates instead of silently billing frontier
+fallback.
+
+## What it shows
+
+**Before (v1.3):** usertrust had no concept of a local endpoint. A free
+`llama3.3:70b` call against `http://localhost:11434/v1` was priced like an
+unknown cloud model — sonnet-class `FALLBACK_RATE`, and a streamed call (no
+usage chunk without `stream_options.include_usage`) settled on the pre-call
+*estimate*: ~615 usertokens of fake dollars per $0 stream. A $50 budget
+evaporated after ~800 free calls.
+
+**After (M2):** `classifyEndpoint()` labels the loopback endpoint `local`, and
+`resolveRates()` settles it from `local.defaultRate` (`{0,0}` by default). The
+per-call `>=1` cost floor turns that into **exactly 1 nominal usertoken per
+call** — free inference stays *inside* budget, anomaly, and audit governance
+instead of being exempted from it. For local OpenAI-compatible streams,
+`stream_options: { include_usage: true }` is auto-injected so settlement uses
+server-truth token counts (`usageSource: "provider"`).
+
+The receipt carries the proof: `endpoint` (class/runtime), `meter.costBasis`
+(`"nominal"` — never fake dollars), and `meter.rateSource` (`"local-default"`).
+
+It also demos the **spoof defense**: `ollama cp llama3.2 gpt-4o` cannot buy
+frontier billing — the *endpoint class*, not the model string, picks the
+settlement regime.
+
+## Run it
+
+From a repo checkout (the script imports the workspace source directly — no
+build step):
+
+```sh
+npm install
+cd examples/ollama-local-governance
+npx tsx run.ts
+```
+
+- **With Ollama running** on `localhost:11434`, the demo uses your first
+  installed model (the spoof-defense call is skipped — a live Ollama 404s
+  models it doesn't have).
+- **Without Ollama**, it starts an inline mock OpenAI-compatible server
+  (in `run.ts`, ~40 lines of `node:http`) that speaks the same shapes:
+  `POST /v1/chat/completions` (stream + non-stream, usage chunk only when
+  `include_usage` was requested) and `GET /v1/models`.
+
+Everything runs in `dryRun` mode against throwaway temp vaults — no
+TigerBeetle needed, nothing written to your project.
+
+## Sample output (mock path)
+
+```text
+[BEFORE — v1.3 behavior: local.autoDetectLoopback: false]
+  streamed "llama3.3:70b" (4 chunks):
+    cost=615 ut  endpoint=cloud/unknown  meter=usd-proxy via fallback
+    usageSource=estimated  budgetRemaining=499385
+    → $0 inference billed 615 ut ($0.0615/call)
+    → a $50 budget is exhausted after ~813 FREE streams
+
+[AFTER — M2 default config]
+  non-stream "llama3.3:70b":
+    cost=1 ut  endpoint=local/openai-compat  meter=nominal via local-default
+    usageSource=provider  budgetRemaining=499999
+  streamed "llama3.3:70b" (include_usage injected):
+    cost=1 ut  endpoint=local/openai-compat  meter=nominal via local-default
+    usageSource=provider  budgetRemaining=499998
+  spoofed model "gpt-4o" on the local endpoint:
+    cost=1 ut  endpoint=local/openai-compat  meter=nominal via local-default
+    usageSource=provider  budgetRemaining=499997
+
+Showback: 3 calls, 510 real tokens metered, 3 ut nominal spend, $0.00 actual.
+Free inference, fully governed.
+```
+
+(Against a live Ollama on port 11434 the runtime label is `ollama` and the
+token counts are real.)
+
+## Using it in your project
+
+Loopback endpoints are classified automatically (`local.autoDetectLoopback`
+defaults to `true`). For LAN GPU boxes, add explicit matchers; for
+GPU-amortized showback, set per-model rates:
+
+```jsonc
+// .usertrust/usertrust.config.json
+{
+	"budget": 500000,
+	"endpoints": [
+		{ "match": "http://gpu-box:8000", "class": "local", "runtime": "vllm" },
+		{ "match": "*.gpu.internal", "class": "local" }
+	],
+	"local": {
+		"rateClass": "amortized-usd",
+		"models": { "llama3.3*": { "inputPer1k": 0.2, "outputPer1k": 0.2 } }
+	}
+}
+```
+
+Or run `usertrust init` — the wizard's "Local inference" step writes the
+endpoint entry and probes `GET /v1/models` for your installed models.
+
+## Security posture
+
+Endpoint classification (config matchers, overrides, loopback autodetect) is a
+**trusted-operator decision** — never wire it to end-user or request input. In
+server/multi-tenant deployments set `local.autoDetectLoopback: false` and
+classify via explicit `endpoints[]` config: loopback inside a container can be
+a forwarding sidecar to a paid API. A compromised local server can under-report
+usage — receipts expose `usageSource` and `meter.rateSource` precisely so this
+is auditable.

--- a/examples/ollama-local-governance/run.ts
+++ b/examples/ollama-local-governance/run.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * ollama-local-governance — before/after demo of first-class local-model
+ * governance (M2).
+ *
+ * BEFORE (v1.3 behavior, reproduced with `local.autoDetectLoopback: false`):
+ * a free local stream settles on the pre-call ESTIMATE at frontier FALLBACK
+ * rates — fake dollars billed for $0 inference.
+ *
+ * AFTER (M2 default config): the loopback endpoint classifies as LOCAL scope
+ * and every call settles at exactly 1 nominal usertoken from server-truth
+ * token counts (`stream_options: { include_usage: true }` is auto-injected).
+ * Free inference stays INSIDE budget/anomaly/audit governance.
+ *
+ * Run from a repo checkout (imports the workspace source directly):
+ *
+ *   npm install
+ *   cd examples/ollama-local-governance
+ *   npx tsx run.ts
+ *
+ * Works with or without a running Ollama: probes http://localhost:11434 and
+ * falls back to an inline mock OpenAI-compatible server (below).
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import OpenAI from "openai";
+import { type TrustReceipt, trust } from "../../packages/core/src/index.js";
+
+const BUDGET = 500_000; // $50 in usertokens (1 ut = $0.0001)
+const MOCK_MODEL = "llama3.3:70b";
+const MOCK_USAGE = { prompt_tokens: 42, completion_tokens: 128 };
+
+// ── Inline mock OpenAI-compatible server (the shapes Ollama serves on /v1) ──
+
+function startMockServer(): Promise<{ url: string; close: () => Promise<void> }> {
+	const server = createServer((req, res) => {
+		let body = "";
+		req.on("data", (chunk) => {
+			body += chunk;
+		});
+		req.on("end", () => {
+			if (req.method === "GET" && req.url?.startsWith("/v1/models")) {
+				res.writeHead(200, { "content-type": "application/json" });
+				res.end(JSON.stringify({ data: [{ id: MOCK_MODEL }] }));
+				return;
+			}
+			const params = JSON.parse(body || "{}") as {
+				model?: string;
+				stream?: boolean;
+				stream_options?: { include_usage?: boolean };
+			};
+			const base = { id: "chatcmpl-mock", model: params.model ?? MOCK_MODEL, created: 0 };
+			if (params.stream === true) {
+				res.writeHead(200, { "content-type": "text/event-stream" });
+				const sse = (data: unknown) => res.write(`data: ${JSON.stringify(data)}\n\n`);
+				for (const text of ["Free ", "inference, ", "fully ", "governed."]) {
+					const choices = [{ index: 0, delta: { content: text }, finish_reason: null }];
+					sse({ ...base, object: "chat.completion.chunk", choices });
+				}
+				// Like Ollama/vLLM: the final usage chunk is emitted ONLY when the
+				// request opted in via stream_options.include_usage.
+				if (params.stream_options?.include_usage === true) {
+					sse({ ...base, object: "chat.completion.chunk", choices: [], usage: MOCK_USAGE });
+				}
+				res.end("data: [DONE]\n\n");
+				return;
+			}
+			const message = { role: "assistant", content: "Free inference, fully governed." };
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					...base,
+					object: "chat.completion",
+					choices: [{ index: 0, message, finish_reason: "stop" }],
+					usage: MOCK_USAGE,
+				}),
+			);
+		});
+	});
+	return new Promise((resolve) => {
+		server.listen(0, "127.0.0.1", () => {
+			const { port } = server.address() as { port: number };
+			resolve({
+				url: `http://127.0.0.1:${port}/v1`,
+				close: () => new Promise((done) => server.close(() => done())),
+			});
+		});
+	});
+}
+
+// ── Endpoint resolution: live Ollama (500ms probe) or the inline mock ──
+
+interface DemoEndpoint {
+	url: string;
+	model: string;
+	live: boolean;
+	close: () => Promise<void>;
+}
+
+async function resolveEndpoint(): Promise<DemoEndpoint> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 500);
+	try {
+		const res = await fetch("http://localhost:11434/api/tags", { signal: controller.signal });
+		if (res.ok) {
+			const body = (await res.json()) as { models?: Array<{ name?: unknown }> };
+			const model = body.models
+				?.map((m) => m.name)
+				.find((name): name is string => typeof name === "string");
+			if (model !== undefined) {
+				return { url: "http://localhost:11434/v1", model, live: true, close: async () => {} };
+			}
+		}
+	} catch {
+		// Not running — fall through to the mock.
+	} finally {
+		clearTimeout(timer);
+	}
+	const mock = await startMockServer();
+	return { url: mock.url, model: MOCK_MODEL, live: false, close: mock.close };
+}
+
+// ── Demo plumbing ──
+
+/** Write a throwaway .usertrust vault holding the given config. */
+function makeVault(config: Record<string, unknown>): string {
+	const dir = mkdtempSync(join(tmpdir(), "ollama-local-governance-"));
+	mkdirSync(join(dir, ".usertrust"), { recursive: true });
+	const configPath = join(dir, ".usertrust", "usertrust.config.json");
+	writeFileSync(configPath, JSON.stringify(config, null, "\t"));
+	return dir;
+}
+
+function printReceipt(label: string, r: TrustReceipt): void {
+	const endpoint = r.endpoint ? `${r.endpoint.class}/${r.endpoint.runtime}` : "(none)";
+	const meter = r.meter ? `${r.meter.costBasis} via ${r.meter.rateSource}` : "(none)";
+	console.log(`  ${label}`);
+	console.log(`    cost=${r.cost} ut  endpoint=${endpoint}  meter=${meter}`);
+	console.log(`    usageSource=${r.usageSource ?? "n/a"}  budgetRemaining=${r.budgetRemaining}`);
+}
+
+interface Usage {
+	prompt_tokens?: number;
+	completion_tokens?: number;
+}
+interface StreamChunk {
+	choices?: Array<{ delta?: { content?: string } }>;
+	usage?: Usage | null;
+}
+/** Runtime shape of a governed streaming call (SDK types report the raw stream). */
+interface GovernedStreamResult {
+	response: AsyncIterable<StreamChunk> & { receipt: Promise<TrustReceipt> };
+	receipt: TrustReceipt;
+}
+/** Runtime shape of a governed non-stream call. */
+interface GovernedCallResult {
+	response: { usage?: Usage };
+	receipt: TrustReceipt;
+}
+
+function usageTokens(usage: Usage | null | undefined): number {
+	return (usage?.prompt_tokens ?? 0) + (usage?.completion_tokens ?? 0);
+}
+
+// ── Demo ──
+
+async function main(): Promise<void> {
+	console.log("── ollama-local-governance ──\n");
+	const endpoint = await resolveEndpoint();
+	console.log(
+		endpoint.live
+			? `Live Ollama at http://localhost:11434 — model "${endpoint.model}"`
+			: `No Ollama at http://localhost:11434 — inline mock OpenAI-compat server at ${endpoint.url}`,
+	);
+
+	const messages = [{ role: "user" as const, content: "Why govern free local inference?" }];
+
+	// ── BEFORE: v1.3 behavior — loopback NOT classified, silent fallback pricing ──
+	console.log("\n[BEFORE — v1.3 behavior: local.autoDetectLoopback: false]");
+	const beforeVault = makeVault({
+		budget: BUDGET,
+		local: { autoDetectLoopback: false },
+		unknownModelPolicy: "fallback", // reproduce the old SILENT frontier fallback
+	});
+	const beforeClient = await trust(new OpenAI({ baseURL: endpoint.url, apiKey: "local" }), {
+		dryRun: true,
+		vaultBase: beforeVault,
+	});
+	const beforeCall = (await beforeClient.chat.completions.create({
+		model: endpoint.model,
+		stream: true,
+		messages,
+	})) as unknown as GovernedStreamResult;
+	let beforeChunks = 0;
+	for await (const chunk of beforeCall.response) {
+		// Consume the stream. No include_usage injection on a "cloud" endpoint,
+		// so settlement falls back to the pre-call estimate at FALLBACK_RATE.
+		if (chunk != null) beforeChunks++;
+	}
+	const beforeReceipt = await beforeCall.response.receipt;
+	printReceipt(`streamed "${endpoint.model}" (${beforeChunks} chunks):`, beforeReceipt);
+	const perCallDollars = (beforeReceipt.cost / 10_000).toFixed(4);
+	const callsToExhaust = Math.floor(BUDGET / beforeReceipt.cost);
+	console.log(`    → $0 inference billed ${beforeReceipt.cost} ut ($${perCallDollars}/call)`);
+	console.log(`    → a $50 budget is exhausted after ~${callsToExhaust} FREE streams`);
+	await beforeClient.destroy();
+
+	// ── AFTER: M2 default config — loopback classifies local, nominal metering ──
+	console.log("\n[AFTER — M2 default config]");
+	const afterVault = makeVault({ budget: BUDGET });
+	const afterClient = await trust(new OpenAI({ baseURL: endpoint.url, apiKey: "local" }), {
+		dryRun: true,
+		vaultBase: afterVault,
+	});
+
+	let calls = 0;
+	let realTokens = 0;
+
+	// (1) Non-stream: provider-reported usage, settles at 1 nominal usertoken.
+	const call1 = (await afterClient.chat.completions.create({
+		model: endpoint.model,
+		messages,
+	})) as unknown as GovernedCallResult;
+	calls++;
+	realTokens += usageTokens(call1.response.usage);
+	printReceipt(`non-stream "${endpoint.model}":`, call1.receipt);
+
+	// (2) Streamed: stream_options.include_usage auto-injected → server-truth usage.
+	const call2 = (await afterClient.chat.completions.create({
+		model: endpoint.model,
+		stream: true,
+		messages,
+	})) as unknown as GovernedStreamResult;
+	let finalUsage: Usage | null | undefined;
+	for await (const chunk of call2.response) {
+		if (chunk?.usage != null) finalUsage = chunk.usage; // forwarded unmodified
+	}
+	const call2Receipt = await call2.response.receipt;
+	calls++;
+	realTokens += usageTokens(finalUsage);
+	printReceipt(`streamed "${endpoint.model}" (include_usage injected):`, call2Receipt);
+	let lastReceipt = call2Receipt;
+
+	// (3) Spoof defense: the ENDPOINT class picks the regime, not the model
+	// string ("ollama cp llama3.2 gpt-4o" cannot buy frontier billing).
+	// Mock-only: a live Ollama would 404 a model it doesn't have installed.
+	if (!endpoint.live) {
+		const call3 = (await afterClient.chat.completions.create({
+			model: "gpt-4o",
+			messages,
+		})) as unknown as GovernedCallResult;
+		calls++;
+		realTokens += usageTokens(call3.response.usage);
+		printReceipt('spoofed model "gpt-4o" on the local endpoint:', call3.receipt);
+		lastReceipt = call3.receipt;
+	}
+
+	const spent = BUDGET - lastReceipt.budgetRemaining;
+	console.log(
+		`\nShowback: ${calls} calls, ${realTokens} real tokens metered, ` +
+			`${spent} ut nominal spend, $0.00 actual.`,
+	);
+	console.log("Free inference, fully governed.");
+
+	await afterClient.destroy();
+	await endpoint.close();
+	for (const dir of [beforeVault, afterVault]) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exitCode = 1;
+});

--- a/packages/core/src/anomaly/detector.ts
+++ b/packages/core/src/anomaly/detector.ts
@@ -15,10 +15,13 @@
  *   - After cooldownMs the detector auto-resets; reset() can be called manually.
  *
  * Defaults are tuned conservatively (500 tok/s sustained, $1/min, 3 injections in 60s).
- * Detection is opt-in (anomaly.enabled=true) — when off, observe/check are no-ops.
+ * Local-scope events (event.endpointClass === "local", stamped by govern.ts) use
+ * local-calibrated thresholds: 5000 tok/s (perModel glob overrides first) and
+ * 10_000 nominal usertokens/min. Detection is opt-in (anomaly.enabled=true) —
+ * when off, observe/check are no-ops.
  */
 
-import { estimateCost } from "../ledger/pricing.js";
+import { costFromRates, estimateCost } from "../ledger/pricing.js";
 import {
 	type InjectionCascadeSignal,
 	createInjectionCascadeSignal,
@@ -62,10 +65,46 @@ export function resolveAnomalyConfig(cfg?: AnomalyConfig): ResolvedAnomalyConfig
 /** USD value of one usertoken. 1 usertoken = $0.0001 (one basis point of a cent). */
 const USERTOKENS_PER_DOLLAR = 10_000;
 
-function defaultCostCalculator(model: string, inputTokens: number, outputTokens: number): number {
-	// estimateCost returns usertokens; convert to dollars.
+function defaultCostCalculator(
+	model: string,
+	inputTokens: number,
+	outputTokens: number,
+	event?: AnomalyChunkEvent,
+): number {
+	if (event?.endpointClass === "local") {
+		// Local scope without an injected calculator: price in nominal usertokens at
+		// the shipped default local rate {0,0}. costFromRates floors at 1, so the
+		// cumulative cost is a constant and spend-velocity stays flat — token_rate is
+		// the primary local signal. govern.ts injects a config-aware calculator that
+		// prices via resolveRates (operator-set local rates enable velocity showback).
+		return costFromRates({ inputPer1k: 0, outputPer1k: 0 }, inputTokens, outputTokens);
+	}
+	// estimateCost returns usertokens; convert to dollars (cloud usd-proxy scope).
 	const usertokens = estimateCost(model, inputTokens, outputTokens);
 	return usertokens / USERTOKENS_PER_DOLLAR;
+}
+
+/** Verdict text for a token-rate result; names non-legacy thresholds (local/perModel). */
+function tokenRateMessage(r: {
+	metric: number;
+	threshold: number;
+	thresholdLabel: string;
+}): string {
+	const base = `tokens/s ${r.metric.toFixed(1)} >= ${r.threshold}`;
+	return r.thresholdLabel === "thresholdTokPerSec" ? base : `${base} (${r.thresholdLabel})`;
+}
+
+/** Verdict text for a spend-velocity result; never fakes dollars for nominal spend. */
+function spendVelocityMessage(r: {
+	metric: number;
+	threshold: number;
+	unit: "dollars" | "usertokens";
+	thresholdLabel: string;
+}): string {
+	if (r.unit === "usertokens") {
+		return `usertokens/min ${r.metric.toFixed(1)} >= ${r.threshold} (${r.thresholdLabel})`;
+	}
+	return `$/min ${r.metric.toFixed(4)} >= ${r.threshold}`;
 }
 
 export interface AnomalyDetector {
@@ -111,9 +150,16 @@ export function createAnomalyDetector(
 
 	function observeChunk(ev: AnomalyChunkEvent): void {
 		const t = ev.at ?? now();
-		tokenRate.observe(ev.deltaTokens, t);
-		const dollars = costCalculator(model, ev.cumulativeInputTokens, ev.cumulativeOutputTokens);
-		spendVelocity.observe(dollars, t);
+		// Per-event scope: the event's model/endpointClass (stamped by govern.ts)
+		// override options.model / the default cloud scope when present (M2).
+		tokenRate.observe(ev.deltaTokens, t, ev);
+		const cost = costCalculator(
+			ev.model ?? model,
+			ev.cumulativeInputTokens,
+			ev.cumulativeOutputTokens,
+			ev,
+		);
+		spendVelocity.observe(cost, t, ev.endpointClass ?? "cloud");
 	}
 
 	function observeInjection(ev: AnomalyInjectionEvent): void {
@@ -144,22 +190,12 @@ export function createAnomalyDetector(
 		// Check signals in priority order: token-rate first (cheapest), spend-velocity, then injection.
 		const tr = tokenRate.check(t);
 		if (tr.tripped) {
-			return markTripped(
-				"token_rate",
-				`tokens/s ${tr.metric.toFixed(1)} >= ${tr.threshold}`,
-				tr.metric,
-				tr.threshold,
-			);
+			return markTripped("token_rate", tokenRateMessage(tr), tr.metric, tr.threshold);
 		}
 
 		const sv = spendVelocity.check(t);
 		if (sv.tripped) {
-			return markTripped(
-				"spend_velocity",
-				`$/min ${sv.metric.toFixed(4)} >= ${sv.threshold}`,
-				sv.metric,
-				sv.threshold,
-			);
+			return markTripped("spend_velocity", spendVelocityMessage(sv), sv.metric, sv.threshold);
 		}
 
 		const ic = injectionCascade.check(t);
@@ -184,7 +220,7 @@ export function createAnomalyDetector(
 				return {
 					tripped: true,
 					kind,
-					message: `tokens/s ${r.metric.toFixed(1)} >= ${r.threshold}`,
+					message: tokenRateMessage(r),
 					metric: r.metric,
 					threshold: r.threshold,
 				};
@@ -194,7 +230,7 @@ export function createAnomalyDetector(
 				return {
 					tripped: true,
 					kind,
-					message: `$/min ${r.metric.toFixed(4)} >= ${r.threshold}`,
+					message: spendVelocityMessage(r),
 					metric: r.metric,
 					threshold: r.threshold,
 				};

--- a/packages/core/src/anomaly/signals/spend-velocity.ts
+++ b/packages/core/src/anomaly/signals/spend-velocity.ts
@@ -4,42 +4,74 @@
 /**
  * spend-velocity.ts — Spend-velocity anomaly signal.
  *
- * Tracks $/min over a rolling window. Each observation records the
- * cumulative cost (in dollars). The signal trips when the rolling
- * dollars-per-minute exceeds the configured ceiling.
+ * Dual denomination (M2): cloud-scope observations accumulate usd-proxy cost
+ * (dollars) against `thresholdDollarsPerMin`; local-scope observations
+ * accumulate NOMINAL USERTOKENS against `localThresholdUsertokensPerMin`
+ * (default 10_000). The two series are independent rolling windows; check()
+ * reports which denomination (and threshold) applied via `unit`/`thresholdLabel`
+ * so verdict text never fakes dollars for nominal spend.
  *
- * Default: $1.00/min over a 10s rolling window.
+ * Explicit documented behavior: with the default local rate {0,0}, per-chunk
+ * cumulative nominal cost is a constant floor of 1 usertoken, so spend_velocity
+ * CANNOT trip on default local config — token_rate is the primary local signal.
+ * Velocity becomes meaningful when the operator sets nonzero local rates
+ * (amortized-usd showback).
+ *
+ * Default: $1.00/min (cloud) / 10_000 ut/min (local) over a 10s rolling window.
  *
  * Cost is computed via a `costCalculator` callback so the signal stays
  * decoupled from the SDK's pricing module.
  */
 
+import type { EndpointClass } from "../../shared/types.js";
 import type { SpendVelocityConfig } from "../types.js";
+
+/** Default local-scope threshold, applied where consumed (resolved config keeps it optional). */
+const LOCAL_THRESHOLD_USERTOKENS_PER_MIN_DEFAULT = 10_000;
+
+/** Denomination of a velocity measurement. */
+export type SpendUnit = "dollars" | "usertokens";
 
 interface CostSample {
 	tMs: number;
-	cumulativeDollars: number;
+	/** Cumulative cost in the series' denomination (dollars or nominal usertokens). */
+	cumulative: number;
 }
 
 export interface SpendVelocitySignalState {
+	/** Cloud-scope samples (cumulative dollars). */
 	samples: CostSample[];
+	/** Local-scope samples (cumulative nominal usertokens). */
+	localSamples: CostSample[];
 	lastDollarsPerMin: number;
+	lastUsertokensPerMin: number;
+}
+
+export interface SpendVelocityCheckResult {
+	tripped: boolean;
+	metric: number;
+	threshold: number;
+	/** Denomination of metric/threshold. */
+	unit: SpendUnit;
+	/** Which config threshold applied: "thresholdDollarsPerMin" | "localThresholdUsertokensPerMin". */
+	thresholdLabel: string;
 }
 
 export interface SpendVelocitySignal {
 	state: Readonly<SpendVelocitySignalState>;
-	/** Record cumulative dollars at time `nowMs`. */
-	observe(cumulativeDollars: number, nowMs: number): void;
-	check(nowMs: number): {
-		tripped: boolean;
-		metric: number;
-		threshold: number;
-	};
+	/**
+	 * Record cumulative cost at time `nowMs`. `scope` selects the series:
+	 * "local" accumulates nominal usertokens, "cloud" (default) dollars.
+	 */
+	observe(cumulativeCost: number, nowMs: number, scope?: EndpointClass): void;
+	check(nowMs: number): SpendVelocityCheckResult;
 	reset(): void;
 }
 
 export interface ResolvedSpendVelocityConfig {
 	thresholdDollarsPerMin: number;
+	/** Local-scope threshold; defaulted to 10_000 at consumption when absent. */
+	localThresholdUsertokensPerMin?: number | undefined;
 	windowMs: number;
 }
 
@@ -52,6 +84,8 @@ export function resolveSpendVelocityConfig(cfg?: SpendVelocityConfig): ResolvedS
 	return {
 		thresholdDollarsPerMin:
 			cfg?.thresholdDollarsPerMin ?? SPEND_VELOCITY_DEFAULTS.thresholdDollarsPerMin,
+		// M2 field stays optional in resolved config — defaulted where consumed.
+		localThresholdUsertokensPerMin: cfg?.localThresholdUsertokensPerMin,
 		windowMs: cfg?.windowMs ?? SPEND_VELOCITY_DEFAULTS.windowMs,
 	};
 }
@@ -59,15 +93,19 @@ export function resolveSpendVelocityConfig(cfg?: SpendVelocityConfig): ResolvedS
 export function createSpendVelocitySignal(cfg: ResolvedSpendVelocityConfig): SpendVelocitySignal {
 	const state: SpendVelocitySignalState = {
 		samples: [],
+		localSamples: [],
 		lastDollarsPerMin: 0,
+		lastUsertokensPerMin: 0,
 	};
+	const localThreshold =
+		cfg.localThresholdUsertokensPerMin ?? LOCAL_THRESHOLD_USERTOKENS_PER_MIN_DEFAULT;
 
-	function pruneOlderThan(cutoffMs: number): void {
+	function pruneOlderThan(series: CostSample[], cutoffMs: number): void {
 		// Keep at least one sample older than the cutoff so we can compute deltas.
 		// Find the most recent sample at or before cutoffMs and drop everything before it.
 		let lastBeforeCutoff = -1;
-		for (let i = 0; i < state.samples.length; i++) {
-			const sample = state.samples[i];
+		for (let i = 0; i < series.length; i++) {
+			const sample = series[i];
 			if (sample !== undefined && sample.tMs <= cutoffMs) {
 				lastBeforeCutoff = i;
 			} else {
@@ -75,66 +113,77 @@ export function createSpendVelocitySignal(cfg: ResolvedSpendVelocityConfig): Spe
 			}
 		}
 		if (lastBeforeCutoff > 0) {
-			state.samples.splice(0, lastBeforeCutoff);
+			series.splice(0, lastBeforeCutoff);
 		}
 	}
 
-	function observe(cumulativeDollars: number, nowMs: number): void {
+	function observe(cumulativeCost: number, nowMs: number, scope: EndpointClass = "cloud"): void {
 		// Reject NaN/negative deltas — keep the cumulative monotonic non-decreasing.
-		if (!Number.isFinite(cumulativeDollars) || cumulativeDollars < 0) return;
-		const last = state.samples[state.samples.length - 1];
-		if (last !== undefined && cumulativeDollars < last.cumulativeDollars) {
+		if (!Number.isFinite(cumulativeCost) || cumulativeCost < 0) return;
+		const series = scope === "local" ? state.localSamples : state.samples;
+		const last = series[series.length - 1];
+		if (last !== undefined && cumulativeCost < last.cumulative) {
 			// Provider regressed (shouldn't happen) — clamp to last
-			state.samples.push({ tMs: nowMs, cumulativeDollars: last.cumulativeDollars });
+			series.push({ tMs: nowMs, cumulative: last.cumulative });
 		} else {
-			state.samples.push({ tMs: nowMs, cumulativeDollars });
+			series.push({ tMs: nowMs, cumulative: cumulativeCost });
 		}
-		pruneOlderThan(nowMs - cfg.windowMs);
+		pruneOlderThan(series, nowMs - cfg.windowMs);
 	}
 
-	function check(nowMs: number): {
-		tripped: boolean;
-		metric: number;
-		threshold: number;
-	} {
-		pruneOlderThan(nowMs - cfg.windowMs);
-		if (state.samples.length < 2) {
-			return {
-				tripped: false,
-				metric: 0,
-				threshold: cfg.thresholdDollarsPerMin,
-			};
-		}
-		const first = state.samples[0];
-		const last = state.samples[state.samples.length - 1];
-		if (first === undefined || last === undefined) {
-			return {
-				tripped: false,
-				metric: 0,
-				threshold: cfg.thresholdDollarsPerMin,
-			};
-		}
-		const dollarsDelta = last.cumulativeDollars - first.cumulativeDollars;
+	/** Rolling per-minute rate over a series, or null when not computable. */
+	function ratePerMin(series: CostSample[], nowMs: number): number | null {
+		pruneOlderThan(series, nowMs - cfg.windowMs);
+		if (series.length < 2) return null;
+		const first = series[0];
+		const last = series[series.length - 1];
+		if (first === undefined || last === undefined) return null;
+		const costDelta = last.cumulative - first.cumulative;
 		const minutesDelta = (last.tMs - first.tMs) / 60_000;
-		if (minutesDelta <= 0) {
-			return {
-				tripped: false,
-				metric: 0,
-				threshold: cfg.thresholdDollarsPerMin,
-			};
-		}
-		const dollarsPerMin = dollarsDelta / minutesDelta;
-		state.lastDollarsPerMin = dollarsPerMin;
-		return {
-			tripped: dollarsPerMin >= cfg.thresholdDollarsPerMin,
-			metric: dollarsPerMin,
+		if (minutesDelta <= 0) return null;
+		return costDelta / minutesDelta;
+	}
+
+	function check(nowMs: number): SpendVelocityCheckResult {
+		const cloudRate = ratePerMin(state.samples, nowMs);
+		const localRate = ratePerMin(state.localSamples, nowMs);
+		if (cloudRate !== null) state.lastDollarsPerMin = cloudRate;
+		if (localRate !== null) state.lastUsertokensPerMin = localRate;
+
+		const cloudResult = (tripped: boolean): SpendVelocityCheckResult => ({
+			tripped,
+			metric: cloudRate ?? 0,
 			threshold: cfg.thresholdDollarsPerMin,
-		};
+			unit: "dollars",
+			thresholdLabel: "thresholdDollarsPerMin",
+		});
+		const localResult = (tripped: boolean, rate: number): SpendVelocityCheckResult => ({
+			tripped,
+			metric: rate,
+			threshold: localThreshold,
+			unit: "usertokens",
+			thresholdLabel: "localThresholdUsertokensPerMin",
+		});
+
+		if (cloudRate !== null && cloudRate >= cfg.thresholdDollarsPerMin) return cloudResult(true);
+		if (localRate !== null && localRate >= localThreshold) return localResult(true, localRate);
+
+		// Neither tripped: report the denomination closer to its threshold
+		// (cloud on tie / when nothing is computable — legacy behavior).
+		if (
+			localRate !== null &&
+			(cloudRate === null || localRate / localThreshold > cloudRate / cfg.thresholdDollarsPerMin)
+		) {
+			return localResult(false, localRate);
+		}
+		return cloudResult(false);
 	}
 
 	function reset(): void {
 		state.samples.length = 0;
+		state.localSamples.length = 0;
 		state.lastDollarsPerMin = 0;
+		state.lastUsertokensPerMin = 0;
 	}
 
 	return { state, observe, check, reset };

--- a/packages/core/src/anomaly/signals/token-rate.ts
+++ b/packages/core/src/anomaly/signals/token-rate.ts
@@ -6,15 +6,44 @@
  *
  * Buckets observed chunks into fixed-width windows (default 2 s) and counts
  * tokens-per-second within each window. Trips when N consecutive windows
- * exceed the configured threshold (default 500 tok/s, 3 windows).
+ * exceed the effective threshold (default 500 tok/s, 3 windows).
  *
  * Brief spikes (1-2 hot windows) are ignored — only sustained runaway
  * behavior trips the circuit.
+ *
+ * M2 scoped thresholds: each observation may carry the event's model and
+ * endpointClass. Local-scope events select `perModel` (trailing-* glob,
+ * matched via matchModelPattern) first, then `localThresholdTokPerSec`
+ * (default 5000 — fast local GPU inference legitimately exceeds the cloud
+ * 500). Cloud/unscoped events keep the legacy `thresholdTokPerSec`. The
+ * check() result names which threshold applied via `thresholdLabel`.
+ *
+ * Cross-scope isolation: cloud and local keep SEPARATE rolling windows, each
+ * judged against its own threshold. A shared detector observes interleaved
+ * cloud+local streams, so a single mutable threshold/window would let one
+ * scope's chunks contaminate the other's verdict — a cloud runaway inheriting
+ * the 10x local threshold (evasion), or a local burst false-tripping the cloud
+ * 500. Mirrors the dual-series pattern in spend-velocity.ts.
  */
 
+import { matchModelPattern } from "../../ledger/pricing.js";
+import type { EndpointClass } from "../../shared/types.js";
 import type { TokenRateConfig } from "../types.js";
 
-export interface TokenRateSignalState {
+/** Default local-scope threshold, applied where consumed (resolved config keeps it optional). */
+const LOCAL_THRESHOLD_TOK_PER_SEC_DEFAULT = 5_000;
+
+/** Threshold-source labels: "thresholdTokPerSec", "localThresholdTokPerSec", or `perModel["<pattern>"]`. */
+export type TokenRateThresholdLabel = string;
+
+/** Per-observation scope context (an AnomalyChunkEvent satisfies this shape). */
+export interface TokenRateObserveContext {
+	model?: string | undefined;
+	endpointClass?: EndpointClass | undefined;
+}
+
+/** Rolling-window state for a single endpoint scope (cloud or local). */
+export interface ScopeWindowState {
 	/** Per-window tokens accumulated in the current bucket. */
 	currentWindowTokens: number;
 	/** Start time of the current window. */
@@ -23,12 +52,29 @@ export interface TokenRateSignalState {
 	consecutiveHotWindows: number;
 	/** Last computed peak rate (for the most recently closed window). */
 	lastWindowRateTokPerSec: number;
+	/** Whether any observation has been routed to this scope yet. */
+	initialized: boolean;
+	/** Effective threshold for this scope's windows (resolved per observation). */
+	threshold: number;
+	/** Source label of the effective threshold. */
+	thresholdLabel: TokenRateThresholdLabel;
+}
+
+export interface TokenRateSignalState {
+	/** Cloud/unscoped window state (legacy `thresholdTokPerSec`). */
+	cloud: Readonly<ScopeWindowState>;
+	/** Local window state (`perModel` glob / `localThresholdTokPerSec`). */
+	local: Readonly<ScopeWindowState>;
 }
 
 export interface TokenRateSignal {
 	state: Readonly<TokenRateSignalState>;
-	/** Observe a chunk's delta tokens at time `nowMs`. */
-	observe(deltaTokens: number, nowMs: number): void;
+	/**
+	 * Observe a chunk's delta tokens at time `nowMs`. `context` (the chunk
+	 * event) selects the effective threshold for subsequent window evaluation;
+	 * omitted/unscoped context means the legacy cloud threshold.
+	 */
+	observe(deltaTokens: number, nowMs: number, context?: TokenRateObserveContext): void;
 	/**
 	 * Check if the threshold has been crossed.
 	 * Returns the metric (peak window rate) when tripped, else null.
@@ -38,12 +84,17 @@ export interface TokenRateSignal {
 		metric: number;
 		threshold: number;
 		hotWindows: number;
+		thresholdLabel: TokenRateThresholdLabel;
 	};
 	reset(): void;
 }
 
 export interface ResolvedTokenRateConfig {
 	thresholdTokPerSec: number;
+	/** Local-scope threshold; defaulted to 5000 at consumption when absent. */
+	localThresholdTokPerSec?: number | undefined;
+	/** Per-model overrides for local-scope events (trailing-* glob keys). */
+	perModel?: Record<string, number> | undefined;
 	windowMs: number;
 	consecutiveWindows: number;
 }
@@ -57,91 +108,153 @@ export const TOKEN_RATE_DEFAULTS: ResolvedTokenRateConfig = {
 export function resolveTokenRateConfig(cfg?: TokenRateConfig): ResolvedTokenRateConfig {
 	return {
 		thresholdTokPerSec: cfg?.thresholdTokPerSec ?? TOKEN_RATE_DEFAULTS.thresholdTokPerSec,
+		// M2 fields stay optional in resolved config — defaulted where consumed.
+		localThresholdTokPerSec: cfg?.localThresholdTokPerSec,
+		perModel: cfg?.perModel,
 		windowMs: cfg?.windowMs ?? TOKEN_RATE_DEFAULTS.windowMs,
 		consecutiveWindows: cfg?.consecutiveWindows ?? TOKEN_RATE_DEFAULTS.consecutiveWindows,
 	};
 }
 
+interface TokenRateCheckResult {
+	tripped: boolean;
+	metric: number;
+	threshold: number;
+	hotWindows: number;
+	thresholdLabel: TokenRateThresholdLabel;
+}
+
 export function createTokenRateSignal(cfg: ResolvedTokenRateConfig): TokenRateSignal {
-	const state: TokenRateSignalState = {
-		currentWindowTokens: 0,
-		currentWindowStartMs: 0,
-		consecutiveHotWindows: 0,
-		lastWindowRateTokPerSec: 0,
-	};
-	let initialized = false;
+	const localDefaultThreshold = cfg.localThresholdTokPerSec ?? LOCAL_THRESHOLD_TOK_PER_SEC_DEFAULT;
 
-	function rollWindowsTo(nowMs: number): void {
-		// Roll forward: close completed windows, evaluate threshold, advance.
-		while (nowMs - state.currentWindowStartMs >= cfg.windowMs) {
-			const windowEndMs = state.currentWindowStartMs + cfg.windowMs;
-			const seconds = cfg.windowMs / 1_000;
-			const rate = state.currentWindowTokens / seconds;
-			state.lastWindowRateTokPerSec = rate;
-			if (rate >= cfg.thresholdTokPerSec) {
-				state.consecutiveHotWindows += 1;
-			} else {
-				state.consecutiveHotWindows = 0;
-			}
-			state.currentWindowStartMs = windowEndMs;
-			state.currentWindowTokens = 0;
-		}
-	}
-
-	function observe(deltaTokens: number, nowMs: number): void {
-		if (!initialized) {
-			state.currentWindowStartMs = nowMs;
-			initialized = true;
-		}
-		rollWindowsTo(nowMs);
-		state.currentWindowTokens += Math.max(0, deltaTokens);
-	}
-
-	function check(nowMs: number): {
-		tripped: boolean;
-		metric: number;
-		threshold: number;
-		hotWindows: number;
-	} {
-		if (!initialized) {
-			return {
-				tripped: false,
-				metric: 0,
-				threshold: cfg.thresholdTokPerSec,
-				hotWindows: 0,
-			};
-		}
-		rollWindowsTo(nowMs);
-		// Also evaluate the current (incomplete) window if it has surpassed threshold
-		// by enough margin to count: only if it would already be a "hot" window.
-		const elapsedMs = nowMs - state.currentWindowStartMs;
-		let inFlightHot = false;
-		let inFlightRate = 0;
-		if (elapsedMs > 0) {
-			inFlightRate = state.currentWindowTokens / (elapsedMs / 1_000);
-			// Only consider in-flight as "hot" once the window has accumulated meaningful
-			// data (>=50% elapsed) to avoid false positives from one large early chunk.
-			if (elapsedMs >= cfg.windowMs / 2 && inFlightRate >= cfg.thresholdTokPerSec) {
-				inFlightHot = true;
-			}
-		}
-		const effectiveHot = state.consecutiveHotWindows + (inFlightHot ? 1 : 0);
-		const tripped = effectiveHot >= cfg.consecutiveWindows;
-		const metric = Math.max(state.lastWindowRateTokPerSec, inFlightRate);
+	function makeWindow(threshold: number, label: TokenRateThresholdLabel): ScopeWindowState {
 		return {
-			tripped,
-			metric,
-			threshold: cfg.thresholdTokPerSec,
-			hotWindows: effectiveHot,
+			currentWindowTokens: 0,
+			currentWindowStartMs: 0,
+			consecutiveHotWindows: 0,
+			lastWindowRateTokPerSec: 0,
+			initialized: false,
+			threshold,
+			thresholdLabel: label,
 		};
 	}
 
+	// Independent per-scope windows: cloud/unscoped events accumulate against the
+	// legacy threshold, local events against the local/perModel threshold. Neither
+	// can move the other's threshold or window (evasion + false-trip fix).
+	const cloud = makeWindow(cfg.thresholdTokPerSec, "thresholdTokPerSec");
+	const local = makeWindow(localDefaultThreshold, "localThresholdTokPerSec");
+	const state: TokenRateSignalState = { cloud, local };
+
+	/** Resolve the local-scope threshold/label for an event's model (perModel glob first). */
+	function applyLocalThreshold(model: string | undefined): void {
+		if (model !== undefined && cfg.perModel !== undefined) {
+			const match = matchModelPattern(model, cfg.perModel);
+			if (match !== undefined) {
+				local.threshold = match.value;
+				local.thresholdLabel = `perModel["${match.pattern}"]`;
+				return;
+			}
+		}
+		local.threshold = localDefaultThreshold;
+		local.thresholdLabel = "localThresholdTokPerSec";
+	}
+
+	function rollWindowsTo(w: ScopeWindowState, nowMs: number): void {
+		// Roll forward: close completed windows, evaluate threshold, advance.
+		while (nowMs - w.currentWindowStartMs >= cfg.windowMs) {
+			const windowEndMs = w.currentWindowStartMs + cfg.windowMs;
+			const seconds = cfg.windowMs / 1_000;
+			const rate = w.currentWindowTokens / seconds;
+			w.lastWindowRateTokPerSec = rate;
+			if (rate >= w.threshold) {
+				w.consecutiveHotWindows += 1;
+			} else {
+				w.consecutiveHotWindows = 0;
+			}
+			w.currentWindowStartMs = windowEndMs;
+			w.currentWindowTokens = 0;
+		}
+	}
+
+	function observe(deltaTokens: number, nowMs: number, context?: TokenRateObserveContext): void {
+		const w = context?.endpointClass === "local" ? local : cloud;
+		if (w === local) {
+			applyLocalThreshold(context?.model);
+		}
+		if (!w.initialized) {
+			w.currentWindowStartMs = nowMs;
+			w.initialized = true;
+		}
+		rollWindowsTo(w, nowMs);
+		w.currentWindowTokens += Math.max(0, deltaTokens);
+	}
+
+	/** Evaluate one scope's window against its own threshold. */
+	function evaluate(w: ScopeWindowState, nowMs: number): TokenRateCheckResult {
+		if (!w.initialized) {
+			return {
+				tripped: false,
+				metric: 0,
+				threshold: w.threshold,
+				hotWindows: 0,
+				thresholdLabel: w.thresholdLabel,
+			};
+		}
+		rollWindowsTo(w, nowMs);
+		// Also evaluate the current (incomplete) window if it has surpassed threshold
+		// by enough margin to count: only if it would already be a "hot" window.
+		const elapsedMs = nowMs - w.currentWindowStartMs;
+		let inFlightHot = false;
+		let inFlightRate = 0;
+		if (elapsedMs > 0) {
+			inFlightRate = w.currentWindowTokens / (elapsedMs / 1_000);
+			// Only consider in-flight as "hot" once the window has accumulated meaningful
+			// data (>=50% elapsed) to avoid false positives from one large early chunk.
+			if (elapsedMs >= cfg.windowMs / 2 && inFlightRate >= w.threshold) {
+				inFlightHot = true;
+			}
+		}
+		const effectiveHot = w.consecutiveHotWindows + (inFlightHot ? 1 : 0);
+		const tripped = effectiveHot >= cfg.consecutiveWindows;
+		const metric = Math.max(w.lastWindowRateTokPerSec, inFlightRate);
+		return {
+			tripped,
+			metric,
+			threshold: w.threshold,
+			hotWindows: effectiveHot,
+			thresholdLabel: w.thresholdLabel,
+		};
+	}
+
+	function check(nowMs: number): TokenRateCheckResult {
+		// Cloud is evaluated first so a cloud runaway is reported with the cloud
+		// threshold even while a slower local stream interleaves.
+		const cloudResult = evaluate(cloud, nowMs);
+		if (cloudResult.tripped) return cloudResult;
+		const localResult = evaluate(local, nowMs);
+		if (localResult.tripped) return localResult;
+		// Neither tripped: report the initialized scope closer to its threshold
+		// (higher metric/threshold ratio); default to cloud (legacy) otherwise.
+		if (!local.initialized) return cloudResult;
+		if (!cloud.initialized) return localResult;
+		const cloudRatio = cloudResult.threshold > 0 ? cloudResult.metric / cloudResult.threshold : 0;
+		const localRatio = localResult.threshold > 0 ? localResult.metric / localResult.threshold : 0;
+		return localRatio > cloudRatio ? localResult : cloudResult;
+	}
+
 	function reset(): void {
-		state.currentWindowTokens = 0;
-		state.currentWindowStartMs = 0;
-		state.consecutiveHotWindows = 0;
-		state.lastWindowRateTokPerSec = 0;
-		initialized = false;
+		for (const w of [cloud, local]) {
+			w.currentWindowTokens = 0;
+			w.currentWindowStartMs = 0;
+			w.consecutiveHotWindows = 0;
+			w.lastWindowRateTokPerSec = 0;
+			w.initialized = false;
+		}
+		cloud.threshold = cfg.thresholdTokPerSec;
+		cloud.thresholdLabel = "thresholdTokPerSec";
+		local.threshold = localDefaultThreshold;
+		local.thresholdLabel = "localThresholdTokPerSec";
 	}
 
 	return { state, observe, check, reset };

--- a/packages/core/src/anomaly/types.ts
+++ b/packages/core/src/anomaly/types.ts
@@ -11,7 +11,7 @@
  * `anomaly_detected` audit event.
  */
 
-import type { LLMClientKind } from "../shared/types.js";
+import type { EndpointClass, LLMClientKind } from "../shared/types.js";
 
 // ── Anomaly kinds ──
 
@@ -24,6 +24,10 @@ export type AnomalyKind = "token_rate" | "spend_velocity" | "injection_cascade";
 export interface TokenRateConfig {
 	/** Threshold tokens-per-second above which a window is "hot". Default 500. */
 	thresholdTokPerSec?: number;
+	/** Local-scope threshold tokens-per-second (M2). Default 5000. */
+	localThresholdTokPerSec?: number | undefined;
+	/** Per-model threshold overrides. Keys: exact model or trailing-* glob (M2). */
+	perModel?: Record<string, number> | undefined;
 	/** Window size in milliseconds. Default 2000. */
 	windowMs?: number;
 	/** Number of consecutive hot windows required to trip. Default 3. */
@@ -34,6 +38,8 @@ export interface TokenRateConfig {
 export interface SpendVelocityConfig {
 	/** Maximum dollars per minute (rolling). Default 1.00. */
 	thresholdDollarsPerMin?: number;
+	/** Local-scope threshold in nominal usertokens per minute (M2). Default 10000. */
+	localThresholdUsertokensPerMin?: number | undefined;
 	/** Rolling window in milliseconds. Default 10000. */
 	windowMs?: number;
 }
@@ -57,11 +63,19 @@ export interface AnomalyConfig {
 	cooldownMs?: number;
 }
 
-/** Resolved (defaulted) config used internally. */
+/**
+ * Resolved (defaulted) config used internally.
+ *
+ * Legacy fields are fully defaulted; the M2 local-scope fields
+ * (localThresholdTokPerSec, perModel, localThresholdUsertokensPerMin) stay
+ * optional here and are defaulted at the signal when absent.
+ */
 export interface ResolvedAnomalyConfig {
 	enabled: boolean;
-	tokenRate: Required<TokenRateConfig>;
-	spendVelocity: Required<SpendVelocityConfig>;
+	tokenRate: Required<Omit<TokenRateConfig, "localThresholdTokPerSec" | "perModel">> &
+		Pick<TokenRateConfig, "localThresholdTokPerSec" | "perModel">;
+	spendVelocity: Required<Omit<SpendVelocityConfig, "localThresholdUsertokensPerMin">> &
+		Pick<SpendVelocityConfig, "localThresholdUsertokensPerMin">;
 	injectionCascade: Required<InjectionCascadeConfig>;
 	cooldownMs: number;
 }
@@ -79,6 +93,10 @@ export interface AnomalyChunkEvent {
 	cumulativeOutputTokens: number;
 	/** Wall-clock timestamp. Defaults to Date.now() if omitted. */
 	at?: number;
+	/** Model of the call this chunk belongs to. Overrides options.model when present (M2). */
+	model?: string | undefined;
+	/** Endpoint scope of the call this chunk belongs to. Default scope: cloud (M2). */
+	endpointClass?: EndpointClass | undefined;
 }
 
 /** Out-of-band injection event (fired when detect.injection finds something). */
@@ -112,8 +130,19 @@ export interface AnomalyDetectorOptions {
 	provider?: LLMClientKind;
 	/** Model name being observed (used for cost calculation in spend-velocity). */
 	model?: string;
-	/** Override the cost calculator (for testing). Returns dollars for given tokens. */
-	costCalculator?: (model: string, inputTokens: number, outputTokens: number) => number;
+	/**
+	 * Override the cost calculator. Returns the cost for the given cumulative tokens —
+	 * dollars for cloud-scope events, nominal usertokens for local-scope events.
+	 * The observed chunk event is passed as the optional 4th argument so an injected
+	 * calculator can price per-event (scoped by event.model/event.endpointClass); 3-arg
+	 * implementations remain assignable (backward compatible).
+	 */
+	costCalculator?: (
+		model: string,
+		inputTokens: number,
+		outputTokens: number,
+		event?: AnomalyChunkEvent,
+	) => number;
 	/** Time source override (for deterministic tests). */
 	now?: () => number;
 }

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -29,6 +29,16 @@ const ENV_VAR_MAP: Record<string, string> = {
 	google: "GOOGLE_API_KEY",
 };
 
+// ── Local inference presets (M2 local-model governance) ──
+
+type LocalPreset = "ollama" | "lmstudio" | "vllm";
+
+const LOCAL_PRESET_URLS: Record<LocalPreset, string> = {
+	ollama: "http://localhost:11434",
+	lmstudio: "http://localhost:1234",
+	vllm: "http://localhost:8000",
+};
+
 const DEFAULT_POLICY = `rules:
   - name: block-budget-overshoot
     effect: deny
@@ -59,6 +69,28 @@ const SUBDIRS = ["audit", "policies", "patterns", "snapshots", "board", "dlq"] a
 
 function envVarName(provider: string): string {
 	return ENV_VAR_MAP[provider] ?? `${provider.toUpperCase()}_API_KEY`;
+}
+
+/**
+ * Probe an OpenAI-compatible endpoint for its installed model list.
+ * Best-effort: global fetch with a 500ms AbortController timeout; any
+ * failure (endpoint down, non-200, bad JSON) returns an empty list and
+ * the wizard proceeds without a model list.
+ */
+async function probeLocalModels(base: string): Promise<string[]> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 500);
+	try {
+		const res = await fetch(`${base}/v1/models`, { signal: controller.signal });
+		if (!res.ok) return [];
+		const body = (await res.json()) as { data?: Array<{ id?: unknown }> };
+		if (!Array.isArray(body.data)) return [];
+		return body.data.map((entry) => entry.id).filter((id): id is string => typeof id === "string");
+	} catch {
+		return [];
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
@@ -282,12 +314,76 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 		}
 	}
 
-	// Step 4: Create vault
+	// Step 4: Local inference — Ollama / LM Studio / vLLM endpoint presets.
+	// The chosen endpoint classifies as LOCAL scope: calls settle at nominal
+	// local rates (default {0,0} + the >=1 floor = 1 usertoken per call)
+	// instead of frontier fallback rates.
+	let endpoints: VaultData["endpoints"];
+	let localModels: Record<string, ModelRates> | undefined;
+
+	// Opt-in confirm gate before the runtime picker (Task 7 integration fix):
+	// declining (the default) reproduces the pre-M2 prompt sequence exactly —
+	// the picker below (clack.select, a prompt primitive the pre-M2 wizard
+	// never used) is only reached on explicit opt-in, so existing interactive
+	// flows and their pinned tests observe an unchanged wizard.
+	const wantsLocal = await clack.confirm({
+		message: "Configure local inference (Ollama / LM Studio / vLLM)?",
+		initialValue: false,
+	});
+	if (clack.isCancel(wantsLocal)) {
+		clack.log.warn("Setup cancelled.");
+		return;
+	}
+
+	if (wantsLocal === true) {
+		const localChoice = await clack.select({
+			message: "Pick your local runtime:",
+			options: [
+				{ value: "skip", label: "Skip — cloud providers only" },
+				{ value: "ollama", label: `Ollama (${LOCAL_PRESET_URLS.ollama})` },
+				{ value: "lmstudio", label: `LM Studio (${LOCAL_PRESET_URLS.lmstudio})` },
+				{ value: "vllm", label: `vLLM (${LOCAL_PRESET_URLS.vllm})` },
+			],
+			initialValue: "skip",
+		});
+
+		if (clack.isCancel(localChoice)) {
+			clack.log.warn("Setup cancelled.");
+			return;
+		}
+
+		if (localChoice !== "skip") {
+			const runtime = localChoice as LocalPreset;
+			const base = LOCAL_PRESET_URLS[runtime];
+			endpoints = [{ match: base, class: "local", runtime }];
+
+			const s = clack.spinner();
+			s.start(`Probing ${base}/v1/models...`);
+			const models = await probeLocalModels(base);
+			if (models.length > 0) {
+				s.stop(`Found ${models.length} model${models.length === 1 ? "" : "s"} at ${base}`);
+				// {0,0} suggested rates: with the >=1 cost floor, every call to these
+				// models settles at exactly 1 nominal usertoken. Raise the rates later
+				// for GPU-amortized showback (local.rateClass: "amortized-usd").
+				localModels = {};
+				for (const model of models) {
+					clack.log.step(`  ${model}`);
+					localModels[model] = { inputPer1k: 0, outputPer1k: 0 };
+				}
+			} else {
+				s.stop("No response — endpoint saved without a model list");
+			}
+		}
+	}
+
+	// Step 5: Create vault
 	createVault(vaultPath, {
 		budget: budgetUsertokens,
 		providers,
 		pricing,
 		...(customRates !== undefined ? { customRates } : {}),
+		...(endpoints !== undefined ? { endpoints } : {}),
+		...(localModels !== undefined ? { localModels } : {}),
 		keys,
 	});
 
@@ -300,6 +396,10 @@ interface VaultData {
 	pricing: "recommended" | "custom";
 	customRates?: Record<string, ModelRates>;
 	keys?: Record<string, string>;
+	/** Local inference endpoint matchers (consumed by classifyEndpoint). */
+	endpoints?: Array<{ match: string; class: "local"; runtime: LocalPreset }>;
+	/** Detected local models, written to local.models with {0,0} nominal rates. */
+	localModels?: Record<string, ModelRates>;
 }
 
 function createVault(vaultPath: string, data: VaultData): void {
@@ -325,6 +425,16 @@ function createVault(vaultPath: string, data: VaultData): void {
 
 	if (data.customRates && Object.keys(data.customRates).length > 0) {
 		config.customRates = data.customRates;
+	}
+
+	if (data.endpoints && data.endpoints.length > 0) {
+		config.endpoints = data.endpoints;
+	}
+
+	if (data.localModels && Object.keys(data.localModels).length > 0) {
+		// All other local.* keys are zod-defaulted (autoDetectLoopback: true,
+		// defaultRate {0,0}, rateClass "nominal", injectUsageOptions: true).
+		config.local = { models: data.localModels };
 	}
 
 	// Write config

--- a/packages/core/src/detect.ts
+++ b/packages/core/src/detect.ts
@@ -20,7 +20,7 @@
  * governed entry points above.
  */
 
-import type { LLMClientKind } from "./shared/types.js";
+import type { EndpointInfo, LLMClientKind, LocalRuntime, TrustConfig } from "./shared/types.js";
 
 /**
  * Detect which LLM SDK a client belongs to by inspecting its shape.
@@ -77,4 +77,140 @@ export function detectClientKind(client: unknown): LLMClientKind {
 	}
 
 	throw new Error("Unsupported LLM client: could not detect Anthropic, OpenAI, or Google SDK");
+}
+
+// ── Endpoint classification (M2 local-model governance) ──
+
+// Compared against normalizeHostname(url.hostname) — the WHATWG-serialized,
+// bracket-stripped form. `::ffff:7f00:1` is how Node's URL serializes the
+// IPv4-mapped IPv6 loopback `::ffff:127.0.0.1` (the last 32 bits render as hex,
+// never dotted-quad), so the map entry MUST be the serialized form to match.
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "::ffff:7f00:1"]);
+
+/** Best-effort runtime hint by conventional default port (metadata only). */
+const RUNTIME_BY_PORT: Record<string, LocalRuntime> = {
+	"11434": "ollama",
+	"1234": "lmstudio",
+	"8000": "vllm",
+};
+
+const CLOUD_DEFAULT: EndpointInfo = { class: "cloud", runtime: "unknown" };
+
+function parseUrl(value: string): URL | null {
+	try {
+		return new URL(value);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Normalize a URL hostname for comparison: lowercase, IPv6 brackets stripped
+ * (Node's WHATWG URL keeps brackets in `hostname` for IPv6 literals).
+ */
+function normalizeHostname(hostname: string): string {
+	const lower = hostname.toLowerCase();
+	if (lower.startsWith("[") && lower.endsWith("]")) return lower.slice(1, -1);
+	return lower;
+}
+
+/**
+ * Match a parsed baseURL against one config.endpoints[].match entry (A1).
+ * Exactly three entry forms — never raw string prefixing:
+ * (i)   scheme entry ("http://gpu-box:8000") → parsed; match iff origins are equal
+ *       (path/query/trailing slash ignored; kills "http://gpu-box:8000.evil.com"
+ *       and "http://gpu-box:8000@evil.com" bypass shapes);
+ * (ii)  leading-star entry ("*.gpu.internal") → hostname SUFFIX match: matches
+ *       "a.gpu.internal" and "x.y.gpu.internal", NOT "gpu.internal" itself;
+ * (iii) bare hostname → case-insensitive hostname equality (any port).
+ * Unparseable scheme entries never match (and never throw).
+ */
+function matchesEndpointEntry(entry: string, url: URL): boolean {
+	if (/^https?:\/\//i.test(entry)) {
+		const entryUrl = parseUrl(entry);
+		return entryUrl !== null && entryUrl.origin === url.origin;
+	}
+	const host = normalizeHostname(url.hostname);
+	if (entry.startsWith("*.")) {
+		const suffix = entry.slice(1).toLowerCase(); // ".gpu.internal"
+		return host.endsWith(suffix);
+	}
+	return host === entry.toLowerCase();
+}
+
+/** Read a string `baseURL` property off an SDK client instance, if present. */
+function readBaseURL(client: unknown): string | undefined {
+	if (client != null && typeof client === "object" && "baseURL" in client) {
+		const value = (client as { baseURL?: unknown }).baseURL;
+		if (typeof value === "string") return value;
+	}
+	return undefined;
+}
+
+/**
+ * Classify the endpoint a client points at — local (self-hosted) or cloud —
+ * selecting the settlement regime for every governed call. Runs BESIDE
+ * `detectClientKind` (which stays the transport detector); the endpoint class,
+ * not the model string, picks local vs cloud metering, so model-name spoofing
+ * (`ollama cp llama3.2 gpt-4o`) cannot change the regime.
+ *
+ * Classification order:
+ * 1. `override.class` provided → override wins (runtime defaults to "unknown").
+ * 2. `client.baseURL` read when it is a string; absent or malformed (URL parse
+ *    failure) → treated as absent → cloud default. Never throws.
+ * 3. `config.endpoints[]` first match (origin / leading-star hostname suffix /
+ *    bare hostname — see matchesEndpointEntry).
+ * 4. Loopback autodetect (config.local.autoDetectLoopback): hostname
+ *    localhost | 127.0.0.1 | ::1 | ::ffff:127.0.0.1 (case-insensitive, IPv6
+ *    brackets stripped, IPv4-mapped form matched by its WHATWG serialization) →
+ *    local, runtime hinted by port (11434 ollama, 1234 lmstudio, 8000 vllm,
+ *    else "openai-compat").
+ * 5. Default `{ class: "cloud", runtime: "unknown" }` — fail-EXPENSIVE:
+ *    over-charging at cloud rates is recoverable, under-charging a paid
+ *    endpoint is not.
+ *
+ * **Security posture (trusted-operator boundary):** endpoint classification —
+ * config matchers, overrides, and loopback autodetect — is a TRUSTED-OPERATOR
+ * decision. Never wire it to end-user or request input. In server/multi-tenant
+ * deployments set `local.autoDetectLoopback: false` and classify via explicit
+ * `endpoints[]` config: loopback inside a container can be a forwarding sidecar
+ * to a paid API. This is the same trust boundary as `budget`/`customRates` —
+ * the config author already controls billing entirely. Note that a compromised
+ * local server can under-report usage; receipts expose `usageSource` and
+ * `meter.rateSource` precisely so that this is auditable.
+ */
+export function classifyEndpoint(
+	client: unknown,
+	config: TrustConfig,
+	override?: Partial<EndpointInfo>,
+): EndpointInfo {
+	const baseURL = readBaseURL(client);
+
+	// (1) Explicit override wins over everything.
+	if (override?.class !== undefined) {
+		const info: EndpointInfo = { class: override.class, runtime: override.runtime ?? "unknown" };
+		const overrideBase = override.baseURL ?? baseURL;
+		if (overrideBase !== undefined) info.baseURL = overrideBase;
+		return info;
+	}
+
+	// (2) No readable baseURL → cloud default. Malformed → treat as absent, never throw.
+	if (baseURL === undefined) return { ...CLOUD_DEFAULT };
+	const url = parseUrl(baseURL);
+	if (url === null) return { ...CLOUD_DEFAULT };
+
+	// (3) config.endpoints[] — first match wins.
+	for (const entry of config.endpoints) {
+		if (matchesEndpointEntry(entry.match, url)) {
+			return { class: entry.class, runtime: entry.runtime, baseURL };
+		}
+	}
+
+	// (4) Loopback autodetect.
+	if (config.local.autoDetectLoopback && LOOPBACK_HOSTS.has(normalizeHostname(url.hostname))) {
+		return { class: "local", runtime: RUNTIME_BY_PORT[url.port] ?? "openai-compat", baseURL };
+	}
+
+	// (5) Cloud default.
+	return { class: "cloud", runtime: "unknown", baseURL };
 }

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -35,9 +35,15 @@ import { join } from "node:path";
 import { CreateTransferError } from "tigerbeetle-node";
 import { type AuditWriter, createAuditWriter } from "./audit/chain.js";
 import { writeReceipt } from "./audit/rotation.js";
-import { detectClientKind } from "./detect.js";
+import { classifyEndpoint, detectClientKind } from "./detect.js";
 import { TBTransferError, TrustTBClient, XFER_SPEND } from "./ledger/client.js";
-import { estimateCost, estimateInputTokens } from "./ledger/pricing.js";
+import {
+	type RateResolution,
+	costFromRates,
+	estimateInputTokens,
+	resolveRates,
+	warnUnknownModel,
+} from "./ledger/pricing.js";
 import { recordPattern } from "./memory/patterns.js";
 import { DEFAULT_RULES, mergePolicies } from "./policy/default-rules.js";
 import { type GateRule, evaluatePolicy, loadPolicies } from "./policy/gate.js";
@@ -61,6 +67,7 @@ import { trustId } from "./shared/ids.js";
 import { TrustConfigSchema } from "./shared/types.js";
 import type {
 	ActionDescriptor,
+	EndpointInfo,
 	GovernedActionResult,
 	LLMClientKind,
 	TrustConfig,
@@ -96,6 +103,13 @@ export interface TrustOpts {
 	dryRun?: boolean;
 	/** Vault directory override (default: cwd). */
 	vaultBase?: string;
+	/**
+	 * Explicit endpoint classification override (M2) — wins over config.endpoints
+	 * matchers and loopback autodetect. TRUSTED-OPERATOR input, same trust
+	 * boundary as budget/customRates: never derive it from end-user or request
+	 * data (A10).
+	 */
+	endpoint?: Partial<EndpointInfo>;
 	/**
 	 * Inject a mock/test engine. When set, used instead of TigerBeetle.
 	 * Primarily for testing failure modes.
@@ -152,6 +166,92 @@ class AsyncMutex {
 		await prev;
 		return release as () => void;
 	}
+}
+
+// ── M2 unknown-model policy (A5) ──
+
+/** USD value of one usertoken: 1 usertoken = $0.0001 (one basis point of a cent). */
+const USERTOKENS_PER_DOLLAR = 10_000;
+
+/**
+ * Enforce config.unknownModelPolicy at AUTHORIZE time (A5). Only cloud-scope
+ * resolutions can be unknown — local scope always resolves to local rates.
+ * "deny" throws before any PENDING hold; "warn" logs once per model string per
+ * process via the shared warnUnknownModel helper (receipts carry
+ * meter.rateSource "fallback" regardless of warn dedup); "fallback" is silent.
+ */
+function enforceUnknownModelPolicy(
+	model: string,
+	resolution: RateResolution,
+	config: TrustConfig,
+): void {
+	if (!resolution.unknown) return;
+	if (config.unknownModelPolicy === "deny") {
+		throw new PolicyDeniedError(`unknown_model: ${model} not in pricing table`);
+	}
+	if (config.unknownModelPolicy === "warn") {
+		warnUnknownModel(model);
+	}
+}
+
+/**
+ * A4: build forward-args for a local openai stream call with
+ * stream_options.include_usage merged in. The caller's other stream_options
+ * fields survive; an explicit include_usage (true OR false) is respected —
+ * only a missing/null value injects. Returns null when no injection applies.
+ */
+function withInjectedUsageOptions(args: unknown[]): unknown[] | null {
+	const params = (args[0] ?? {}) as Record<string, unknown>;
+	if (params.stream !== true) return null;
+	const rawOptions = params.stream_options;
+	const streamOptions =
+		rawOptions != null && typeof rawOptions === "object"
+			? (rawOptions as Record<string, unknown>)
+			: undefined;
+	if (streamOptions?.include_usage != null) return null;
+	return [
+		{ ...params, stream_options: { ...streamOptions, include_usage: true } },
+		...args.slice(1),
+	];
+}
+
+/** Message shapes an OpenAI-compat server emits when it rejects an unknown field. */
+const STREAM_OPTIONS_REJECTION_RE =
+	/stream_options|include_usage|unrecognized|unknown.{0,20}(field|argument|parameter|option)/i;
+
+/**
+ * A4 retry heuristic: does `err` plausibly indicate that the server rejected the
+ * injected `stream_options.include_usage`? We only retry-without-injection for
+ * these — a blanket retry on ANY error would double the provider call on
+ * transient failures (ECONNRESET, timeouts, 5xx) and mask the real root cause,
+ * so everything else rethrows the ORIGINAL error immediately. Matches the
+ * rejection message on the error, its nested `error.message`, or a cheaply
+ * reachable `response` body; or an HTTP-shaped 400/422 status on the error
+ * object. Tradeoff: a server that rejects the field with an opaque 500 and no
+ * telltale text is NOT retried — acceptable, since include_usage is widely
+ * supported and the caller still receives the original error.
+ */
+function looksLikeStreamOptionsRejection(err: unknown): boolean {
+	if (err == null || typeof err !== "object") {
+		return err instanceof Error && STREAM_OPTIONS_REJECTION_RE.test(err.message);
+	}
+	const e = err as Record<string, unknown>;
+	const status = e.status ?? e.statusCode;
+	if (status === 400 || status === 422) return true;
+	const candidates: unknown[] = [e.message, e.body];
+	if (err instanceof Error) candidates.push(err.message);
+	const nested = e.error;
+	if (nested != null && typeof nested === "object") {
+		candidates.push((nested as Record<string, unknown>).message);
+	}
+	const response = e.response;
+	if (typeof response === "string") {
+		candidates.push(response);
+	} else if (response != null && typeof response === "object") {
+		const r = response as Record<string, unknown>;
+		candidates.push(r.data, r.body);
+	}
+	return candidates.some((c) => typeof c === "string" && STREAM_OPTIONS_REJECTION_RE.test(c));
 }
 
 // ── AUD-457: Budget persistence helpers ──
@@ -238,8 +338,6 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		});
 	}
 
-	const customRates = config.pricing === "custom" ? config.customRates : undefined;
-
 	const isDryRun = opts?.dryRun ?? process.env.USERTRUST_DRY_RUN === "true";
 
 	// AUD-470: Only accept injected _engine/_audit in test environments.
@@ -296,8 +394,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		engine = null;
 	}
 
-	// 5. Detect client kind
+	// 5. Detect client kind (transport) + classify the endpoint (settlement
+	// regime, M2). classifyEndpoint runs BESIDE detectClientKind — the endpoint
+	// class, not the model string, picks local vs cloud metering (A3: this scope
+	// is captured once here and used verbatim at every authorize/settle below).
 	const kind: LLMClientKind = detectClientKind(client);
+	const endpoint: EndpointInfo = classifyEndpoint(client, config, opts?.endpoint);
 
 	// 6. Track state
 	let destroyed = false;
@@ -308,7 +410,31 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 
 	// Streaming anomaly detector — shared across calls so injection-cascade
 	// can track signals across the conversation. Disabled when config.anomaly.enabled=false.
-	const anomalyDetector = createAnomalyDetector(config.anomaly, { provider: kind });
+	// M2 seam fix: the injected costCalculator prices spend-velocity with the
+	// SAME scoped rates as settlement, using the observed event's
+	// model/endpointClass (the detector is shared while the model varies per
+	// call). Denominations differ by design: cloud events → DOLLARS against
+	// thresholdDollarsPerMin; local events → nominal usertokens against
+	// localThresholdUsertokensPerMin, WITHOUT the per-call >=1 settlement floor.
+	// Settlement floors per call; the anomaly signal measures flow — so a
+	// default {0,0}-rate local stream contributes 0 and can never false-trip
+	// spend_velocity (rejected-merge design note, pinned by Task 3 tests).
+	const anomalyDetector = createAnomalyDetector(config.anomaly, {
+		provider: kind,
+		costCalculator: (calcModel, inputTokens, outputTokens, event) => {
+			const scope = event?.endpointClass ?? "cloud";
+			const resolution = resolveRates(event?.model ?? calcModel, scope, config);
+			if (scope === "local") {
+				const inTok = Number.isFinite(inputTokens) && inputTokens > 0 ? inputTokens : 0;
+				const outTok = Number.isFinite(outputTokens) && outputTokens > 0 ? outputTokens : 0;
+				return (
+					(inTok / 1000) * resolution.rates.inputPer1k +
+					(outTok / 1000) * resolution.rates.outputPer1k
+				);
+			}
+			return costFromRates(resolution.rates, inputTokens, outputTokens) / USERTOKENS_PER_DOLLAR;
+		},
+	});
 
 	// 7. Two-phase intercept
 	async function interceptCall(
@@ -344,11 +470,21 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			const cb = breaker.get(kind);
 			cb.allowRequest();
 
-			// b. Estimate cost (before policy, so cost fields are available in context)
+			// b. Estimate cost (before policy, so cost fields are available in context).
+			// M2: rates resolve within the endpoint scope CAPTURED AT AUTHORIZE (A3) —
+			// this one resolution prices the hold, both settlement paths, and the
+			// receipt's meter provenance. unknownModelPolicy is enforced here, at
+			// authorize time, before any PENDING hold (A5).
 			const transferId = trustId("tx");
 			const estimatedInputTokens = estimateInputTokens(promptParts);
 			const maxOutputTokens = (params.max_tokens as number) ?? 4096;
-			const estimatedCost = estimateCost(model, estimatedInputTokens, maxOutputTokens, customRates);
+			const rateResolution = resolveRates(model, endpoint.class, config);
+			enforceUnknownModelPolicy(model, rateResolution, config);
+			const estimatedCost = costFromRates(
+				rateResolution.rates,
+				estimatedInputTokens,
+				maxOutputTokens,
+			);
 
 			// AUD-453: Acquire mutex to serialise budget-check + PENDING hold.
 			// This prevents concurrent calls from both passing the budget check
@@ -483,14 +619,44 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				releaseBudgetLock();
 			}
 
+			// e0. M2 usage injection (A4): for local openai streams, opt in to the
+			// server's final usage chunk (Ollama emits /v1 streaming usage ONLY when
+			// stream_options.include_usage is set). The merge preserves the caller's
+			// other stream_options fields and respects an explicit include_usage.
+			// The resulting usage chunk is FORWARDED to the consumer unmodified
+			// (transparent middleware).
+			let preInjectionArgs: unknown[] | null = null;
+			if (kind === "openai" && endpoint.class === "local" && config.local.injectUsageOptions) {
+				const injected = withInjectedUsageOptions(forwardArgs);
+				if (injected != null) {
+					preInjectionArgs = forwardArgs;
+					forwardArgs = injected;
+				}
+			}
+
 			// e. Forward to original SDK. P3-PII-REDACT-EGRESS: forwardArgs is the
 			// redacted clone in redact mode, or the original args otherwise.
 			let settled = true;
 			try {
-				const response = await (originalFn as (...a: unknown[]) => unknown).apply(
-					thisArg,
-					forwardArgs,
-				);
+				let response: unknown;
+				try {
+					response = await (originalFn as (...a: unknown[]) => unknown).apply(thisArg, forwardArgs);
+				} catch (callErr) {
+					// A4: some OpenAI-compat servers reject unknown stream_options. When
+					// WE injected them AND the error plausibly says so (message/HTTP-status
+					// heuristic), retry ONCE without the injection; the retried stream
+					// simply settles on the estimate if no usage tail arrives (A7). Any
+					// other error — transient network failures, unrelated 5xx — rethrows
+					// the ORIGINAL immediately rather than duplicating compute and masking
+					// the root cause.
+					if (preInjectionArgs == null || !looksLikeStreamOptionsRejection(callErr)) {
+						throw callErr;
+					}
+					response = await (originalFn as (...a: unknown[]) => unknown).apply(
+						thisArg,
+						preInjectionArgs,
+					);
+				}
 
 				// e2. Streaming detection: if response is an async iterable, wrap with
 				// token accumulation. Settlement and audit happen when the stream ends.
@@ -504,15 +670,16 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						stream,
 						kind,
 						async (completion: StreamCompletion) => {
-							// Determine cost: use provider usage if reported, else fall back to estimate
+							// Determine cost: use provider usage if reported, else fall back to
+							// estimate. A3: priced with the rate resolution captured at
+							// authorize; A11: costFromRates floors at 1 even for 0/0 usage.
 							let streamCost: number;
 							let usageSource: "provider" | "estimated";
 							if (completion.usageReported) {
-								streamCost = estimateCost(
-									model,
+								streamCost = costFromRates(
+									rateResolution.rates,
 									completion.usage.inputTokens,
 									completion.usage.outputTokens,
-									customRates,
 								);
 								usageSource = "provider";
 							} else {
@@ -600,6 +767,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									transferId,
 									usageSource,
 									chunksDelivered: completion.chunksDelivered,
+									// M2: metering provenance mirrors the receipt (A3 authorize-time scope).
+									endpointClass: endpoint.class,
+									costBasis: rateResolution.costBasis,
+									rateSource: rateResolution.rateSource,
 								};
 								if (config.pii === "warn" || config.pii === "redact") {
 									const piiResult = redactPII(promptParts);
@@ -641,6 +812,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 								timestamp: new Date().toISOString(),
 								usageSource,
 								chunksDelivered: completion.chunksDelivered,
+								// M2 provenance (A6: computeMs omitted — no compute-time source here).
+								endpoint: { class: endpoint.class, runtime: endpoint.runtime },
+								meter: {
+									costBasis: rateResolution.costBasis,
+									rateSource: rateResolution.rateSource,
+								},
 								...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 								// AUD-456: Flag proxy stub receipts
 								...(proxyConn != null ? { proxyStub: true as const } : {}),
@@ -697,6 +874,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 								deltaTokens: obs.deltaTokens,
 								cumulativeInputTokens: obs.cumulativeInputTokens,
 								cumulativeOutputTokens: obs.cumulativeOutputTokens,
+								// M2: stamp the per-call scope so the SHARED detector prices
+								// this event with the same scoped rates as settlement.
+								model,
+								endpointClass: endpoint.class,
 							});
 							const verdict = anomalyDetector.check();
 							if (verdict.tripped) {
@@ -742,6 +923,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						model,
 						provider: kind,
 						timestamp: new Date().toISOString(),
+						// M2: authorize-time scope, already fixed for the eventual settle (A3).
+						endpoint: { class: endpoint.class, runtime: endpoint.runtime },
+						meter: {
+							costBasis: rateResolution.costBasis,
+							rateSource: rateResolution.rateSource,
+						},
 						...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 						// AUD-456: Flag proxy stub receipts
 						...(proxyConn != null ? { proxyStub: true as const } : {}),
@@ -751,8 +938,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					return { response: governedStream, receipt: estimatedReceipt };
 				}
 
-				// f. Compute actual cost from response usage
+				// f. Compute actual cost from response usage. A3: priced with the rate
+				// resolution captured at authorize. costFromRates clamps NaN/negative
+				// counts (A7) and floors at 1 even for 0/0 provider usage (A11).
 				let actualCost = estimatedCost;
+				let usageSource: "provider" | "estimated" = "estimated";
 				if (response != null && typeof response === "object" && "usage" in response) {
 					const usage = (response as Record<string, unknown>).usage as Record<
 						string,
@@ -767,7 +957,8 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							(usage.output_tokens as number | undefined) ??
 							(usage.completion_tokens as number | undefined) ??
 							0;
-						actualCost = estimateCost(model, inputTokens, outputTokens, customRates);
+						actualCost = costFromRates(rateResolution.rates, inputTokens, outputTokens);
+						usageSource = "provider";
 					}
 				}
 
@@ -785,6 +976,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						cost: actualCost,
 						settled: true,
 						transferId,
+						usageSource,
+						// M2: metering provenance mirrors the receipt (A3 authorize-time scope).
+						endpointClass: endpoint.class,
+						costBasis: rateResolution.costBasis,
+						rateSource: rateResolution.rateSource,
 					};
 					if (config.pii === "warn" || config.pii === "redact") {
 						const piiResult = redactPII(promptParts);
@@ -934,6 +1130,13 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					model,
 					provider: kind,
 					timestamp: new Date().toISOString(),
+					usageSource,
+					// M2 provenance (A6: computeMs omitted — no compute-time source here).
+					endpoint: { class: endpoint.class, runtime: endpoint.runtime },
+					meter: {
+						costBasis: rateResolution.costBasis,
+						rateSource: rateResolution.rateSource,
+					},
 					...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 					// AUD-456: Flag proxy stub receipts
 					...(proxyConn != null ? { proxyStub: true as const } : {}),

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -109,7 +109,7 @@ export interface TrustOpts {
 	 * boundary as budget/customRates: never derive it from end-user or request
 	 * data (A10).
 	 */
-	endpoint?: Partial<EndpointInfo>;
+	endpoint?: Partial<EndpointInfo> | undefined;
 	/**
 	 * Inject a mock/test engine. When set, used instead of TigerBeetle.
 	 * Primarily for testing failure modes.

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -86,7 +86,7 @@ export interface GovernorOpts extends TrustOpts {
 	 * it to end-user/request input. It sits on the same trust boundary as
 	 * budget/customRates: whoever sets it already controls billing entirely.
 	 */
-	endpoint?: EndpointInfo;
+	endpoint?: EndpointInfo | undefined;
 }
 
 /** Handle returned by authorize(), passed to settle() or abort(). */

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -86,7 +86,7 @@ export interface GovernorOpts extends TrustOpts {
 	 * it to end-user/request input. It sits on the same trust boundary as
 	 * budget/customRates: whoever sets it already controls billing entirely.
 	 */
-	endpoint?: EndpointInfo | undefined;
+	endpoint?: Partial<EndpointInfo> | undefined;
 }
 
 /** Handle returned by authorize(), passed to settle() or abort(). */
@@ -100,7 +100,8 @@ export interface Authorization {
 	createdAt: number;
 	/**
 	 * @internal Endpoint scope captured at authorize (A3). settle()/abort() use
-	 * THIS scope — never a later governor-level value.
+	 * THIS scope — never a later governor-level value. Always the NORMALIZED
+	 * full shape (normalizeEndpoint output), unlike the Partial caller inputs.
 	 */
 	endpoint?: EndpointInfo | undefined;
 }
@@ -125,9 +126,10 @@ export interface AuthorizeParams {
 	 * settle()/abort() and the receipt's endpoint/meter fields.
 	 *
 	 * SECURITY (A10): trusted-operator input only — never derive from
-	 * end-user/request data.
+	 * end-user/request data. Partial: omitted fields normalize (class →
+	 * "cloud", runtime → "unknown") — fail-expensive.
 	 */
-	endpoint?: EndpointInfo | undefined;
+	endpoint?: Partial<EndpointInfo> | undefined;
 }
 
 /** Parameters for settling an authorized call. */

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -46,7 +46,13 @@ import { type AuditWriter, createAuditWriter } from "./audit/chain.js";
 import { writeReceipt } from "./audit/rotation.js";
 import type { TrustEngine, TrustOpts } from "./govern.js";
 import { TBTransferError, TrustTBClient, XFER_SPEND } from "./ledger/client.js";
-import { estimateCost, estimateInputTokens } from "./ledger/pricing.js";
+import {
+	costFromRates,
+	estimateCost,
+	estimateInputTokens,
+	resolveRates,
+	warnUnknownModel,
+} from "./ledger/pricing.js";
 import { recordPattern } from "./memory/patterns.js";
 import { DEFAULT_RULES, mergePolicies } from "./policy/default-rules.js";
 import { type GateRule, evaluatePolicy, loadPolicies } from "./policy/gate.js";
@@ -61,9 +67,27 @@ import {
 } from "./shared/errors.js";
 import { trustId } from "./shared/ids.js";
 import { TrustConfigSchema } from "./shared/types.js";
-import type { TrustConfig, TrustReceipt } from "./shared/types.js";
+import type { EndpointInfo, TrustConfig, TrustReceipt } from "./shared/types.js";
 
 // ── Public types ──
+
+/**
+ * Options for createGovernor(): TrustOpts plus a governor-wide default
+ * endpoint scope (M2 local-model governance).
+ */
+export interface GovernorOpts extends TrustOpts {
+	/**
+	 * Governor-wide default endpoint scope for rate resolution. Applies to every
+	 * authorize() call that does not carry its own per-call `endpoint` override
+	 * (A3). Omitted → cloud scope (`{ class: "cloud", runtime: "unknown" }`),
+	 * which preserves pre-M2 metering exactly.
+	 *
+	 * SECURITY (A10): endpoint scope is a TRUSTED-OPERATOR decision — never wire
+	 * it to end-user/request input. It sits on the same trust boundary as
+	 * budget/customRates: whoever sets it already controls billing entirely.
+	 */
+	endpoint?: EndpointInfo;
+}
 
 /** Handle returned by authorize(), passed to settle() or abort(). */
 export interface Authorization {
@@ -74,6 +98,11 @@ export interface Authorization {
 	proxyTransferId?: string | undefined;
 	/** @internal Timestamp when authorization was created. */
 	createdAt: number;
+	/**
+	 * @internal Endpoint scope captured at authorize (A3). settle()/abort() use
+	 * THIS scope — never a later governor-level value.
+	 */
+	endpoint?: EndpointInfo | undefined;
 }
 
 /** Parameters for authorizing an LLM call. */
@@ -90,6 +119,15 @@ export interface AuthorizeParams {
 	params?: Record<string, unknown> | undefined;
 	/** Actor identity. Defaults to "local". */
 	actor?: string | undefined;
+	/**
+	 * Per-call endpoint scope override — wins over the governor-wide default
+	 * (A3). The effective scope is captured on the Authorization and governs
+	 * settle()/abort() and the receipt's endpoint/meter fields.
+	 *
+	 * SECURITY (A10): trusted-operator input only — never derive from
+	 * end-user/request data.
+	 */
+	endpoint?: EndpointInfo | undefined;
 }
 
 /** Parameters for settling an authorized call. */
@@ -102,6 +140,12 @@ export interface SettleParams {
 	chunksDelivered?: number | undefined;
 	/** Whether usage came from the provider or our estimate. */
 	usageSource?: "provider" | "estimated" | undefined;
+	/**
+	 * Wall-clock compute duration in milliseconds (local runtimes report it,
+	 * e.g. Ollama eval_duration). Flows to receipt.meter.computeMs. Non-finite
+	 * or negative values are dropped (A6: the field is then omitted entirely).
+	 */
+	computeMs?: number | undefined;
 }
 
 /** Headless governance engine for non-SDK integrations. */
@@ -144,6 +188,21 @@ export interface Governor {
 // ── Verify URL base ──
 
 const VERIFY_URL_BASE = "https://verify.usertrust.dev";
+
+// ── M2 endpoint scope helpers ──
+
+/**
+ * Normalize a (possibly partial, e.g. untyped-JS-caller) endpoint shape into a
+ * full EndpointInfo. Missing class defaults to "cloud" — the fail-EXPENSIVE
+ * safe default — and missing runtime to "unknown".
+ */
+function normalizeEndpoint(endpoint: Partial<EndpointInfo> | undefined): EndpointInfo {
+	return {
+		class: endpoint?.class ?? "cloud",
+		runtime: endpoint?.runtime ?? "unknown",
+		...(endpoint?.baseURL !== undefined ? { baseURL: endpoint.baseURL } : {}),
+	};
+}
 
 // ── Async mutex (same as govern.ts AUD-453) ──
 
@@ -350,7 +409,7 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
  * lifecycle. This is designed for systems like OpenClaw that make raw
  * LLM calls via streaming libraries (pi-ai) rather than SDK clients.
  */
-export async function createGovernor(opts?: TrustOpts): Promise<Governor> {
+export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 	// 1. Load config
 	const vaultBase = opts?.vaultBase ?? process.cwd();
 	const configPath = opts?.configPath ?? join(vaultBase, VAULT_DIR, "usertrust.config.json");
@@ -369,6 +428,9 @@ export async function createGovernor(opts?: TrustOpts): Promise<Governor> {
 	}
 
 	const customRates = config.pricing === "custom" ? config.customRates : undefined;
+	// M2: governor-wide default endpoint scope; per-call AuthorizeParams.endpoint
+	// overrides it (A3). Defaults to cloud — pre-M2 metering exactly.
+	const defaultEndpoint = normalizeEndpoint(opts?.endpoint);
 	const isDryRun = opts?.dryRun ?? process.env.USERTRUST_DRY_RUN === "true";
 	const isTestEnv = process.env.USERTRUST_TEST === "1" || process.env.NODE_ENV === "test";
 
@@ -472,11 +534,32 @@ export async function createGovernor(opts?: TrustOpts): Promise<Governor> {
 			const cb = breaker.get("headless" as never);
 			cb.allowRequest();
 
+			// M2: effective endpoint scope — per-call override wins over the
+			// governor-wide default (A3). Captured on the Authorization below so
+			// settle() meters with the AUTHORIZE-time scope.
+			const endpoint =
+				params.endpoint !== undefined ? normalizeEndpoint(params.endpoint) : defaultEndpoint;
+
+			// Scope-aware rate resolution. resolveRates never throws;
+			// unknownModelPolicy is enforced HERE, at authorize time. `unknown` is
+			// only ever true for cloud scope — local misses resolve to
+			// "local-default" by definition (A5), so local calls never deny/warn.
+			const rateInfo = resolveRates(model, endpoint.class, config);
+			if (rateInfo.unknown) {
+				if (config.unknownModelPolicy === "deny") {
+					throw new PolicyDeniedError(`unknown_model: ${model} not in pricing table`);
+				}
+				if (config.unknownModelPolicy === "warn") {
+					// Shared once-per-process helper — identical wording to trust() (F5).
+					warnUnknownModel(model);
+				}
+			}
+
 			// Estimate cost
 			const transferId = trustId("tx");
 			const estInputTokens = params.estimatedInputTokens ?? estimateInputTokens(messages);
 			const maxOutputTokens = params.maxOutputTokens ?? 4096;
-			const estCost = estimateCost(model, estInputTokens, maxOutputTokens, customRates);
+			const estCost = costFromRates(rateInfo.rates, estInputTokens, maxOutputTokens);
 
 			// Acquire mutex for budget atomicity (AUD-453)
 			const releaseBudgetLock = await budgetMutex.acquire();
@@ -555,6 +638,7 @@ export async function createGovernor(opts?: TrustOpts): Promise<Governor> {
 				model,
 				proxyTransferId,
 				createdAt: Date.now(),
+				endpoint,
 			};
 			activeAuths.set(transferId, auth);
 			return auth;
@@ -571,15 +655,19 @@ export async function createGovernor(opts?: TrustOpts): Promise<Governor> {
 			const model = auth.model;
 			let callAuditDegraded = false;
 
+			// A3: settlement meters with the endpoint scope CAPTURED AT AUTHORIZE —
+			// SettleParams carries no endpoint field by design.
+			const endpoint = auth.endpoint ?? defaultEndpoint;
+			const rateInfo = resolveRates(model, endpoint.class, config);
+
 			// Determine actual cost
 			let actualCost: number;
 			let usageSource: "provider" | "estimated";
 			if (params?.inputTokens != null || params?.outputTokens != null) {
-				actualCost = estimateCost(
-					model,
+				actualCost = costFromRates(
+					rateInfo.rates,
 					params.inputTokens ?? 0,
 					params.outputTokens ?? 0,
-					customRates,
 				);
 				usageSource = params.usageSource ?? "provider";
 			} else {
@@ -719,6 +807,18 @@ export async function createGovernor(opts?: TrustOpts): Promise<Governor> {
 				provider: "headless",
 				timestamp: new Date().toISOString(),
 				usageSource,
+				// M2: endpoint classification + metering provenance (A6: computeMs is
+				// OMITTED, never undefined, when absent/invalid).
+				endpoint: { class: endpoint.class, runtime: endpoint.runtime },
+				meter: {
+					costBasis: rateInfo.costBasis,
+					rateSource: rateInfo.rateSource,
+					...(params?.computeMs != null &&
+					Number.isFinite(params.computeMs) &&
+					params.computeMs >= 0
+						? { computeMs: params.computeMs }
+						: {}),
+				},
 				...(params?.chunksDelivered != null ? { chunksDelivered: params.chunksDelivered } : {}),
 				...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 				...(proxyConn != null ? { proxyStub: true as const } : {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,11 +14,19 @@ export type { Governor, Authorization, AuthorizeParams, SettleParams } from "./h
 // Config
 export { loadConfig, defineConfig } from "./config.js";
 
+// Endpoint classification
+export { classifyEndpoint } from "./detect.js";
+
 // Types
 export type {
 	TrustedResponse,
 	TrustReceipt,
 	TrustConfig,
+	EndpointClass,
+	EndpointInfo,
+	LocalRuntime,
+	CostBasis,
+	RateSource,
 	PolicyRule,
 	FieldCondition,
 	FieldOperator,
@@ -97,8 +105,13 @@ export type {
 } from "./audit/merkle.js";
 
 // Pricing
-export { getModelRates, estimateCost, estimateInputTokens } from "./ledger/pricing.js";
-export type { ModelRates } from "./ledger/pricing.js";
+export {
+	getModelRates,
+	estimateCost,
+	estimateInputTokens,
+	resolveRates,
+} from "./ledger/pricing.js";
+export type { ModelRates, RateResolution } from "./ledger/pricing.js";
 
 // Board
 export { createBoard } from "./board/board.js";

--- a/packages/core/src/ledger/pricing.ts
+++ b/packages/core/src/ledger/pricing.ts
@@ -9,6 +9,8 @@
  * Canonical pricing source for supported LLM models.
  */
 
+import type { CostBasis, EndpointClass, RateSource, TrustConfig } from "../shared/types.js";
+
 export interface ModelRates {
 	inputPer1k: number;
 	outputPer1k: number;
@@ -88,6 +90,9 @@ const PROVIDER_MODEL_MAP: Record<string, string[]> = {
 
 /** Return all PRICING_TABLE model keys that belong to a given provider. */
 export function modelsForProvider(provider: string): string[] {
+	// Object.hasOwn guards against inherited Object.prototype keys: a provider
+	// name like "constructor" must resolve to nothing, not Object's constructor.
+	if (!Object.hasOwn(PROVIDER_MODEL_MAP, provider)) return [];
 	const prefixes = PROVIDER_MODEL_MAP[provider];
 	if (!prefixes) return [];
 	return Object.keys(PRICING_TABLE).filter((model) => prefixes.some((p) => model.startsWith(p)));
@@ -98,13 +103,20 @@ export function modelsForProvider(provider: string): string[] {
  * then FALLBACK_RATE for unknown models.
  */
 export function getModelRates(model: string, customRates?: Record<string, ModelRates>): ModelRates {
-	if (customRates) {
+	// Object.hasOwn guards both direct lookups against inherited Object.prototype
+	// members: a model string like "constructor"/"__proto__"/"toString" would
+	// otherwise resolve to a Function/object, survive the truthiness check, and
+	// yield NaN cost (NaN then defeats the Math.max(1, ...) floor and poisons the
+	// ledger). Prefix matching below is already own-key-only (SORTED_TABLE).
+	if (customRates && Object.hasOwn(customRates, model)) {
 		const custom = customRates[model];
 		if (custom) return custom;
 	}
 
-	const exact = PRICING_TABLE[model];
-	if (exact) return exact;
+	if (Object.hasOwn(PRICING_TABLE, model)) {
+		const exact = PRICING_TABLE[model];
+		if (exact) return exact;
+	}
 
 	// Prefix match — longest key first prevents partial matches
 	for (const [key, rates] of SORTED_TABLE) {
@@ -112,6 +124,47 @@ export function getModelRates(model: string, customRates?: Record<string, ModelR
 	}
 
 	return FALLBACK_RATE;
+}
+
+/** Models already warned about — unknownModelPolicy "warn" fires once per model per process. */
+const warnedUnknownModels = new Set<string>();
+
+/**
+ * Emit the once-per-process cloud-scope "unknown model" warning for
+ * unknownModelPolicy "warn". Shared by trust() and createGovernor() so both
+ * governance paths log identical text and share a single dedup set. Idempotent
+ * per model string; the receipt's meter.rateSource "fallback" marker is set by
+ * the caller independently of this dedup.
+ */
+export function warnUnknownModel(model: string): void {
+	if (warnedUnknownModels.has(model)) return;
+	warnedUnknownModels.add(model);
+	console.warn(
+		`[usertrust] unknown model "${model}": metering at FALLBACK_RATE (sonnet-class); add it to customRates or set unknownModelPolicy`,
+	);
+}
+
+/**
+ * Compute usertoken cost from explicit rates.
+ * Applies the same non-finite/negative clamp and >=1 floor as estimateCost —
+ * the floor is per-call and load-bearing (zero-amount ledger transfers are
+ * invalid; it is what makes a {0,0}-rate local call settle at exactly 1
+ * nominal usertoken).
+ */
+export function costFromRates(
+	rates: ModelRates,
+	inputTokens: number,
+	outputTokens: number,
+): number {
+	// Defend against non-finite/negative token counts (garbage `max_tokens`, or
+	// provider usage that reports a negative/NaN value): any count that is not a
+	// finite number >= 0 is treated as 0. A NaN would otherwise poison budget
+	// state permanently; a negative would collapse a real cost to the floor of 1.
+	const inTok = Number.isFinite(inputTokens) && inputTokens > 0 ? inputTokens : 0;
+	const outTok = Number.isFinite(outputTokens) && outputTokens > 0 ? outputTokens : 0;
+	const inputCost = (inTok / 1000) * rates.inputPer1k;
+	const outputCost = (outTok / 1000) * rates.outputPer1k;
+	return Math.max(1, Math.ceil(inputCost + outputCost));
 }
 
 /**
@@ -124,16 +177,123 @@ export function estimateCost(
 	outputTokens: number,
 	customRates?: Record<string, ModelRates>,
 ): number {
-	const rates = getModelRates(model, customRates);
-	// Defend against non-finite/negative token counts (garbage `max_tokens`, or
-	// provider usage that reports a negative/NaN value): any count that is not a
-	// finite number >= 0 is treated as 0. A NaN would otherwise poison budget
-	// state permanently; a negative would collapse a real cost to the floor of 1.
-	const inTok = Number.isFinite(inputTokens) && inputTokens > 0 ? inputTokens : 0;
-	const outTok = Number.isFinite(outputTokens) && outputTokens > 0 ? outputTokens : 0;
-	const inputCost = (inTok / 1000) * rates.inputPer1k;
-	const outputCost = (outTok / 1000) * rates.outputPer1k;
-	return Math.max(1, Math.ceil(inputCost + outputCost));
+	return costFromRates(getModelRates(model, customRates), inputTokens, outputTokens);
+}
+
+// ── Scoped rate resolution (M2 local-model governance) ──
+
+/** A matched model-pattern entry: the pattern key that won and its value. */
+export interface ModelPatternMatch<T> {
+	pattern: string;
+	value: T;
+}
+
+/**
+ * Match a model string against a record keyed by exact models or TRAILING-star
+ * globs ("llama3.3*"; "*" matches everything). Exact match beats any glob;
+ * among globs the longest prefix wins. This is the model-pattern matcher (A2) —
+ * hostname patterns use a different leading-star syntax, implemented in detect.ts.
+ *
+ * Used by local.models, anomaly tokenRate.perModel.
+ */
+export function matchModelPattern<T>(
+	model: string,
+	patterns: Record<string, T>,
+): ModelPatternMatch<T> | undefined {
+	// Object.hasOwn guards against inherited Object.prototype keys
+	// (model "constructor" must not resolve to a Function).
+	if (Object.hasOwn(patterns, model)) {
+		return { pattern: model, value: patterns[model] as T };
+	}
+	let best: ModelPatternMatch<T> | undefined;
+	let bestLen = -1;
+	for (const [pattern, value] of Object.entries(patterns)) {
+		if (!pattern.endsWith("*")) continue;
+		const prefix = pattern.slice(0, -1);
+		if (model.startsWith(prefix) && prefix.length > bestLen) {
+			best = { pattern, value };
+			bestLen = prefix.length;
+		}
+	}
+	return best;
+}
+
+/** Result of scope-aware rate resolution. */
+export interface RateResolution {
+	rates: ModelRates;
+	scope: EndpointClass;
+	costBasis: CostBasis;
+	rateSource: RateSource;
+	/** true when cloud scope missed table+custom+prefix and fell back. */
+	unknown: boolean;
+}
+
+/**
+ * Resolve rates for a model within an endpoint scope. Never throws —
+ * unknownModelPolicy enforcement lives in the callers (govern/headless).
+ *
+ * Local scope: local.models exact match → longest trailing-* glob →
+ * local.defaultRate (rateSource "local-default"). NEVER FALLBACK_RATE, never
+ * the cloud table, never `unknown: true` (A5). costBasis is "usd-proxy" when
+ * local.rateClass is "amortized-usd", else "nominal".
+ *
+ * Cloud scope: delegates to the existing getModelRates(model, customRates)
+ * semantics, including the callers' pricing==="custom" gate on customRates;
+ * costBasis "usd-proxy"; unknown=true iff the result came from FALLBACK_RATE.
+ */
+export function resolveRates(
+	model: string,
+	scope: EndpointClass,
+	config: TrustConfig,
+): RateResolution {
+	if (scope === "local") {
+		const costBasis: CostBasis =
+			config.local.rateClass === "amortized-usd" ? "usd-proxy" : "nominal";
+		const match = matchModelPattern(model, config.local.models);
+		if (match !== undefined) {
+			return { rates: match.value, scope, costBasis, rateSource: "local-model", unknown: false };
+		}
+		return {
+			rates: config.local.defaultRate,
+			scope,
+			costBasis,
+			rateSource: "local-default",
+			unknown: false,
+		};
+	}
+
+	// Cloud scope — mirrors getModelRates(model, customRates) exactly, including
+	// the pricing==="custom" gate applied at the existing govern/headless call sites.
+	// Object.hasOwn guards both lookups so a model string like "constructor"/
+	// "__proto__" resolves to FALLBACK_RATE, never an inherited prototype member.
+	const customRates = config.pricing === "custom" ? config.customRates : undefined;
+	if (customRates && Object.hasOwn(customRates, model)) {
+		const custom = customRates[model];
+		if (custom) {
+			return { rates: custom, scope, costBasis: "usd-proxy", rateSource: "custom", unknown: false };
+		}
+	}
+
+	if (Object.hasOwn(PRICING_TABLE, model)) {
+		const exact = PRICING_TABLE[model];
+		if (exact) {
+			return { rates: exact, scope, costBasis: "usd-proxy", rateSource: "table", unknown: false };
+		}
+	}
+
+	for (const [key, rates] of SORTED_TABLE) {
+		if (model.startsWith(key)) {
+			return { rates, scope, costBasis: "usd-proxy", rateSource: "table", unknown: false };
+		}
+	}
+
+	return {
+		rates: FALLBACK_RATE,
+		scope,
+		costBasis: "usd-proxy",
+		rateSource: "fallback",
+		unknown: true,
+	};
 }
 
 /**

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -3,6 +3,27 @@
 
 import { z } from "zod";
 
+// ── Endpoint classification (M2 local-model governance) ──
+
+/** Settlement scope of an endpoint: local (self-hosted) or cloud (metered provider). */
+export type EndpointClass = "local" | "cloud";
+
+/** Best-effort runtime label for a local endpoint (receipt/UX metadata only). */
+export type LocalRuntime = "ollama" | "vllm" | "lmstudio" | "openai-compat" | "unknown";
+
+/** Result of endpoint classification — selects the settlement regime for a call. */
+export interface EndpointInfo {
+	class: EndpointClass;
+	runtime: LocalRuntime;
+	baseURL?: string | undefined;
+}
+
+/** Denomination of a settled cost: real-dollar proxy or nominal bookkeeping units. */
+export type CostBasis = "usd-proxy" | "nominal";
+
+/** Where the applied rates came from during resolution. */
+export type RateSource = "table" | "custom" | "local-model" | "local-default" | "fallback";
+
 // ── Trust Receipt ──
 export interface TrustReceipt {
 	transferId: string;
@@ -23,6 +44,10 @@ export interface TrustReceipt {
 	chunksDelivered?: number;
 	/** Action kind for governed non-LLM actions. Absent for LLM calls (backward compat). */
 	actionKind?: ActionKind;
+	/** Endpoint classification for this call. Absent on pre-M2 receipts. */
+	endpoint?: { class: EndpointClass; runtime: LocalRuntime };
+	/** Metering provenance: denomination and rate origin of the settled cost. */
+	meter?: { costBasis: CostBasis; rateSource: RateSource; computeMs?: number };
 }
 
 // ── TrustedResponse — returned by every governed LLM call ──
@@ -32,6 +57,13 @@ export interface TrustedResponse<T> {
 }
 
 // ── Config schema ──
+
+/** Per-1k-token rate pair (usertokens). Shared by customRates and local.* rates. */
+const RateSchema = z.object({
+	inputPer1k: z.number().finite().nonnegative(),
+	outputPer1k: z.number().finite().nonnegative(),
+});
+
 export const TrustConfigSchema = z.object({
 	budget: z.number().int().positive(),
 	tier: z.enum(["free", "mini", "pro", "mega", "ultra"]).default("mini"),
@@ -83,15 +115,53 @@ export const TrustConfigSchema = z.object({
 		)
 		.default([]),
 	pricing: z.enum(["recommended", "custom"]).default("recommended"),
-	customRates: z
-		.record(
-			z.string(),
+	customRates: z.record(z.string(), RateSchema).optional(),
+	/**
+	 * Endpoint matchers consumed by classifyEndpoint(). First match wins.
+	 * match forms: scheme URL ("http://gpu-box:8000", matched by origin),
+	 * leading-star hostname suffix ("*.gpu.internal"), or bare hostname ("gpu-box").
+	 */
+	endpoints: z
+		.array(
 			z.object({
-				inputPer1k: z.number().finite().nonnegative(),
-				outputPer1k: z.number().finite().nonnegative(),
+				match: z.string().min(1),
+				class: z.enum(["local", "cloud"]).default("local"),
+				runtime: z
+					.enum(["ollama", "vllm", "lmstudio", "openai-compat", "unknown"])
+					.default("unknown"),
 			}),
 		)
-		.optional(),
+		.default([]),
+	/** Local (zero-marginal-cost) settlement scope. */
+	local: z
+		.object({
+			/** Loopback hosts (localhost/127.0.0.1/[::1]) classify as local without config. */
+			autoDetectLoopback: z.boolean().default(true),
+			/**
+			 * Rate applied to any local-scope model with no local.models match. Default {0,0}:
+			 * with the >=1 floor, every local call settles at exactly 1 nominal usertoken.
+			 */
+			defaultRate: RateSchema.default({ inputPer1k: 0, outputPer1k: 0 }),
+			/**
+			 * Denomination of local rates: "nominal" (bookkeeping units) or "amortized-usd"
+			 * (operator's GPU-chargeback rate; 1 usertoken = $0.0001 as usual).
+			 */
+			rateClass: z.enum(["nominal", "amortized-usd"]).default("nominal"),
+			/**
+			 * Per-model local rates. Keys: exact model strings or trailing-* globs
+			 * ("llama3.3*", "*"). Exact match beats glob; longest glob wins.
+			 */
+			models: z.record(z.string(), RateSchema).default({}),
+			/** Inject stream_options:{include_usage:true} into local openai-kind streams. */
+			injectUsageOptions: z.boolean().default(true),
+		})
+		.default({}),
+	/**
+	 * Cloud-scope policy when a model misses customRates, PRICING_TABLE, and prefix match.
+	 * "fallback" = silent sonnet-class rate (legacy) · "warn" = same rate + one-time warn +
+	 * receipt.meter.rateSource "fallback" · "deny" = PolicyDeniedError before the PENDING hold.
+	 */
+	unknownModelPolicy: z.enum(["fallback", "warn", "deny"]).default("warn"),
 	supplyChain: z
 		.object({
 			// SC-3: fail-closed by default. A skill with no registered signing key
@@ -141,6 +211,10 @@ export const TrustConfigSchema = z.object({
 			tokenRate: z
 				.object({
 					thresholdTokPerSec: z.number().positive().default(500),
+					/** Local-scope threshold (fast local GPU inference legitimately exceeds 500). */
+					localThresholdTokPerSec: z.number().positive().default(5000),
+					/** Per-model threshold overrides. Keys: exact model or trailing-* glob. */
+					perModel: z.record(z.string(), z.number().positive()).default({}),
 					windowMs: z.number().int().positive().default(2_000),
 					consecutiveWindows: z.number().int().positive().default(3),
 				})
@@ -148,6 +222,8 @@ export const TrustConfigSchema = z.object({
 			spendVelocity: z
 				.object({
 					thresholdDollarsPerMin: z.number().positive().default(1.0),
+					/** Local-scope velocity threshold in nominal usertokens per minute. */
+					localThresholdUsertokensPerMin: z.number().positive().default(10_000),
 					windowMs: z.number().int().positive().default(10_000),
 				})
 				.default({}),

--- a/packages/core/src/streaming.ts
+++ b/packages/core/src/streaming.ts
@@ -9,9 +9,14 @@
  * the yielded data.
  *
  * Provider-specific extraction:
- *   - Anthropic: message_start (input_tokens), message_delta (output_tokens)
- *   - OpenAI: usage field on final chunk (prompt_tokens, completion_tokens)
- *   - Google: usageMetadata field (promptTokenCount, candidatesTokenCount)
+ *   - Anthropic: message_start (input_tokens), message_delta (output_tokens) —
+ *     incremental fields on distinct chunk types, accumulated as before.
+ *   - OpenAI: usage field (prompt_tokens, completion_tokens) — REPLACE-WITH-LATEST:
+ *     every usage-bearing chunk is an absolute snapshot. vLLM's
+ *     continuous_usage_stats stamps RUNNING totals on every chunk, so summing
+ *     would multiply-count (M2 design decision 5.2 / plan Task 2).
+ *   - Google: usageMetadata field (promptTokenCount, candidatesTokenCount) —
+ *     same replace-with-latest snapshot semantics.
  *
  * Usage:
  * ```ts
@@ -43,51 +48,64 @@ export interface GovernedStream<T> extends AsyncIterable<T> {
 
 // ── Token extraction ──
 
-function extractTokensFromChunk(chunk: unknown, kind: LLMClientKind): StreamUsage {
+/** Anthropic chunks carry incremental fields on distinct chunk types. */
+function extractAnthropicTokens(chunk: unknown): StreamUsage {
 	if (chunk == null || typeof chunk !== "object") {
 		return { inputTokens: 0, outputTokens: 0 };
 	}
 
 	const c = chunk as Record<string, unknown>;
 
-	if (kind === "anthropic") {
-		if (c.type === "message_start" && c.message != null && typeof c.message === "object") {
-			const msg = c.message as Record<string, unknown>;
-			if (msg.usage != null && typeof msg.usage === "object") {
-				const usage = msg.usage as Record<string, number>;
-				return { inputTokens: usage.input_tokens ?? 0, outputTokens: 0 };
-			}
+	if (c.type === "message_start" && c.message != null && typeof c.message === "object") {
+		const msg = c.message as Record<string, unknown>;
+		if (msg.usage != null && typeof msg.usage === "object") {
+			const usage = msg.usage as Record<string, number>;
+			return { inputTokens: usage.input_tokens ?? 0, outputTokens: 0 };
 		}
-		if (c.type === "message_delta") {
-			if (c.usage != null && typeof c.usage === "object") {
-				const usage = c.usage as Record<string, number>;
-				return { inputTokens: 0, outputTokens: usage.output_tokens ?? 0 };
-			}
-		}
-		return { inputTokens: 0, outputTokens: 0 };
 	}
+	if (c.type === "message_delta") {
+		if (c.usage != null && typeof c.usage === "object") {
+			const usage = c.usage as Record<string, number>;
+			return { inputTokens: 0, outputTokens: usage.output_tokens ?? 0 };
+		}
+	}
+	return { inputTokens: 0, outputTokens: 0 };
+}
+
+/** A7 sanitation: non-finite or negative provider counts are clamped to 0. */
+function sanitizeCount(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * Extract an ABSOLUTE usage snapshot from an OpenAI/Google chunk, or null when
+ * the chunk carries no usage object at all. A present-but-empty usage object IS
+ * a snapshot (explicit zeros count as reported usage — A11).
+ */
+function extractUsageSnapshot(chunk: unknown, kind: "openai" | "google"): StreamUsage | null {
+	if (chunk == null || typeof chunk !== "object") return null;
+	const c = chunk as Record<string, unknown>;
 
 	if (kind === "openai") {
 		if (c.usage != null && typeof c.usage === "object") {
-			const usage = c.usage as Record<string, number>;
+			const usage = c.usage as Record<string, unknown>;
 			return {
-				inputTokens: usage.prompt_tokens ?? 0,
-				outputTokens: usage.completion_tokens ?? 0,
+				inputTokens: sanitizeCount(usage.prompt_tokens),
+				outputTokens: sanitizeCount(usage.completion_tokens),
 			};
 		}
-		return { inputTokens: 0, outputTokens: 0 };
+		return null;
 	}
 
 	// google
 	if (c.usageMetadata != null && typeof c.usageMetadata === "object") {
-		const meta = c.usageMetadata as Record<string, number>;
+		const meta = c.usageMetadata as Record<string, unknown>;
 		return {
-			inputTokens: meta.promptTokenCount ?? 0,
-			outputTokens: meta.candidatesTokenCount ?? 0,
+			inputTokens: sanitizeCount(meta.promptTokenCount),
+			outputTokens: sanitizeCount(meta.candidatesTokenCount),
 		};
 	}
-
-	return { inputTokens: 0, outputTokens: 0 };
+	return null;
 }
 
 // ── Stream wrapper ──
@@ -146,19 +164,36 @@ async function* wrapStreamImpl<T>(
 	let errored = false;
 	try {
 		for await (const chunk of stream) {
-			const tokens = extractTokensFromChunk(chunk, kind);
 			let deltaInput = 0;
 			let deltaOutput = 0;
-			// Use latest non-zero value (providers report cumulative or final)
-			if (tokens.inputTokens > 0) {
-				deltaInput = Math.max(0, tokens.inputTokens - inputTokens);
-				inputTokens = tokens.inputTokens;
-				usageReported = true;
-			}
-			if (tokens.outputTokens > 0) {
-				deltaOutput = Math.max(0, tokens.outputTokens - outputTokens);
-				outputTokens = tokens.outputTokens;
-				usageReported = true;
+			if (kind === "openai" || kind === "google") {
+				// M2 REPLACE-WITH-LATEST (design decision 5.2 / plan Task 2): each
+				// usage-bearing chunk is an absolute snapshot, assigned wholesale.
+				// Fixes double-counting under vLLM continuous_usage_stats (running
+				// totals on every chunk); a decreasing final total takes the last
+				// chunk's values (A7); explicit zeros count as reported usage (A11).
+				const snapshot = extractUsageSnapshot(chunk, kind);
+				if (snapshot != null) {
+					deltaInput = Math.max(0, snapshot.inputTokens - inputTokens);
+					deltaOutput = Math.max(0, snapshot.outputTokens - outputTokens);
+					inputTokens = snapshot.inputTokens;
+					outputTokens = snapshot.outputTokens;
+					usageReported = true;
+				}
+			} else {
+				// Anthropic: message_start carries input, message_delta carries output —
+				// genuinely incremental chunk types; keep the latest non-zero value.
+				const tokens = extractAnthropicTokens(chunk);
+				if (tokens.inputTokens > 0) {
+					deltaInput = Math.max(0, tokens.inputTokens - inputTokens);
+					inputTokens = tokens.inputTokens;
+					usageReported = true;
+				}
+				if (tokens.outputTokens > 0) {
+					deltaOutput = Math.max(0, tokens.outputTokens - outputTokens);
+					outputTokens = tokens.outputTokens;
+					usageReported = true;
+				}
 			}
 
 			// Run hook BEFORE yielding so a throw aborts before the consumer sees it.

--- a/packages/core/tests/anomaly/local-anomaly.test.ts
+++ b/packages/core/tests/anomaly/local-anomaly.test.ts
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * local-anomaly.test.ts — M2 scoped anomaly governance.
+ *
+ * Covers: per-event model/endpointClass overrides, local token-rate thresholds
+ * (localThresholdTokPerSec default 5000 + perModel trailing-* globs), and
+ * dual-denomination spend velocity (cloud dollars vs local nominal usertokens).
+ *
+ * Pinned explicit behavior: with the default local rate {0,0}, per-chunk nominal
+ * cost is a constant floor of 1, so spend_velocity CANNOT trip on default local
+ * config — token_rate is the primary local signal. Velocity becomes meaningful
+ * when the operator sets nonzero local rates (amortized-usd showback).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createAnomalyDetector } from "../../src/anomaly/detector.js";
+import {
+	createSpendVelocitySignal,
+	resolveSpendVelocityConfig,
+} from "../../src/anomaly/signals/spend-velocity.js";
+import type { AnomalyChunkEvent } from "../../src/anomaly/types.js";
+import { costFromRates, resolveRates } from "../../src/ledger/pricing.js";
+import { type TrustConfig, TrustConfigSchema } from "../../src/shared/types.js";
+
+const USERTOKENS_PER_DOLLAR = 10_000;
+
+/**
+ * Mirrors the calculator govern.ts injects (Task 2): resolves rates from the
+ * event's model/endpointClass and returns dollars for cloud-scope events,
+ * nominal usertokens for local-scope events.
+ */
+function makeScopedCalculator(config: TrustConfig) {
+	return (
+		model: string,
+		inputTokens: number,
+		outputTokens: number,
+		event?: AnomalyChunkEvent,
+	): number => {
+		const scope = event?.endpointClass ?? "cloud";
+		const resolution = resolveRates(event?.model ?? model, scope, config);
+		const usertokens = costFromRates(resolution.rates, inputTokens, outputTokens);
+		return scope === "local" ? usertokens : usertokens / USERTOKENS_PER_DOLLAR;
+	};
+}
+
+function localChunk(overrides: Partial<AnomalyChunkEvent> = {}): AnomalyChunkEvent {
+	return {
+		kind: "chunk",
+		deltaTokens: 0,
+		cumulativeInputTokens: 0,
+		cumulativeOutputTokens: 0,
+		model: "llama3.3:70b",
+		endpointClass: "local",
+		...overrides,
+	};
+}
+
+describe("local token-rate thresholds", () => {
+	function driveLocalStream(
+		detector: ReturnType<typeof createAnomalyDetector>,
+		setNow: (t: number) => void,
+		tokPerSec: number,
+	): void {
+		// deltaTokens every 100ms, sustained for 3 seconds.
+		const delta = tokPerSec / 10;
+		for (let t = 0; t <= 3_000; t += 100) {
+			setNow(t);
+			detector.observe(
+				localChunk({
+					deltaTokens: delta,
+					cumulativeOutputTokens: (t / 100 + 1) * delta,
+					at: t,
+				}),
+			);
+		}
+	}
+
+	it("local stream at 6000 tok/s trips at the default local threshold (5000), named in the verdict", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				// localThresholdTokPerSec intentionally unset — the signal defaults it to 5000.
+				tokenRate: { thresholdTokPerSec: 500, windowMs: 1_000, consecutiveWindows: 2 },
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		driveLocalStream(
+			detector,
+			(t) => {
+				nowMs = t;
+			},
+			6_000,
+		);
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("token_rate");
+			// Local default threshold applied — NOT the cloud 500.
+			expect(verdict.threshold).toBe(5_000);
+			expect(verdict.metric).toBeGreaterThanOrEqual(5_000);
+			expect(verdict.message).toContain("localThresholdTokPerSec");
+		}
+	});
+
+	it('same 6000 tok/s with perModel {"llama3.3*": 10000} does NOT trip', () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: {
+					thresholdTokPerSec: 500,
+					windowMs: 1_000,
+					consecutiveWindows: 2,
+					perModel: { "llama3.3*": 10_000 },
+				},
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		driveLocalStream(
+			detector,
+			(t) => {
+				nowMs = t;
+			},
+			6_000,
+		);
+		expect(detector.check().tripped).toBe(false);
+	});
+
+	it("perModel glob below the observed rate trips and names the pattern in the verdict", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: {
+					thresholdTokPerSec: 500,
+					windowMs: 1_000,
+					consecutiveWindows: 2,
+					perModel: { "llama3.3*": 5_500 },
+				},
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		driveLocalStream(
+			detector,
+			(t) => {
+				nowMs = t;
+			},
+			6_000,
+		);
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("token_rate");
+			expect(verdict.threshold).toBe(5_500);
+			expect(verdict.message).toContain('perModel["llama3.3*"]');
+		}
+	});
+
+	it("local event without a model skips perModel and uses the local threshold", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: {
+					thresholdTokPerSec: 500,
+					windowMs: 1_000,
+					consecutiveWindows: 2,
+					perModel: { "llama3.3*": 10_000 },
+				},
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		// 6000 tok/s local stream with NO model on the events.
+		for (let t = 0; t <= 3_000; t += 100) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 600,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 100 + 1) * 600,
+				endpointClass: "local",
+			});
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.threshold).toBe(5_000);
+			expect(verdict.message).toContain("localThresholdTokPerSec");
+		}
+	});
+
+	it("perModel with no matching pattern falls through to the local threshold", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: {
+					thresholdTokPerSec: 500,
+					windowMs: 1_000,
+					consecutiveWindows: 2,
+					perModel: { "qwen*": 10_000 },
+				},
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		driveLocalStream(
+			detector,
+			(t) => {
+				nowMs = t;
+			},
+			6_000,
+		);
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.threshold).toBe(5_000);
+			expect(verdict.message).toContain("localThresholdTokPerSec");
+		}
+	});
+
+	it("cloud stream math unchanged: 750 tok/s trips at 500 even with local/perModel config present", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: {
+					thresholdTokPerSec: 500,
+					localThresholdTokPerSec: 5_000,
+					// perModel applies to LOCAL-scope events only — must not touch cloud.
+					perModel: { "claude*": 1_000_000 },
+					windowMs: 2_000,
+					consecutiveWindows: 3,
+				},
+				spendVelocity: { thresholdDollarsPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		// 75 tokens every 100ms = 750 tok/s for 7s — no endpointClass (legacy cloud events).
+		for (let t = 0; t <= 7_000; t += 100) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 75,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 100) * 75,
+				model: "claude-sonnet-4-6",
+			});
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("token_rate");
+			expect(verdict.threshold).toBe(500);
+			expect(verdict.message).not.toContain("localThresholdTokPerSec");
+			expect(verdict.message).not.toContain("perModel");
+		}
+	});
+});
+
+describe("token-rate cross-scope isolation (interleaved cloud + local)", () => {
+	function cloudChunk(deltaTokens: number, t: number, cumOut: number): AnomalyChunkEvent {
+		return {
+			kind: "chunk",
+			deltaTokens,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: cumOut,
+			model: "claude-sonnet-4-6",
+			at: t,
+		};
+	}
+
+	it("a cloud runaway (750 tok/s) interleaved with a slow local stream STILL trips at the cloud 500", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: {
+					thresholdTokPerSec: 500,
+					localThresholdTokPerSec: 5_000,
+					windowMs: 1_000,
+					consecutiveWindows: 2,
+				},
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		// Each step: a hot cloud chunk (75/100ms = 750 tok/s) THEN a slow local chunk
+		// (10/100ms = 100 tok/s). Local is observed LAST on purpose — with a single
+		// shared threshold it would leave 5000 in effect and the cloud window would
+		// evade; per-scope windows judge cloud on its own 500.
+		let cloudOut = 0;
+		let localOut = 0;
+		for (let t = 0; t <= 3_000; t += 100) {
+			nowMs = t;
+			cloudOut += 75;
+			detector.observe(cloudChunk(75, t, cloudOut));
+			localOut += 10;
+			detector.observe(localChunk({ deltaTokens: 10, cumulativeOutputTokens: localOut, at: t }));
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("token_rate");
+			// Cloud window judged at its own 500 — NOT the interleaved local 5000.
+			expect(verdict.threshold).toBe(500);
+			expect(verdict.metric).toBeGreaterThanOrEqual(500);
+			expect(verdict.message).not.toContain("localThresholdTokPerSec");
+			expect(verdict.message).not.toContain("perModel");
+		}
+	});
+
+	it("a local stream at 3000 tok/s interleaved with a slow cloud stream does NOT trip", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: {
+					thresholdTokPerSec: 500,
+					localThresholdTokPerSec: 5_000,
+					windowMs: 1_000,
+					consecutiveWindows: 2,
+				},
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 1e9 },
+			},
+			{ now: () => nowMs },
+		);
+		// Local 300/100ms = 3000 tok/s (< 5000, legitimate fast GPU) interleaved with a
+		// slow cloud 10/100ms = 100 tok/s (< 500). Neither window crosses its own
+		// threshold — a shared window would sum both (3100 tok/s) and could false-trip.
+		let localOut = 0;
+		let cloudOut = 0;
+		for (let t = 0; t <= 3_000; t += 100) {
+			nowMs = t;
+			localOut += 300;
+			detector.observe(localChunk({ deltaTokens: 300, cumulativeOutputTokens: localOut, at: t }));
+			cloudOut += 10;
+			detector.observe(cloudChunk(10, t, cloudOut));
+		}
+		expect(detector.check().tripped).toBe(false);
+	});
+});
+
+describe("dual-denomination spend velocity", () => {
+	it("local nonzero-rate velocity trips at localThresholdUsertokensPerMin (default 10000), unit in verdict", () => {
+		let nowMs = 0;
+		// Operator showback rates: 1 usertoken per output token.
+		const config = TrustConfigSchema.parse({
+			budget: 1_000,
+			local: { defaultRate: { inputPer1k: 0, outputPer1k: 1_000 } },
+		});
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 1e9, localThresholdTokPerSec: 1e9 },
+				// localThresholdUsertokensPerMin intentionally unset — signal defaults to 10_000.
+				spendVelocity: { thresholdDollarsPerMin: 1e9, windowMs: 10_000 },
+			},
+			{ now: () => nowMs, costCalculator: makeScopedCalculator(config) },
+		);
+		// Cumulative output grows 500 tok/s → 500 ut/s → 30_000 ut/min >> 10_000.
+		for (let t = 0; t <= 10_000; t += 500) {
+			nowMs = t;
+			detector.observe(localChunk({ cumulativeOutputTokens: (t / 1_000) * 500 }));
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("spend_velocity");
+			expect(verdict.threshold).toBe(10_000);
+			expect(verdict.metric).toBeGreaterThanOrEqual(10_000);
+			// Never fake dollars for nominal spend.
+			expect(verdict.message).toContain("usertokens/min");
+			expect(verdict.message).not.toContain("$");
+		}
+		// Idempotent while tripped (cooldown): re-check keeps the usertoken verdict.
+		const again = detector.check();
+		expect(again.tripped).toBe(true);
+		if (again.tripped) {
+			expect(again.kind).toBe("spend_velocity");
+			expect(again.message).toContain("usertokens/min");
+		}
+	});
+
+	it("local cumulative regression is clamped monotonic (no trip, no negative velocity)", () => {
+		let nowMs = 0;
+		const config = TrustConfigSchema.parse({
+			budget: 1_000,
+			local: { defaultRate: { inputPer1k: 0, outputPer1k: 1_000 } },
+		});
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 1e9, localThresholdTokPerSec: 1e9 },
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 60 },
+			},
+			{ now: () => nowMs, costCalculator: makeScopedCalculator(config) },
+		);
+		// Cumulative output regresses mid-stream (provider glitch) — clamped to last.
+		for (const [t, cumOut] of [
+			[0, 1_000],
+			[1_000, 500],
+			[5_000, 1_000],
+			[10_000, 1_000],
+		] as const) {
+			nowMs = t;
+			detector.observe(localChunk({ cumulativeOutputTokens: cumOut }));
+		}
+		expect(detector.check().tripped).toBe(false);
+	});
+
+	it("explicit localThresholdUsertokensPerMin is respected (raised threshold does not trip)", () => {
+		let nowMs = 0;
+		const config = TrustConfigSchema.parse({
+			budget: 1_000,
+			local: { defaultRate: { inputPer1k: 0, outputPer1k: 1_000 } },
+		});
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 1e9, localThresholdTokPerSec: 1e9 },
+				spendVelocity: {
+					thresholdDollarsPerMin: 1e9,
+					localThresholdUsertokensPerMin: 100_000,
+					windowMs: 10_000,
+				},
+			},
+			{ now: () => nowMs, costCalculator: makeScopedCalculator(config) },
+		);
+		// Same 30_000 ut/min stream — below the raised 100_000 threshold.
+		for (let t = 0; t <= 10_000; t += 500) {
+			nowMs = t;
+			detector.observe(localChunk({ cumulativeOutputTokens: (t / 1_000) * 500 }));
+		}
+		expect(detector.check().tripped).toBe(false);
+	});
+
+	it("zero-rate local velocity never trips (default local config; token_rate is the primary local signal)", () => {
+		let nowMs = 0;
+		// Default config: local.defaultRate is {0,0} → cumulative nominal cost is a
+		// constant floor of 1 → velocity is exactly 0 ut/min, forever.
+		const config = TrustConfigSchema.parse({ budget: 1_000 });
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 1e9, localThresholdTokPerSec: 1e9 },
+				// Absurdly low local threshold: even 60 ut/min cannot trip on a flat cumulative.
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 60 },
+			},
+			{ now: () => nowMs, costCalculator: makeScopedCalculator(config) },
+		);
+		// A million output tokens over 10 seconds — free inference, flat nominal cost.
+		for (let t = 0; t <= 10_000; t += 500) {
+			nowMs = t;
+			detector.observe(localChunk({ cumulativeOutputTokens: (t / 10) * 1_000 }));
+		}
+		expect(detector.check().tripped).toBe(false);
+	});
+
+	it("zero-rate local velocity never trips with the built-in default calculator either", () => {
+		let nowMs = 0;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				tokenRate: { thresholdTokPerSec: 1e9, localThresholdTokPerSec: 1e9 },
+				spendVelocity: { thresholdDollarsPerMin: 1e9, localThresholdUsertokensPerMin: 60 },
+			},
+			{ now: () => nowMs }, // no injected calculator
+		);
+		for (let t = 0; t <= 10_000; t += 500) {
+			nowMs = t;
+			detector.observe(localChunk({ cumulativeOutputTokens: (t / 10) * 1_000 }));
+		}
+		expect(detector.check().tripped).toBe(false);
+	});
+
+	it("cloud spend-velocity math unchanged: $/min verdict with dollar threshold (3-arg legacy calculator)", () => {
+		let nowMs = 0;
+		// Legacy 3-arg calculator stays assignable (backward compatible).
+		const costCalc = (_m: string, _i: number, output: number) => output;
+		const detector = createAnomalyDetector(
+			{
+				enabled: true,
+				spendVelocity: {
+					thresholdDollarsPerMin: 1.0,
+					localThresholdUsertokensPerMin: 1e9,
+					windowMs: 10_000,
+				},
+			},
+			{ now: () => nowMs, costCalculator: costCalc, model: "test" },
+		);
+		// $0.02/s = $1.20/min — over the $1/min threshold. No endpointClass (legacy events).
+		for (let t = 0; t <= 10_000; t += 1_000) {
+			nowMs = t;
+			detector.observe({
+				kind: "chunk",
+				deltaTokens: 0,
+				cumulativeInputTokens: 0,
+				cumulativeOutputTokens: (t / 1_000) * 0.02,
+			});
+		}
+		const verdict = detector.check();
+		expect(verdict.tripped).toBe(true);
+		if (verdict.tripped) {
+			expect(verdict.kind).toBe("spend_velocity");
+			expect(verdict.threshold).toBe(1.0);
+			expect(verdict.metric).toBeGreaterThanOrEqual(1.0);
+			expect(verdict.message).toContain("$/min");
+			expect(verdict.message).not.toContain("usertokens");
+		}
+	});
+});
+
+describe("spend-velocity signal: mixed-scope denomination reporting", () => {
+	it("non-tripped check reports the denomination closer to its threshold", () => {
+		const signal = createSpendVelocitySignal(
+			resolveSpendVelocityConfig({
+				thresholdDollarsPerMin: 100,
+				localThresholdUsertokensPerMin: 1_000,
+				windowMs: 60_000,
+			}),
+		);
+		// cloud: $10/min → 10% of threshold; local: 500 ut/min → 50% of threshold.
+		signal.observe(0, 0, "cloud");
+		signal.observe(0, 0, "local");
+		signal.observe(10, 60_000, "cloud");
+		signal.observe(500, 60_000, "local");
+		const r = signal.check(60_000);
+		expect(r.tripped).toBe(false);
+		expect(r.unit).toBe("usertokens");
+		expect(r.thresholdLabel).toBe("localThresholdUsertokensPerMin");
+		expect(r.metric).toBeCloseTo(500);
+
+		// Flip: cloud closer to its threshold → dollars reported.
+		signal.reset();
+		signal.observe(0, 0, "cloud");
+		signal.observe(0, 0, "local");
+		signal.observe(90, 60_000, "cloud");
+		signal.observe(100, 60_000, "local");
+		const r2 = signal.check(60_000);
+		expect(r2.tripped).toBe(false);
+		expect(r2.unit).toBe("dollars");
+		expect(r2.metric).toBeCloseTo(90);
+	});
+});
+
+describe("per-event calculator seam", () => {
+	it("per-event model override and the event object reach the injected calculator", () => {
+		const seen: Array<{
+			model: string;
+			eventModel: string | undefined;
+			scope: string | undefined;
+		}> = [];
+		const calc = vi.fn(
+			(model: string, _input: number, _output: number, event?: AnomalyChunkEvent): number => {
+				seen.push({ model, eventModel: event?.model, scope: event?.endpointClass });
+				return 0;
+			},
+		);
+		const detector = createAnomalyDetector(
+			{ enabled: true },
+			{ model: "governor-default", costCalculator: calc, now: () => 0 },
+		);
+
+		const localEvent = localChunk({ model: "qwen2.5:7b" });
+		detector.observe(localEvent);
+		detector.observe({
+			kind: "chunk",
+			deltaTokens: 0,
+			cumulativeInputTokens: 0,
+			cumulativeOutputTokens: 0,
+		});
+
+		// Event model overrides options.model; the observed event is passed through.
+		expect(seen[0]).toEqual({ model: "qwen2.5:7b", eventModel: "qwen2.5:7b", scope: "local" });
+		expect(calc.mock.calls[0]?.[3]).toBe(localEvent);
+		// Without an event model, options.model is the fallback.
+		expect(seen[1]).toEqual({ model: "governor-default", eventModel: undefined, scope: undefined });
+	});
+});

--- a/packages/core/tests/detect/classify-endpoint.test.ts
+++ b/packages/core/tests/detect/classify-endpoint.test.ts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { classifyEndpoint } from "../../src/detect.js";
+import { type TrustConfig, TrustConfigSchema } from "../../src/shared/types.js";
+
+function makeConfig(overrides: Record<string, unknown> = {}): TrustConfig {
+	return TrustConfigSchema.parse({ budget: 1000, ...overrides });
+}
+
+/** Minimal OpenAI-SDK-shaped client with an optional baseURL. */
+function openaiClient(baseURL?: string | unknown): unknown {
+	const client: Record<string, unknown> = {
+		chat: { completions: { create: () => Promise.resolve({}) } },
+	};
+	if (baseURL !== undefined) client.baseURL = baseURL;
+	return client;
+}
+
+describe("classifyEndpoint — loopback autodetect", () => {
+	it("classifies http://localhost:11434/v1 as local/ollama", () => {
+		const info = classifyEndpoint(openaiClient("http://localhost:11434/v1"), makeConfig());
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("ollama");
+		expect(info.baseURL).toBe("http://localhost:11434/v1");
+	});
+
+	it("classifies http://127.0.0.1:1234/v1 as local/lmstudio", () => {
+		const info = classifyEndpoint(openaiClient("http://127.0.0.1:1234/v1"), makeConfig());
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("lmstudio");
+	});
+
+	it("classifies http://[::1]:8000/v1 as local/vllm (IPv6 brackets normalized)", () => {
+		const info = classifyEndpoint(openaiClient("http://[::1]:8000/v1"), makeConfig());
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("vllm");
+	});
+
+	it("classifies the IPv4-mapped IPv6 loopback http://[::ffff:127.0.0.1]:11434 as local/ollama (F6)", () => {
+		// Node serializes ::ffff:127.0.0.1 to ::ffff:7f00:1 — the loopback set must
+		// carry that WHATWG form, not the human dotted spelling, or it classifies cloud.
+		const info = classifyEndpoint(openaiClient("http://[::ffff:127.0.0.1]:11434/v1"), makeConfig());
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("ollama");
+	});
+
+	it("classifies http://localhost:9999/v1 as local/openai-compat (unknown port)", () => {
+		const info = classifyEndpoint(openaiClient("http://localhost:9999/v1"), makeConfig());
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("openai-compat");
+	});
+
+	it("is case-insensitive on the hostname", () => {
+		const info = classifyEndpoint(openaiClient("http://LOCALHOST:11434/v1"), makeConfig());
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("ollama");
+	});
+
+	it("classifies loopback as cloud when autoDetectLoopback is false", () => {
+		const config = makeConfig({ local: { autoDetectLoopback: false } });
+		const info = classifyEndpoint(openaiClient("http://localhost:11434/v1"), config);
+		expect(info.class).toBe("cloud");
+		expect(info.runtime).toBe("unknown");
+	});
+});
+
+describe("classifyEndpoint — config.endpoints matchers", () => {
+	it("matches a scheme entry by origin, ignoring path/query/trailing slash", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "http://gpu-box:8000", class: "local", runtime: "vllm" }],
+		});
+		for (const baseURL of [
+			"http://gpu-box:8000",
+			"http://gpu-box:8000/",
+			"http://gpu-box:8000/v1",
+			"http://gpu-box:8000/v1?x=1",
+		]) {
+			const info = classifyEndpoint(openaiClient(baseURL), config);
+			expect(info.class, baseURL).toBe("local");
+			expect(info.runtime, baseURL).toBe("vllm");
+		}
+	});
+
+	it("scheme entries with a path still match by origin", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "http://gpu-box:8000/v1/", class: "local", runtime: "vllm" }],
+		});
+		const info = classifyEndpoint(openaiClient("http://gpu-box:8000/other"), config);
+		expect(info.class).toBe("local");
+	});
+
+	it("A1 adversarial: http://gpu-box:8000.evil.com does NOT match http://gpu-box:8000", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "http://gpu-box:8000", class: "local", runtime: "vllm" }],
+		});
+		// Non-numeric port makes this an invalid URL — treated as absent, never a match.
+		let info: ReturnType<typeof classifyEndpoint> | undefined;
+		expect(() => {
+			info = classifyEndpoint(openaiClient("http://gpu-box:8000.evil.com/v1"), config);
+		}).not.toThrow();
+		expect(info?.class).toBe("cloud");
+		expect(info?.runtime).toBe("unknown");
+	});
+
+	it("A1 adversarial: http://gpu-box:8000@evil.com does NOT match http://gpu-box:8000", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "http://gpu-box:8000", class: "local", runtime: "vllm" }],
+		});
+		// "gpu-box:8000" parses as userinfo; the real host is evil.com → origin mismatch.
+		const info = classifyEndpoint(openaiClient("http://gpu-box:8000@evil.com/v1"), config);
+		expect(info.class).toBe("cloud");
+		expect(info.runtime).toBe("unknown");
+	});
+
+	it("scheme mismatch does not match (https entry vs http baseURL)", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "https://gpu-box:8000", class: "local", runtime: "vllm" }],
+		});
+		const info = classifyEndpoint(openaiClient("http://gpu-box:8000/v1"), config);
+		expect(info.class).toBe("cloud");
+	});
+
+	it("*.gpu.internal matches subdomains at any depth but not the bare domain", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "*.gpu.internal", class: "local", runtime: "openai-compat" }],
+		});
+		expect(classifyEndpoint(openaiClient("http://a.gpu.internal:8000/v1"), config).class).toBe(
+			"local",
+		);
+		expect(classifyEndpoint(openaiClient("http://x.y.gpu.internal:1234/v1"), config).class).toBe(
+			"local",
+		);
+		expect(classifyEndpoint(openaiClient("http://gpu.internal:8000/v1"), config).class).toBe(
+			"cloud",
+		);
+	});
+
+	it("A1 adversarial: *.gpu.internal does not match evilgpu.internal or gpu.internal.evil.com", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "*.gpu.internal", class: "local", runtime: "openai-compat" }],
+		});
+		expect(classifyEndpoint(openaiClient("http://evilgpu.internal:8000/v1"), config).class).toBe(
+			"cloud",
+		);
+		expect(
+			classifyEndpoint(openaiClient("http://a.gpu.internal.evil.com:8000/v1"), config).class,
+		).toBe("cloud");
+	});
+
+	it("bare hostname entries match case-insensitively on any port", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "GPU-BOX", class: "local", runtime: "ollama" }],
+		});
+		const info = classifyEndpoint(openaiClient("http://gpu-box:9999/v1"), config);
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("ollama");
+	});
+
+	it("first matching entry wins", () => {
+		const config = makeConfig({
+			endpoints: [
+				{ match: "*.internal", class: "cloud", runtime: "unknown" },
+				{ match: "*.gpu.internal", class: "local", runtime: "vllm" },
+			],
+		});
+		const info = classifyEndpoint(openaiClient("http://a.gpu.internal:8000/v1"), config);
+		expect(info.class).toBe("cloud");
+	});
+
+	it("config.endpoints entries take precedence over loopback autodetect", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "http://localhost:11434", class: "cloud", runtime: "unknown" }],
+		});
+		const info = classifyEndpoint(openaiClient("http://localhost:11434/v1"), config);
+		expect(info.class).toBe("cloud");
+	});
+
+	it("an unparseable scheme entry is skipped without throwing", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "http://", class: "cloud", runtime: "unknown" }],
+		});
+		// Entry parse fails → skipped → loopback autodetect still applies.
+		const info = classifyEndpoint(openaiClient("http://localhost:11434/v1"), config);
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("ollama");
+	});
+});
+
+describe("classifyEndpoint — override", () => {
+	it("override.class wins over loopback autodetect", () => {
+		const info = classifyEndpoint(openaiClient("http://localhost:11434/v1"), makeConfig(), {
+			class: "cloud",
+		});
+		expect(info.class).toBe("cloud");
+		expect(info.runtime).toBe("unknown");
+	});
+
+	it("override.class wins over config.endpoints matchers", () => {
+		const config = makeConfig({
+			endpoints: [{ match: "http://gpu-box:8000", class: "local", runtime: "vllm" }],
+		});
+		const info = classifyEndpoint(openaiClient("http://gpu-box:8000/v1"), config, {
+			class: "cloud",
+		});
+		expect(info.class).toBe("cloud");
+	});
+
+	it("override can force local on a cloud URL, defaulting runtime to unknown", () => {
+		const info = classifyEndpoint(openaiClient("https://api.openai.com/v1"), makeConfig(), {
+			class: "local",
+		});
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("unknown");
+	});
+
+	it("override carries an explicit runtime", () => {
+		const info = classifyEndpoint(openaiClient("https://api.openai.com/v1"), makeConfig(), {
+			class: "local",
+			runtime: "vllm",
+		});
+		expect(info.runtime).toBe("vllm");
+	});
+
+	it("override without class does not short-circuit classification", () => {
+		const info = classifyEndpoint(openaiClient("http://localhost:11434/v1"), makeConfig(), {
+			runtime: "vllm",
+		});
+		// No override.class → normal flow; loopback wins and port hint applies.
+		expect(info.class).toBe("local");
+		expect(info.runtime).toBe("ollama");
+	});
+});
+
+describe("classifyEndpoint — cloud defaults and malformed input", () => {
+	it("classifies a client without baseURL as cloud", () => {
+		const info = classifyEndpoint(openaiClient(), makeConfig());
+		expect(info).toEqual({ class: "cloud", runtime: "unknown" });
+	});
+
+	it("classifies a non-string baseURL as cloud", () => {
+		const info = classifyEndpoint(openaiClient(42), makeConfig());
+		expect(info).toEqual({ class: "cloud", runtime: "unknown" });
+	});
+
+	it("treats a malformed baseURL string as absent (cloud, no throw)", () => {
+		let info: ReturnType<typeof classifyEndpoint> | undefined;
+		expect(() => {
+			info = classifyEndpoint(openaiClient("not a url at all"), makeConfig());
+		}).not.toThrow();
+		expect(info?.class).toBe("cloud");
+		expect(info?.runtime).toBe("unknown");
+	});
+
+	it("classifies https://api.openai.com/v1 as cloud", () => {
+		const info = classifyEndpoint(openaiClient("https://api.openai.com/v1"), makeConfig());
+		expect(info.class).toBe("cloud");
+		expect(info.runtime).toBe("unknown");
+		expect(info.baseURL).toBe("https://api.openai.com/v1");
+	});
+
+	it("classifies a non-object client as cloud", () => {
+		expect(classifyEndpoint(null, makeConfig())).toEqual({ class: "cloud", runtime: "unknown" });
+		expect(classifyEndpoint("client", makeConfig())).toEqual({
+			class: "cloud",
+			runtime: "unknown",
+		});
+	});
+});

--- a/packages/core/tests/e2e/local-openai-compat.e2e.test.ts
+++ b/packages/core/tests/e2e/local-openai-compat.e2e.test.ts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * local-openai-compat.e2e.test.ts — M2 end-to-end: trust() wrapping an
+ * OpenAI-SDK-shaped client pointed at a real (in-process) OpenAI-compatible
+ * HTTP server, exercising the full governed path over the wire: loopback
+ * classification → nominal metering → include_usage injection → server-truth
+ * settlement → budget math, plus the BEFORE-behavior regression guard that
+ * documents the pre-M2 frontier-fallback bug as the contrast case.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// Zero-dep verify package, imported by relative path across the workspace
+// (same pattern as tests/harden/differential.test.ts). Source is READ, never modified.
+import { verifyVault } from "../../../verify/src/index.js";
+import { trust } from "../../src/govern.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
+import type { TrustReceipt } from "../../src/shared/types.js";
+import {
+	type MockOpenAIServer,
+	startMockOpenAIServer,
+} from "../fixtures/mock-openai-compat-server.js";
+
+// Mock tigerbeetle-node (native module, never loaded in tests)
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: {
+		linked: 1,
+		pending: 2,
+		post_pending_transfer: 4,
+		void_pending_transfer: 8,
+	},
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Helpers ──
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `local-e2e-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function writeVaultConfig(vaultBase: string, config: Record<string, unknown>): void {
+	const configDir = join(vaultBase, VAULT_DIR);
+	mkdirSync(configDir, { recursive: true });
+	writeFileSync(join(configDir, "usertrust.config.json"), JSON.stringify(config));
+}
+
+/** Minimal SSE reader for the mock server's text/event-stream responses. */
+async function* sseStream(res: Response): AsyncGenerator<unknown> {
+	const body = res.body;
+	if (body == null) return;
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let buffer = "";
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			let sep = buffer.indexOf("\n\n");
+			while (sep !== -1) {
+				const event = buffer.slice(0, sep);
+				buffer = buffer.slice(sep + 2);
+				sep = buffer.indexOf("\n\n");
+				const dataLine = event.split("\n").find((l) => l.startsWith("data: "));
+				if (dataLine === undefined) continue;
+				const payload = dataLine.slice(6);
+				if (payload === "[DONE]") return;
+				yield JSON.parse(payload) as unknown;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+/**
+ * An OpenAI-SDK-shaped client that actually speaks HTTP to the mock server —
+ * exposes `baseURL` (like the real OpenAI SDK) so classifyEndpoint can read it.
+ */
+function makeOpenAICompatClient(baseURL: string) {
+	return {
+		baseURL,
+		chat: {
+			completions: {
+				create: async (params: Record<string, unknown>): Promise<unknown> => {
+					const res = await fetch(`${baseURL}/chat/completions`, {
+						method: "POST",
+						headers: { "content-type": "application/json" },
+						body: JSON.stringify(params),
+					});
+					if (!res.ok) throw new Error(`HTTP ${res.status}`);
+					if (params.stream === true) return sseStream(res);
+					return (await res.json()) as unknown;
+				},
+			},
+		},
+	};
+}
+
+interface CallResult {
+	response: unknown;
+	receipt: TrustReceipt;
+}
+
+async function call(governed: unknown, params: Record<string, unknown>): Promise<CallResult> {
+	const g = governed as {
+		chat: { completions: { create: (p: Record<string, unknown>) => Promise<CallResult> } };
+	};
+	return g.chat.completions.create(params);
+}
+
+async function destroy(governed: unknown): Promise<void> {
+	await (governed as { destroy(): Promise<void> }).destroy();
+}
+
+// ── Tests ──
+
+describe("local OpenAI-compat endpoint — e2e over HTTP (M2)", () => {
+	let server: MockOpenAIServer;
+	let tmpVault: string;
+
+	beforeEach(async () => {
+		server = await startMockOpenAIServer({ promptTokens: 100, completionTokens: 50 });
+		tmpVault = makeTmpVault();
+	});
+
+	afterEach(async () => {
+		await server.close();
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+		vi.restoreAllMocks();
+	});
+
+	it("(a) non-stream call settles at exactly 1 nominal usertoken from provider usage", async () => {
+		const client = makeOpenAICompatClient(`${server.url}/v1`);
+		const governed = await trust(client, { dryRun: true, budget: 200, vaultBase: tmpVault });
+
+		const result = await call(governed, {
+			model: "llama3.3:70b",
+			messages: [{ role: "user", content: "Explain governance briefly" }],
+		});
+
+		expect(result.receipt.cost).toBe(1);
+		expect(result.receipt.usageSource).toBe("provider");
+		expect(result.receipt.endpoint).toEqual({ class: "local", runtime: "openai-compat" });
+		// A6: computeMs is omitted, not undefined — toEqual pins the exact key set.
+		expect(result.receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+		expect(result.receipt.settled).toBe(true);
+		expect(result.receipt.budgetRemaining).toBe(199);
+
+		await destroy(governed);
+	});
+
+	it("(b) streamed call: include_usage injected over the wire, settles from server-truth usage", async () => {
+		writeVaultConfig(tmpVault, {
+			budget: 200,
+			local: { models: { "llama3.3*": { inputPer1k: 10, outputPer1k: 20 } } },
+		});
+		const client = makeOpenAICompatClient(`${server.url}/v1`);
+		const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+		const result = await call(governed, {
+			model: "llama3.3:70b",
+			stream: true,
+			messages: [{ role: "user", content: "stream please" }],
+		});
+
+		const collected: unknown[] = [];
+		for await (const chunk of result.response as AsyncIterable<unknown>) {
+			collected.push(chunk);
+		}
+		const receipt = await (result.response as { receipt: Promise<TrustReceipt> }).receipt;
+
+		// The governed layer injected the opt-in the caller never wrote…
+		expect(server.lastRequest()?.stream_options).toEqual({ include_usage: true });
+		// …and the resulting usage tail chunk was forwarded to the consumer unmodified.
+		expect(collected).toHaveLength(4);
+		const tail = collected[3] as { usage?: { prompt_tokens: number; completion_tokens: number } };
+		expect(tail.usage).toMatchObject({ prompt_tokens: 100, completion_tokens: 50 });
+
+		// Server-truth settlement: (100/1000)*10 + (50/1000)*20 = 2.
+		expect(receipt.cost).toBe(2);
+		expect(receipt.usageSource).toBe("provider");
+		expect(receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-model" });
+		expect(receipt.endpoint).toEqual({ class: "local", runtime: "openai-compat" });
+
+		await destroy(governed);
+	});
+
+	it("(b2) streamed call on default {0,0} local rates settles at 1 nominal usertoken", async () => {
+		const client = makeOpenAICompatClient(`${server.url}/v1`);
+		const governed = await trust(client, { dryRun: true, budget: 200, vaultBase: tmpVault });
+
+		const result = await call(governed, {
+			model: "llama3.3:70b",
+			stream: true,
+			messages: [{ role: "user", content: "stream please" }],
+		});
+		for await (const _ of result.response as AsyncIterable<unknown>) {
+			// consume
+		}
+		const receipt = await (result.response as { receipt: Promise<TrustReceipt> }).receipt;
+
+		expect(receipt.cost).toBe(1);
+		expect(receipt.usageSource).toBe("provider");
+		expect(receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+
+		await destroy(governed);
+	});
+
+	it("(c) budget is decremented by exactly 1 per call", async () => {
+		const client = makeOpenAICompatClient(`${server.url}/v1`);
+		const governed = await trust(client, { dryRun: true, budget: 200, vaultBase: tmpVault });
+
+		const params = {
+			model: "llama3.3:70b",
+			messages: [{ role: "user", content: "count me" }],
+		};
+		const r1 = await call(governed, params);
+		const r2 = await call(governed, params);
+		const r3 = await call(governed, params);
+
+		expect(r1.receipt.cost).toBe(1);
+		expect(r2.receipt.cost).toBe(1);
+		expect(r3.receipt.cost).toBe(1);
+		expect(r1.receipt.budgetRemaining).toBe(199);
+		expect(r2.receipt.budgetRemaining).toBe(198);
+		expect(r3.receipt.budgetRemaining).toBe(197);
+
+		await destroy(governed);
+	});
+
+	it("(d) BEFORE-behavior guard: autoDetectLoopback:false meters the same call at FALLBACK_RATE", async () => {
+		// This is the pre-M2 bug as a contrast case: with loopback autodetect off,
+		// the endpoint classifies as cloud, "llama3.3:70b" misses the pricing
+		// table, and free inference is billed at sonnet-class FALLBACK_RATE.
+		// Budget is 5000 (not 200) because the fallback-rate PENDING hold alone
+		// (~617 ut for a $0 call) would overshoot a 200-ut budget — that
+		// over-reservation is itself part of the documented old bug.
+		writeVaultConfig(tmpVault, { budget: 5000, local: { autoDetectLoopback: false } });
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const client = makeOpenAICompatClient(`${server.url}/v1`);
+		const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+		const result = await call(governed, {
+			model: "llama3.3:70b",
+			messages: [{ role: "user", content: "Explain governance briefly" }],
+		});
+
+		expect(result.receipt.endpoint).toEqual({ class: "cloud", runtime: "unknown" });
+		expect(result.receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "fallback" });
+		// FALLBACK_RATE {30, 150}: (100/1000)*30 + (50/1000)*150 = 3 + 7.5 → ceil = 11.
+		expect(result.receipt.cost).toBe(11);
+		// Default unknownModelPolicy "warn" surfaces the fallback footgun.
+		expect(
+			warnSpy.mock.calls.filter((c) => String(c[0]).includes("llama3.3:70b")).length,
+		).toBeGreaterThanOrEqual(1);
+
+		await destroy(governed);
+	});
+
+	it("(e) A6 verify-parity smoke: dryRun audit chain with local nominal receipts passes usertrust-verify", async () => {
+		const client = makeOpenAICompatClient(`${server.url}/v1`);
+		const governed = await trust(client, { dryRun: true, budget: 200, vaultBase: tmpVault });
+
+		// One non-stream + one streamed local call so the chain contains llm_call
+		// events carrying the M2 metering provenance (endpoint/meter receipts).
+		const nonStream = await call(governed, {
+			model: "llama3.3:70b",
+			messages: [{ role: "user", content: "audit me" }],
+		});
+		expect(nonStream.receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+
+		const streamed = await call(governed, {
+			model: "llama3.3:70b",
+			stream: true,
+			messages: [{ role: "user", content: "audit the stream too" }],
+		});
+		for await (const _ of streamed.response as AsyncIterable<unknown>) {
+			// consume
+		}
+		await (streamed.response as { receipt: Promise<TrustReceipt> }).receipt;
+		await destroy(governed);
+
+		// The chain actually contains local-nominal llm_call events (not a vacuous pass)…
+		const eventsRaw = readFileSync(join(tmpVault, VAULT_DIR, "audit", "events.jsonl"), "utf8");
+		const events = eventsRaw
+			.trim()
+			.split("\n")
+			.map((line) => JSON.parse(line) as { kind: string; data?: Record<string, unknown> });
+		const localCalls = events.filter(
+			(e) =>
+				e.kind === "llm_call" &&
+				e.data?.endpointClass === "local" &&
+				e.data?.costBasis === "nominal" &&
+				e.data?.rateSource === "local-default",
+		);
+		expect(localCalls.length).toBeGreaterThanOrEqual(2);
+
+		// …and the standalone verifier (packages/verify, untouched by M2) accepts it.
+		const result = verifyVault(join(tmpVault, VAULT_DIR));
+		expect(result.errors).toEqual([]);
+		expect(result.valid).toBe(true);
+		expect(result.chainLength).toBeGreaterThanOrEqual(events.length);
+		expect(result.validHashes).toBe(result.chainLength);
+		expect(result.merkleRoot).not.toBeNull();
+	});
+});

--- a/packages/core/tests/fixtures/mock-openai-compat-server.ts
+++ b/packages/core/tests/fixtures/mock-openai-compat-server.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * mock-openai-compat-server.ts — zero-dependency OpenAI-compatible HTTP fixture.
+ *
+ * Emulates the /v1 surface local runtimes expose (Ollama, vLLM, LM Studio):
+ *   - POST /v1/chat/completions — non-stream JSON, or an SSE stream whose final
+ *     usage chunk is emitted ONLY when the request body carried
+ *     `stream_options.include_usage: true` (mirrors Ollama's openai.go ChatWriter,
+ *     the behavior that makes govern.ts's A4 usage injection load-bearing).
+ *   - GET /v1/models — Ollama-style model ids.
+ *
+ * Consumed by tests/e2e/local-openai-compat.e2e.test.ts. The examples/ demo
+ * carries its own inline copy (plan amendment A9) — never import this file from
+ * outside packages/core.
+ */
+
+import { type Server, createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export interface MockOpenAIServerOpts {
+	/** prompt_tokens reported in usage. Default 100. */
+	promptTokens?: number;
+	/** completion_tokens reported in usage. Default 50. */
+	completionTokens?: number;
+	/** Number of SSE content chunks before the usage/[DONE] tail. Default 3. */
+	chunkCount?: number;
+}
+
+export interface MockOpenAIServer {
+	port: number;
+	/** Server origin, e.g. "http://127.0.0.1:53211" — append "/v1" for a baseURL. */
+	url: string;
+	/** JSON body of the most recent POST /v1/chat/completions request. */
+	lastRequest(): Record<string, unknown> | undefined;
+	close(): Promise<void>;
+}
+
+interface ChatBody extends Record<string, unknown> {
+	model?: unknown;
+	stream?: unknown;
+	stream_options?: unknown;
+}
+
+export async function startMockOpenAIServer(
+	opts?: MockOpenAIServerOpts,
+): Promise<MockOpenAIServer> {
+	const promptTokens = opts?.promptTokens ?? 100;
+	const completionTokens = opts?.completionTokens ?? 50;
+	const chunkCount = opts?.chunkCount ?? 3;
+	let lastBody: Record<string, unknown> | undefined;
+
+	const server: Server = createServer((req, res) => {
+		if (req.method === "GET" && req.url === "/v1/models") {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(JSON.stringify({ object: "list", data: [{ id: "llama3.3:70b", object: "model" }] }));
+			return;
+		}
+
+		if (req.method === "POST" && req.url === "/v1/chat/completions") {
+			const raw: Buffer[] = [];
+			req.on("data", (c: Buffer) => raw.push(c));
+			req.on("end", () => {
+				let body: ChatBody = {};
+				try {
+					body = JSON.parse(Buffer.concat(raw).toString("utf-8")) as ChatBody;
+				} catch {
+					// permissive mock — treat unparseable bodies as empty
+				}
+				lastBody = body;
+				const model = typeof body.model === "string" ? body.model : "llama3.3:70b";
+				const usage = {
+					prompt_tokens: promptTokens,
+					completion_tokens: completionTokens,
+					total_tokens: promptTokens + completionTokens,
+				};
+
+				if (body.stream === true) {
+					res.writeHead(200, {
+						"content-type": "text/event-stream",
+						"cache-control": "no-cache",
+					});
+					const sse = (payload: unknown): void => {
+						res.write(`data: ${JSON.stringify(payload)}\n\n`);
+					};
+					for (let i = 0; i < chunkCount; i++) {
+						sse({
+							id: "chatcmpl-mock",
+							object: "chat.completion.chunk",
+							model,
+							choices: [
+								{
+									index: 0,
+									delta: { content: `tok${i} ` },
+									finish_reason: i === chunkCount - 1 ? "stop" : null,
+								},
+							],
+						});
+					}
+					const streamOptions =
+						body.stream_options != null && typeof body.stream_options === "object"
+							? (body.stream_options as Record<string, unknown>)
+							: undefined;
+					// The usage tail is emitted ONLY on explicit opt-in — exactly like Ollama.
+					if (streamOptions?.include_usage === true) {
+						sse({
+							id: "chatcmpl-mock",
+							object: "chat.completion.chunk",
+							model,
+							choices: [],
+							usage,
+						});
+					}
+					res.write("data: [DONE]\n\n");
+					res.end();
+					return;
+				}
+
+				res.writeHead(200, { "content-type": "application/json" });
+				res.end(
+					JSON.stringify({
+						id: "chatcmpl-mock",
+						object: "chat.completion",
+						model,
+						choices: [
+							{
+								index: 0,
+								message: { role: "assistant", content: "mock completion" },
+								finish_reason: "stop",
+							},
+						],
+						usage,
+					}),
+				);
+			});
+			return;
+		}
+
+		res.writeHead(404, { "content-type": "application/json" });
+		res.end(JSON.stringify({ error: { message: `no route: ${req.method} ${req.url}` } }));
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const port = (server.address() as AddressInfo).port;
+
+	return {
+		port,
+		url: `http://127.0.0.1:${port}`,
+		lastRequest: () => lastBody,
+		close: () =>
+			new Promise<void>((resolve, reject) => {
+				// Undici's fetch pools keep-alive sockets; sever them so close() resolves.
+				server.closeAllConnections();
+				server.close((err) => (err ? reject(err) : resolve()));
+			}),
+	};
+}

--- a/packages/core/tests/govern/local-endpoint.test.ts
+++ b/packages/core/tests/govern/local-endpoint.test.ts
@@ -1,0 +1,748 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * local-endpoint.test.ts — M2 local-model governance through trust() (plan Task 2).
+ *
+ * Covers: stream_options.include_usage injection + A4 merge/retry semantics,
+ * unknownModelPolicy enforcement at authorize (A5), receipt endpoint/meter
+ * provenance (A6), usage sanitation (A7), the per-call >=1 nominal floor (A11),
+ * and the streaming.ts REPLACE-WITH-LATEST accumulation for OpenAI/Google usage
+ * snapshots (design decision 5.2 — vLLM continuous_usage_stats double-count fix).
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trust } from "../../src/govern.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
+import { PolicyDeniedError } from "../../src/shared/errors.js";
+import type { TrustReceipt } from "../../src/shared/types.js";
+import { type StreamCompletion, wrapStream } from "../../src/streaming.js";
+
+// Mock tigerbeetle-node (native module, never loaded in tests)
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: {
+		linked: 1,
+		pending: 2,
+		post_pending_transfer: 4,
+		void_pending_transfer: 8,
+	},
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Helpers ──
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `local-endpoint-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function writeVaultConfig(vaultBase: string, config: Record<string, unknown>): void {
+	const configDir = join(vaultBase, VAULT_DIR);
+	mkdirSync(configDir, { recursive: true });
+	writeFileSync(join(configDir, "usertrust.config.json"), JSON.stringify(config));
+}
+
+const LOCAL_BASE_URL = "http://localhost:11434/v1";
+
+/** OpenAI-SDK-shaped mock whose create() returns an async-iterable stream. */
+function makeStreamClient(
+	chunks: unknown[],
+	opts?: { baseURL?: string | null; rejectStreamOptions?: boolean },
+) {
+	const createFn = vi.fn(async (params: Record<string, unknown>) => {
+		if (opts?.rejectStreamOptions === true && params.stream_options != null) {
+			throw new Error("400: unknown parameter stream_options");
+		}
+		async function* gen(): AsyncGenerator<unknown> {
+			for (const c of chunks) yield c;
+		}
+		return gen();
+	});
+	const client: Record<string, unknown> = {
+		chat: { completions: { create: createFn } },
+	};
+	if (opts?.baseURL !== null) {
+		client.baseURL = opts?.baseURL ?? LOCAL_BASE_URL;
+	}
+	return { client, createFn };
+}
+
+/** OpenAI-SDK-shaped mock whose create() resolves a non-stream response. */
+function makeJsonClient(response: Record<string, unknown>, opts?: { baseURL?: string | null }) {
+	const createFn = vi.fn(async () => response);
+	const client: Record<string, unknown> = {
+		chat: { completions: { create: createFn } },
+	};
+	if (opts?.baseURL !== null) {
+		client.baseURL = opts?.baseURL ?? LOCAL_BASE_URL;
+	}
+	return { client, createFn };
+}
+
+interface CallResult {
+	response: unknown;
+	receipt: TrustReceipt;
+}
+
+/** Call the governed chat.completions.create and cast past the mock's type. */
+async function call(governed: unknown, params: Record<string, unknown>): Promise<CallResult> {
+	const g = governed as {
+		chat: { completions: { create: (p: Record<string, unknown>) => Promise<CallResult> } };
+	};
+	return g.chat.completions.create(params);
+}
+
+async function consumeStream(result: CallResult): Promise<{
+	chunks: unknown[];
+	receipt: TrustReceipt;
+}> {
+	const stream = result.response as AsyncIterable<unknown>;
+	const chunks: unknown[] = [];
+	for await (const chunk of stream) chunks.push(chunk);
+	const receipt = await (result.response as { receipt: Promise<TrustReceipt> }).receipt;
+	return { chunks, receipt };
+}
+
+async function destroy(governed: unknown): Promise<void> {
+	await (governed as { destroy(): Promise<void> }).destroy();
+}
+
+const STREAM_CHUNKS_WITH_USAGE = [
+	{ choices: [{ delta: { content: "Hello" } }] },
+	{ choices: [{ delta: { content: " world" } }] },
+	{ choices: [], usage: { prompt_tokens: 100, completion_tokens: 50 } },
+];
+
+const STREAM_CHUNKS_NO_USAGE = [
+	{ choices: [{ delta: { content: "Hello" } }] },
+	{ choices: [{ delta: { content: " world" } }] },
+];
+
+// ── Tests ──
+
+describe("M2 local endpoint governance (govern.ts + streaming.ts)", () => {
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = makeTmpVault();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+		vi.restoreAllMocks();
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// wrapStream: REPLACE-WITH-LATEST usage accumulation (OpenAI/Google)
+	// ───────────────────────────────────────────────────────────────────────
+
+	describe("wrapStream replace-with-latest usage accumulation", () => {
+		async function collect(chunks: unknown[], kind: "openai" | "google" | "anthropic") {
+			const onComplete = vi.fn();
+			const onError = vi.fn();
+			const wrapped = wrapStream(
+				(async function* () {
+					for (const c of chunks) yield c;
+				})(),
+				kind,
+				onComplete,
+				onError,
+			);
+			for await (const _ of wrapped) {
+				// consume
+			}
+			expect(onError).not.toHaveBeenCalled();
+			return onComplete.mock.calls[0]?.[0] as StreamCompletion;
+		}
+
+		it("openai: cumulative running totals on every chunk are not double-counted", async () => {
+			// vLLM continuous_usage_stats shape: RUNNING totals on each chunk.
+			const completion = await collect(
+				[
+					{
+						choices: [{ delta: { content: "a" } }],
+						usage: { prompt_tokens: 10, completion_tokens: 5 },
+					},
+					{
+						choices: [{ delta: { content: "b" } }],
+						usage: { prompt_tokens: 10, completion_tokens: 12 },
+					},
+					{ choices: [], usage: { prompt_tokens: 10, completion_tokens: 20 } },
+				],
+				"openai",
+			);
+			expect(completion.usage).toEqual({ inputTokens: 10, outputTokens: 20 });
+			expect(completion.usageReported).toBe(true);
+		});
+
+		it("openai: decreasing cumulative totals take the LAST chunk's values (A7)", async () => {
+			const completion = await collect(
+				[
+					{ choices: [], usage: { prompt_tokens: 100, completion_tokens: 40 } },
+					{ choices: [], usage: { prompt_tokens: 100, completion_tokens: 25 } },
+				],
+				"openai",
+			);
+			expect(completion.usage).toEqual({ inputTokens: 100, outputTokens: 25 });
+		});
+
+		it("openai: a usage-bearing chunk with explicit zeros counts as reported usage (A11)", async () => {
+			const completion = await collect(
+				[{ choices: [], usage: { prompt_tokens: 0, completion_tokens: 0 } }],
+				"openai",
+			);
+			expect(completion.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+			expect(completion.usageReported).toBe(true);
+		});
+
+		it("openai: NaN/negative usage values are clamped to 0 (A7)", async () => {
+			const completion = await collect(
+				[
+					{
+						choices: [],
+						usage: { prompt_tokens: Number.NaN, completion_tokens: -7 },
+					},
+				],
+				"openai",
+			);
+			expect(completion.usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+			expect(completion.usageReported).toBe(true);
+		});
+
+		it("google: usageMetadata snapshots replace, never sum", async () => {
+			const completion = await collect(
+				[
+					{ candidates: [], usageMetadata: { promptTokenCount: 60, candidatesTokenCount: 10 } },
+					{ candidates: [], usageMetadata: { promptTokenCount: 60, candidatesTokenCount: 33 } },
+				],
+				"google",
+			);
+			expect(completion.usage).toEqual({ inputTokens: 60, outputTokens: 33 });
+		});
+
+		it("anthropic: incremental message_start/message_delta path is unchanged (regression)", async () => {
+			const completion = await collect(
+				[
+					{ type: "message_start", message: { usage: { input_tokens: 100 } } },
+					{ type: "message_delta", usage: { output_tokens: 25 } },
+				],
+				"anthropic",
+			);
+			expect(completion.usage).toEqual({ inputTokens: 100, outputTokens: 25 });
+			expect(completion.usageReported).toBe(true);
+		});
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// include_usage injection (A4)
+	// ───────────────────────────────────────────────────────────────────────
+
+	describe("stream_options.include_usage injection (A4)", () => {
+		it("injects include_usage for local openai streams without mutating caller params", async () => {
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_WITH_USAGE);
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const params: Record<string, unknown> = {
+				model: "qwen2.5:7b",
+				stream: true,
+				messages: [{ role: "user", content: "hi" }],
+			};
+			const result = await call(governed, params);
+
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(forwarded.stream_options).toEqual({ include_usage: true });
+			// Transparent middleware: the caller's params object is never mutated.
+			expect("stream_options" in params).toBe(false);
+
+			const { receipt } = await consumeStream(result);
+			expect(receipt.usageSource).toBe("provider");
+			expect(receipt.cost).toBe(1);
+			await destroy(governed);
+		});
+
+		it("merges with the caller's other stream_options fields", async () => {
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_WITH_USAGE);
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				stream: true,
+				stream_options: { chunk_size: 8 },
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(forwarded.stream_options).toEqual({ chunk_size: 8, include_usage: true });
+
+			await consumeStream(result);
+			await destroy(governed);
+		});
+
+		it("respects an explicit include_usage: false (never overridden)", async () => {
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_NO_USAGE);
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				stream: true,
+				stream_options: { include_usage: false },
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(forwarded.stream_options).toEqual({ include_usage: false });
+
+			await consumeStream(result);
+			await destroy(governed);
+		});
+
+		it("leaves an explicit include_usage: true untouched", async () => {
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_WITH_USAGE);
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				stream: true,
+				stream_options: { include_usage: true },
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(forwarded.stream_options).toEqual({ include_usage: true });
+			expect(createFn).toHaveBeenCalledTimes(1);
+
+			await consumeStream(result);
+			await destroy(governed);
+		});
+
+		it("does not inject when config local.injectUsageOptions is false", async () => {
+			writeVaultConfig(tmpVault, { budget: 1000, local: { injectUsageOptions: false } });
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_NO_USAGE);
+			const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				stream: true,
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect("stream_options" in forwarded).toBe(false);
+
+			await consumeStream(result);
+			await destroy(governed);
+		});
+
+		it("does not inject for cloud endpoints", async () => {
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_NO_USAGE, {
+				baseURL: "https://api.openai.com/v1",
+			});
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "gpt-4o",
+				stream: true,
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect("stream_options" in forwarded).toBe(false);
+
+			await consumeStream(result);
+			await destroy(governed);
+		});
+
+		it("does not inject for non-stream local calls", async () => {
+			const { client, createFn } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "hi" } }],
+				usage: { prompt_tokens: 10, completion_tokens: 5 },
+			});
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			await call(governed, { model: "qwen2.5:7b", messages: [{ role: "user", content: "hi" }] });
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect("stream_options" in forwarded).toBe(false);
+
+			await destroy(governed);
+		});
+
+		it("retries ONCE without the injection when the server rejects stream_options (A4)", async () => {
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_NO_USAGE, {
+				rejectStreamOptions: true,
+			});
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				stream: true,
+				messages: [{ role: "user", content: "hi" }],
+			});
+
+			expect(createFn).toHaveBeenCalledTimes(2);
+			const first = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			const second = createFn.mock.calls[1]?.[0] as Record<string, unknown>;
+			expect(first.stream_options).toEqual({ include_usage: true });
+			expect("stream_options" in second).toBe(false);
+
+			// No usage tail without the injection → settles on the estimate.
+			const { receipt } = await consumeStream(result);
+			expect(receipt.usageSource).toBe("estimated");
+			expect(receipt.cost).toBe(1);
+			await destroy(governed);
+		});
+
+		it("does NOT retry an injected stream that fails with a generic (non-stream_options) error (F3)", async () => {
+			// Local + stream ⇒ include_usage IS injected, so a retry path exists. But
+			// this failure is a transient network error, not a stream_options
+			// rejection — govern must surface it as-is and NOT duplicate the provider
+			// call (indiscriminate retry would double compute and mask the root cause).
+			const createFn = vi.fn(async () => {
+				throw new Error("ECONNRESET: socket hang up");
+			});
+			const client = {
+				baseURL: LOCAL_BASE_URL,
+				chat: { completions: { create: createFn } },
+			};
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			await expect(
+				call(governed, {
+					model: "qwen2.5:7b",
+					stream: true,
+					messages: [{ role: "user", content: "hi" }],
+				}),
+			).rejects.toThrow("ECONNRESET");
+			// Exactly once — the injected call failed and was NOT retried without it.
+			expect(createFn).toHaveBeenCalledTimes(1);
+			await destroy(governed);
+		});
+
+		it("does not retry when nothing was injected", async () => {
+			const createFn = vi.fn(async () => {
+				throw new Error("boom");
+			});
+			const client = {
+				baseURL: "https://api.openai.com/v1",
+				chat: { completions: { create: createFn } },
+			};
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			await expect(
+				call(governed, {
+					model: "gpt-4o",
+					stream: true,
+					messages: [{ role: "user", content: "hi" }],
+				}),
+			).rejects.toThrow("boom");
+			expect(createFn).toHaveBeenCalledTimes(1);
+			await destroy(governed);
+		});
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// unknownModelPolicy at authorize (A5)
+	// ───────────────────────────────────────────────────────────────────────
+
+	describe("unknownModelPolicy enforcement at authorize (A5)", () => {
+		it("deny: cloud-scope unknown model throws PolicyDeniedError before the LLM call", async () => {
+			writeVaultConfig(tmpVault, { budget: 1000, unknownModelPolicy: "deny" });
+			const { client, createFn } = makeJsonClient({ id: "x" }, { baseURL: null });
+			const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+			await expect(
+				call(governed, {
+					model: "made-up-model-deny-1",
+					messages: [{ role: "user", content: "hi" }],
+				}),
+			).rejects.toThrow(PolicyDeniedError);
+			await expect(
+				call(governed, {
+					model: "made-up-model-deny-1",
+					messages: [{ role: "user", content: "hi" }],
+				}),
+			).rejects.toThrow("unknown_model: made-up-model-deny-1 not in pricing table");
+			expect(createFn).not.toHaveBeenCalled();
+			await destroy(governed);
+		});
+
+		it("deny: local-scope unknown model NEVER denies — resolves at local-default", async () => {
+			writeVaultConfig(tmpVault, { budget: 1000, unknownModelPolicy: "deny" });
+			const { client, createFn } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "hi" } }],
+				usage: { prompt_tokens: 10, completion_tokens: 5 },
+			});
+			const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "made-up-model-deny-2",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			expect(createFn).toHaveBeenCalledTimes(1);
+			expect(result.receipt.cost).toBe(1);
+			expect(result.receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+			await destroy(governed);
+		});
+
+		it("warn: console.warn fires ONCE per model; every receipt still carries rateSource fallback", async () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const { client } = makeJsonClient(
+				{
+					id: "x",
+					choices: [{ message: { role: "assistant", content: "hi" } }],
+					usage: { prompt_tokens: 10, completion_tokens: 5 },
+				},
+				{ baseURL: null },
+			);
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const r1 = await call(governed, {
+				model: "made-up-model-warn-1",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const r2 = await call(governed, {
+				model: "made-up-model-warn-1",
+				messages: [{ role: "user", content: "hi" }],
+			});
+
+			const unknownModelWarns = warnSpy.mock.calls.filter((c) =>
+				String(c[0]).includes("made-up-model-warn-1"),
+			);
+			expect(unknownModelWarns).toHaveLength(1);
+			expect(r1.receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "fallback" });
+			expect(r2.receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "fallback" });
+			await destroy(governed);
+		});
+
+		it("fallback: silent — no warn, receipt still marked fallback", async () => {
+			writeVaultConfig(tmpVault, { budget: 1000, unknownModelPolicy: "fallback" });
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			const { client } = makeJsonClient(
+				{
+					id: "x",
+					choices: [{ message: { role: "assistant", content: "hi" } }],
+					usage: { prompt_tokens: 10, completion_tokens: 5 },
+				},
+				{ baseURL: null },
+			);
+			const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "made-up-model-silent-1",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const unknownModelWarns = warnSpy.mock.calls.filter((c) =>
+				String(c[0]).includes("made-up-model-silent-1"),
+			);
+			expect(unknownModelWarns).toHaveLength(0);
+			expect(result.receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "fallback" });
+			await destroy(governed);
+		});
+	});
+
+	// ───────────────────────────────────────────────────────────────────────
+	// Receipt endpoint/meter provenance (A6) + floors (A11) + sanitation (A7)
+	// ───────────────────────────────────────────────────────────────────────
+
+	describe("receipt endpoint/meter provenance", () => {
+		it("local non-stream receipt carries endpoint, meter, usageSource — computeMs omitted (A6)", async () => {
+			const { client } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "hi" } }],
+				usage: { prompt_tokens: 100, completion_tokens: 50 },
+			});
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			expect(result.receipt.endpoint).toEqual({ class: "local", runtime: "ollama" });
+			// A6: absent optional fields are OMITTED — toEqual proves no computeMs key.
+			expect(result.receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+			expect(result.receipt.usageSource).toBe("provider");
+			expect(result.receipt.cost).toBe(1);
+			await destroy(governed);
+		});
+
+		it("A11: provider usage of 0 input + 0 output still floors at 1 nominal usertoken", async () => {
+			const { client } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "" } }],
+				usage: { prompt_tokens: 0, completion_tokens: 0 },
+			});
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			expect(result.receipt.usageSource).toBe("provider");
+			expect(result.receipt.cost).toBe(1);
+			await destroy(governed);
+		});
+
+		it("A7: negative/NaN non-stream usage is clamped — cost floors at 1", async () => {
+			const { client } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "hi" } }],
+				usage: { prompt_tokens: -10, completion_tokens: Number.NaN },
+			});
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			expect(result.receipt.usageSource).toBe("provider");
+			expect(result.receipt.cost).toBe(1);
+			await destroy(governed);
+		});
+
+		it("A7: stream ending WITHOUT a usage tail despite injection settles on the estimate", async () => {
+			const { client, createFn } = makeStreamClient(STREAM_CHUNKS_NO_USAGE);
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				stream: true,
+				messages: [{ role: "user", content: "hi" }],
+			});
+			const forwarded = createFn.mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(forwarded.stream_options).toEqual({ include_usage: true });
+
+			const { receipt } = await consumeStream(result);
+			expect(receipt.usageSource).toBe("estimated");
+			expect(receipt.cost).toBe(1);
+			await destroy(governed);
+		});
+
+		it("streamed local settlement uses server-truth usage against local.models rates", async () => {
+			writeVaultConfig(tmpVault, {
+				budget: 1000,
+				local: { models: { "llama3.3*": { inputPer1k: 10, outputPer1k: 20 } } },
+			});
+			const { client } = makeStreamClient(STREAM_CHUNKS_WITH_USAGE);
+			const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "llama3.3:70b",
+				stream: true,
+				messages: [{ role: "user", content: "hi" }],
+			});
+
+			// Pre-settlement (estimated) receipt already carries authorize-time scope (A3).
+			expect(result.receipt.endpoint).toEqual({ class: "local", runtime: "ollama" });
+			expect(result.receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-model" });
+
+			const { chunks, receipt } = await consumeStream(result);
+			// The injected usage chunk is forwarded to the consumer unmodified.
+			expect(chunks).toHaveLength(3);
+			// (100/1000)*10 + (50/1000)*20 = 1 + 1 = 2
+			expect(receipt.cost).toBe(2);
+			expect(receipt.usageSource).toBe("provider");
+			expect(receipt.endpoint).toEqual({ class: "local", runtime: "ollama" });
+			expect(receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-model" });
+			await destroy(governed);
+		});
+
+		it("cloud known-model receipt carries usd-proxy/table meter", async () => {
+			const { client } = makeJsonClient(
+				{
+					id: "x",
+					choices: [{ message: { role: "assistant", content: "hi" } }],
+					usage: { prompt_tokens: 200, completion_tokens: 100 },
+				},
+				{ baseURL: null },
+			);
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "gpt-4o",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			expect(result.receipt.endpoint).toEqual({ class: "cloud", runtime: "unknown" });
+			expect(result.receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "table" });
+			// (200/1000)*25 + (100/1000)*100 = 5 + 10 = 15
+			expect(result.receipt.cost).toBe(15);
+			await destroy(governed);
+		});
+
+		it("spoof defense: model 'gpt-4o' on a LOCAL endpoint still settles nominal", async () => {
+			const { client } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "hi" } }],
+				usage: { prompt_tokens: 200, completion_tokens: 100 },
+			});
+			const governed = await trust(client, { dryRun: true, budget: 1000, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "gpt-4o",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			// Endpoint class — not the model string — picks the settlement regime.
+			expect(result.receipt.cost).toBe(1);
+			expect(result.receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+			await destroy(governed);
+		});
+
+		it("trust() opts.endpoint override wins over loopback autodetect", async () => {
+			const { client } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "hi" } }],
+				usage: { prompt_tokens: 100, completion_tokens: 50 },
+			});
+			const governed = await trust(client, {
+				dryRun: true,
+				budget: 1000,
+				vaultBase: tmpVault,
+				endpoint: { class: "cloud" },
+			});
+
+			const result = await call(governed, {
+				model: "gpt-4o",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			expect(result.receipt.endpoint).toEqual({ class: "cloud", runtime: "unknown" });
+			expect(result.receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "table" });
+			await destroy(governed);
+		});
+
+		it("local rateClass amortized-usd flips costBasis to usd-proxy", async () => {
+			writeVaultConfig(tmpVault, {
+				budget: 1000,
+				local: { rateClass: "amortized-usd", defaultRate: { inputPer1k: 1, outputPer1k: 2 } },
+			});
+			const { client } = makeJsonClient({
+				id: "x",
+				choices: [{ message: { role: "assistant", content: "hi" } }],
+				usage: { prompt_tokens: 1000, completion_tokens: 500 },
+			});
+			const governed = await trust(client, { dryRun: true, vaultBase: tmpVault });
+
+			const result = await call(governed, {
+				model: "qwen2.5:7b",
+				messages: [{ role: "user", content: "hi" }],
+			});
+			expect(result.receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "local-default" });
+			// (1000/1000)*1 + (500/1000)*2 = 2
+			expect(result.receipt.cost).toBe(2);
+			await destroy(governed);
+		});
+	});
+});

--- a/packages/core/tests/headless/local-scope.test.ts
+++ b/packages/core/tests/headless/local-scope.test.ts
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * M2 Task 4 — Headless Governor endpoint scope.
+ *
+ * Pins: governor-wide default endpoint scope (GovernorOpts.endpoint), per-call
+ * AuthorizeParams.endpoint override (A3: scope is CAPTURED at authorize and
+ * governs settle), SettleParams.computeMs passthrough into receipt.meter,
+ * unknownModelPolicy enforcement at authorize for cloud scope (A5), and A6
+ * receipt-field discipline (absent optional fields are OMITTED).
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGovernor } from "../../src/headless.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
+import { PolicyDeniedError } from "../../src/shared/errors.js";
+import type { EndpointInfo } from "../../src/shared/types.js";
+
+// Mock tigerbeetle-node (native module, never loaded in tests)
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: {
+		linked: 1,
+		pending: 2,
+		post_pending_transfer: 4,
+		void_pending_transfer: 8,
+	},
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Test helpers ──
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `headless-local-scope-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function writeConfig(vaultBase: string, config: Record<string, unknown>): void {
+	const configDir = join(vaultBase, VAULT_DIR);
+	mkdirSync(configDir, { recursive: true });
+	writeFileSync(join(configDir, "usertrust.config.json"), JSON.stringify(config));
+}
+
+// ── Tests ──
+
+describe("headless governor — M2 endpoint scope", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+	});
+
+	// ── Plan-named test 1: governor-wide local default → 1 nominal usertoken ──
+
+	it("dryRun governor with local endpoint authorizes+settles qwen2.5:7b at 1 nominal ut", async () => {
+		const gov = await createGovernor({
+			dryRun: true,
+			budget: 100_000,
+			vaultBase,
+			endpoint: { class: "local", runtime: "ollama" },
+		});
+
+		const auth = await gov.authorize({
+			model: "qwen2.5:7b",
+			estimatedInputTokens: 5_000,
+			maxOutputTokens: 4_096,
+		});
+		// Local default rate {0,0} + the >=1 per-call floor → exactly 1 (A11 analogue).
+		expect(auth.estimatedCost).toBe(1);
+
+		const receipt = await gov.settle(auth, {
+			inputTokens: 123_456,
+			outputTokens: 999_999,
+			usageSource: "provider",
+		});
+
+		expect(receipt.cost).toBe(1);
+		expect(receipt.usageSource).toBe("provider");
+		expect(receipt.endpoint).toEqual({ class: "local", runtime: "ollama" });
+		// toEqual (not objectContaining) pins A6: no computeMs key when absent.
+		expect(receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+		expect(gov.budgetRemaining()).toBe(100_000 - 1);
+
+		// Second call decrements by exactly 1 again.
+		const auth2 = await gov.authorize({ model: "qwen2.5:7b" });
+		await gov.settle(auth2, { inputTokens: 10, outputTokens: 10 });
+		expect(gov.budgetRemaining()).toBe(100_000 - 2);
+
+		await gov.destroy();
+	});
+
+	// ── Plan-named test 2 (A3): per-call local override beats governor-default cloud ──
+
+	it("per-call local endpoint override wins over the governor-default cloud scope (A3)", async () => {
+		// No governor-wide endpoint → default cloud scope.
+		const gov = await createGovernor({ dryRun: true, budget: 100_000, vaultBase });
+
+		const auth = await gov.authorize({
+			model: "qwen2.5:7b",
+			estimatedInputTokens: 1_000,
+			maxOutputTokens: 1_000,
+			endpoint: { class: "local", runtime: "vllm" },
+		});
+		expect(auth.estimatedCost).toBe(1);
+
+		// A3: settle carries the LOCAL meter captured at authorize, even though the
+		// governor default is cloud.
+		const receipt = await gov.settle(auth, { inputTokens: 1_000, outputTokens: 1_000 });
+		expect(receipt.cost).toBe(1);
+		expect(receipt.endpoint).toEqual({ class: "local", runtime: "vllm" });
+		expect(receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+
+		await gov.destroy();
+	});
+
+	it("per-call cloud endpoint override wins over a governor-default local scope (A3)", async () => {
+		const gov = await createGovernor({
+			dryRun: true,
+			budget: 100_000,
+			vaultBase,
+			endpoint: { class: "local", runtime: "ollama" },
+		});
+
+		const auth = await gov.authorize({
+			model: "claude-sonnet-4-6",
+			estimatedInputTokens: 1_000,
+			maxOutputTokens: 1_000,
+			endpoint: { class: "cloud", runtime: "unknown" },
+		});
+
+		const receipt = await gov.settle(auth, { inputTokens: 1_000, outputTokens: 1_000 });
+		// Cloud table rates for claude-sonnet-4-6: 30 in + 150 out per 1k → 180.
+		expect(receipt.cost).toBe(180);
+		expect(receipt.endpoint).toEqual({ class: "cloud", runtime: "unknown" });
+		expect(receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "table" });
+
+		await gov.destroy();
+	});
+
+	// ── Plan-named test 3: computeMs lands in receipt.meter ──
+
+	it("SettleParams.computeMs lands in receipt.meter.computeMs", async () => {
+		const gov = await createGovernor({
+			dryRun: true,
+			budget: 100_000,
+			vaultBase,
+			endpoint: { class: "local", runtime: "ollama" },
+		});
+
+		const auth = await gov.authorize({ model: "qwen2.5:7b" });
+		const receipt = await gov.settle(auth, {
+			inputTokens: 50,
+			outputTokens: 200,
+			computeMs: 842,
+		});
+
+		expect(receipt.meter).toEqual({
+			costBasis: "nominal",
+			rateSource: "local-default",
+			computeMs: 842,
+		});
+
+		await gov.destroy();
+	});
+
+	it("non-finite or negative computeMs is omitted from receipt.meter (A6)", async () => {
+		const gov = await createGovernor({
+			dryRun: true,
+			budget: 100_000,
+			vaultBase,
+			endpoint: { class: "local", runtime: "ollama" },
+		});
+
+		const auth1 = await gov.authorize({ model: "qwen2.5:7b" });
+		const r1 = await gov.settle(auth1, {
+			inputTokens: 10,
+			outputTokens: 10,
+			computeMs: Number.NaN,
+		});
+		expect(r1.meter).toBeDefined();
+		expect(Object.hasOwn(r1.meter as object, "computeMs")).toBe(false);
+
+		const auth2 = await gov.authorize({ model: "qwen2.5:7b" });
+		const r2 = await gov.settle(auth2, { inputTokens: 10, outputTokens: 10, computeMs: -5 });
+		expect(Object.hasOwn(r2.meter as object, "computeMs")).toBe(false);
+
+		await gov.destroy();
+	});
+
+	// ── Plan-named test 4: cloud governor + deny policy throws on unknown model ──
+
+	it("cloud governor with unknownModelPolicy deny throws PolicyDeniedError at authorize", async () => {
+		writeConfig(vaultBase, { budget: 100_000, unknownModelPolicy: "deny" });
+		const gov = await createGovernor({ dryRun: true, vaultBase });
+
+		await expect(gov.authorize({ model: "m2-deny-model-xyz" })).rejects.toThrow(PolicyDeniedError);
+		await expect(gov.authorize({ model: "m2-deny-model-xyz" })).rejects.toThrow(
+			"unknown_model: m2-deny-model-xyz not in pricing table",
+		);
+		// Deny happens BEFORE any hold — no budget leak.
+		expect(gov.budgetRemaining()).toBe(100_000);
+
+		// Known models are unaffected under deny.
+		const auth = await gov.authorize({ model: "claude-sonnet-4-6" });
+		await gov.settle(auth, { inputTokens: 100, outputTokens: 100 });
+
+		await gov.destroy();
+	});
+
+	it("local scope never denies unknown models even under deny policy (A5)", async () => {
+		writeConfig(vaultBase, { budget: 100_000, unknownModelPolicy: "deny" });
+		const gov = await createGovernor({ dryRun: true, vaultBase });
+
+		const auth = await gov.authorize({
+			model: "m2-deny-model-xyz",
+			endpoint: { class: "local", runtime: "ollama" },
+		});
+		const receipt = await gov.settle(auth, { inputTokens: 500, outputTokens: 500 });
+
+		expect(receipt.cost).toBe(1);
+		expect(receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+
+		await gov.destroy();
+	});
+
+	// ── A5: warn semantics ──
+
+	it("unknownModelPolicy warn warns ONCE per model string; rateSource fallback regardless", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			// Default config: unknownModelPolicy defaults to "warn".
+			const gov = await createGovernor({ dryRun: true, budget: 100_000, vaultBase });
+
+			const auth1 = await gov.authorize({
+				model: "m2-warn-model",
+				estimatedInputTokens: 100,
+				maxOutputTokens: 100,
+			});
+			const r1 = await gov.settle(auth1, { inputTokens: 1_000, outputTokens: 1_000 });
+
+			const auth2 = await gov.authorize({ model: "m2-warn-model" });
+			const r2 = await gov.settle(auth2, { inputTokens: 1_000, outputTokens: 1_000 });
+
+			const unknownModelWarns = warnSpy.mock.calls.filter((c) =>
+				String(c[0]).includes("m2-warn-model"),
+			);
+			expect(unknownModelWarns).toHaveLength(1);
+
+			// Receipt marker is set on EVERY receipt, regardless of warn dedup (A5).
+			expect(r1.meter).toEqual({ costBasis: "usd-proxy", rateSource: "fallback" });
+			expect(r2.meter).toEqual({ costBasis: "usd-proxy", rateSource: "fallback" });
+			// FALLBACK_RATE (sonnet-class): 30 in + 150 out per 1k → 180.
+			expect(r1.cost).toBe(180);
+
+			await gov.destroy();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it('unknownModelPolicy "fallback" is silent but still stamps rateSource fallback', async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			writeConfig(vaultBase, { budget: 100_000, unknownModelPolicy: "fallback" });
+			const gov = await createGovernor({ dryRun: true, vaultBase });
+
+			const auth = await gov.authorize({ model: "m2-silent-model" });
+			const receipt = await gov.settle(auth, { inputTokens: 1_000, outputTokens: 0 });
+
+			const silentModelWarns = warnSpy.mock.calls.filter((c) =>
+				String(c[0]).includes("m2-silent-model"),
+			);
+			expect(silentModelWarns).toHaveLength(0);
+			expect(receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "fallback" });
+			expect(receipt.cost).toBe(30);
+
+			await gov.destroy();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	// ── local.models + rateClass flow through the headless meter ──
+
+	it("local.models glob rates + amortized-usd rateClass surface as local-model/usd-proxy", async () => {
+		writeConfig(vaultBase, {
+			budget: 100_000,
+			local: {
+				rateClass: "amortized-usd",
+				models: { "qwen*": { inputPer1k: 1, outputPer1k: 2 } },
+			},
+		});
+		const gov = await createGovernor({
+			dryRun: true,
+			vaultBase,
+			endpoint: { class: "local", runtime: "vllm" },
+		});
+
+		const auth = await gov.authorize({ model: "qwen2.5:7b" });
+		const receipt = await gov.settle(auth, { inputTokens: 1_000, outputTokens: 1_000 });
+
+		// ceil(1000/1000*1 + 1000/1000*2) = 3
+		expect(receipt.cost).toBe(3);
+		expect(receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "local-model" });
+
+		await gov.destroy();
+	});
+
+	// ── Estimated-usage settle keeps the authorize-captured scope (A3) ──
+
+	it("settle without usage on a local call falls back to the local nominal estimate", async () => {
+		const gov = await createGovernor({
+			dryRun: true,
+			budget: 100_000,
+			vaultBase,
+			endpoint: { class: "local", runtime: "lmstudio" },
+		});
+
+		const auth = await gov.authorize({
+			model: "qwen2.5:7b",
+			estimatedInputTokens: 9_999,
+			maxOutputTokens: 9_999,
+		});
+		const receipt = await gov.settle(auth);
+
+		expect(receipt.cost).toBe(auth.estimatedCost);
+		expect(receipt.cost).toBe(1);
+		expect(receipt.usageSource).toBe("estimated");
+		expect(receipt.endpoint).toEqual({ class: "local", runtime: "lmstudio" });
+		expect(receipt.meter).toEqual({ costBasis: "nominal", rateSource: "local-default" });
+
+		await gov.destroy();
+	});
+
+	// ── Defensive normalization for JS callers ──
+
+	it("partial endpoint shapes normalize (runtime → unknown) and baseURL never leaks to receipts", async () => {
+		const gov = await createGovernor({
+			dryRun: true,
+			budget: 100_000,
+			vaultBase,
+			// Untyped JS callers can pass partial shapes — runtime defaults to "unknown".
+			endpoint: { class: "local", baseURL: "http://localhost:11434" } as EndpointInfo,
+		});
+
+		const auth = await gov.authorize({ model: "qwen2.5:7b" });
+		const receipt = await gov.settle(auth, { inputTokens: 10, outputTokens: 10 });
+
+		expect(receipt.cost).toBe(1);
+		// Exactly class+runtime — baseURL is classification input, not receipt data.
+		expect(receipt.endpoint).toEqual({ class: "local", runtime: "unknown" });
+
+		await gov.destroy();
+	});
+
+	// ── Pre-M2 behavior: default cloud scope keeps table metering ──
+
+	it("governor without any endpoint config meters cloud table rates (regression)", async () => {
+		const gov = await createGovernor({ dryRun: true, budget: 100_000, vaultBase });
+
+		const auth = await gov.authorize({
+			model: "claude-sonnet-4-6",
+			estimatedInputTokens: 1_000,
+			maxOutputTokens: 1_000,
+		});
+		const receipt = await gov.settle(auth, { inputTokens: 1_000, outputTokens: 1_000 });
+
+		expect(receipt.cost).toBe(180);
+		expect(receipt.endpoint).toEqual({ class: "cloud", runtime: "unknown" });
+		expect(receipt.meter).toEqual({ costBasis: "usd-proxy", rateSource: "table" });
+
+		await gov.destroy();
+	});
+});

--- a/packages/core/tests/ledger/pricing-local.test.ts
+++ b/packages/core/tests/ledger/pricing-local.test.ts
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import {
+	FALLBACK_RATE,
+	costFromRates,
+	estimateCost,
+	getModelRates,
+	matchModelPattern,
+	resolveRates,
+} from "../../src/ledger/pricing.js";
+import { type TrustConfig, TrustConfigSchema } from "../../src/shared/types.js";
+
+function makeConfig(overrides: Record<string, unknown> = {}): TrustConfig {
+	return TrustConfigSchema.parse({ budget: 1000, ...overrides });
+}
+
+describe("matchModelPattern", () => {
+	it("returns exact match with its pattern key", () => {
+		const m = matchModelPattern("llama3.3:70b", { "llama3.3:70b": 1, "llama3.3*": 2 });
+		expect(m).toEqual({ pattern: "llama3.3:70b", value: 1 });
+	});
+
+	it("exact match beats a longer glob", () => {
+		const m = matchModelPattern("llama3.3:70b", {
+			"llama3.3:70b*": 2, // longer glob prefix than the exact key
+			"llama3.3:70b": 1,
+		});
+		expect(m?.value).toBe(1);
+	});
+
+	it("longest glob prefix wins among globs", () => {
+		const patterns = { "llama3.3*": 1, "llama*": 2, "*": 3 };
+		expect(matchModelPattern("llama3.3:70b", patterns)?.value).toBe(1);
+		expect(matchModelPattern("llama2:7b", patterns)?.value).toBe(2);
+		expect(matchModelPattern("qwen2.5:7b", patterns)?.value).toBe(3);
+	});
+
+	it('"*" matches everything', () => {
+		expect(matchModelPattern("anything-at-all", { "*": 42 })).toEqual({
+			pattern: "*",
+			value: 42,
+		});
+		expect(matchModelPattern("", { "*": 42 })?.value).toBe(42);
+	});
+
+	it("returns undefined when nothing matches", () => {
+		expect(matchModelPattern("qwen2.5:7b", { "llama*": 1 })).toBeUndefined();
+		expect(matchModelPattern("qwen2.5:7b", {})).toBeUndefined();
+	});
+
+	it("only trailing-star patterns are globs (A2)", () => {
+		// "llama*3" is not a trailing-star glob and must only match exactly.
+		expect(matchModelPattern("llama2:7b", { "llama*3": 1 })).toBeUndefined();
+		expect(matchModelPattern("llama*3", { "llama*3": 1 })?.value).toBe(1);
+	});
+
+	it("does not resolve inherited Object.prototype keys as exact matches", () => {
+		expect(matchModelPattern("constructor", {})).toBeUndefined();
+		expect(matchModelPattern("toString", { "llama*": 1 })).toBeUndefined();
+	});
+});
+
+describe("resolveRates — local scope", () => {
+	it("never returns FALLBACK_RATE, even for unknown models", () => {
+		const config = makeConfig();
+		const r = resolveRates("totally-unknown-model-xyz", "local", config);
+		expect(r.rates).not.toEqual(FALLBACK_RATE);
+		expect(r.rates).toEqual({ inputPer1k: 0, outputPer1k: 0 });
+		expect(r.scope).toBe("local");
+		expect(r.rateSource).toBe("local-default");
+		expect(r.unknown).toBe(false);
+	});
+
+	it("local misses are never unknown and never 'fallback' (A5)", () => {
+		const config = makeConfig();
+		// Same model misses the cloud table entirely — cloud says unknown, local never does.
+		const cloud = resolveRates("does-not-exist-anywhere", "cloud", config);
+		const local = resolveRates("does-not-exist-anywhere", "local", config);
+		expect(cloud.unknown).toBe(true);
+		expect(local.unknown).toBe(false);
+		expect(local.rateSource).toBe("local-default");
+	});
+
+	it("local.models exact match beats glob", () => {
+		const config = makeConfig({
+			local: {
+				models: {
+					"llama3.3:70b": { inputPer1k: 1, outputPer1k: 2 },
+					"llama3.3*": { inputPer1k: 5, outputPer1k: 10 },
+				},
+			},
+		});
+		const r = resolveRates("llama3.3:70b", "local", config);
+		expect(r.rates).toEqual({ inputPer1k: 1, outputPer1k: 2 });
+		expect(r.rateSource).toBe("local-model");
+	});
+
+	it("longest glob wins in local.models", () => {
+		const config = makeConfig({
+			local: {
+				models: {
+					"llama3.3*": { inputPer1k: 1, outputPer1k: 1 },
+					"llama*": { inputPer1k: 2, outputPer1k: 2 },
+					"*": { inputPer1k: 3, outputPer1k: 3 },
+				},
+			},
+		});
+		expect(resolveRates("llama3.3:70b-q4_K_M", "local", config).rates.inputPer1k).toBe(1);
+		expect(resolveRates("llama2:7b", "local", config).rates.inputPer1k).toBe(2);
+		expect(resolveRates("qwen2.5:7b", "local", config).rates.inputPer1k).toBe(3);
+	});
+
+	it('"*" catch-all in local.models resolves as local-model, not local-default', () => {
+		const config = makeConfig({
+			local: { models: { "*": { inputPer1k: 0.5, outputPer1k: 0.5 } } },
+		});
+		const r = resolveRates("anything", "local", config);
+		expect(r.rateSource).toBe("local-model");
+		expect(r.rates).toEqual({ inputPer1k: 0.5, outputPer1k: 0.5 });
+	});
+
+	it("default local rates {0,0} + the >=1 floor cost exactly 1 for any token counts", () => {
+		const config = makeConfig();
+		const r = resolveRates("llama3.3:70b", "local", config);
+		expect(costFromRates(r.rates, 0, 0)).toBe(1);
+		expect(costFromRates(r.rates, 1, 1)).toBe(1);
+		expect(costFromRates(r.rates, 1_000_000, 1_000_000)).toBe(1);
+		expect(costFromRates(r.rates, Number.NaN, -50)).toBe(1);
+	});
+
+	it('costBasis is "nominal" by default and "usd-proxy" under rateClass "amortized-usd"', () => {
+		const nominal = resolveRates("llama3.3:70b", "local", makeConfig());
+		expect(nominal.costBasis).toBe("nominal");
+
+		const amortized = resolveRates(
+			"llama3.3:70b",
+			"local",
+			makeConfig({ local: { rateClass: "amortized-usd" } }),
+		);
+		expect(amortized.costBasis).toBe("usd-proxy");
+		expect(amortized.rateSource).toBe("local-default");
+	});
+});
+
+describe("resolveRates — cloud scope", () => {
+	it('table hit resolves rateSource "table", unknown false, costBasis "usd-proxy"', () => {
+		const r = resolveRates("claude-sonnet-4-6", "cloud", makeConfig());
+		expect(r.rates).toEqual({ inputPer1k: 30, outputPer1k: 150 });
+		expect(r.scope).toBe("cloud");
+		expect(r.rateSource).toBe("table");
+		expect(r.costBasis).toBe("usd-proxy");
+		expect(r.unknown).toBe(false);
+	});
+
+	it('prefix hit resolves rateSource "table"', () => {
+		const r = resolveRates("claude-haiku-4-5-20251001", "cloud", makeConfig());
+		expect(r.rates).toEqual({ inputPer1k: 10, outputPer1k: 50 });
+		expect(r.rateSource).toBe("table");
+		expect(r.unknown).toBe(false);
+	});
+
+	it('customRates hit resolves rateSource "custom" when pricing is "custom"', () => {
+		const config = makeConfig({
+			pricing: "custom",
+			customRates: { "my-fine-tune": { inputPer1k: 7, outputPer1k: 9 } },
+		});
+		const r = resolveRates("my-fine-tune", "cloud", config);
+		expect(r.rates).toEqual({ inputPer1k: 7, outputPer1k: 9 });
+		expect(r.rateSource).toBe("custom");
+		expect(r.unknown).toBe(false);
+	});
+
+	it('customRates are ignored when pricing is "recommended" (existing caller gate preserved)', () => {
+		const config = makeConfig({
+			// pricing defaults to "recommended" — same gate as govern.ts/headless.ts call sites.
+			customRates: { "claude-sonnet-4-6": { inputPer1k: 1, outputPer1k: 1 } },
+		});
+		const r = resolveRates("claude-sonnet-4-6", "cloud", config);
+		expect(r.rates).toEqual({ inputPer1k: 30, outputPer1k: 150 });
+		expect(r.rateSource).toBe("table");
+	});
+
+	it('miss resolves FALLBACK_RATE with rateSource "fallback" and unknown true', () => {
+		const r = resolveRates("totally-unknown-model-xyz", "cloud", makeConfig());
+		expect(r.rates).toEqual(FALLBACK_RATE);
+		expect(r.rateSource).toBe("fallback");
+		expect(r.unknown).toBe(true);
+		expect(r.costBasis).toBe("usd-proxy");
+	});
+
+	it("matches getModelRates for the same inputs (delegation regression)", () => {
+		const config = makeConfig({
+			pricing: "custom",
+			customRates: { "gpt-4o": { inputPer1k: 20, outputPer1k: 80 } },
+		});
+		for (const model of ["gpt-4o", "claude-sonnet-4-6", "gpt-4o-mini-2025", "no-such-model"]) {
+			const r = resolveRates(model, "cloud", config);
+			expect(r.rates).toEqual(getModelRates(model, config.customRates));
+		}
+	});
+});
+
+describe("costFromRates", () => {
+	it("agrees with estimateCost for table models (refactor regression)", () => {
+		expect(costFromRates(getModelRates("claude-sonnet-4-6"), 1000, 500)).toBe(
+			estimateCost("claude-sonnet-4-6", 1000, 500),
+		);
+		expect(costFromRates(getModelRates("gpt-4o-mini"), 1000, 1000)).toBe(
+			estimateCost("gpt-4o-mini", 1000, 1000),
+		);
+	});
+
+	it("floors at 1 and clamps non-finite/negative token counts", () => {
+		const rates = { inputPer1k: 30, outputPer1k: 150 };
+		expect(costFromRates(rates, 0, 0)).toBe(1);
+		expect(costFromRates(rates, -1000, Number.NaN)).toBe(1);
+		expect(costFromRates(rates, 1000, 500)).toBe(105);
+	});
+});
+
+describe("prototype-safe rate lookups (F4)", () => {
+	it("getModelRates ignores inherited Object.prototype keys and falls back", () => {
+		for (const evil of ["constructor", "__proto__", "toString", "hasOwnProperty"]) {
+			const rates = getModelRates(evil);
+			// FALLBACK_RATE, not a Function/object whose .inputPer1k is undefined → NaN.
+			expect(rates).toEqual(FALLBACK_RATE);
+			expect(Number.isNaN(rates.inputPer1k)).toBe(false);
+			expect(Number.isNaN(rates.outputPer1k)).toBe(false);
+		}
+	});
+
+	it("getModelRates ignores inherited keys in customRates too", () => {
+		// customRates has no OWN "constructor" key — the inherited Function must not
+		// resolve; the lookup falls through to table/fallback.
+		const rates = getModelRates("constructor", { "my-model": { inputPer1k: 1, outputPer1k: 2 } });
+		expect(rates).toEqual(FALLBACK_RATE);
+	});
+
+	it("resolveRates cloud scope returns FALLBACK_RATE (unknown) for prototype keys", () => {
+		const config = makeConfig();
+		for (const evil of ["__proto__", "constructor", "toString"]) {
+			const r = resolveRates(evil, "cloud", config);
+			expect(r.rates).toEqual(FALLBACK_RATE);
+			expect(r.unknown).toBe(true);
+			expect(r.rateSource).toBe("fallback");
+		}
+	});
+
+	it("estimateCost for a prototype-key model is a finite number >= 1 (no NaN poison)", () => {
+		const cost = estimateCost("constructor", 1000, 500);
+		expect(Number.isFinite(cost)).toBe(true);
+		expect(cost).toBeGreaterThanOrEqual(1);
+		// Identical to any unknown model — FALLBACK_RATE all the way through.
+		expect(cost).toBe(estimateCost("some-unknown-model", 1000, 500));
+	});
+});
+
+describe("TrustConfigSchema — pre-M2 config regression", () => {
+	it("parses a minimal pre-M2 config unchanged and populates all M2 defaults", () => {
+		const config = TrustConfigSchema.parse({ budget: 1000 });
+
+		expect(config.endpoints).toEqual([]);
+		expect(config.local).toEqual({
+			autoDetectLoopback: true,
+			defaultRate: { inputPer1k: 0, outputPer1k: 0 },
+			rateClass: "nominal",
+			models: {},
+			injectUsageOptions: true,
+		});
+		expect(config.unknownModelPolicy).toBe("warn");
+
+		// New anomaly keys defaulted; legacy anomaly keys untouched.
+		expect(config.anomaly.tokenRate.localThresholdTokPerSec).toBe(5000);
+		expect(config.anomaly.tokenRate.perModel).toEqual({});
+		expect(config.anomaly.tokenRate.thresholdTokPerSec).toBe(500);
+		expect(config.anomaly.spendVelocity.localThresholdUsertokensPerMin).toBe(10_000);
+		expect(config.anomaly.spendVelocity.thresholdDollarsPerMin).toBe(1.0);
+	});
+
+	it("parses a typical pre-M2 config with existing keys set", () => {
+		const config = TrustConfigSchema.parse({
+			budget: 5000,
+			tier: "pro",
+			pii: "block",
+			anomaly: { enabled: true, tokenRate: { thresholdTokPerSec: 800 } },
+			customRates: { "gpt-4o": { inputPer1k: 20, outputPer1k: 80 } },
+		});
+		expect(config.anomaly.enabled).toBe(true);
+		expect(config.anomaly.tokenRate.thresholdTokPerSec).toBe(800);
+		expect(config.anomaly.tokenRate.localThresholdTokPerSec).toBe(5000);
+		expect(config.local.autoDetectLoopback).toBe(true);
+		expect(config.unknownModelPolicy).toBe("warn");
+	});
+
+	it("accepts explicit M2 config values", () => {
+		const config = TrustConfigSchema.parse({
+			budget: 1000,
+			endpoints: [{ match: "*.gpu.internal", class: "local", runtime: "vllm" }],
+			local: {
+				defaultRate: { inputPer1k: 0.1, outputPer1k: 0.2 },
+				rateClass: "amortized-usd",
+				models: { "llama3.3*": { inputPer1k: 1, outputPer1k: 2 } },
+			},
+			unknownModelPolicy: "deny",
+		});
+		expect(config.endpoints[0]?.runtime).toBe("vllm");
+		expect(config.endpoints[0]?.class).toBe("local");
+		expect(config.local.rateClass).toBe("amortized-usd");
+		expect(config.unknownModelPolicy).toBe("deny");
+	});
+
+	it("defaults endpoints[].class to local and runtime to unknown", () => {
+		const config = TrustConfigSchema.parse({
+			budget: 1000,
+			endpoints: [{ match: "http://gpu-box:8000" }],
+		});
+		expect(config.endpoints[0]).toEqual({
+			match: "http://gpu-box:8000",
+			class: "local",
+			runtime: "unknown",
+		});
+	});
+});

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -200,6 +200,22 @@ function initGovernor(config: UsertrustPluginConfig): Promise<Governor> {
 			...(config.proxy != null ? { proxy: config.proxy } : {}),
 			...(config.proxyKey != null ? { key: config.proxyKey } : {}),
 			...(config.vaultBase != null ? { vaultBase: config.vaultBase } : {}),
+			// M2: forward the operator's endpoint declaration into the headless
+			// governor (GovernorOpts.endpoint). Without this, every OpenClaw call
+			// defaults to cloud scope — local models would meter at frontier
+			// fallback and inherit strict cloud anomaly thresholds. runtime defaults
+			// to "unknown"; baseURL is omitted (never undefined) when absent.
+			...(config.endpoint != null
+				? {
+						endpoint: {
+							class: config.endpoint.class,
+							runtime: config.endpoint.runtime ?? "unknown",
+							...(config.endpoint.baseURL !== undefined
+								? { baseURL: config.endpoint.baseURL }
+								: {}),
+						},
+					}
+				: {}),
 		}).then((gov) => {
 			governor = gov;
 			return gov;

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -87,6 +87,10 @@ async function* governedStream(
 				: {}),
 			chunksDelivered: usage.chunksDelivered,
 			usageSource: usage.usageReported ? "provider" : "estimated",
+			// Ollama-native eval_duration (when the stream carried it) flows to
+			// receipt.meter.computeMs. Spread keeps the key OMITTED when absent —
+			// never `computeMs: undefined` (plan A6).
+			...(usage.computeMs != null ? { computeMs: usage.computeMs } : {}),
 		});
 	} catch (err) {
 		// 4. Abort — VOID the hold (catch abort errors to preserve original)

--- a/packages/openclaw/src/token-extractor.ts
+++ b/packages/openclaw/src/token-extractor.ts
@@ -19,10 +19,19 @@ export interface AccumulatedUsage {
 	outputTokens: number;
 	chunksDelivered: number;
 	usageReported: boolean;
+	/**
+	 * Generation wall time in ms, from an Ollama-native final chunk's
+	 * eval_duration. Omitted (never `undefined`-valued) when the stream
+	 * carried no native duration.
+	 */
+	computeMs?: number | undefined;
 }
 
 /** Max tokens to accept from a provider (prevents Infinity/overflow in cost math). */
 const MAX_TOKENS = 2_000_000;
+
+/** Max computeMs to accept — 24h; guards absurd/hostile eval_duration values (plan A8). */
+const MAX_COMPUTE_MS = 86_400_000;
 
 function clampTokens(n: number): number {
 	if (!Number.isFinite(n)) return 0;
@@ -42,6 +51,9 @@ function clampTokens(n: number): number {
  *
  *   Gemini:
  *     { candidates: [{ content: { parts: [...] } }], usageMetadata: { promptTokenCount, candidatesTokenCount } }
+ *
+ *   Ollama native (/api/chat, /api/generate final chunk):
+ *     { done: true, prompt_eval_count, eval_count, eval_duration }
  *
  * Returns null if the chunk is not a recognized usage-bearing shape.
  */
@@ -113,7 +125,54 @@ export function extractUsageFromProviderChunk(chunk: unknown): StreamUsage | nul
 		}
 	}
 
+	// ── Ollama native final chunk (done: true + eval counts) ──
+	const ollama = extractOllamaUsage(c);
+	if (ollama != null) return ollama;
+
 	return null;
+}
+
+/**
+ * Ollama-native final chunk (/api/chat, /api/generate): `done === true` with
+ * numeric prompt_eval_count / eval_count token counts. OpenAI chunks carry
+ * neither field (they report prompt_tokens/completion_tokens under `usage`),
+ * so OpenAI-compat streams cannot misfire into this family.
+ */
+function extractOllamaUsage(chunk: unknown): StreamUsage | null {
+	if (chunk == null || typeof chunk !== "object") return null;
+	const c = chunk as Record<string, unknown>;
+	if (c.done !== true) return null;
+	const input = readNum(c.prompt_eval_count);
+	const output = readNum(c.eval_count);
+	if (input == null && output == null) return null;
+	return {
+		inputTokens: clampTokens(input ?? 0),
+		outputTokens: clampTokens(output ?? 0),
+	};
+}
+
+/**
+ * Extract generation compute time (ms) from an Ollama-native final chunk.
+ *
+ * Ollama reports `eval_duration` in NANOSECONDS on the `done: true` chunk.
+ * Converted to whole milliseconds and clamped to [0, 86_400_000] (24h) to
+ * guard absurd or hostile values (plan A8).
+ *
+ * `prompt_eval_duration` is explicitly IGNORED in M2 (plan A8): computeMs
+ * meters generation (eval) wall time only; prompt-processing time is a
+ * future enrichment once its KV-cache interaction semantics are pinned.
+ *
+ * Returns undefined for non-final chunks, non-Ollama shapes, or
+ * missing/non-finite durations.
+ */
+export function extractComputeMs(chunk: unknown): number | undefined {
+	if (chunk == null || typeof chunk !== "object") return undefined;
+	const c = chunk as Record<string, unknown>;
+	if (c.done !== true) return undefined;
+	const ns = Number(c.eval_duration);
+	if (!Number.isFinite(ns)) return undefined;
+	const ms = Math.round(ns / 1e6);
+	return Math.min(Math.max(0, ms), MAX_COMPUTE_MS);
 }
 
 /**
@@ -124,6 +183,7 @@ export function extractUsageFromProviderChunk(chunk: unknown): StreamUsage | nul
  *   Anthropic: chunk.delta.text                    (content_block_delta)
  *   OpenAI:    chunk.choices[0].delta.content
  *   Gemini:    chunk.candidates[0].content.parts[0].text
+ *   Ollama:    chunk.message.content  (native /api/chat, non-final only)
  *   pi-ai:     chunk.text  (text_delta event)
  */
 export function extractTextDeltaLength(chunk: unknown): number {
@@ -161,6 +221,16 @@ export function extractTextDeltaLength(chunk: unknown): number {
 			}
 			return len;
 		}
+	}
+
+	// Ollama native /api/chat delta: { message: { content }, done: false }.
+	// Only NON-final chunks are deltas — the done chunk repeats an empty
+	// content alongside the usage totals, so it must not count as text.
+	// (Anthropic message_start also carries `message`, but its content is an
+	// array, so the string check keeps it at 0 as before.)
+	if (c.done !== true && typeof c.message === "object" && c.message != null) {
+		const msg = c.message as Record<string, unknown>;
+		if (typeof msg.content === "string") return msg.content.length;
 	}
 
 	return 0;
@@ -204,21 +274,39 @@ export function createAccumulator(): {
 	let outputTokens = 0;
 	let chunksDelivered = 0;
 	let usageReported = false;
+	let computeMs: number | undefined;
 
 	return {
 		update(event: StreamEvent): void {
 			chunksDelivered++;
 
-			const usage = extractUsageFromEvent(event);
+			// pi-ai events are the primary shape. Ollama-native chunks are the one
+			// raw-provider family the accumulator also understands (OpenClaw can hand
+			// /api/chat NDJSON through un-normalized); other raw provider shapes stay
+			// with extractUsageFromProviderChunk consumers, so e.g. raw Anthropic
+			// message_start/message_delta pairs can't half-replace each other here.
+			const usage = extractUsageFromEvent(event) ?? extractOllamaUsage(event);
 			if (usage != null) {
 				inputTokens = usage.inputTokens;
 				outputTokens = usage.outputTokens;
 				usageReported = true;
 			}
+
+			const ms = extractComputeMs(event);
+			if (ms != null) {
+				computeMs = ms;
+			}
 		},
 
 		result(): AccumulatedUsage {
-			return { inputTokens, outputTokens, chunksDelivered, usageReported };
+			return {
+				inputTokens,
+				outputTokens,
+				chunksDelivered,
+				usageReported,
+				// Omitted entirely when absent — never `computeMs: undefined` (plan A6).
+				...(computeMs != null ? { computeMs } : {}),
+			};
 		},
 	};
 }

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -9,6 +9,8 @@
  * the packages at compile time.
  */
 
+import type { EndpointClass, LocalRuntime } from "usertrust";
+
 // ── pi-ai Stream Events ──
 
 export interface StreamUsage {
@@ -108,6 +110,18 @@ export interface UsertrustPluginConfig {
 	proxyKey?: string;
 	/** Vault directory (audit chain, spend ledger). Defaults to cwd. */
 	vaultBase?: string;
+	/**
+	 * Explicit endpoint scope for this OpenClaw runtime (M2). TRUSTED-OPERATOR
+	 * declaration: the headless/OpenClaw path has no client baseURL to sniff, so
+	 * core's config.endpoints[] URL matchers do NOT apply here (design decision 6)
+	 * — declare `{ class: "local" }` yourself or every call meters as cloud
+	 * (frontier fallback pricing for local models + strict cloud anomaly thresholds).
+	 */
+	endpoint?: {
+		class: EndpointClass;
+		runtime?: LocalRuntime;
+		baseURL?: string;
+	};
 }
 
 // ── Stream Function Types ──

--- a/packages/openclaw/tests/endpoint-scope.test.ts
+++ b/packages/openclaw/tests/endpoint-scope.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * endpoint-scope.test.ts — F1: UsertrustPluginConfig.endpoint threading.
+ *
+ * The headless/OpenClaw path has no client baseURL to classify, so the operator
+ * must declare the endpoint scope on the plugin config. This verifies the
+ * declaration reaches the headless governor: a declared local endpoint meters a
+ * "llama3.3:70b" call at the 1 nominal-usertoken local floor, while the absence
+ * of a declaration preserves cloud scope (frontier fallback pricing + the
+ * once-per-model unknown-model warning).
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+
+// Mock tigerbeetle-node (native module; dry-run never touches it, keep hermetic)
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `openclaw-endpoint-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+/** A pi-ai stream that reports 26 input / 298 output tokens on its done event. */
+function llamaStream(): StreamFn {
+	const events: StreamEvent[] = [
+		{ type: "start" },
+		{ type: "text_delta", text: "hello world" },
+		{ type: "done", stopReason: "stop", usage: { inputTokens: 26, outputTokens: 298 } },
+	];
+	return (_model: string, _context: StreamContext, _options?: Record<string, unknown>) =>
+		(async function* () {
+			for (const e of events) yield e;
+		})();
+}
+
+const CONTEXT: StreamContext = {
+	messages: [{ role: "user", content: "hi" }],
+	model: "llama3.3:70b",
+};
+
+const BUDGET = 100_000;
+
+describe("UsertrustPluginConfig.endpoint threading (F1)", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		const mod = await import("../src/index.js");
+		await mod.shutdown();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+	});
+
+	it("a declared local endpoint settles a llama3.3:70b call at 1 nominal usertoken", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { createGovernedStreamFn } = await import("../src/index.js");
+
+		const { governedStreamFn, governor } = await createGovernedStreamFn(llamaStream(), {
+			budget: BUDGET,
+			dryRun: true,
+			vaultBase,
+			endpoint: { class: "local", runtime: "ollama" },
+		});
+
+		for await (const _event of governedStreamFn("llama3.3:70b", CONTEXT)) {
+			// drain — settlement runs after the final event
+		}
+
+		// Local default rate {0,0} + the per-call >=1 floor = exactly 1 usertoken.
+		expect(BUDGET - governor.budgetRemaining()).toBe(1);
+		// Local scope never routes through the cloud unknown-model warning.
+		const modelWarns = warnSpy.mock.calls.filter((c) => String(c[0]).includes("llama3.3:70b"));
+		expect(modelWarns).toHaveLength(0);
+
+		warnSpy.mockRestore();
+		await governor.destroy();
+	});
+
+	it("without an endpoint declaration the same call stays cloud-scoped (frontier fallback)", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const { createGovernedStreamFn } = await import("../src/index.js");
+
+		const { governedStreamFn, governor } = await createGovernedStreamFn(llamaStream(), {
+			budget: BUDGET,
+			dryRun: true,
+			vaultBase,
+		});
+
+		for await (const _event of governedStreamFn("llama3.3:70b", CONTEXT)) {
+			// drain
+		}
+
+		// Cloud scope: unknown model → sonnet-class FALLBACK_RATE {30,150}.
+		// ceil(26/1000*30 + 298/1000*150) = ceil(45.48) = 46 usertokens.
+		expect(BUDGET - governor.budgetRemaining()).toBe(46);
+		// Cloud unknown model warns once per model string (default unknownModelPolicy "warn").
+		const modelWarns = warnSpy.mock.calls.filter((c) => String(c[0]).includes("llama3.3:70b"));
+		expect(modelWarns.length).toBeGreaterThanOrEqual(1);
+
+		warnSpy.mockRestore();
+		await governor.destroy();
+	});
+});

--- a/packages/openclaw/tests/token-extractor.ollama.test.ts
+++ b/packages/openclaw/tests/token-extractor.ollama.test.ts
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * token-extractor.ollama.test.ts — M2 Ollama-native chunk family
+ *
+ * Ollama's native /api/chat and /api/generate NDJSON streams carry token
+ * counts (prompt_eval_count / eval_count) and generation wall time
+ * (eval_duration, NANOSECONDS) only on the final `done: true` chunk.
+ * Non-final chunks carry the text delta at message.content.
+ *
+ * Plan A8: computeMs = round(eval_duration / 1e6), clamped to [0, 86_400_000];
+ * prompt_eval_duration is explicitly ignored in M2.
+ */
+
+import type { Authorization, Governor } from "usertrust";
+import { describe, expect, it, vi } from "vitest";
+import { wrapStreamWithGovernance } from "../src/stream-governor.js";
+import {
+	createAccumulator,
+	extractComputeMs,
+	extractTextDeltaLength,
+	extractUsageFromProviderChunk,
+} from "../src/token-extractor.js";
+import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+
+/** A realistic Ollama /api/chat final chunk (values from a llama3.3 run). */
+const ollamaFinalChunk = {
+	model: "llama3.3:70b",
+	created_at: "2026-07-26T12:00:00.000Z",
+	message: { role: "assistant", content: "" },
+	done_reason: "stop",
+	done: true,
+	total_duration: 5_100_000_000,
+	load_duration: 1_334_875,
+	prompt_eval_count: 26,
+	prompt_eval_duration: 342_546_000,
+	eval_count: 298,
+	eval_duration: 4_709_213_000,
+};
+
+/** A non-final Ollama /api/chat delta chunk. */
+const ollamaDeltaChunk = {
+	model: "llama3.3:70b",
+	created_at: "2026-07-26T12:00:00.000Z",
+	message: { role: "assistant", content: "Hello" },
+	done: false,
+};
+
+describe("extractUsageFromProviderChunk — Ollama native", () => {
+	it("parses the final done chunk's prompt_eval_count/eval_count", () => {
+		const usage = extractUsageFromProviderChunk(ollamaFinalChunk);
+		expect(usage).not.toBeNull();
+		expect(usage?.inputTokens).toBe(26);
+		expect(usage?.outputTokens).toBe(298);
+	});
+
+	it("defaults a missing prompt_eval_count to 0 when eval_count is present", () => {
+		const usage = extractUsageFromProviderChunk({ done: true, eval_count: 42 });
+		expect(usage).toEqual({ inputTokens: 0, outputTokens: 42 });
+	});
+
+	it("clamps oversized counts to the existing 2M ceiling", () => {
+		const usage = extractUsageFromProviderChunk({
+			done: true,
+			prompt_eval_count: 999_999_999,
+			eval_count: 999_999_999,
+		});
+		expect(usage?.inputTokens).toBe(2_000_000);
+		expect(usage?.outputTokens).toBe(2_000_000);
+	});
+
+	it("clamps negative counts to 0", () => {
+		const usage = extractUsageFromProviderChunk({
+			done: true,
+			prompt_eval_count: -26,
+			eval_count: -298,
+		});
+		expect(usage).toEqual({ inputTokens: 0, outputTokens: 0 });
+	});
+
+	it("returns null for a done chunk without eval counts", () => {
+		expect(
+			extractUsageFromProviderChunk({ done: true, message: { role: "assistant", content: "" } }),
+		).toBeNull();
+	});
+
+	it("returns null for non-final (done: false) chunks", () => {
+		expect(extractUsageFromProviderChunk(ollamaDeltaChunk)).toBeNull();
+	});
+
+	it("requires strict done === true (string 'true' is not the family)", () => {
+		expect(
+			extractUsageFromProviderChunk({ done: "true", prompt_eval_count: 26, eval_count: 298 }),
+		).toBeNull();
+	});
+
+	// The plan-mandated discrimination test: OpenAI chunks lack
+	// prompt_eval_count/eval_count and must never hit the Ollama branch.
+	it("does not misfire on OpenAI delta chunks (no prompt_eval_count)", () => {
+		const openAIDelta = {
+			id: "chatcmpl_01",
+			object: "chat.completion.chunk",
+			choices: [{ index: 0, delta: { content: "hello" }, finish_reason: null }],
+		};
+		expect(extractUsageFromProviderChunk(openAIDelta)).toBeNull();
+	});
+
+	it("still parses OpenAI final usage chunks via the OpenAI branch", () => {
+		const openAIUsageChunk = {
+			id: "chatcmpl_01",
+			choices: [],
+			usage: { prompt_tokens: 200, completion_tokens: 87, total_tokens: 287 },
+		};
+		const usage = extractUsageFromProviderChunk(openAIUsageChunk);
+		expect(usage).toEqual({ inputTokens: 200, outputTokens: 87 });
+	});
+});
+
+describe("extractComputeMs — A8 duration guards", () => {
+	it("converts eval_duration nanoseconds to rounded milliseconds", () => {
+		expect(extractComputeMs(ollamaFinalChunk)).toBe(4709); // round(4709.213)
+	});
+
+	it("rounds half-up at the ms boundary", () => {
+		expect(extractComputeMs({ done: true, eval_duration: 1_500_000 })).toBe(2);
+	});
+
+	it("returns undefined when eval_duration is absent", () => {
+		expect(extractComputeMs({ done: true, eval_count: 298 })).toBeUndefined();
+	});
+
+	it("returns undefined for non-finite eval_duration", () => {
+		expect(
+			extractComputeMs({ done: true, eval_duration: Number.POSITIVE_INFINITY }),
+		).toBeUndefined();
+		expect(extractComputeMs({ done: true, eval_duration: Number.NaN })).toBeUndefined();
+		expect(extractComputeMs({ done: true, eval_duration: "fast" })).toBeUndefined();
+	});
+
+	it("clamps negative durations to 0", () => {
+		expect(extractComputeMs({ done: true, eval_duration: -5_000_000_000 })).toBe(0);
+	});
+
+	it("clamps absurd durations to 24h (86_400_000 ms)", () => {
+		expect(extractComputeMs({ done: true, eval_duration: 1e18 })).toBe(86_400_000);
+	});
+
+	it("ignores prompt_eval_duration (M2 scope — plan A8)", () => {
+		expect(
+			extractComputeMs({ done: true, prompt_eval_duration: 342_546_000, eval_count: 26 }),
+		).toBeUndefined();
+	});
+
+	it("returns undefined for non-final chunks even with a duration", () => {
+		expect(extractComputeMs({ done: false, eval_duration: 4_709_213_000 })).toBeUndefined();
+	});
+
+	it("returns undefined for null / primitive / non-Ollama chunks", () => {
+		expect(extractComputeMs(null)).toBeUndefined();
+		expect(extractComputeMs(undefined)).toBeUndefined();
+		expect(extractComputeMs("chunk")).toBeUndefined();
+		expect(extractComputeMs({ choices: [] })).toBeUndefined();
+	});
+});
+
+describe("extractTextDeltaLength — Ollama native", () => {
+	it("counts message.content length on non-final chunks", () => {
+		expect(extractTextDeltaLength(ollamaDeltaChunk)).toBe(5);
+	});
+
+	it("returns 0 for the final done chunk (its content is not a delta)", () => {
+		expect(extractTextDeltaLength({ ...ollamaFinalChunk, message: { content: "xyz" } })).toBe(0);
+	});
+
+	it("returns 0 when message.content is not a string", () => {
+		expect(extractTextDeltaLength({ done: false, message: { content: 42 } })).toBe(0);
+		expect(extractTextDeltaLength({ done: false, message: {} })).toBe(0);
+	});
+
+	it("keeps Anthropic message_start (content array) at 0 — regression", () => {
+		const chunk = {
+			type: "message_start",
+			message: { content: [], usage: { input_tokens: 10, output_tokens: 1 } },
+		};
+		expect(extractTextDeltaLength(chunk)).toBe(0);
+	});
+});
+
+describe("createAccumulator — Ollama-native capture", () => {
+	it("captures usage + computeMs from a raw Ollama stream", () => {
+		const acc = createAccumulator();
+		acc.update(ollamaDeltaChunk as unknown as StreamEvent);
+		acc.update({
+			...ollamaDeltaChunk,
+			message: { role: "assistant", content: " world" },
+		} as unknown as StreamEvent);
+		acc.update(ollamaFinalChunk as unknown as StreamEvent);
+
+		const result = acc.result();
+		expect(result.inputTokens).toBe(26);
+		expect(result.outputTokens).toBe(298);
+		expect(result.usageReported).toBe(true);
+		expect(result.chunksDelivered).toBe(3);
+		expect(result.computeMs).toBe(4709);
+	});
+
+	it("omits computeMs entirely for pi-ai event streams (A6 discipline)", () => {
+		const acc = createAccumulator();
+		acc.update({ type: "text_delta", text: "hi" });
+		acc.update({ type: "done", stopReason: "stop", usage: { inputTokens: 10, outputTokens: 5 } });
+
+		const result = acc.result();
+		expect(result.usageReported).toBe(true);
+		expect(result).not.toHaveProperty("computeMs");
+	});
+
+	it("does not misfire on raw OpenAI usage chunks (Ollama family only)", () => {
+		const acc = createAccumulator();
+		acc.update({
+			id: "chatcmpl_01",
+			choices: [],
+			usage: { prompt_tokens: 200, completion_tokens: 87 },
+		} as unknown as StreamEvent);
+
+		const result = acc.result();
+		expect(result.usageReported).toBe(false);
+		expect(result).not.toHaveProperty("computeMs");
+	});
+
+	it("captures a done chunk that has counts but no eval_duration (usage without computeMs)", () => {
+		const acc = createAccumulator();
+		acc.update({ done: true, prompt_eval_count: 12, eval_count: 34 } as unknown as StreamEvent);
+
+		const result = acc.result();
+		expect(result.inputTokens).toBe(12);
+		expect(result.outputTokens).toBe(34);
+		expect(result.usageReported).toBe(true);
+		expect(result).not.toHaveProperty("computeMs");
+	});
+});
+
+// ── stream-governor computeMs forwarding ──
+
+function fakeGovernor(): { governor: Governor; settle: ReturnType<typeof vi.fn> } {
+	const auth: Authorization = {
+		transferId: "t_test",
+		estimatedCost: 1,
+		model: "llama3.3:70b",
+		createdAt: Date.now(),
+	};
+	const settle = vi.fn(async () => ({}) as never);
+	const governor = {
+		budgetRemaining: () => 1_000,
+		authorize: vi.fn(async () => auth),
+		settle,
+		abort: vi.fn(async () => {}),
+	} as unknown as Governor;
+	return { governor, settle };
+}
+
+function streamOf(chunks: unknown[]): StreamFn {
+	return (_model: string, _context: StreamContext, _options?: Record<string, unknown>) =>
+		(async function* () {
+			for (const chunk of chunks) {
+				yield chunk as StreamEvent;
+			}
+		})();
+}
+
+const context: StreamContext = { messages: [{ role: "user", content: "hi" }], model: "m" };
+
+describe("stream-governor — computeMs forwarding", () => {
+	it("forwards accumulated computeMs into governor.settle()", async () => {
+		const { governor, settle } = fakeGovernor();
+		const governed = wrapStreamWithGovernance(
+			streamOf([ollamaDeltaChunk, ollamaFinalChunk]),
+			governor,
+		);
+
+		const events: StreamEvent[] = [];
+		for await (const event of governed("llama3.3:70b", context)) {
+			events.push(event);
+		}
+
+		expect(events).toHaveLength(2); // transparent middleware — chunks forwarded unchanged
+		expect(settle).toHaveBeenCalledTimes(1);
+		expect(settle.mock.calls[0]?.[1]).toEqual({
+			inputTokens: 26,
+			outputTokens: 298,
+			chunksDelivered: 2,
+			usageSource: "provider",
+			computeMs: 4709,
+		});
+	});
+
+	it("omits computeMs from settle params when the stream never carried one", async () => {
+		const { governor, settle } = fakeGovernor();
+		const governed = wrapStreamWithGovernance(
+			streamOf([
+				{ type: "text_delta", text: "hi" },
+				{ type: "done", stopReason: "stop", usage: { inputTokens: 10, outputTokens: 5 } },
+			]),
+			governor,
+		);
+
+		for await (const _event of governed("claude-sonnet-4-6", context)) {
+			// drain
+		}
+
+		expect(settle).toHaveBeenCalledTimes(1);
+		const params = settle.mock.calls[0]?.[1] as Record<string, unknown>;
+		expect(params).not.toHaveProperty("computeMs");
+		expect(params).toMatchObject({ inputTokens: 10, outputTokens: 5, usageSource: "provider" });
+	});
+});


### PR DESCRIPTION
## Summary
Local inference (Ollama/vLLM/LM Studio) becomes first-class in the governed path:
- **`classifyEndpoint()`** — parsed-URL endpoint classification (origin equality, `*.suffix` hostname globs, loopback autodetect incl. IPv4-mapped IPv6); trusted-operator surface; unknown/malformed fails **expensive** (cloud)
- **`resolveRates()`** — local scope resolves `local.models` globs → `local.defaultRate` (`{0,0}` + ≥1 floor = **1 nominal usertoken/call**), never frontier fallback; cloud gains `unknownModelPolicy` (default `warn`) ending the silent sonnet-rate fallback; prototype-safe lookups
- **Streaming** — `include_usage` injection for local streams (merge-preserving; retry-once only on stream_options-shaped rejections); replace-with-latest accumulation
- **Anomaly** — per-scope token-rate windows (no cross-contamination), local thresholds + `perModel` globs, dual-denomination velocity, dead `costCalculator` seam wired
- **Headless/OpenClaw** — scope locked at authorize; `UsertrustPluginConfig.endpoint` declaration; Ollama-native extraction with `computeMs`
- Receipts gain optional `endpoint`/`meter`; **verify-parity pinned by e2e smoke**; CLI wizard step; runnable before/after demo

## Test plan
- 1905 tests green (150+ new incl. adversarial URL-bypass, interleaved-scope anomaly, injection-retry discrimination, e2e vs a zero-dep mock OpenAI-compat server)
- Coverage: 93.19 lines / 85.02 branches / 93.08 functions (gates 92/84/90)
- `npx tsx examples/ollama-local-governance/run.ts` — before/after receipts
- Verify parity: dryRun audit chain with local nominal receipts passes usertrust-verify

## Review audit trail
GPT-5.4 plan review: 18 findings, 11 accepted / 7 rejected · Code review: 2 HIGH + 1 MEDIUM, all fixed (OpenClaw endpoint surface, per-scope token-rate windows, retry discrimination) · In-house security: no P0–P2, invariant verified per bypass shape; 2 P3s fixed · Trail of Bits: zero PR findings; relayed pre-existing prototype-lookup hardening, fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)