### PR TITLE
feat(audit): external anchoring — signed checkpoints make the chain independently verifiable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ All commands support `--json` for machine-readable output.
 usertrust init          # Create .usertrust/ vault
 usertrust inspect       # Vault bank statement
 usertrust health        # Entropy diagnostics (6 signals, 0-100 score)
-usertrust verify        # Verify audit chain integrity
+usertrust verify        # Verify audit chain integrity (+ external anchors)
+usertrust anchor        # External anchoring: init|now|status|export|rotate|resume
 usertrust snapshot      # Checkpoint/restore vault state
 usertrust tb            # TigerBeetle process management
 usertrust completions   # Shell completions (bash, zsh, fish)
@@ -189,6 +190,8 @@ const config = defineConfig({
 
 **Merkle proofs (RFC 6962)** — Inclusion and consistency proofs for public verifiability. Any third party can verify a specific event existed in the chain.
 
+**External anchoring** — Ed25519-signed chain-head checkpoints pushed to an append-only store the vault operator cannot rewrite (S3 Object Lock, protected git branch, SIEM). Even a fully re-hashed, internally-consistent rewrite fails verification against the externally-held root. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md).
+
 **Policy engine** — 12 field operators (`eq`, `gt`, `in`, `regex`, etc.) with soft/hard enforcement. Block specific models, cap costs, require approvals.
 
 **PII detection** — Luhn-validated credit card numbers, SSN patterns, email addresses, phone numbers, IPv4 addresses. Block or warn before data leaves your network.
@@ -254,6 +257,15 @@ All hashes: valid (847/847)
 ```
 
 The verify package has zero runtime dependencies. It reads JSONL, recomputes SHA-256 hashes, and checks the chain. Anyone can verify a vault without trusting the usertrust SDK.
+
+With [external anchoring](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md) enabled, verification goes further: the auditor fetches signed checkpoints from an append-only store the operator cannot rewrite and pins the public key out-of-band — so even a fully re-hashed rewrite of the vault fails:
+
+```bash
+usertrust anchor init                                     # once: mint identity, pin the key
+usertrust anchor now --sink-file /mnt/worm/anchors.jsonl  # from cron/CI, or in-process
+
+npx usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem --require-external-anchor
+```
 
 ## License
 

--- a/docs/anchoring.md
+++ b/docs/anchoring.md
@@ -1,0 +1,176 @@
+# External audit anchoring
+
+The audit chain is tamper-evident on its own — but only *if you trust the operator's files*.
+Hashing has no secret input, so anyone with write access to the vault can rewrite an event,
+recompute every hash, and present a perfectly consistent chain. External anchoring closes that
+gap: the writer periodically emits a **signed checkpoint** of the chain head (Merkle root + size
++ last hash, Ed25519-signed, hash-chained to the previous checkpoint) to an **append-only store
+the vault operator cannot silently rewrite**. An auditor then verifies the vault against a
+checkpoint they fetched themselves, with a public key they pinned out-of-band — using only the
+zero-dependency [`usertrust-verify`](../packages/verify/README.md) package.
+
+Tamper-**evident**, not tamper-proof: detection produces a hard FAIL verdict, not restored data.
+
+## Quick start
+
+```bash
+# 1. Mint the vault's anchor identity (Ed25519 key — stored OUTSIDE the vault)
+usertrust anchor init
+# → prints the public key PEM + keyId. PIN THESE OUT-OF-BAND (see "Key ceremony").
+
+# 2. Anchor the current chain head to your append-only store
+usertrust anchor now --sink-file /mnt/worm/anchors.jsonl
+
+# 3. Anyone verifies — fetching the checkpoint themselves, never from the vault
+aws s3 cp s3://audit-anchors/vault-a/anchors.jsonl - \
+  | npx usertrust-verify .usertrust --anchors - --pubkey pinned-root.pem
+```
+
+Run `usertrust anchor now` from cron/CI (it exits non-zero if the record was not delivered), or
+start the in-process scheduler via the SDK. Defaults: an anchor every **1000 events** or **60
+seconds**, whichever comes first — the gap to the live head (the *unanchored tail*) is protected
+only by internal chain consistency and is always reported, never hidden.
+
+## The deployment invariant
+
+> **The identity that can write the vault must have append-only — not delete, not overwrite —
+> access to the anchor store.**
+
+That single asymmetry is the entire security argument: an attacker who owns the vault host can
+rewrite the vault, but cannot un-publish the checkpoints that contradict the rewrite. A store
+without this property silently degrades to "the attacker can rewrite the anchors too."
+
+### Store recipes
+
+**S3 with Object Lock (compliance mode)** — the same WORM control SEC 17a-4 / FINRA buyers
+already run. The writer role gets `PutObject` only:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "AnchorAppendOnly",
+    "Effect": "Allow",
+    "Action": ["s3:PutObject"],
+    "Resource": "arn:aws:s3:::audit-anchors/anchors/*"
+  }]
+}
+```
+
+No `s3:DeleteObject*`, no `s3:PutBucketPolicy`, no `s3:BypassGovernanceRetention`. Create the
+bucket with Object Lock enabled (compliance mode + retention period). Ship records with the
+command sink:
+
+```bash
+usertrust anchor now --sink-file /tmp/latest.json && \
+  aws s3 cp /tmp/latest.json "s3://audit-anchors/anchors/$VAULT_ID/$(printf %012d $SEQ).json"
+```
+
+(or wire `aws s3 cp -` directly as a `command` sink via the SDK config). Immutable object names
+mean an overwrite attempt of a past anchor is a denied write, never a silent replace — and a
+bucket listing exposes the true anchor high-water mark in one command.
+
+**Protected git branch** — push each record to a branch with force-push and deletion disabled
+(GitHub/GitLab branch protection). History rewrites are loud by construction.
+
+**SIEM (Splunk HEC / Datadog logs)** — `--sink-url https://…` POSTs each record; SIEM ingest
+credentials are inherently append-only.
+
+**File on a different mount/principal** (`--sink-file`) — weakest option; acceptable only when
+the path is owned by a different principal with append-only ACLs. Prefer the others.
+
+## Monitor the cadence (do not skip this)
+
+An attacker's cheapest move is to *stop anchoring* and tamper later. The absence of expected
+anchors in the store is the alarm, and it fires on the **customer side**, where the attacker
+can't suppress it. One rule:
+
+> Alert when no new object/record has arrived in the anchor store for longer than 2× your
+> anchoring interval.
+
+That is a two-line CloudWatch metric filter on `PutObject` events, or a scheduled SIEM search on
+the ingest index. Writer-side, `usertrust anchor status` reports the unanchored tail, outbox
+depth, and a `degraded` flag; scheduled emitters also surface `lastEmitError`.
+
+## Pull mode (zero-egress runtimes)
+
+Configure **no sinks**: the emitter writes only the vault-local mirror, and a customer job ships
+records on its own schedule:
+
+```bash
+usertrust anchor export --since 41 >> /mnt/worm/anchors.jsonl
+```
+
+Honest caveat: pull mode bounds detection *latency*, not detectability. Tampering that happens
+*and is anchored over* between exports is caught at the next export diff — provided at least one
+honest export of an earlier head exists. Push mode with the monitor rule above is stronger.
+
+## Key ceremony
+
+- `anchor init` prints the public key PEM + keyId. Give them to whoever will audit the vault —
+  their records, an engagement letter, a compliance portal. **Never** distribute the key via the
+  vault itself; the verifier deliberately refuses to read trust material from the directory
+  under audit.
+- Also drop `pubkey.pem` into the anchor store (object-locked) as a belt-and-braces copy.
+- The **private key never lives inside the vault**. Default: `~/.usertrust/keys/<vaultId>.anchor.pem`
+  (mode 0600), or `USERTRUST_ANCHOR_KEY` (PEM or path) injected from a secret manager, or an
+  external signer callback (KMS/HSM/PKCS#11) via the SDK — the key never touches disk at all.
+- **Rotation**: `usertrust anchor rotate` emits a rotation record cross-signed by the outgoing
+  key, then prints the new fingerprint. Auditors keep pinning the *original* root key and add the
+  new fingerprint as `--successor-pin` — a hijacked rotation to an attacker key then fails
+  verification outright. Without pins, an unpinned rotation still verifies but is flagged with a
+  prominent `rotation-unpinned` warning: confirm the fingerprint out-of-band before relying on
+  post-rotation records.
+- **Compromise**: a stolen key can sign forks — it cannot rewrite stored anchors. Competing
+  records at the same position in the append-only store are cryptographic fork evidence. Rotate
+  immediately, re-pin out-of-band, re-anchor from a trusted snapshot.
+
+## Verifying (the auditor side)
+
+The contract is **caller fetches, verifier checks**: you fetch the checkpoint(s) from the store
+with your own credentials (`aws s3 cp`, `git show`, a SIEM export) and pass them as files or
+stdin. The verifier never talks to S3/git/SIEM and works fully offline (air-gapped audits).
+
+```bash
+# Full history (strongest — linkage + append-only consistency between all checkpoints)
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem
+
+# Single latest checkpoint
+usertrust-verify .usertrust --anchor latest.json --pubkey root.pem
+
+# Per-transaction receipt, inclusion proven against the anchored root
+usertrust-verify .usertrust --tx tr_123 --anchor latest.json --pubkey root.pem
+
+# CI gate: must be externally anchored, fresh, and verified — or exit 1
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
+  --require-anchor --require-external-anchor --max-unanchored-events 5000
+```
+
+| State | Meaning | Exit (default / strict) |
+|---|---|---|
+| `ANCHORED_VERIFIED` | chain valid; checkpoints verify against your pinned key and bind to the vault content | 0 / 0 |
+| `UNANCHORED` | valid chain, no anchors — internal consistency only (legacy vaults) | 0 / 1 |
+| `ANCHOR_UNVERIFIABLE` | anchors exist but no key supplied, or the requested witness URL was unreachable | 0 + warning / 1 |
+| `ANCHOR_STALE` | verified prefix, but the tail exceeds your `--max-*` freshness policy | 0 + warning / 1 |
+| `ANCHOR_INVALID` | malformed record or signature fails against your pinned key | **1** |
+| `ANCHOR_MISMATCH` | valid signature, content contradicts the vault: rewrite, rollback, deletion, fork | **1** |
+
+Prefer `--max-unanchored-events` over `--max-anchor-age` for freshness policy: record timestamps
+are operator-claimed, event counts are not.
+
+The core CLI (`usertrust verify`) accepts the same flags. `usertrust anchor` subcommands:
+`init`, `now`, `status`, `export`, `rotate`, `resume` (re-seed a lost local mirror from the
+store's newest record).
+
+## What each attack looks like
+
+| Attack (attacker has full vault write access) | Verdict |
+|---|---|
+| Mutate an anchored event, recompute **every** hash + the `.meta` sidecar | `ANCHOR_MISMATCH` — recomputed Merkle root ≠ the signed, externally-held root |
+| Delete the entire audit directory | `ANCHOR_MISMATCH` — the store's checkpoint attests N events; the vault presents 0 |
+| Roll back to an older, internally-valid snapshot | `ANCHOR_MISMATCH` — anchored size exceeds observed size |
+| Re-sign history with a substituted keypair dropped into the vault | `ANCHOR_INVALID` — your pinned key governs; vault-resident keys are ignored |
+| Stop anchoring, tamper later | the unanchored tail is reported on every verify, and the store-side monitor fires |
+
+The full adversarial matrix (30+ scenarios) is pinned as CI tests under
+`packages/core/tests/harden/anchoring/`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -112,7 +112,8 @@ All commands support `--json` for machine-readable output.
 usertrust init          # Create .usertrust/ vault
 usertrust inspect       # Vault bank statement
 usertrust health        # Entropy diagnostics (6 signals, 0-100 score)
-usertrust verify        # Verify audit chain integrity
+usertrust verify        # Verify audit chain integrity (+ external anchors)
+usertrust anchor        # External anchoring: init|now|status|export|rotate|resume
 usertrust snapshot      # Checkpoint/restore vault state
 usertrust tb            # TigerBeetle process management
 usertrust completions   # Shell completions (bash, zsh, fish)
@@ -189,6 +190,8 @@ const config = defineConfig({
 
 **Merkle proofs (RFC 6962)** — Inclusion and consistency proofs for public verifiability. Any third party can verify a specific event existed in the chain.
 
+**External anchoring** — Ed25519-signed chain-head checkpoints pushed to an append-only store the vault operator cannot rewrite (S3 Object Lock, protected git branch, SIEM). Even a fully re-hashed, internally-consistent rewrite fails verification against the externally-held root. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md).
+
 **Policy engine** — 12 field operators (`eq`, `gt`, `in`, `regex`, etc.) with soft/hard enforcement. Block specific models, cap costs, require approvals.
 
 **PII detection** — Luhn-validated credit card numbers, SSN patterns, email addresses, phone numbers, IPv4 addresses. Block or warn before data leaves your network.
@@ -254,6 +257,15 @@ All hashes: valid (847/847)
 ```
 
 The verify package has zero runtime dependencies. It reads JSONL, recomputes SHA-256 hashes, and checks the chain. Anyone can verify a vault without trusting the usertrust SDK.
+
+With [external anchoring](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md) enabled, verification goes further: the auditor fetches signed checkpoints from an append-only store the operator cannot rewrite and pins the public key out-of-band — so even a fully re-hashed rewrite of the vault fails:
+
+```bash
+usertrust anchor init                                     # once: mint identity, pin the key
+usertrust anchor now --sink-file /mnt/worm/anchors.jsonl  # from cron/CI, or in-process
+
+npx usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem --require-external-anchor
+```
 
 ## License
 

--- a/packages/core/src/audit/anchor-verify.ts
+++ b/packages/core/src/audit/anchor-verify.ts
@@ -1,0 +1,975 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * External Anchor Verification — Zero-dependency standalone
+ *
+ * INTENTIONAL DUPLICATION: this file exists byte-for-byte in BOTH
+ * packages/verify/src/anchor-verify.ts and
+ * packages/core/src/audit/anchor-verify.ts — only the import paths differ.
+ * The anchor differential/parity tests pin the two together; any change must
+ * land in both packages.
+ *
+ * Verifies signed anchor checkpoints (spec: docs/superpowers/specs/
+ * 2026-07-26-external-anchoring-design.md) against a caller-pinned trust root:
+ *  - strict record parsing (unknown fields / range violations are INVALID)
+ *  - Ed25519 signature verification via node:crypto (ECDSA P-256 helper kept
+ *    alg-agile for Phase 2 transparency-log checkpoints)
+ *  - anchor-chain verification: prevAnchorHash linkage, anchorSeq contiguity,
+ *    key epochs via cross-signed rotation records, fork/duplicate semantics
+ *  - vault binding: Merkle root / head hash at each anchored treeSize, with
+ *    externally-bound consistency proofs between anchors
+ *  - the spec §7.2 state machine (UNANCHORED / ANCHORED_VERIFIED / ANCHOR_STALE
+ *    / ANCHOR_UNVERIFIABLE / ANCHOR_INVALID / ANCHOR_MISMATCH)
+ *
+ * Trust NEVER comes from the vault under audit: the caller pins the genesis
+ * root key (and optional rotation-successor pins) out-of-band.
+ */
+
+import { type KeyObject, createHash, createPublicKey, verify as cryptoVerify } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { GENESIS_HASH } from "../shared/constants.js";
+import { canonicalize } from "./canonical.js";
+import {
+	type MerkleInclusionProof,
+	buildMerkleTree,
+	generateConsistencyProof,
+	verifyConsistencyProof,
+	verifyInclusionProof,
+} from "./merkle.js";
+
+// ── Types ──
+
+export interface AnchorRotation {
+	readonly nextKeyId: string;
+	readonly nextPublicKeySpki: string;
+}
+
+export interface AnchorRecord {
+	readonly v: 1;
+	readonly vaultId: string;
+	readonly anchorSeq: number;
+	readonly prevAnchorHash: string;
+	readonly treeSize: number;
+	readonly lastHash: string;
+	readonly merkleRoot: string;
+	readonly timestamp: string;
+	readonly keyId: string;
+	readonly rotation?: AnchorRotation;
+	readonly sig: string;
+}
+
+/** Caller-pinned trust material. NEVER read from the vault under audit. */
+export interface AnchorTrust {
+	/** THE pinned genesis root key (PEM). anchorSeq 1 MUST verify under it. */
+	readonly rootPem: string;
+	/** Optional out-of-band pins for rotation successors. */
+	readonly successorPinsPem?: readonly string[];
+}
+
+export type AnchorState =
+	| "UNANCHORED"
+	| "ANCHORED_VERIFIED"
+	| "ANCHOR_STALE"
+	| "ANCHOR_UNVERIFIABLE"
+	| "ANCHOR_INVALID"
+	| "ANCHOR_MISMATCH";
+
+export type AnchorSource = "external" | "vault-mirror" | "none";
+export type WitnessStatus = "agrees" | "disagrees" | "unreachable" | "not-consulted";
+
+export interface WitnessInput {
+	readonly requested: boolean;
+	readonly ok?: boolean;
+	readonly error?: string;
+}
+
+export interface AnchorEvaluationOptions {
+	readonly maxAnchorAgeMs?: number;
+	readonly maxUnanchoredEvents?: number;
+	readonly expectedVaultId?: string;
+	/** Injectable clock for tests. Defaults to Date.now(). */
+	readonly nowMs?: number;
+}
+
+export interface AnchorEvaluationInput {
+	/** Globally sequence-ordered stored event hashes (verifyVault ordering). */
+	readonly orderedHashes: readonly string[];
+	/** Caller-fetched external anchor records (already parsed). */
+	readonly externalAnchors: readonly AnchorRecord[];
+	/** Parse errors from caller-supplied artifacts (fail-closed). */
+	readonly externalErrors: readonly string[];
+	/** Records from the vault-local mirror — CACHE, never a trust root alone. */
+	readonly mirrorAnchors: readonly AnchorRecord[];
+	readonly mirrorErrors: readonly string[];
+	readonly trust: AnchorTrust | null;
+	readonly witness: WitnessInput;
+	readonly opts?: AnchorEvaluationOptions;
+}
+
+export interface AnchorEvaluation {
+	anchorState: AnchorState;
+	/** false only on ANCHOR_INVALID / ANCHOR_MISMATCH. */
+	anchorsValid: boolean;
+	anchorSource: AnchorSource;
+	anchorCount: number;
+	latestAnchor: {
+		anchorSeq: number;
+		treeSize: number;
+		lastHash: string;
+		keyId: string;
+		timestamp: string;
+	} | null;
+	unanchoredTail: { events: number; sinceTimestampMs: number | null };
+	witness: { requested: boolean; status: WitnessStatus; error?: string };
+	reasons: string[];
+	warnings: string[];
+	errors: string[];
+}
+
+function nullIfNaN(n: number): number | null {
+	return Number.isFinite(n) ? n : null;
+}
+
+// ── Reason-code classes (see spec §7.2) ──
+
+const INVALID_REASONS = new Set(["malformed-anchor", "range-invalid", "sig-invalid"]);
+const NON_FAIL_REASONS = new Set(["no-trust-material", "witness-unreachable"]);
+
+// ── Strict parsing ──
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const KEY_ID = /^sha256:[0-9a-f]{64}$/;
+const RECORD_KEYS = new Set([
+	"v",
+	"vaultId",
+	"anchorSeq",
+	"prevAnchorHash",
+	"treeSize",
+	"lastHash",
+	"merkleRoot",
+	"timestamp",
+	"keyId",
+	"rotation",
+	"sig",
+]);
+const ROTATION_KEYS = new Set(["nextKeyId", "nextPublicKeySpki"]);
+
+function isSafePositiveInt(n: unknown): n is number {
+	return typeof n === "number" && Number.isSafeInteger(n) && n >= 1;
+}
+
+/**
+ * Strict parse of a single anchor record. Unknown fields, missing fields, and
+ * range violations are all rejected (fail-closed — spec §3 strict-parse rules;
+ * range checks run BEFORE any Merkle primitive so a validly-signed-but-
+ * degenerate record yields a deterministic verdict, never a throw).
+ * Returns `{ record }` or `{ error }` with a code-prefixed message.
+ */
+export function parseAnchorRecord(raw: string): {
+	record: AnchorRecord | null;
+	error: string | null;
+} {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return { record: null, error: "malformed-anchor: not valid JSON" };
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { record: null, error: "malformed-anchor: not an object" };
+	}
+	const obj = parsed as Record<string, unknown>;
+	for (const key of Object.keys(obj)) {
+		if (!RECORD_KEYS.has(key)) {
+			return { record: null, error: `malformed-anchor: unknown field "${key}"` };
+		}
+	}
+	if (obj.v !== 1) {
+		return { record: null, error: "malformed-anchor: unsupported version" };
+	}
+	if (typeof obj.vaultId !== "string" || obj.vaultId.length === 0) {
+		return { record: null, error: "malformed-anchor: missing vaultId" };
+	}
+	if (!isSafePositiveInt(obj.anchorSeq)) {
+		return { record: null, error: "range-invalid: anchorSeq must be a safe integer >= 1" };
+	}
+	if (!isSafePositiveInt(obj.treeSize)) {
+		return { record: null, error: "range-invalid: treeSize must be a safe integer >= 1" };
+	}
+	if (typeof obj.prevAnchorHash !== "string" || !HEX64.test(obj.prevAnchorHash)) {
+		return { record: null, error: "malformed-anchor: prevAnchorHash must be 64-hex" };
+	}
+	if (typeof obj.lastHash !== "string" || !HEX64.test(obj.lastHash)) {
+		return { record: null, error: "malformed-anchor: lastHash must be 64-hex" };
+	}
+	if (typeof obj.merkleRoot !== "string" || !HEX64.test(obj.merkleRoot)) {
+		return { record: null, error: "malformed-anchor: merkleRoot must be 64-hex" };
+	}
+	if (typeof obj.timestamp !== "string" || obj.timestamp.length === 0) {
+		return { record: null, error: "malformed-anchor: missing timestamp" };
+	}
+	if (typeof obj.keyId !== "string" || !KEY_ID.test(obj.keyId)) {
+		return { record: null, error: "malformed-anchor: keyId must be sha256:<64-hex>" };
+	}
+	if (typeof obj.sig !== "string" || obj.sig.length === 0) {
+		return { record: null, error: "malformed-anchor: missing sig" };
+	}
+	if (obj.rotation !== undefined) {
+		const rot = obj.rotation;
+		if (rot === null || typeof rot !== "object" || Array.isArray(rot)) {
+			return { record: null, error: "malformed-anchor: rotation must be an object" };
+		}
+		const rotObj = rot as Record<string, unknown>;
+		for (const key of Object.keys(rotObj)) {
+			if (!ROTATION_KEYS.has(key)) {
+				return { record: null, error: `malformed-anchor: unknown rotation field "${key}"` };
+			}
+		}
+		if (typeof rotObj.nextKeyId !== "string" || !KEY_ID.test(rotObj.nextKeyId)) {
+			return {
+				record: null,
+				error: "malformed-anchor: rotation.nextKeyId must be sha256:<64-hex>",
+			};
+		}
+		if (
+			typeof rotObj.nextPublicKeySpki !== "string" ||
+			Buffer.from(rotObj.nextPublicKeySpki, "base64").length === 0
+		) {
+			return {
+				record: null,
+				error: "malformed-anchor: rotation.nextPublicKeySpki must be base64",
+			};
+		}
+	}
+	return { record: obj as unknown as AnchorRecord, error: null };
+}
+
+/** Parse a JSONL (or single-JSON) anchors artifact. Every line must parse. */
+export function parseAnchorsContent(content: string): {
+	records: AnchorRecord[];
+	errors: string[];
+} {
+	const records: AnchorRecord[] = [];
+	const errors: string[] = [];
+	const lines = content
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l.length > 0);
+	for (let i = 0; i < lines.length; i++) {
+		const { record, error } = parseAnchorRecord(lines[i] as string);
+		if (record) {
+			records.push(record);
+		} else {
+			errors.push(`anchor line ${i + 1}: ${error}`);
+		}
+	}
+	return { records, errors };
+}
+
+// ── Crypto helpers ──
+
+/** Signing pre-image = canonicalize(record − sig). Spec §3. */
+export function anchorSigningPreimage(record: AnchorRecord): string {
+	const { sig: _sig, ...rest } = record;
+	return canonicalize(rest);
+}
+
+/** sha256 hex of the signing pre-image — what the successor's prevAnchorHash carries. */
+export function anchorPayloadHash(record: AnchorRecord): string {
+	return createHash("sha256").update(anchorSigningPreimage(record), "utf8").digest("hex");
+}
+
+export function keyIdFromSpkiDer(der: Buffer): string {
+	return `sha256:${createHash("sha256").update(der).digest("hex")}`;
+}
+
+export function publicKeyFromPem(pem: string): KeyObject | null {
+	try {
+		return createPublicKey(pem);
+	} catch {
+		return null;
+	}
+}
+
+export function publicKeyFromSpkiBase64(b64: string): KeyObject | null {
+	try {
+		return createPublicKey({ key: Buffer.from(b64, "base64"), format: "der", type: "spki" });
+	} catch {
+		return null;
+	}
+}
+
+export function keyIdFromKeyObject(key: KeyObject): string {
+	return keyIdFromSpkiDer(key.export({ type: "spki", format: "der" }) as Buffer);
+}
+
+/**
+ * Raw signature verification over UTF-8 data. Ed25519 for usertrust anchor
+ * records; ECDSA P-256 kept alg-agile for Phase 2 transparency-log checkpoints
+ * (Rekor signs with ECDSA — spec reconciliation R2). Never throws.
+ */
+export function verifySignatureRaw(
+	alg: "ed25519" | "ecdsa-p256",
+	dataUtf8: string,
+	publicKey: KeyObject,
+	sigBase64: string,
+): boolean {
+	const data = Buffer.from(dataUtf8, "utf8");
+	const sig = Buffer.from(sigBase64, "base64");
+	if (sig.length === 0) return false;
+	try {
+		if (alg === "ed25519") {
+			return cryptoVerify(null, data, publicKey, sig);
+		}
+		return (
+			cryptoVerify("sha256", data, { key: publicKey, dsaEncoding: "ieee-p1363" }, sig) ||
+			cryptoVerify("sha256", data, { key: publicKey, dsaEncoding: "der" }, sig)
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Verify one record's Ed25519 signature against explicit candidate keys.
+ * The candidate whose keyId matches the record's keyId is used; a record whose
+ * keyId matches none of the candidates fails with a distinct error.
+ */
+export function verifyAnchorSignature(
+	record: AnchorRecord,
+	candidateKeysPem: readonly string[],
+): { ok: boolean; keyId: string; errors: string[] } {
+	const errors: string[] = [];
+	for (const pem of candidateKeysPem) {
+		const key = publicKeyFromPem(pem);
+		if (key === null) {
+			errors.push("sig-invalid: unparseable candidate public key");
+			continue;
+		}
+		if (keyIdFromKeyObject(key) !== record.keyId) continue;
+		if (verifySignatureRaw("ed25519", anchorSigningPreimage(record), key, record.sig)) {
+			return { ok: true, keyId: record.keyId, errors: [] };
+		}
+		errors.push(`sig-invalid: signature does not verify under keyId ${record.keyId}`);
+		return { ok: false, keyId: record.keyId, errors };
+	}
+	errors.push(`sig-invalid: no candidate key matches keyId ${record.keyId}`);
+	return { ok: false, keyId: record.keyId, errors };
+}
+
+// ── Duplicate / fork semantics (spec §7.2) ──
+
+/** Committed-field equality: everything except timestamp and sig. */
+export function committedFieldsEqual(a: AnchorRecord, b: AnchorRecord): boolean {
+	const strip = (r: AnchorRecord): string => {
+		const { sig: _s, timestamp: _t, ...rest } = r;
+		return canonicalize(rest);
+	};
+	return strip(a) === strip(b);
+}
+
+/**
+ * Collapse same-anchorSeq records WITHIN one stream (store or mirror):
+ * identical committed content = benign duplicate (warn, keep first);
+ * divergent committed content = fork evidence (MISMATCH).
+ */
+export function dedupeAnchorSet(records: readonly AnchorRecord[]): {
+	unique: AnchorRecord[];
+	/** Committed-equal twins collapsed out — still signature-checked by the walk. */
+	dropped: AnchorRecord[];
+	warnings: string[];
+	errors: string[];
+	mismatchReasons: string[];
+} {
+	const warnings: string[] = [];
+	const errors: string[] = [];
+	const mismatchReasons: string[] = [];
+	const dropped: AnchorRecord[] = [];
+	const bySeq = new Map<number, AnchorRecord>();
+	for (const r of records) {
+		const existing = bySeq.get(r.anchorSeq);
+		if (existing === undefined) {
+			bySeq.set(r.anchorSeq, r);
+		} else if (committedFieldsEqual(existing, r)) {
+			// Benign duplicate ONLY if its signature also verifies — the walk
+			// re-checks every dropped twin under its epoch key (spec §7.2
+			// "both signatures valid"). Order must not decide the verdict.
+			warnings.push("duplicate-anchor");
+			dropped.push(r);
+		} else {
+			errors.push(
+				`fork: divergent records at anchorSeq ${r.anchorSeq} (same position, different committed content)`,
+			);
+			mismatchReasons.push("fork");
+		}
+	}
+	const unique = [...bySeq.values()].sort((a, b) => a.anchorSeq - b.anchorSeq);
+	return { unique, dropped, warnings, errors, mismatchReasons };
+}
+
+// ── Anchor chain verification ──
+
+export interface AnchorChainResult {
+	/** anchorSeq-ordered records that entered the walk. */
+	records: AnchorRecord[];
+	errors: string[];
+	/** ANCHOR_INVALID-class reason codes. */
+	invalidReasons: string[];
+	/** ANCHOR_MISMATCH-class reason codes. */
+	mismatchReasons: string[];
+	warnings: string[];
+}
+
+/**
+ * Verify the anchor stream as its own hash chain under the pinned trust root:
+ * signatures per key epoch (rotations walked forward from the root),
+ * prevAnchorHash linkage from GENESIS, anchorSeq contiguity from 1, treeSize
+ * monotonicity, single vaultId, and — when event hashes are supplied —
+ * consistency binding between consecutive anchored roots. The proof's
+ * firstRoot/secondRoot are compared to the SIGNED roots before
+ * verifyConsistencyProof is called: the bare call checks only internal proof
+ * consistency and passes unconditionally on locally generated proofs
+ * (spec §7.2 — omitting the binding recreates F1).
+ *
+ * Callers pass a set already deduped per stream (dedupeAnchorSet); same-seq
+ * survivors here are treated as forks.
+ */
+export function verifyAnchorChain(
+	records: readonly AnchorRecord[],
+	trust: AnchorTrust,
+	eventHashes?: readonly string[],
+): AnchorChainResult {
+	const errors: string[] = [];
+	const invalidReasons: string[] = [];
+	const mismatchReasons: string[] = [];
+	const warnings: string[] = [];
+
+	const rootKey = publicKeyFromPem(trust.rootPem);
+	if (rootKey === null) {
+		errors.push("trust root public key is not a parseable PEM");
+		invalidReasons.push("sig-invalid");
+		return { records: [], errors, invalidReasons, mismatchReasons, warnings };
+	}
+	const pinKeyIds = new Set<string>();
+	const knownKeys = new Map<string, KeyObject>();
+	const rootKeyId = keyIdFromKeyObject(rootKey);
+	knownKeys.set(rootKeyId, rootKey);
+	for (const pem of trust.successorPinsPem ?? []) {
+		const k = publicKeyFromPem(pem);
+		if (k !== null) {
+			const id = keyIdFromKeyObject(k);
+			pinKeyIds.add(id);
+			knownKeys.set(id, k);
+		}
+	}
+
+	// A mixed-vaultId set is rejected wholesale, BEFORE dedup can collapse a
+	// replayed foreign record into a same-seq group (cross-vault replay).
+	const vaultIds = new Set(records.map((r) => r.vaultId));
+	if (vaultIds.size > 1) {
+		errors.push(`vault-id-mismatch: anchor set mixes ${vaultIds.size} distinct vaultIds`);
+		mismatchReasons.push("vault-id-mismatch");
+	}
+
+	const dedup = dedupeAnchorSet(records);
+	warnings.push(...dedup.warnings);
+	errors.push(...dedup.errors);
+	mismatchReasons.push(...dedup.mismatchReasons);
+	const ordered = dedup.unique;
+	const droppedBySeq = new Map<number, AnchorRecord[]>();
+	for (const d of dedup.dropped) {
+		const list = droppedBySeq.get(d.anchorSeq) ?? [];
+		list.push(d);
+		droppedBySeq.set(d.anchorSeq, list);
+	}
+
+	let epochKeyId = rootKeyId;
+	let epochKey: KeyObject | null = rootKey;
+	let prev: AnchorRecord | null = null;
+
+	for (let i = 0; i < ordered.length; i++) {
+		const r = ordered[i] as AnchorRecord;
+
+		if (i === 0 && r.anchorSeq !== 1) {
+			// A supplied history that simply does not START at genesis (e.g. the
+			// documented single-checkpoint bind, §7.5) is PARTIAL, not tampered:
+			// the missing prefix is unprovable, not proof of deletion, and every
+			// present record still binds to the vault content. A gap BETWEEN two
+			// present records (checked below) remains a hard MISMATCH.
+			warnings.push("partial-history");
+		}
+		if (prev !== null && r.anchorSeq !== prev.anchorSeq + 1) {
+			errors.push(`anchor-chain-gap: anchorSeq ${r.anchorSeq} follows ${prev.anchorSeq}`);
+			mismatchReasons.push("anchor-chain-gap");
+		}
+		if (r.anchorSeq === 1 && r.prevAnchorHash !== GENESIS_HASH) {
+			errors.push("anchor-chain-gap: anchorSeq 1 prevAnchorHash must be GENESIS");
+			mismatchReasons.push("anchor-chain-gap");
+		}
+		if (prev !== null && r.anchorSeq === prev.anchorSeq + 1) {
+			if (r.prevAnchorHash !== anchorPayloadHash(prev)) {
+				errors.push(
+					`anchor-chain-gap: anchorSeq ${r.anchorSeq} prevAnchorHash does not link to its predecessor`,
+				);
+				mismatchReasons.push("anchor-chain-gap");
+			}
+		}
+		if (prev !== null && r.treeSize < prev.treeSize) {
+			errors.push(
+				`anchor monotonicity violation: treeSize ${r.treeSize} at anchorSeq ${r.anchorSeq} decreases from ${prev.treeSize}`,
+			);
+			mismatchReasons.push("rollback");
+		}
+		if (prev !== null && r.vaultId !== prev.vaultId) {
+			errors.push(`vault-id-mismatch: mixed vaultId in anchor set at anchorSeq ${r.anchorSeq}`);
+			mismatchReasons.push("vault-id-mismatch");
+		}
+
+		// Signature under the current epoch key. A cryptographically valid
+		// signature under a trusted key that is WRONG for this chain position
+		// is MISMATCH (key/rotation continuity); a signature no trusted key
+		// verifies is INVALID (spec §7.1 rule).
+		let sigOk = false;
+		if (r.keyId === epochKeyId && epochKey !== null) {
+			if (verifySignatureRaw("ed25519", anchorSigningPreimage(r), epochKey, r.sig)) {
+				sigOk = true;
+			} else {
+				errors.push(`sig-invalid: anchorSeq ${r.anchorSeq} signature fails under keyId ${r.keyId}`);
+				invalidReasons.push("sig-invalid");
+			}
+		} else {
+			const candidate = knownKeys.get(r.keyId);
+			if (
+				candidate !== undefined &&
+				verifySignatureRaw("ed25519", anchorSigningPreimage(r), candidate, r.sig)
+			) {
+				errors.push(
+					`rotation-continuity: anchorSeq ${r.anchorSeq} signed by keyId ${r.keyId}, expected epoch key ${epochKeyId}`,
+				);
+				mismatchReasons.push("rotation-continuity");
+			} else {
+				errors.push(
+					`sig-invalid: anchorSeq ${r.anchorSeq} signed by untrusted or failing keyId ${r.keyId}`,
+				);
+				invalidReasons.push("sig-invalid");
+			}
+		}
+
+		// A committed-equal twin dropped by dedup must ALSO verify (spec §7.2
+		// "both signatures valid") — otherwise record order would decide the
+		// verdict. keyId is a committed field, so the twin resolves to the
+		// same epoch/known key as its survivor.
+		for (const twin of droppedBySeq.get(r.anchorSeq) ?? []) {
+			const twinKey = twin.keyId === epochKeyId ? epochKey : (knownKeys.get(twin.keyId) ?? null);
+			if (
+				twinKey === null ||
+				!verifySignatureRaw("ed25519", anchorSigningPreimage(twin), twinKey, twin.sig)
+			) {
+				errors.push(
+					`sig-invalid: duplicate record at anchorSeq ${r.anchorSeq} has a signature that does not verify under keyId ${twin.keyId}`,
+				);
+				invalidReasons.push("sig-invalid");
+			}
+		}
+
+		// Rotation: cross-signed successor introduction. Only a record whose
+		// own signature verified in its epoch may advance the epoch — a forged
+		// rotation must never install a key.
+		if (r.rotation !== undefined && sigOk) {
+			const nextKey = publicKeyFromSpkiBase64(r.rotation.nextPublicKeySpki);
+			if (nextKey === null || keyIdFromKeyObject(nextKey) !== r.rotation.nextKeyId) {
+				errors.push(
+					`malformed-anchor: rotation at anchorSeq ${r.anchorSeq} — nextKeyId does not match nextPublicKeySpki`,
+				);
+				invalidReasons.push("malformed-anchor");
+			} else {
+				if (pinKeyIds.size > 0 && !pinKeyIds.has(r.rotation.nextKeyId)) {
+					errors.push(
+						`rotation-unpinned: rotation at anchorSeq ${r.anchorSeq} to keyId ${r.rotation.nextKeyId} not in the supplied successor pins`,
+					);
+					mismatchReasons.push("rotation-unpinned");
+				} else if (pinKeyIds.size === 0) {
+					warnings.push("rotation-unpinned");
+				}
+				knownKeys.set(r.rotation.nextKeyId, nextKey);
+				epochKeyId = r.rotation.nextKeyId;
+				epochKey = nextKey;
+			}
+		}
+
+		// Consistency binding between consecutive anchored roots (spec §7.2).
+		if (
+			eventHashes !== undefined &&
+			prev !== null &&
+			prev.treeSize >= 1 &&
+			r.treeSize <= eventHashes.length &&
+			prev.treeSize <= r.treeSize
+		) {
+			if (prev.treeSize === r.treeSize) {
+				if (prev.merkleRoot !== r.merkleRoot) {
+					errors.push(
+						`consistency-failure: anchorSeq ${prev.anchorSeq}->${r.anchorSeq} same treeSize, different roots`,
+					);
+					mismatchReasons.push("consistency-failure");
+				}
+			} else {
+				const proof = generateConsistencyProof(prev.treeSize, r.treeSize, [...eventHashes]);
+				if (
+					proof.firstRoot !== prev.merkleRoot ||
+					proof.secondRoot !== r.merkleRoot ||
+					!verifyConsistencyProof(proof)
+				) {
+					errors.push(
+						`consistency-failure: anchored root at treeSize ${prev.treeSize} is not a prefix of the tree at ${r.treeSize}`,
+					);
+					mismatchReasons.push("consistency-failure");
+				}
+			}
+		}
+
+		prev = r;
+	}
+
+	return { records: ordered, errors, invalidReasons, mismatchReasons, warnings };
+}
+
+// ── Vault gathering ──
+
+/**
+ * Gather the globally sequence-ordered stored event hashes of a vault, using
+ * the exact segment-gathering and ordering semantics of verifyVault
+ * (events.jsonl first, then every other *.jsonl sorted; order by persisted
+ * global `sequence` when every event has one, else file order). Malformed
+ * lines are skipped here — chain-level errors are verifyVault's job, not the
+ * anchor evaluator's.
+ */
+export function gatherOrderedEventHashes(vaultPath: string): string[] {
+	const auditDir = join(vaultPath, "audit");
+	const segmentFiles: string[] = [];
+	const mainLog = join(auditDir, "events.jsonl");
+	if (existsSync(mainLog)) {
+		segmentFiles.push(mainLog);
+	}
+	if (existsSync(auditDir)) {
+		try {
+			for (const entry of readdirSync(auditDir).sort()) {
+				if (entry.endsWith(".jsonl") && entry !== "events.jsonl") {
+					segmentFiles.push(join(auditDir, entry));
+				}
+			}
+		} catch {
+			// Directory read failure — non-fatal
+		}
+	}
+	const events: { hash: string; sequence?: number | undefined }[] = [];
+	for (const segmentFile of segmentFiles) {
+		let content: string;
+		try {
+			content = readFileSync(segmentFile, "utf-8").trim();
+		} catch {
+			continue;
+		}
+		if (content === "") continue;
+		for (const raw of content.split("\n").filter((l) => l.trim())) {
+			try {
+				const parsed = JSON.parse(raw) as Record<string, unknown>;
+				events.push({
+					hash: typeof parsed.hash === "string" ? parsed.hash : "",
+					sequence: typeof parsed.sequence === "number" ? parsed.sequence : undefined,
+				});
+			} catch {
+				// skip malformed line
+			}
+		}
+	}
+	const allHaveSeq = events.every((e) => typeof e.sequence === "number");
+	const ordered = allHaveSeq
+		? [...events].sort((a, b) => (a.sequence as number) - (b.sequence as number))
+		: events;
+	return ordered.map((e) => e.hash);
+}
+
+/** Read the vault-local anchor mirror (cache, never a trust root alone). */
+export function readAnchorMirror(vaultPath: string): {
+	records: AnchorRecord[];
+	errors: string[];
+} {
+	const mirrorPath = join(vaultPath, "audit", "anchors", "anchors.jsonl");
+	if (!existsSync(mirrorPath)) return { records: [], errors: [] };
+	try {
+		return parseAnchorsContent(readFileSync(mirrorPath, "utf-8"));
+	} catch {
+		return { records: [], errors: ["malformed-anchor: anchor mirror unreadable"] };
+	}
+}
+
+// ── State machine ──
+
+const STATE_SEVERITY: Record<AnchorState, number> = {
+	ANCHORED_VERIFIED: 0,
+	UNANCHORED: 1,
+	ANCHOR_UNVERIFIABLE: 2,
+	ANCHOR_STALE: 3,
+	ANCHOR_INVALID: 4,
+	ANCHOR_MISMATCH: 5,
+};
+
+function worseState(a: AnchorState, b: AnchorState): AnchorState {
+	return (STATE_SEVERITY[a] ?? 0) >= (STATE_SEVERITY[b] ?? 0) ? a : b;
+}
+
+/**
+ * The spec §7.2 state machine. Pure function over gathered inputs so both
+ * packages (and the differential test) evaluate identically. Evaluation order
+ * per constraints §4.2: discover → trust check → parse/signature → content
+ * cross-checks → freshness; worst state wins. The witness-fetch-failure rule
+ * (AC-2.4) caps the state below ANCHORED_VERIFIED without discarding
+ * caller-supplied artifacts.
+ */
+export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvaluation {
+	const opts = input.opts ?? {};
+	const nowMs = opts.nowMs ?? Date.now();
+	const reasons: string[] = [];
+	const warnings: string[] = [];
+	const errors: string[] = [];
+
+	const witnessRequested = input.witness.requested;
+	const witnessOk = input.witness.ok === true;
+	const witnessFailed = witnessRequested && !witnessOk;
+
+	const observed = input.orderedHashes.length;
+	const anchorsPresent =
+		input.externalAnchors.length > 0 ||
+		input.mirrorAnchors.length > 0 ||
+		input.externalErrors.length > 0 ||
+		input.mirrorErrors.length > 0;
+
+	// "external" requires at least one PARSED external record (or a parse error
+	// to fail on) — a witness that returned 2xx with an empty/zero-record body
+	// must not launder vault-mirror-only evidence into "external" and slip past
+	// --require-external-anchor (AC-2.4 defense in depth).
+	const hasExternal = input.externalAnchors.length > 0 || input.externalErrors.length > 0;
+	const anchorSource: AnchorSource = hasExternal
+		? "external"
+		: anchorsPresent
+			? "vault-mirror"
+			: "none";
+
+	const finish = (state: AnchorState, records: readonly AnchorRecord[]): AnchorEvaluation => {
+		// Witness-unreachable cap: inconclusive, never a silent downgrade
+		// (AC-2.4). MISMATCH/INVALID/STALE from remaining inputs still win;
+		// ANCHORED_VERIFIED and UNANCHORED are capped to UNVERIFIABLE.
+		let finalState = state;
+		if (witnessFailed) {
+			reasons.push("witness-unreachable");
+			finalState = worseState(finalState, "ANCHOR_UNVERIFIABLE");
+			errors.push(`witness-unreachable: ${input.witness.error ?? "anchor URL fetch failed"}`);
+		}
+		let witness: { requested: boolean; status: WitnessStatus; error?: string };
+		if (!witnessRequested) {
+			witness = { requested: false, status: "not-consulted" };
+		} else if (!witnessOk) {
+			witness =
+				input.witness.error !== undefined
+					? { requested: true, status: "unreachable", error: input.witness.error }
+					: { requested: true, status: "unreachable" };
+		} else {
+			const disagrees = finalState === "ANCHOR_MISMATCH" || finalState === "ANCHOR_INVALID";
+			witness = { requested: true, status: disagrees ? "disagrees" : "agrees" };
+		}
+		const latest =
+			records.length > 0 ? ([...records].sort((a, b) => b.treeSize - a.treeSize)[0] ?? null) : null;
+		const tailEvents = latest === null ? observed : Math.max(0, observed - latest.treeSize);
+		return {
+			anchorState: finalState,
+			anchorsValid: finalState !== "ANCHOR_INVALID" && finalState !== "ANCHOR_MISMATCH",
+			anchorSource,
+			anchorCount: records.length,
+			latestAnchor:
+				latest === null
+					? null
+					: {
+							anchorSeq: latest.anchorSeq,
+							treeSize: latest.treeSize,
+							lastHash: latest.lastHash,
+							keyId: latest.keyId,
+							timestamp: latest.timestamp,
+						},
+			unanchoredTail: {
+				events: tailEvents,
+				sinceTimestampMs: latest === null ? null : nullIfNaN(Date.parse(latest.timestamp)),
+			},
+			witness,
+			reasons: [...new Set(reasons)],
+			warnings: [...new Set(warnings)],
+			errors,
+		};
+	};
+
+	// Step 2 — discovery.
+	if (!anchorsPresent) {
+		return finish("UNANCHORED", []);
+	}
+
+	// Step 3 — trust material (before parse escalation, per constraints §4.2).
+	if (input.trust === null) {
+		reasons.push("no-trust-material");
+		errors.push("anchor artifacts present but no trust material supplied (pin the public key)");
+		return finish("ANCHOR_UNVERIFIABLE", [...input.externalAnchors, ...input.mirrorAnchors]);
+	}
+
+	// Step 4 — parse failures are fail-closed (mirrors the `.meta` precedent).
+	for (const e of [...input.externalErrors, ...input.mirrorErrors]) {
+		errors.push(e);
+		reasons.push(e.includes("range-invalid") ? "range-invalid" : "malformed-anchor");
+	}
+
+	// Cross-vault replay: a mixed-vaultId union is rejected BEFORE dedup can
+	// collapse a replayed foreign record into a same-seq group.
+	const allVaultIds = new Set(
+		[...input.externalAnchors, ...input.mirrorAnchors].map((r) => r.vaultId),
+	);
+	if (allVaultIds.size > 1) {
+		errors.push(`vault-id-mismatch: anchor set mixes ${allVaultIds.size} distinct vaultIds`);
+		reasons.push("vault-id-mismatch");
+	}
+
+	// Dedup within each stream (racing-emitter duplicates live in ONE stream),
+	// then merge external over mirror. A mirror copy of an external record is
+	// expected, not a duplicate; divergence at one anchorSeq is MISMATCH
+	// (AC-1.2 — the external copy governs).
+	const ext = dedupeAnchorSet(input.externalAnchors);
+	const mir = dedupeAnchorSet(input.mirrorAnchors);
+	for (const set of [ext, mir]) {
+		warnings.push(...set.warnings);
+		errors.push(...set.errors);
+		reasons.push(...set.mismatchReasons);
+	}
+	const extBySeq = new Map(ext.unique.map((r) => [r.anchorSeq, r]));
+	const mergedBySeq = new Map(extBySeq);
+	for (const m of mir.unique) {
+		const e = extBySeq.get(m.anchorSeq);
+		if (e === undefined) {
+			mergedBySeq.set(m.anchorSeq, m);
+		} else if (!committedFieldsEqual(e, m)) {
+			errors.push(
+				`mirror-disagreement: vault mirror and external copy differ at anchorSeq ${m.anchorSeq} (external governs)`,
+			);
+			reasons.push("mirror-disagreement");
+		}
+	}
+	const mergedRecords = [...mergedBySeq.values()].sort((a, b) => a.anchorSeq - b.anchorSeq);
+
+	// Steps 4-5 — signatures, chain linkage, consistency binding. Per-stream
+	// dropped twins are re-appended so the walk signature-checks them too
+	// (spec §7.2 "both signatures valid" — a bad-sig committed-equal twin is
+	// ANCHOR_INVALID regardless of record order).
+	const chain = verifyAnchorChain(
+		[...mergedRecords, ...ext.dropped, ...mir.dropped],
+		input.trust,
+		input.orderedHashes,
+	);
+	errors.push(...chain.errors);
+	reasons.push(...chain.invalidReasons, ...chain.mismatchReasons);
+	warnings.push(...chain.warnings);
+	const records = chain.records;
+
+	// Step 5 — vault binding per record.
+	for (const r of records) {
+		if (opts.expectedVaultId !== undefined && r.vaultId !== opts.expectedVaultId) {
+			errors.push(
+				`vault-id-mismatch: anchorSeq ${r.anchorSeq} carries vaultId ${r.vaultId}, expected ${opts.expectedVaultId}`,
+			);
+			reasons.push("vault-id-mismatch");
+		}
+		if (r.treeSize > observed) {
+			if (observed === 0) {
+				errors.push(
+					`deletion: anchor anchorSeq ${r.anchorSeq} attests ${r.treeSize} event(s); vault presents 0 (deletion detected)`,
+				);
+				reasons.push("deletion");
+			} else {
+				errors.push(
+					`rollback: anchor anchorSeq ${r.anchorSeq} attests ${r.treeSize} event(s); vault presents ${observed}`,
+				);
+				reasons.push("rollback");
+			}
+			continue;
+		}
+		const tree = buildMerkleTree(input.orderedHashes.slice(0, r.treeSize));
+		if (tree.root === undefined || tree.root !== r.merkleRoot) {
+			errors.push(
+				`root-mismatch: recomputed Merkle root at treeSize ${r.treeSize} does not match anchorSeq ${r.anchorSeq}`,
+			);
+			reasons.push("root-mismatch");
+		}
+		if (input.orderedHashes[r.treeSize - 1] !== r.lastHash) {
+			errors.push(
+				`head-mismatch: stored hash at sequence ${r.treeSize} does not match anchorSeq ${r.anchorSeq} lastHash`,
+			);
+			reasons.push("head-mismatch");
+		}
+	}
+
+	// Classify: MISMATCH ≥ INVALID (constraints §4.2 severity).
+	const hasMismatch = reasons.some((c) => !INVALID_REASONS.has(c) && !NON_FAIL_REASONS.has(c));
+	const hasInvalid = reasons.some((c) => INVALID_REASONS.has(c));
+	if (hasMismatch) {
+		return finish("ANCHOR_MISMATCH", records);
+	}
+	if (hasInvalid) {
+		return finish("ANCHOR_INVALID", records);
+	}
+
+	// Step 6 — freshness (caller-supplied policy only; tail always reported).
+	const latest = [...records].sort((a, b) => b.treeSize - a.treeSize)[0];
+	if (latest !== undefined) {
+		const ts = Date.parse(latest.timestamp);
+		if (Number.isFinite(ts) && ts > nowMs) {
+			// Operator-claimed time is in the auditor's future — clock gaming
+			// (buyer-rejection §5.13). --max-unanchored-events is the
+			// clock-independent control.
+			warnings.push("future-timestamp");
+		}
+		const tail = Math.max(0, observed - latest.treeSize);
+		if (opts.maxUnanchoredEvents !== undefined && tail > opts.maxUnanchoredEvents) {
+			errors.push(
+				`stale: ${tail} event(s) since the newest anchor exceed the supplied threshold ${opts.maxUnanchoredEvents}`,
+			);
+			return finish("ANCHOR_STALE", records);
+		}
+		if (
+			opts.maxAnchorAgeMs !== undefined &&
+			Number.isFinite(ts) &&
+			nowMs - ts > opts.maxAnchorAgeMs &&
+			observed > latest.treeSize
+		) {
+			errors.push(
+				"stale: newest anchor is older than the supplied --max-anchor-age (operator-claimed time)",
+			);
+			return finish("ANCHOR_STALE", records);
+		}
+	}
+
+	return finish("ANCHORED_VERIFIED", records);
+}
+
+// ── Inclusion against an external anchor (the F1 fix) ──
+
+/**
+ * Verify a Merkle inclusion proof against a SIGNED EXTERNAL anchor record —
+ * root and treeSize come from the record, never recomputed from the events
+ * under check (spec §7.1; closes F1). The record must verify under the pinned
+ * root or a supplied successor pin.
+ */
+export function verifyInclusionAgainstAnchor(
+	proof: MerkleInclusionProof,
+	record: AnchorRecord,
+	trust: AnchorTrust,
+): boolean {
+	const sig = verifyAnchorSignature(record, [trust.rootPem, ...(trust.successorPinsPem ?? [])]);
+	if (!sig.ok) return false;
+	return verifyInclusionProof(proof, record.merkleRoot, record.treeSize);
+}

--- a/packages/core/src/audit/anchor-verify.ts
+++ b/packages/core/src/audit/anchor-verify.ts
@@ -207,8 +207,15 @@ export function parseAnchorRecord(raw: string): {
 	if (typeof obj.merkleRoot !== "string" || !HEX64.test(obj.merkleRoot)) {
 		return { record: null, error: "malformed-anchor: merkleRoot must be 64-hex" };
 	}
-	if (typeof obj.timestamp !== "string" || obj.timestamp.length === 0) {
-		return { record: null, error: "malformed-anchor: missing timestamp" };
+	if (
+		typeof obj.timestamp !== "string" ||
+		obj.timestamp.length === 0 ||
+		!Number.isFinite(Date.parse(obj.timestamp))
+	) {
+		// A signed-but-unparseable timestamp would make the --max-anchor-age
+		// staleness gate silently fail open (Date.parse → NaN) — an
+		// adversary-controlled bypass of the caller's freshness policy.
+		return { record: null, error: "malformed-anchor: timestamp must be a parseable date-time" };
 	}
 	if (typeof obj.keyId !== "string" || !KEY_ID.test(obj.keyId)) {
 		return { record: null, error: "malformed-anchor: keyId must be sha256:<64-hex>" };
@@ -489,6 +496,20 @@ export function verifyAnchorChain(
 	let epochKey: KeyObject | null = rootKey;
 	let prev: AnchorRecord | null = null;
 
+	// A partial history may legitimately START in a later key epoch — the
+	// documented lone-checkpoint bind (§7.5) fetched after a rotation. When
+	// the first record's key is a caller-TRUSTED key (root or successor pin),
+	// adopt it as the starting epoch instead of condemning the unprovable
+	// prefix; an untrusted key stays fail-closed (sig-invalid below).
+	const firstRecord = ordered[0];
+	if (firstRecord !== undefined && firstRecord.anchorSeq !== 1 && firstRecord.keyId !== rootKeyId) {
+		const pinnedStart = knownKeys.get(firstRecord.keyId);
+		if (pinnedStart !== undefined) {
+			epochKeyId = firstRecord.keyId;
+			epochKey = pinnedStart;
+		}
+	}
+
 	for (let i = 0; i < ordered.length; i++) {
 		const r = ordered[i] as AnchorRecord;
 
@@ -509,7 +530,13 @@ export function verifyAnchorChain(
 			mismatchReasons.push("anchor-chain-gap");
 		}
 		if (prev !== null && r.anchorSeq === prev.anchorSeq + 1) {
-			if (r.prevAnchorHash !== anchorPayloadHash(prev)) {
+			// The predecessor may exist as several benign committed-equal twins
+			// (differing only in timestamp/sig — racing-emitter duplicates), and
+			// timestamp IS part of the signing pre-image: the successor
+			// legitimately links to WHICHEVER twin its emitter had as the mirror
+			// tail, so linkage accepts any twin's payload hash.
+			const prevTwins = [prev, ...(droppedBySeq.get(prev.anchorSeq) ?? [])];
+			if (!prevTwins.some((t) => r.prevAnchorHash === anchorPayloadHash(t))) {
 				errors.push(
 					`anchor-chain-gap: anchorSeq ${r.anchorSeq} prevAnchorHash does not link to its predecessor`,
 				);

--- a/packages/core/src/audit/anchor.ts
+++ b/packages/core/src/audit/anchor.ts
@@ -1,0 +1,926 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * External Anchor Emitter — signed chain-head checkpoints
+ *
+ * Periodically commits the audit chain's head (Merkle root + size + last
+ * hash), Ed25519-signed and hash-chained to the previous checkpoint, to an
+ * append-only store the vault operator cannot silently rewrite. Spec:
+ * docs/superpowers/specs/2026-07-26-external-anchoring-design.md §5.
+ *
+ * Additive by construction: the append path (events.jsonl / .meta bytes) is
+ * untouched; the emitter only OBSERVES the writer's outputs. Emission is
+ * serialized by its own advisory lock (`audit/anchors/.anchor-writer.lock`)
+ * so an in-process scheduler and a cron-driven `usertrust anchor now` cannot
+ * race the mirror and mint fork evidence. `appendEvent` never blocks on any
+ * of this.
+ *
+ * The vault-local mirror (`audit/anchors/anchors.jsonl`) is a CACHE — trust
+ * comes from the external store copies. The private key NEVER lives inside
+ * the vault.
+ */
+
+import { spawn } from "node:child_process";
+import {
+	createPrivateKey,
+	createPublicKey,
+	sign as cryptoSign,
+	generateKeyPairSync,
+	randomUUID,
+} from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import {
+	closeSync,
+	existsSync,
+	fsyncSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readdirSync,
+	unlinkSync,
+	writeFileSync,
+	writeSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { GENESIS_HASH, VAULT_DIR } from "../shared/constants.js";
+import {
+	type AnchorRecord,
+	anchorPayloadHash,
+	gatherOrderedEventHashes,
+	keyIdFromKeyObject,
+	parseAnchorRecord,
+	parseAnchorsContent,
+} from "./anchor-verify.js";
+import { canonicalize } from "./canonical.js";
+import { buildMerkleTree } from "./merkle.js";
+
+// ── Config types (spec §5.4) ──
+
+export type AnchorSignerConfig =
+	| { type: "pem"; env?: string; file?: string }
+	| {
+			/** Non-exportable key (KMS/HSM/PKCS#11/Vault-transit). The key never
+			 * touches this host; the backend signs the §3 pre-image. Bounds key
+			 * exfiltration — but does NOT defeat an attacker who can drive it as
+			 * a signing oracle; the append-only witness is the anti-A1 control. */
+			type: "external";
+			keyId: string;
+			publicKeySpki: string;
+			sign(preimage: Uint8Array): Promise<Uint8Array>;
+	  };
+
+export type SinkConfig =
+	| { type: "file"; path: string }
+	| { type: "https"; url: string; headers?: Record<string, string> }
+	| { type: "command"; argv: string[] };
+
+export interface AnchorSink {
+	readonly name: string;
+	/** MUST be append-only from the writer's credentials. Resolve = durably accepted. */
+	publish(record: AnchorRecord): Promise<void>;
+}
+
+export interface AnchoringConfig {
+	signer: AnchorSignerConfig;
+	cadence?: { everyEvents?: number; everyMs?: number };
+	/** Declarative sink configs and/or pre-built AnchorSink instances. */
+	sinks?: (SinkConfig | AnchorSink)[];
+	/** Per-publish retry attempts (exponential backoff + jitter). Default 5. */
+	publishRetries?: number;
+}
+
+export interface AnchorEmitterStatus {
+	lastAnchor: { anchorSeq: number; treeSize: number; timestamp: string } | null;
+	eventsSinceLastAnchor: number;
+	msSinceLastAnchor: number | null;
+	outboxDepth: number;
+	anchorSkips: number;
+	publishFailures: number;
+	degraded: boolean;
+	/** Last emit-cycle error surfaced by the scheduler (null when healthy). */
+	lastEmitError: string | null;
+}
+
+export interface AnchorEmitResult {
+	emitted: boolean;
+	record?: AnchorRecord;
+	reason?: string;
+}
+
+export interface AnchorEmitter {
+	/** One snapshot→sign→mirror→publish cycle (spec §5.1). */
+	anchorNow(): Promise<AnchorEmitResult>;
+	/** Emit a rotation record cross-signed by the CURRENT key (spec §6). */
+	rotate(next: { keyId: string; publicKeySpki: string }): Promise<AnchorEmitResult>;
+	status(): AnchorEmitterStatus;
+	/** Start the cadence scheduler (unref'd timer; never blocks appends). */
+	start(): void;
+	stop(): Promise<void>;
+	/** Mirror records with anchorSeq > since, for pull-mode shipping. */
+	exportSince(since: number): AnchorRecord[];
+}
+
+export const DEFAULT_ANCHOR_EVERY_EVENTS = 1000;
+export const DEFAULT_ANCHOR_EVERY_MS = 60_000;
+const DEFAULT_KEY_ENV = "USERTRUST_ANCHOR_KEY";
+const SNAPSHOT_RETRIES = 3;
+
+// ── Identity ──
+
+export interface AnchorIdentity {
+	v: 1;
+	vaultId: string;
+	keyId: string;
+	/** Informational cross-check ONLY — verifiers never take trust from the vault. */
+	publicKeySpki: string;
+	createdAt: string;
+	/**
+	 * Durable monotonic high-water of the highest anchorSeq ever minted. Lives
+	 * OUTSIDE the mirror so an emptied/corrupt/lost mirror cannot trick the
+	 * emitter into re-minting a lower (e.g. GENESIS-linked) anchorSeq — which
+	 * would publish permanent fork evidence into the append-only store
+	 * (spec §5.1). Absent on a fresh identity (first anchor allowed).
+	 */
+	lastAnchorSeq?: number;
+}
+
+/** Persist the durable anchorSeq high-water (never decreases). */
+function bumpAnchorHighWater(rootDir: string, anchorSeq: number): void {
+	const identity = readAnchorIdentity(rootDir);
+	if (identity === null) return;
+	if ((identity.lastAnchorSeq ?? 0) >= anchorSeq) return;
+	const updated: AnchorIdentity = { ...identity, lastAnchorSeq: anchorSeq };
+	writeFileSync(join(anchorsDir(rootDir), "identity.json"), JSON.stringify(updated, null, "\t"));
+}
+
+export function anchorsDir(rootDir: string): string {
+	return join(rootDir, VAULT_DIR, "audit", "anchors");
+}
+
+export function readAnchorIdentity(rootDir: string): AnchorIdentity | null {
+	const p = join(anchorsDir(rootDir), "identity.json");
+	if (!existsSync(p)) return null;
+	try {
+		const parsed = JSON.parse(readFileSync(p, "utf-8")) as AnchorIdentity;
+		if (parsed.v === 1 && typeof parsed.vaultId === "string" && typeof parsed.keyId === "string") {
+			return parsed;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+export function defaultKeyPath(vaultId: string): string {
+	return join(homedir(), ".usertrust", "keys", `${vaultId}.anchor.pem`);
+}
+
+/**
+ * Mint the vault's anchor identity: Ed25519 keypair (private key OUTSIDE the
+ * vault, mode 0600), `identity.json`, and an empty mirror file. Returns the
+ * public PEM + keyId for out-of-band pinning. Idempotent: refuses to
+ * overwrite an existing identity.
+ */
+export function initAnchorIdentity(
+	rootDir: string,
+	opts?: { keyFile?: string },
+): { identity: AnchorIdentity; publicKeyPem: string; keyFile: string } {
+	const dir = anchorsDir(rootDir);
+	const identityPath = join(dir, "identity.json");
+	if (existsSync(identityPath)) {
+		throw new Error(`Anchor identity already exists: ${identityPath}`);
+	}
+	const vaultId = randomUUID();
+	const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+	const keyId = keyIdFromKeyObject(publicKey);
+	const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }) as string;
+	const publicKeySpki = (publicKey.export({ type: "spki", format: "der" }) as Buffer).toString(
+		"base64",
+	);
+
+	const keyFile = opts?.keyFile ?? defaultKeyPath(vaultId);
+	const keyDir = join(keyFile, "..");
+	if (keyFile.startsWith(join(rootDir, VAULT_DIR))) {
+		throw new Error("Refusing to write the anchor private key inside the vault (AC-6.2)");
+	}
+	mkdirSync(keyDir, { recursive: true, mode: 0o700 });
+	writeFileSync(keyFile, privateKey.export({ type: "pkcs8", format: "pem" }) as string, {
+		mode: 0o600,
+	});
+
+	mkdirSync(join(dir, "outbox"), { recursive: true });
+	const identity: AnchorIdentity = {
+		v: 1,
+		vaultId,
+		keyId,
+		publicKeySpki,
+		createdAt: new Date().toISOString(),
+	};
+	writeFileSync(identityPath, JSON.stringify(identity, null, "\t"));
+	// Touch the mirror so "mirror file missing" (accidental loss / partial
+	// restore) is distinguishable from "fresh vault, no anchors yet".
+	const mirrorPath = join(dir, "anchors.jsonl");
+	if (!existsSync(mirrorPath)) {
+		writeFileSync(mirrorPath, "", { mode: 0o600 });
+	}
+	return { identity, publicKeyPem, keyFile };
+}
+
+// ── Signer resolution ──
+
+interface ResolvedSigner {
+	keyId: string;
+	sign(preimageUtf8: string): Promise<string>;
+}
+
+export function resolveSigner(config: AnchorSignerConfig, vaultId?: string): ResolvedSigner {
+	if (config.type === "external") {
+		const pub = createPublicKey({
+			key: Buffer.from(config.publicKeySpki, "base64"),
+			format: "der",
+			type: "spki",
+		});
+		const derivedKeyId = keyIdFromKeyObject(pub);
+		if (derivedKeyId !== config.keyId) {
+			throw new Error("external signer keyId does not match its publicKeySpki");
+		}
+		return {
+			keyId: config.keyId,
+			sign: async (preimage) =>
+				Buffer.from(await config.sign(Buffer.from(preimage, "utf8"))).toString("base64"),
+		};
+	}
+	let pem: string | undefined;
+	const envName = config.env ?? DEFAULT_KEY_ENV;
+	const envValue = process.env[envName];
+	if (envValue !== undefined && envValue !== "") {
+		pem = envValue.includes("-----BEGIN") ? envValue : readFileSync(envValue, "utf-8");
+	} else if (config.file !== undefined) {
+		pem = readFileSync(config.file, "utf-8");
+	} else if (vaultId !== undefined && existsSync(defaultKeyPath(vaultId))) {
+		pem = readFileSync(defaultKeyPath(vaultId), "utf-8");
+	}
+	if (pem === undefined) {
+		throw new Error(
+			`No anchor private key: set ${envName}, pass signer.file, or run \`usertrust anchor init\``,
+		);
+	}
+	const privateKey = createPrivateKey(pem);
+	const publicKey = createPublicKey(privateKey);
+	return {
+		keyId: keyIdFromKeyObject(publicKey),
+		sign: async (preimage) =>
+			cryptoSign(null, Buffer.from(preimage, "utf8"), privateKey).toString("base64"),
+	};
+}
+
+// ── Sinks ──
+
+function fileSink(path: string): AnchorSink {
+	return {
+		name: `file:${path}`,
+		publish: async (record) => {
+			const fd = openSync(path, "a", 0o600);
+			try {
+				writeSync(fd, `${canonicalize(record)}\n`);
+				fsyncSync(fd);
+			} finally {
+				closeSync(fd);
+			}
+		},
+	};
+}
+
+function httpsSink(url: string, headers?: Record<string, string>): AnchorSink {
+	return {
+		name: `https:${url}`,
+		publish: (record) =>
+			new Promise<void>((resolve, reject) => {
+				import("node:https")
+					.then((https) => {
+						const body = Buffer.from(`${canonicalize(record)}\n`, "utf8");
+						const req = https.request(
+							url,
+							{
+								method: "POST",
+								headers: {
+									"content-type": "application/json",
+									"content-length": String(body.length),
+									...headers,
+								},
+								timeout: 15_000,
+							},
+							(res) => {
+								res.resume();
+								const code = res.statusCode ?? 0;
+								if (code >= 200 && code < 300) {
+									resolve();
+								} else {
+									reject(new Error(`anchor sink HTTP ${code}`));
+								}
+							},
+						);
+						req.on("timeout", () => req.destroy(new Error("anchor sink timeout")));
+						req.on("error", reject);
+						req.end(body);
+					})
+					.catch(reject);
+			}),
+	};
+}
+
+function commandSink(argv: string[]): AnchorSink {
+	const [cmd, ...args] = argv;
+	return {
+		name: `command:${cmd ?? ""}`,
+		publish: (record) =>
+			new Promise<void>((resolve, reject) => {
+				if (cmd === undefined) {
+					reject(new Error("command sink: empty argv"));
+					return;
+				}
+				const child = spawn(cmd, args, { stdio: ["pipe", "ignore", "pipe"] });
+				let stderr = "";
+				child.stderr.on("data", (d: Buffer) => {
+					stderr += d.toString();
+				});
+				child.on("error", reject);
+				child.on("close", (code) => {
+					if (code === 0) {
+						resolve();
+					} else {
+						reject(new Error(`command sink exited ${code}: ${stderr.slice(0, 300)}`));
+					}
+				});
+				// A command that exits without reading stdin (crash, refusal)
+				// races the write and emits EPIPE on the stdin stream — as an
+				// UNHANDLED error unless listened for. The exit code above is
+				// the verdict; the broken pipe is just its symptom.
+				child.stdin.on("error", () => {
+					/* verdict comes from the close handler's exit code */
+				});
+				child.stdin.end(`${canonicalize(record)}\n`);
+			}),
+	};
+}
+
+export function createSink(config: SinkConfig | AnchorSink): AnchorSink {
+	// Already an AnchorSink instance (custom/test sink) — pass through.
+	if ("publish" in config && typeof config.publish === "function") {
+		return config;
+	}
+	const cfg = config as SinkConfig;
+	switch (cfg.type) {
+		case "file":
+			return fileSink(cfg.path);
+		case "https":
+			return httpsSink(cfg.url, cfg.headers);
+		case "command":
+			return commandSink(cfg.argv);
+	}
+}
+
+// ── Emitter advisory lock (anchor path only — never touches .audit-writer.lock) ──
+
+/**
+ * Lock paths currently held by a LIVE emitter in THIS process. A same-PID
+ * lock file is only reclaimable when no live emitter here owns it (i.e. it
+ * is a leftover from a crashed prior instance) — otherwise a sibling emitter
+ * in the same process would steal a live lock and race the mirror (the
+ * exact fork-evidence scenario the lock exists to prevent).
+ */
+const inProcessAnchorLocks = new Set<string>();
+
+function tryAcquireAnchorLock(dir: string): (() => void) | null {
+	const lockPath = join(dir, ".anchor-writer.lock");
+	if (inProcessAnchorLocks.has(lockPath)) return null;
+	const content = JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() });
+	const attempt = (): (() => void) | null => {
+		try {
+			const fd = openSync(
+				lockPath,
+				fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+				0o600,
+			);
+			try {
+				writeSync(fd, content);
+				fsyncSync(fd);
+			} finally {
+				closeSync(fd);
+			}
+			inProcessAnchorLocks.add(lockPath);
+			return () => {
+				inProcessAnchorLocks.delete(lockPath);
+				try {
+					unlinkSync(lockPath);
+				} catch {
+					/* already removed */
+				}
+			};
+		} catch {
+			return null;
+		}
+	};
+	const first = attempt();
+	if (first !== null) return first;
+	// Stale-lock detection: same pattern as the audit writer lock.
+	try {
+		const existing = JSON.parse(readFileSync(lockPath, "utf-8")) as { pid?: number };
+		if (typeof existing.pid === "number" && existing.pid !== process.pid) {
+			try {
+				process.kill(existing.pid, 0);
+				return null; // live holder
+			} catch (err: unknown) {
+				if (
+					!(err instanceof Error && "code" in err && (err as { code?: string }).code === "ESRCH")
+				) {
+					return null;
+				}
+			}
+		} else if (typeof existing.pid === "number" && existing.pid === process.pid) {
+			// Same-PID lock file with no live in-process owner (checked above):
+			// leftover from a crashed prior emitter — safe to reclaim.
+		} else {
+			return null;
+		}
+		unlinkSync(lockPath);
+	} catch {
+		// Corrupt lock file — remove and retry once.
+		try {
+			unlinkSync(lockPath);
+		} catch {
+			return null;
+		}
+	}
+	return attempt();
+}
+
+// ── Mirror / outbox helpers ──
+
+function readMirrorRecords(dir: string): {
+	present: boolean;
+	records: AnchorRecord[];
+	errors: string[];
+} {
+	const mirrorPath = join(dir, "anchors.jsonl");
+	if (!existsSync(mirrorPath)) return { present: false, records: [], errors: [] };
+	try {
+		const { records, errors } = parseAnchorsContent(readFileSync(mirrorPath, "utf-8"));
+		return { present: true, records: records.sort((a, b) => a.anchorSeq - b.anchorSeq), errors };
+	} catch (err) {
+		return {
+			present: true,
+			records: [],
+			errors: [`mirror unreadable: ${err instanceof Error ? err.message : String(err)}`],
+		};
+	}
+}
+
+/** Read pending outbox record CONTENTS in anchorSeq order (for redelivery). */
+function pendingOutboxRecords(dir: string): AnchorRecord[] {
+	return outboxSeqs(dir)
+		.sort((a, b) => a - b)
+		.flatMap((seq) => {
+			try {
+				const { record } = parseAnchorRecord(readFileSync(outboxPath(dir, seq), "utf-8").trim());
+				return record !== null && record.anchorSeq === seq ? [record] : [];
+			} catch {
+				return [];
+			}
+		});
+}
+
+function outboxSeqs(dir: string): number[] {
+	const outDir = join(dir, "outbox");
+	if (!existsSync(outDir)) return [];
+	try {
+		return readdirSync(outDir)
+			.filter((f) => f.endsWith(".json"))
+			.map((f) => Number.parseInt(f.slice(0, -5), 10))
+			.filter((n) => Number.isSafeInteger(n) && n >= 1);
+	} catch {
+		return [];
+	}
+}
+
+function outboxPath(dir: string, anchorSeq: number): string {
+	return join(dir, "outbox", `${String(anchorSeq).padStart(12, "0")}.json`);
+}
+
+function readMeta(
+	rootDir: string,
+): { lastHash: string; sequence: number } | "absent" | "unreadable" {
+	const metaPath = join(rootDir, VAULT_DIR, "audit", "events.jsonl.meta");
+	if (!existsSync(metaPath)) return "absent";
+	try {
+		const raw = readFileSync(metaPath, "utf-8");
+		if (raw.trim() === "") return "unreadable";
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		if (typeof parsed.lastHash === "string" && typeof parsed.sequence === "number") {
+			return { lastHash: parsed.lastHash, sequence: parsed.sequence };
+		}
+		return "unreadable";
+	} catch {
+		return "unreadable";
+	}
+}
+
+// ── Emitter ──
+
+export function createAnchorEmitter(rootDir: string, config: AnchoringConfig): AnchorEmitter {
+	const vaultPath = join(rootDir, VAULT_DIR);
+	const dir = anchorsDir(rootDir);
+	const maybeIdentity = readAnchorIdentity(rootDir);
+	if (maybeIdentity === null) {
+		throw new Error("No anchor identity — run `usertrust anchor init` first");
+	}
+	// Non-null binding usable inside closures (control-flow narrowing of the
+	// original is lost across the async emit() closure below).
+	const identity: AnchorIdentity = maybeIdentity;
+	const vaultId = identity.vaultId;
+	const signer = resolveSigner(config.signer, vaultId);
+	const sinks = (config.sinks ?? []).map(createSink);
+	const retries = config.publishRetries ?? 5;
+
+	let anchorSkips = 0;
+	let publishFailures = 0;
+	let degraded = false;
+	let lastEmitError: string | null = null;
+	let timer: ReturnType<typeof setInterval> | null = null;
+	const inFlight = new Set<Promise<void>>();
+	// Serialize publish cycles so an overlapping cycle cannot interleave the
+	// outbox drain and double-publish a record.
+	let publishChain: Promise<void> = Promise.resolve();
+
+	async function deliverToSinks(record: AnchorRecord): Promise<void> {
+		let lastErr: unknown = null;
+		for (const sink of sinks) {
+			let delivered = false;
+			for (let attempt = 0; attempt < retries && !delivered; attempt++) {
+				try {
+					await sink.publish(record);
+					delivered = true;
+				} catch (err) {
+					lastErr = err;
+					publishFailures++;
+					const backoff = Math.min(30_000, 250 * 2 ** attempt) * (0.5 + Math.random());
+					await new Promise((r) => setTimeout(r, backoff));
+				}
+			}
+			if (!delivered) {
+				degraded = true;
+				throw lastErr instanceof Error
+					? lastErr
+					: new Error(`anchor publish failed to sink ${sink.name}`);
+			}
+		}
+	}
+
+	async function publishRecord(record: AnchorRecord): Promise<void> {
+		if (sinks.length === 0) {
+			// Pull mode (spec §5.5): mirror-only; a customer job ships records
+			// via `usertrust anchor export`. With no sinks there is nothing to
+			// deliver, so the outbox entry is not needed.
+			try {
+				unlinkSync(outboxPath(dir, record.anchorSeq));
+			} catch {
+				/* best effort */
+			}
+			return;
+		}
+		// Drain the backlog oldest-first BEFORE (and including) the current
+		// record so a transient sink outage cannot leave a permanent
+		// anchorSeq gap in the append-only store (spec §5.3). Stop on the
+		// first failure to preserve store ordering; the emitter stays degraded
+		// until the whole backlog clears.
+		const backlog = pendingOutboxRecords(dir);
+		const queue = backlog.some((r) => r.anchorSeq === record.anchorSeq)
+			? backlog
+			: [...backlog, record].sort((a, b) => a.anchorSeq - b.anchorSeq);
+		for (const rec of queue) {
+			await deliverToSinks(rec);
+			try {
+				unlinkSync(outboxPath(dir, rec.anchorSeq));
+			} catch {
+				/* best effort */
+			}
+		}
+		// Clear degraded only when nothing is left undelivered.
+		if (outboxSeqs(dir).length === 0) degraded = false;
+	}
+
+	function trackPublish(record: AnchorRecord): Promise<void> {
+		const p = publishChain
+			.then(() => publishRecord(record))
+			.catch(() => {
+				/* failure already counted; outbox entry retained for retry */
+			})
+			.finally(() => {
+				inFlight.delete(p);
+			});
+		publishChain = p;
+		inFlight.add(p);
+		return p;
+	}
+
+	async function snapshotHead(): Promise<
+		{ sequence: number; lastHash: string; hashes: string[] } | { skip: string }
+	> {
+		for (let attempt = 0; attempt < SNAPSHOT_RETRIES; attempt++) {
+			const meta = readMeta(rootDir);
+			if (meta === "unreadable") {
+				// .meta is truncate-rewritten in place; a cross-process reader
+				// can catch it mid-write. Retry, then skip the cycle.
+				await new Promise((r) => setTimeout(r, 25 * (attempt + 1)));
+				continue;
+			}
+			const hashes = gatherOrderedEventHashes(vaultPath);
+			if (meta === "absent") {
+				// Legacy vault: fall back to the ordered segment tail.
+				if (hashes.length === 0) return { skip: "empty" };
+				return {
+					sequence: hashes.length,
+					lastHash: hashes[hashes.length - 1] as string,
+					hashes,
+				};
+			}
+			if (meta.sequence === 0 || hashes.length === 0) return { skip: "empty" };
+			// Guard against a torn read of the tail line during a concurrent
+			// append: the prefix [0..sequence) is stable, the tail may not be.
+			if (hashes.length >= meta.sequence && hashes[meta.sequence - 1] === meta.lastHash) {
+				return { sequence: meta.sequence, lastHash: meta.lastHash, hashes };
+			}
+			await new Promise((r) => setTimeout(r, 25 * (attempt + 1)));
+		}
+		return { skip: "snapshot-unstable" };
+	}
+
+	async function emit(rotation?: {
+		nextKeyId: string;
+		nextPublicKeySpki: string;
+	}): Promise<AnchorEmitResult> {
+		const release = tryAcquireAnchorLock(dir);
+		if (release === null) {
+			anchorSkips++;
+			return { emitted: false, reason: "locked" };
+		}
+		try {
+			// Re-read identity fresh: the durable high-water is bumped on disk
+			// each emit, so the creation-time closure copy is stale.
+			const liveIdentity = readAnchorIdentity(rootDir) ?? identity;
+			const snap = await snapshotHead();
+			if ("skip" in snap) {
+				if (snap.skip !== "empty") anchorSkips++;
+				return { emitted: false, reason: snap.skip };
+			}
+			const mirror = readMirrorRecords(dir);
+			if (!mirror.present) {
+				// Mirror FILE missing while an identity exists: accidental loss
+				// or partial restore. Refusing (loudly) beats silently minting a
+				// second GENESIS-linked record — permanent fork evidence in an
+				// append-only store. `usertrust anchor resume` re-seeds it.
+				degraded = true;
+				return { emitted: false, reason: "mirror-missing (run `usertrust anchor resume`)" };
+			}
+			if (mirror.errors.length > 0) {
+				// Corrupt-but-present mirror: same accident class as
+				// mirror-missing (disk fault / partial restore / torn tail). An
+				// anchorSeq allocated from a partial view can re-occupy a
+				// published position with divergent content — permanent fork
+				// evidence (spec §5.1). Repair/move the mirror aside first.
+				degraded = true;
+				return {
+					emitted: false,
+					reason: "mirror-corrupt (repair the mirror, then `usertrust anchor resume`)",
+				};
+			}
+			const tail = mirror.records.at(-1) ?? null;
+			// Durable high-water lives outside the mirror: an emptied mirror
+			// (tail null) with a prior anchor recorded must NOT restart at 1.
+			const durableHighWater = liveIdentity.lastAnchorSeq ?? 0;
+			const highWater = Math.max(tail?.anchorSeq ?? 0, durableHighWater, ...outboxSeqs(dir), 0);
+			if ((tail?.anchorSeq ?? 0) < highWater) {
+				degraded = true;
+				return {
+					emitted: false,
+					reason: "mirror-behind-highwater (run `usertrust anchor resume`)",
+				};
+			}
+			// Epoch guard: the resolved signer MUST be the chain's current key.
+			// A superseded key (e.g. the pre-rotation PEM still at the default
+			// path after `anchor rotate`) would mint permanent
+			// rotation-continuity MISMATCH evidence in an append-only store.
+			const expectedKeyId = tail?.rotation?.nextKeyId ?? tail?.keyId ?? liveIdentity.keyId;
+			if (signer.keyId !== expectedKeyId) {
+				degraded = true;
+				return {
+					emitted: false,
+					reason: `stale-signer-key: signer ${signer.keyId} is not the current epoch key ${expectedKeyId} — point USERTRUST_ANCHOR_KEY/--key-file at the post-rotation private key`,
+				};
+			}
+			if (tail !== null && tail.treeSize === snap.sequence && rotation === undefined) {
+				return { emitted: false, reason: "no-new-events" };
+			}
+			const tree = buildMerkleTree(snap.hashes.slice(0, snap.sequence));
+			if (tree.root === undefined) {
+				return { emitted: false, reason: "empty" };
+			}
+			const unsigned = {
+				v: 1 as const,
+				vaultId,
+				anchorSeq: highWater + 1,
+				prevAnchorHash: tail === null ? GENESIS_HASH : anchorPayloadHash(tail),
+				treeSize: snap.sequence,
+				lastHash: snap.lastHash,
+				merkleRoot: tree.root,
+				timestamp: new Date().toISOString(),
+				keyId: signer.keyId,
+				...(rotation !== undefined ? { rotation } : {}),
+			};
+			const sig = await signer.sign(canonicalize(unsigned));
+			const record = { ...unsigned, sig } as AnchorRecord;
+			const check = parseAnchorRecord(canonicalize(record));
+			if (check.record === null) {
+				throw new Error(`emitter produced an invalid record: ${check.error}`);
+			}
+			// Mirror append (canonical bytes — the same bytes the hash covers).
+			const mirrorPath = join(dir, "anchors.jsonl");
+			const fd = openSync(mirrorPath, "a", 0o600);
+			try {
+				writeSync(fd, `${canonicalize(record)}\n`);
+				fsyncSync(fd);
+			} finally {
+				closeSync(fd);
+			}
+			// Bump the durable high-water AFTER the mirror append is fsync'd, so
+			// a crash leaves high-water ≤ mirror tail (never ahead).
+			bumpAnchorHighWater(rootDir, record.anchorSeq);
+			mkdirSync(join(dir, "outbox"), { recursive: true });
+			writeFileSync(outboxPath(dir, record.anchorSeq), canonicalize(record), { mode: 0o600 });
+			trackPublish(record);
+			return { emitted: true, record };
+		} finally {
+			release();
+		}
+	}
+
+	function status(): AnchorEmitterStatus {
+		const mirror = readMirrorRecords(dir);
+		const tail = mirror.records.at(-1) ?? null;
+		const meta = readMeta(rootDir);
+		const headSeq = typeof meta === "object" ? meta.sequence : null;
+		const ts = tail === null ? Number.NaN : Date.parse(tail.timestamp);
+		return {
+			lastAnchor:
+				tail === null
+					? null
+					: { anchorSeq: tail.anchorSeq, treeSize: tail.treeSize, timestamp: tail.timestamp },
+			eventsSinceLastAnchor: headSeq === null ? 0 : Math.max(0, headSeq - (tail?.treeSize ?? 0)),
+			msSinceLastAnchor: Number.isFinite(ts) ? Math.max(0, Date.now() - ts) : null,
+			outboxDepth: outboxSeqs(dir).length,
+			anchorSkips,
+			publishFailures,
+			degraded,
+			lastEmitError,
+		};
+	}
+
+	return {
+		anchorNow: () => emit(),
+		rotate: (next) => emit({ nextKeyId: next.keyId, nextPublicKeySpki: next.publicKeySpki }),
+		status,
+		start(): void {
+			if (timer !== null) return;
+			const everyMs = config.cadence?.everyMs ?? DEFAULT_ANCHOR_EVERY_MS;
+			const everyEvents = config.cadence?.everyEvents ?? DEFAULT_ANCHOR_EVERY_EVENTS;
+			let lastAnchorAt = Date.now();
+			const tick = (): void => {
+				const meta = readMeta(rootDir);
+				const headSeq = typeof meta === "object" ? meta.sequence : 0;
+				const mirror = readMirrorRecords(dir);
+				const anchored = mirror.records.at(-1)?.treeSize ?? 0;
+				const due =
+					headSeq - anchored >= everyEvents ||
+					(headSeq > anchored && Date.now() - lastAnchorAt >= everyMs);
+				if (due) {
+					lastAnchorAt = Date.now();
+					// A scheduler-driven emit() must never reject into the void:
+					// an unhandled rejection (KMS signer outage, ENOSPC on the
+					// mirror, self-check throw) would crash the host process the
+					// emitter is embedded in. Capture it as a loud, inspectable
+					// degraded signal instead (spec §5.2/constraints §4.4).
+					emit()
+						.then((r) => {
+							if (r.emitted) lastEmitError = null;
+						})
+						.catch((err: unknown) => {
+							anchorSkips++;
+							degraded = true;
+							lastEmitError = err instanceof Error ? err.message : String(err);
+						});
+				}
+			};
+			// Check at a fraction of the interval so the everyEvents trigger
+			// fires promptly; unref so the scheduler never holds the process.
+			timer = setInterval(tick, Math.max(250, Math.min(everyMs, 5_000)));
+			timer.unref?.();
+		},
+		async stop(): Promise<void> {
+			if (timer !== null) {
+				clearInterval(timer);
+				timer = null;
+			}
+			await Promise.allSettled([...inFlight]);
+		},
+		exportSince(since: number): AnchorRecord[] {
+			return readMirrorRecords(dir).records.filter((r) => r.anchorSeq > since);
+		},
+	};
+}
+
+/**
+ * Re-seed a lost mirror from the store's newest record (spec §5.1 step 4).
+ * The record must belong to this vault's identity; it becomes the mirror
+ * tail so the next emission allocates anchorSeq correctly instead of minting
+ * a second GENESIS-linked chain.
+ */
+export function resumeAnchorMirror(rootDir: string, latestRecordRaw: string): AnchorRecord {
+	const identity = readAnchorIdentity(rootDir);
+	if (identity === null) {
+		throw new Error("No anchor identity — run `usertrust anchor init` first");
+	}
+	const { record, error } = parseAnchorRecord(latestRecordRaw.trim());
+	if (record === null) {
+		throw new Error(`resume: supplied record is invalid: ${error}`);
+	}
+	if (record.vaultId !== identity.vaultId) {
+		throw new Error(
+			`resume: record vaultId ${record.vaultId} does not match this vault (${identity.vaultId})`,
+		);
+	}
+	const dir = anchorsDir(rootDir);
+	const mirror = readMirrorRecords(dir);
+	const tail = mirror.records.at(-1);
+	if (tail !== undefined && tail.anchorSeq >= record.anchorSeq) {
+		throw new Error(
+			`resume: mirror already at anchorSeq ${tail.anchorSeq} (supplied ${record.anchorSeq})`,
+		);
+	}
+	mkdirSync(dir, { recursive: true });
+	const fd = openSync(join(dir, "anchors.jsonl"), "a", 0o600);
+	try {
+		writeSync(fd, `${canonicalize(record)}\n`);
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+	// Re-seeding advances the durable high-water so the next emission allocates
+	// from the re-seeded tail, not from a stale value.
+	bumpAnchorHighWater(rootDir, record.anchorSeq);
+	return record;
+}
+
+/**
+ * Mint a successor keypair for `usertrust anchor rotate` (spec §6): the new
+ * private key is written OUTSIDE the vault; the caller emits the cross-signed
+ * rotation record via AnchorEmitter.rotate() and then updates identity.json.
+ */
+export function mintSuccessorKey(vaultId: string): {
+	keyId: string;
+	publicKeyPem: string;
+	publicKeySpki: string;
+	keyFile: string;
+} {
+	const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+	const keyId = keyIdFromKeyObject(publicKey);
+	const keyFile = join(homedir(), ".usertrust", "keys", `${vaultId}.anchor.${Date.now()}.pem`);
+	mkdirSync(join(keyFile, ".."), { recursive: true, mode: 0o700 });
+	writeFileSync(keyFile, privateKey.export({ type: "pkcs8", format: "pem" }) as string, {
+		mode: 0o600,
+	});
+	return {
+		keyId,
+		publicKeyPem: publicKey.export({ type: "spki", format: "pem" }) as string,
+		publicKeySpki: (publicKey.export({ type: "spki", format: "der" }) as Buffer).toString("base64"),
+		keyFile,
+	};
+}
+
+/** Update identity.json after a successful rotation emission. */
+export function recordRotatedIdentity(
+	rootDir: string,
+	next: { keyId: string; publicKeySpki: string },
+): void {
+	const identity = readAnchorIdentity(rootDir);
+	if (identity === null) {
+		throw new Error("No anchor identity to rotate");
+	}
+	const updated: AnchorIdentity = {
+		...identity,
+		keyId: next.keyId,
+		publicKeySpki: next.publicKeySpki,
+	};
+	writeFileSync(join(anchorsDir(rootDir), "identity.json"), JSON.stringify(updated, null, "\t"));
+}

--- a/packages/core/src/audit/anchor.ts
+++ b/packages/core/src/audit/anchor.ts
@@ -38,20 +38,25 @@ import {
 	openSync,
 	readFileSync,
 	readdirSync,
+	realpathSync,
+	renameSync,
 	unlinkSync,
 	writeFileSync,
 	writeSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve, sep } from "node:path";
 import { GENESIS_HASH, VAULT_DIR } from "../shared/constants.js";
 import {
 	type AnchorRecord,
 	anchorPayloadHash,
+	anchorSigningPreimage,
 	gatherOrderedEventHashes,
 	keyIdFromKeyObject,
 	parseAnchorRecord,
 	parseAnchorsContent,
+	publicKeyFromSpkiBase64,
+	verifySignatureRaw,
 } from "./anchor-verify.js";
 import { canonicalize } from "./canonical.js";
 import { buildMerkleTree } from "./merkle.js";
@@ -146,13 +151,30 @@ export interface AnchorIdentity {
 	lastAnchorSeq?: number;
 }
 
+/**
+ * Atomic identity.json write: temp file + fsync + rename. A bare in-place
+ * writeFileSync could be truncated by a crash mid-write, wedging the vault
+ * between "no anchor identity" (emitter) and "identity already exists" (init).
+ */
+function writeIdentityFile(rootDir: string, identity: AnchorIdentity): void {
+	const path = join(anchorsDir(rootDir), "identity.json");
+	const tmp = `${path}.tmp-${process.pid}`;
+	const fd = openSync(tmp, "w", 0o600);
+	try {
+		writeSync(fd, JSON.stringify(identity, null, "\t"));
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+	renameSync(tmp, path);
+}
+
 /** Persist the durable anchorSeq high-water (never decreases). */
 function bumpAnchorHighWater(rootDir: string, anchorSeq: number): void {
 	const identity = readAnchorIdentity(rootDir);
 	if (identity === null) return;
 	if ((identity.lastAnchorSeq ?? 0) >= anchorSeq) return;
-	const updated: AnchorIdentity = { ...identity, lastAnchorSeq: anchorSeq };
-	writeFileSync(join(anchorsDir(rootDir), "identity.json"), JSON.stringify(updated, null, "\t"));
+	writeIdentityFile(rootDir, { ...identity, lastAnchorSeq: anchorSeq });
 }
 
 export function anchorsDir(rootDir: string): string {
@@ -178,6 +200,29 @@ export function defaultKeyPath(vaultId: string): string {
 }
 
 /**
+ * Resolve a path to its canonical absolute form, realpath-ing the deepest
+ * EXISTING ancestor so symlinked parents (macOS /var → /private/var) compare
+ * equal even when the leaf doesn't exist yet.
+ */
+function realResolve(p: string): string {
+	const abs = resolve(p);
+	let base = abs;
+	const suffix: string[] = [];
+	while (!existsSync(base)) {
+		const parent = join(base, "..");
+		if (parent === base) break;
+		suffix.unshift(base.slice(parent.length + (parent.endsWith(sep) ? 0 : 1)));
+		base = parent;
+	}
+	try {
+		base = realpathSync(base);
+	} catch {
+		/* keep the resolved form */
+	}
+	return suffix.length === 0 ? base : join(base, ...suffix);
+}
+
+/**
  * Mint the vault's anchor identity: Ed25519 keypair (private key OUTSIDE the
  * vault, mode 0600), `identity.json`, and an empty mirror file. Returns the
  * public PEM + keyId for out-of-band pinning. Idempotent: refuses to
@@ -200,9 +245,15 @@ export function initAnchorIdentity(
 		"base64",
 	);
 
-	const keyFile = opts?.keyFile ?? defaultKeyPath(vaultId);
+	// Canonicalize BOTH sides before comparing: a relative --key-file (e.g.
+	// ".usertrust/keys/anchor.pem") would never match an absolute prefix, and
+	// symlinked temp dirs (macOS /var → /private/var) would defeat a plain
+	// resolve() comparison — either way silently landing the signing key
+	// inside the vault it vouches for (AC-6.2).
+	const keyFile = realResolve(opts?.keyFile ?? defaultKeyPath(vaultId));
 	const keyDir = join(keyFile, "..");
-	if (keyFile.startsWith(join(rootDir, VAULT_DIR))) {
+	const vaultAbs = realResolve(join(rootDir, VAULT_DIR));
+	if (keyFile === vaultAbs || keyFile.startsWith(vaultAbs + sep)) {
 		throw new Error("Refusing to write the anchor private key inside the vault (AC-6.2)");
 	}
 	mkdirSync(keyDir, { recursive: true, mode: 0o700 });
@@ -218,7 +269,7 @@ export function initAnchorIdentity(
 		publicKeySpki,
 		createdAt: new Date().toISOString(),
 	};
-	writeFileSync(identityPath, JSON.stringify(identity, null, "\t"));
+	writeIdentityFile(rootDir, identity);
 	// Touch the mirror so "mirror file missing" (accidental loss / partial
 	// restore) is distinguishable from "fresh vault, no anchors yet".
 	const mirrorPath = join(dir, "anchors.jsonl");
@@ -425,7 +476,7 @@ function tryAcquireAnchorLock(dir: string): (() => void) | null {
 	};
 	const first = attempt();
 	if (first !== null) return first;
-	// Stale-lock detection: same pattern as the audit writer lock.
+	// Stale-lock detection: same liveness check as the audit writer lock.
 	try {
 		const existing = JSON.parse(readFileSync(lockPath, "utf-8")) as { pid?: number };
 		if (typeof existing.pid === "number" && existing.pid !== process.pid) {
@@ -445,14 +496,20 @@ function tryAcquireAnchorLock(dir: string): (() => void) | null {
 		} else {
 			return null;
 		}
-		unlinkSync(lockPath);
 	} catch {
-		// Corrupt lock file — remove and retry once.
-		try {
-			unlinkSync(lockPath);
-		} catch {
-			return null;
-		}
+		// Corrupt lock file — also reclaimed, but only via the atomic rename
+		// below so a concurrent reclaimer cannot double-acquire.
+	}
+	// ATOMIC reclaim: exactly one contender wins the rename; the loser's
+	// rename throws (ENOENT) and backs off. A bare check-then-unlink would let
+	// a slow contender delete the winner's freshly created lock (TOCTOU) and
+	// admit two emitters — the exact race the lock exists to prevent.
+	try {
+		const reclaimPath = `${lockPath}.reclaim-${process.pid}-${Date.now()}`;
+		renameSync(lockPath, reclaimPath);
+		unlinkSync(reclaimPath);
+	} catch {
+		return null;
 	}
 	return attempt();
 }
@@ -509,6 +566,18 @@ function outboxPath(dir: string, anchorSeq: number): string {
 	return join(dir, "outbox", `${String(anchorSeq).padStart(12, "0")}.json`);
 }
 
+/** Fsync'd outbox write — the record's durable delivery intent. */
+function writeOutboxEntry(dir: string, record: AnchorRecord): void {
+	mkdirSync(join(dir, "outbox"), { recursive: true });
+	const fd = openSync(outboxPath(dir, record.anchorSeq), "w", 0o600);
+	try {
+		writeSync(fd, canonicalize(record));
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+}
+
 function readMeta(
 	rootDir: string,
 ): { lastHash: string; sequence: number } | "absent" | "unreadable" {
@@ -550,6 +619,17 @@ export function createAnchorEmitter(rootDir: string, config: AnchoringConfig): A
 	let lastEmitError: string | null = null;
 	let timer: ReturnType<typeof setInterval> | null = null;
 	const inFlight = new Set<Promise<void>>();
+
+	/** Mirror append: the canonical bytes the record hash covers, fsync'd. */
+	function appendToMirror(record: AnchorRecord): void {
+		const fd = openSync(join(dir, "anchors.jsonl"), "a", 0o600);
+		try {
+			writeSync(fd, `${canonicalize(record)}\n`);
+			fsyncSync(fd);
+		} finally {
+			closeSync(fd);
+		}
+	}
 	// Serialize publish cycles so an overlapping cycle cannot interleave the
 	// outbox drain and double-publish a record.
 	let publishChain: Promise<void> = Promise.resolve();
@@ -696,7 +776,38 @@ export function createAnchorEmitter(rootDir: string, config: AnchoringConfig): A
 					reason: "mirror-corrupt (repair the mirror, then `usertrust anchor resume`)",
 				};
 			}
-			const tail = mirror.records.at(-1) ?? null;
+			let tail = mirror.records.at(-1) ?? null;
+
+			// Self-heal: a crash between the outbox write and the mirror append
+			// leaves a fully minted record in the outbox that the mirror lacks.
+			// Re-append it (validated: ours, signed by our key, contiguous)
+			// instead of wedging or re-minting the seq — re-minting would
+			// publish divergent content at an occupied position (permanent fork
+			// evidence in the append-only store).
+			for (const orphan of pendingOutboxRecords(dir).filter(
+				(o) => o.anchorSeq > (mirror.records.at(-1)?.anchorSeq ?? 0),
+			)) {
+				const expectedPrev = tail === null ? GENESIS_HASH : anchorPayloadHash(tail);
+				const idKey = publicKeyFromSpkiBase64(liveIdentity.publicKeySpki);
+				const orphanOk =
+					orphan.vaultId === vaultId &&
+					orphan.anchorSeq === (tail?.anchorSeq ?? 0) + 1 &&
+					orphan.prevAnchorHash === expectedPrev &&
+					idKey !== null &&
+					verifySignatureRaw("ed25519", anchorSigningPreimage(orphan), idKey, orphan.sig);
+				if (!orphanOk) {
+					degraded = true;
+					return {
+						emitted: false,
+						reason:
+							"outbox-orphan-invalid (inspect audit/anchors/outbox, then `usertrust anchor resume`)",
+					};
+				}
+				appendToMirror(orphan);
+				bumpAnchorHighWater(rootDir, orphan.anchorSeq);
+				tail = orphan;
+			}
+
 			// Durable high-water lives outside the mirror: an emptied mirror
 			// (tail null) with a prior anchor recorded must NOT restart at 1.
 			const durableHighWater = liveIdentity.lastAnchorSeq ?? 0;
@@ -718,6 +829,17 @@ export function createAnchorEmitter(rootDir: string, config: AnchoringConfig): A
 				return {
 					emitted: false,
 					reason: `stale-signer-key: signer ${signer.keyId} is not the current epoch key ${expectedKeyId} — point USERTRUST_ANCHOR_KEY/--key-file at the post-rotation private key`,
+				};
+			}
+			// Vault-behind guard (symmetric to mirror-behind): an events head
+			// BELOW the anchored treeSize means the event log was rolled back
+			// (partial restore) — emitting would publish a decreasing-treeSize
+			// anchor: permanent rollback evidence from an honest accident.
+			if (tail !== null && snap.sequence < tail.treeSize) {
+				degraded = true;
+				return {
+					emitted: false,
+					reason: `vault-behind-anchors: events head ${snap.sequence} < anchored treeSize ${tail.treeSize} — restore the newer events before anchoring`,
 				};
 			}
 			if (tail !== null && tail.treeSize === snap.sequence && rotation === undefined) {
@@ -745,20 +867,17 @@ export function createAnchorEmitter(rootDir: string, config: AnchoringConfig): A
 			if (check.record === null) {
 				throw new Error(`emitter produced an invalid record: ${check.error}`);
 			}
-			// Mirror append (canonical bytes — the same bytes the hash covers).
-			const mirrorPath = join(dir, "anchors.jsonl");
-			const fd = openSync(mirrorPath, "a", 0o600);
-			try {
-				writeSync(fd, `${canonicalize(record)}\n`);
-				fsyncSync(fd);
-			} finally {
-				closeSync(fd);
-			}
-			// Bump the durable high-water AFTER the mirror append is fsync'd, so
-			// a crash leaves high-water ≤ mirror tail (never ahead).
+			// Durability order: outbox FIRST (fsync'd delivery intent), then the
+			// mirror append, then the high-water bump. A crash after only the
+			// outbox write is self-healed above (orphan re-appended to the
+			// mirror); the reverse order would strand a mirrored-but-never-
+			// published record — a permanent anchor-chain gap in the store that
+			// verifies as tampering.
+			writeOutboxEntry(dir, record);
+			appendToMirror(record);
+			// High-water AFTER the mirror append is fsync'd, so a crash leaves
+			// high-water ≤ mirror tail (never ahead of what exists).
 			bumpAnchorHighWater(rootDir, record.anchorSeq);
-			mkdirSync(join(dir, "outbox"), { recursive: true });
-			writeFileSync(outboxPath(dir, record.anchorSeq), canonicalize(record), { mode: 0o600 });
 			trackPublish(record);
 			return { emitted: true, record };
 		} finally {
@@ -860,6 +979,27 @@ export function resumeAnchorMirror(rootDir: string, latestRecordRaw: string): An
 			`resume: record vaultId ${record.vaultId} does not match this vault (${identity.vaultId})`,
 		);
 	}
+	// The record becomes the trusted mirror tail (next emission links its
+	// prevAnchorHash to it), so it MUST be provably ours: signed under the
+	// CURRENT identity key, or a rotation handoff INTO the current key.
+	// vaultId alone is public (printed by `anchor status`) — accepting any
+	// well-formed record would let a stale/forged file seed a fork.
+	const idKey = publicKeyFromSpkiBase64(identity.publicKeySpki);
+	const sigOk =
+		idKey !== null &&
+		record.keyId === identity.keyId &&
+		verifySignatureRaw("ed25519", anchorSigningPreimage(record), idKey, record.sig);
+	const handoffOk = record.rotation !== undefined && record.rotation.nextKeyId === identity.keyId;
+	if (!sigOk && !handoffOk) {
+		throw new Error(
+			"resume: record does not verify under this vault's current anchor key — fetch the STORE'S newest record",
+		);
+	}
+	if ((identity.lastAnchorSeq ?? 0) > record.anchorSeq) {
+		throw new Error(
+			`resume: durable high-water ${identity.lastAnchorSeq} exceeds the supplied record (${record.anchorSeq}) — fetch the store's newest record`,
+		);
+	}
 	const dir = anchorsDir(rootDir);
 	const mirror = readMirrorRecords(dir);
 	const tail = mirror.records.at(-1);
@@ -922,5 +1062,5 @@ export function recordRotatedIdentity(
 		keyId: next.keyId,
 		publicKeySpki: next.publicKeySpki,
 	};
-	writeFileSync(join(anchorsDir(rootDir), "identity.json"), JSON.stringify(updated, null, "\t"));
+	writeIdentityFile(rootDir, updated);
 }

--- a/packages/core/src/audit/chain.ts
+++ b/packages/core/src/audit/chain.ts
@@ -349,7 +349,17 @@ function writeDeadLetter(
 		// imply integrity it cannot provide (the old HMAC key was derived from
 		// the vault path — forgeable from public inputs). Tamper-evidence for
 		// audit data lives in the hash chain + external anchoring.
-		const checksum = createHash("sha256").update(canonicalize(entry)).digest("hex");
+		let checksumSource: string;
+		try {
+			checksumSource = canonicalize(entry);
+		} catch {
+			// canonicalize throws on NaN/Infinity — but a payload carrying NaN
+			// is exactly the kind of failure a dead letter must still record.
+			// JSON.stringify coerces them to null (the pre-checksum behavior);
+			// the entry must be persisted, never dropped.
+			checksumSource = JSON.stringify(entry);
+		}
+		const checksum = createHash("sha256").update(checksumSource).digest("hex");
 		const sealed = { ...entry, checksum, checksumAlg: "sha256" };
 
 		const dlqPath = join(dlqDir, "dead-letters.jsonl");

--- a/packages/core/src/audit/chain.ts
+++ b/packages/core/src/audit/chain.ts
@@ -9,7 +9,7 @@
  * semantics are enforced via advisory file lock + in-process async mutex.
  */
 
-import { createHash, createHmac, randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import {
 	closeSync,
@@ -333,7 +333,8 @@ function writeDeadLetter(
 		payload: unknown;
 		error: string;
 		timestamp: string;
-		hmac?: string;
+		checksum?: string;
+		checksumAlg?: string;
 	},
 ): void {
 	try {
@@ -342,10 +343,14 @@ function writeDeadLetter(
 			mkdirSync(dlqDir, { recursive: true, mode: 0o700 });
 		}
 
-		// AUD-469: Compute HMAC over the entry for integrity protection
-		const key = createHash("sha256").update(`dlq-integrity:${vaultPath}`).digest("hex");
-		const hmac = createHmac("sha256", key).update(JSON.stringify(entry)).digest("hex");
-		const sealed = { ...entry, hmac };
+		// AUD-469 / F3: best-effort corruption-detection checksum — NOT
+		// tamper-evidence. Any key readable by this writer is readable by an
+		// attacker with the same host access, so a keyed MAC here would only
+		// imply integrity it cannot provide (the old HMAC key was derived from
+		// the vault path — forgeable from public inputs). Tamper-evidence for
+		// audit data lives in the hash chain + external anchoring.
+		const checksum = createHash("sha256").update(canonicalize(entry)).digest("hex");
+		const sealed = { ...entry, checksum, checksumAlg: "sha256" };
 
 		const dlqPath = join(dlqDir, "dead-letters.jsonl");
 		const fd = openSync(dlqPath, "a", 0o600);

--- a/packages/core/src/audit/verify.ts
+++ b/packages/core/src/audit/verify.ts
@@ -24,8 +24,22 @@ import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
 import { GENESIS_HASH } from "../shared/constants.js";
 import type { AuditEvent } from "../shared/types.js";
+import {
+	type AnchorRecord,
+	type AnchorSource,
+	type AnchorState,
+	type AnchorTrust,
+	type WitnessInput,
+	type WitnessStatus,
+	evaluateAnchoredVault,
+	gatherOrderedEventHashes,
+	parseAnchorsContent,
+	readAnchorMirror,
+} from "./anchor-verify.js";
 import { canonicalize } from "./canonical.js";
 import { buildMerkleTree } from "./merkle.js";
+
+export type { AnchorRecord, AnchorSource, AnchorState, AnchorTrust, WitnessInput };
 
 export interface ChainVerificationResult {
 	valid: boolean;
@@ -355,4 +369,123 @@ export function verifyVault(vaultPath: string): VaultVerificationResult {
 		firstEvent,
 		lastEvent,
 	};
+}
+
+// ── Anchored Vault Verification (spec §7) ──
+
+export interface AnchorVerifyParams {
+	/** Raw contents of caller-fetched anchor artifacts (single JSON or JSONL). */
+	readonly externalAnchorsRaw?: readonly string[] | undefined;
+	/** Caller-pinned trust material — NEVER read from the vault under audit. */
+	readonly trust?: AnchorTrust | undefined;
+	readonly witness?: WitnessInput | undefined;
+	readonly maxAnchorAgeMs?: number | undefined;
+	readonly maxUnanchoredEvents?: number | undefined;
+	readonly expectedVaultId?: string | undefined;
+	readonly nowMs?: number | undefined;
+}
+
+export interface AnchoringReport {
+	anchorSource: AnchorSource;
+	anchorCount: number;
+	latestAnchor: {
+		anchorSeq: number;
+		treeSize: number;
+		lastHash: string;
+		keyId: string;
+		timestamp: string;
+	} | null;
+	unanchoredTail: { events: number; sinceTimestampMs: number | null };
+	witness: { requested: boolean; status: WitnessStatus; error?: string };
+	reasons: string[];
+	warnings: string[];
+}
+
+export interface AnchoredVaultVerificationResult extends VaultVerificationResult {
+	anchorState: AnchorState;
+	anchoring: AnchoringReport;
+}
+
+/**
+ * verifyVault + the spec §7.2 anchor state machine. Existing chain semantics
+ * are UNCHANGED (verifyVault runs as-is); anchor evaluation is layered on
+ * top additively. IDENTICAL function body in packages/core/src/audit/verify.ts
+ * — the anchor differential test pins the two.
+ */
+export function verifyVaultWithAnchors(
+	vaultPath: string,
+	params: AnchorVerifyParams = {},
+): AnchoredVaultVerificationResult {
+	const base = verifyVault(vaultPath);
+	const externalRecords: AnchorRecord[] = [];
+	const externalErrors: string[] = [];
+	for (const raw of params.externalAnchorsRaw ?? []) {
+		const parsed = parseAnchorsContent(raw);
+		externalRecords.push(...parsed.records);
+		externalErrors.push(...parsed.errors);
+	}
+	const mirror = readAnchorMirror(vaultPath);
+	const evaluation = evaluateAnchoredVault({
+		orderedHashes: gatherOrderedEventHashes(vaultPath),
+		externalAnchors: externalRecords,
+		externalErrors,
+		mirrorAnchors: mirror.records,
+		mirrorErrors: mirror.errors,
+		trust: params.trust ?? null,
+		witness: params.witness ?? { requested: false },
+		opts: {
+			...(params.maxAnchorAgeMs !== undefined ? { maxAnchorAgeMs: params.maxAnchorAgeMs } : {}),
+			...(params.maxUnanchoredEvents !== undefined
+				? { maxUnanchoredEvents: params.maxUnanchoredEvents }
+				: {}),
+			...(params.expectedVaultId !== undefined ? { expectedVaultId: params.expectedVaultId } : {}),
+			...(params.nowMs !== undefined ? { nowMs: params.nowMs } : {}),
+		},
+	});
+	return {
+		...base,
+		valid: base.valid && evaluation.anchorsValid,
+		errors: [...base.errors, ...evaluation.errors],
+		anchorState: evaluation.anchorState,
+		anchoring: {
+			anchorSource: evaluation.anchorSource,
+			anchorCount: evaluation.anchorCount,
+			latestAnchor: evaluation.latestAnchor,
+			unanchoredTail: evaluation.unanchoredTail,
+			witness: evaluation.witness,
+			reasons: evaluation.reasons,
+			warnings: evaluation.warnings,
+		},
+	};
+}
+
+/**
+ * Exit-code policy for anchored verification. Exit codes stay 0/1
+ * (constraints §4.3); `--require-anchor` and `--require-external-anchor` are
+ * new INPUTS, not changed defaults.
+ */
+export function exitCodeForAnchored(
+	result: {
+		valid: boolean;
+		anchorState: AnchorState;
+		anchoring: { anchorSource: AnchorSource };
+	},
+	opts?: { requireAnchor?: boolean; requireExternalAnchor?: boolean },
+): number {
+	if (!result.valid) return 1;
+	if (
+		opts?.requireAnchor === true &&
+		(result.anchorState === "UNANCHORED" ||
+			result.anchorState === "ANCHOR_UNVERIFIABLE" ||
+			result.anchorState === "ANCHOR_STALE")
+	) {
+		return 1;
+	}
+	if (
+		opts?.requireExternalAnchor === true &&
+		(result.anchorState !== "ANCHORED_VERIFIED" || result.anchoring.anchorSource !== "external")
+	) {
+		return 1;
+	}
+	return 0;
 }

--- a/packages/core/src/cli/anchor.ts
+++ b/packages/core/src/cli/anchor.ts
@@ -56,10 +56,15 @@ function emitterConfig(args: string[]): AnchoringConfig {
 	const keyFile = flagValue(args, "--key-file");
 	const retriesRaw = flagValue(args, "--publish-retries");
 	const retries = retriesRaw !== undefined ? Number.parseInt(retriesRaw, 10) : undefined;
+	if (retriesRaw !== undefined && (!Number.isSafeInteger(retries) || (retries as number) < 1)) {
+		// Silently ignoring a bad value would fall back to the default and
+		// mask the operator's intent — fail loudly instead.
+		throw new Error(`Invalid --publish-retries: ${retriesRaw} (integer >= 1 required)`);
+	}
 	return {
 		signer: { type: "pem", ...(keyFile !== undefined ? { file: keyFile } : {}) },
 		sinks: sinksFromArgs(args),
-		...(retries !== undefined && Number.isFinite(retries) ? { publishRetries: retries } : {}),
+		...(retries !== undefined ? { publishRetries: retries } : {}),
 	};
 }
 

--- a/packages/core/src/cli/anchor.ts
+++ b/packages/core/src/cli/anchor.ts
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * CLI: usertrust anchor — external audit anchoring
+ *
+ * init    Mint the vault's anchor identity (Ed25519 key OUTSIDE the vault)
+ * now     One snapshot → sign → mirror → publish cycle
+ * status  Last anchor, unanchored tail, outbox depth
+ * export  Print mirror records (JSONL) for pull-mode shipping
+ * rotate  Cross-signed key rotation (spec §6)
+ * resume  Re-seed a lost mirror from the store's newest record
+ *
+ * Spec: docs/superpowers/specs/2026-07-26-external-anchoring-design.md
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import pc from "picocolors";
+import { parseAnchorsContent } from "../audit/anchor-verify.js";
+import {
+	type AnchoringConfig,
+	type SinkConfig,
+	anchorsDir,
+	createAnchorEmitter,
+	initAnchorIdentity,
+	mintSuccessorKey,
+	readAnchorIdentity,
+	recordRotatedIdentity,
+	resumeAnchorMirror,
+} from "../audit/anchor.js";
+import { VAULT_DIR } from "../shared/constants.js";
+import type { CliOptions } from "./init.js";
+
+function sinksFromArgs(args: string[]): SinkConfig[] {
+	const sinks: SinkConfig[] = [];
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === "--sink-file" && args[i + 1] !== undefined) {
+			sinks.push({ type: "file", path: args[i + 1] as string });
+			i++;
+		} else if (args[i] === "--sink-url" && args[i + 1] !== undefined) {
+			sinks.push({ type: "https", url: args[i + 1] as string });
+			i++;
+		}
+	}
+	return sinks;
+}
+
+function flagValue(args: string[], flag: string): string | undefined {
+	const idx = args.indexOf(flag);
+	if (idx === -1 || args[idx + 1] === undefined) return undefined;
+	return args[idx + 1];
+}
+
+function emitterConfig(args: string[]): AnchoringConfig {
+	const keyFile = flagValue(args, "--key-file");
+	const retriesRaw = flagValue(args, "--publish-retries");
+	const retries = retriesRaw !== undefined ? Number.parseInt(retriesRaw, 10) : undefined;
+	return {
+		signer: { type: "pem", ...(keyFile !== undefined ? { file: keyFile } : {}) },
+		sinks: sinksFromArgs(args),
+		...(retries !== undefined && Number.isFinite(retries) ? { publishRetries: retries } : {}),
+	};
+}
+
+export async function run(args: string[] = [], opts?: CliOptions): Promise<void> {
+	const json = opts?.json === true;
+	const root = process.cwd();
+	const action = args[0];
+
+	try {
+		switch (action) {
+			case "init": {
+				const keyFile = flagValue(args, "--key-file");
+				const {
+					identity,
+					publicKeyPem,
+					keyFile: writtenKeyFile,
+				} = initAnchorIdentity(root, keyFile !== undefined ? { keyFile } : undefined);
+				if (json) {
+					console.log(
+						JSON.stringify({
+							command: "anchor init",
+							success: true,
+							data: { vaultId: identity.vaultId, keyId: identity.keyId, keyFile: writtenKeyFile },
+						}),
+					);
+					return;
+				}
+				console.log(pc.green("Anchor identity created."));
+				console.log(`  vaultId: ${identity.vaultId}`);
+				console.log(`  keyId:   ${identity.keyId}`);
+				console.log(`  private key: ${writtenKeyFile} (mode 0600 — NEVER inside the vault)`);
+				console.log("");
+				console.log("Public key (PEM) — PIN THIS OUT-OF-BAND:");
+				console.log(publicKeyPem.trim());
+				console.log("");
+				console.log(pc.bold("Next steps:"));
+				console.log("  1. Give the PEM + keyId to whoever will audit this vault (their records,");
+				console.log(
+					"     not the vault). Verification: usertrust-verify <vault> --anchor <file> --pubkey pub.pem",
+				);
+				console.log("  2. Configure an APPEND-ONLY store and publish anchors to it:");
+				console.log("     usertrust anchor now --sink-file /mnt/worm/anchors.jsonl");
+				console.log("     Deployment invariant: the identity that writes the vault has");
+				console.log("     append-only (no delete/overwrite) access to the store.");
+				return;
+			}
+			case "now": {
+				const emitter = createAnchorEmitter(root, emitterConfig(args));
+				const result = await emitter.anchorNow();
+				await emitter.stop();
+				const status = emitter.status();
+				if (json) {
+					// Delivery-gated: emitted-but-undelivered (all sinks failed,
+					// outbox retained) is a FAILURE in the mode cron/CI consumes —
+					// mirror the non-JSON contract exactly (spec §5.3).
+					const delivered = status.outboxDepth === 0;
+					console.log(
+						JSON.stringify({
+							command: "anchor now",
+							success: result.emitted && delivered,
+							data: { ...result, outboxDepth: status.outboxDepth, delivered },
+						}),
+					);
+					if (
+						(!result.emitted && result.reason !== "no-new-events") ||
+						(result.emitted && !delivered)
+					) {
+						process.exitCode = 1;
+					}
+					return;
+				}
+				if (result.emitted && result.record) {
+					console.log(
+						pc.green(
+							`Anchored: #${result.record.anchorSeq} treeSize ${result.record.treeSize} root ${result.record.merkleRoot.slice(0, 16)}…`,
+						),
+					);
+					if (status.outboxDepth > 0) {
+						console.log(
+							pc.yellow(`Outbox: ${status.outboxDepth} record(s) not yet acknowledged by sinks.`),
+						);
+						process.exitCode = 1;
+					}
+				} else if (result.reason === "no-new-events") {
+					console.log("Nothing to anchor (no new events since the last anchor).");
+				} else {
+					console.log(pc.red(`Anchor skipped: ${result.reason}`));
+					process.exitCode = 1;
+				}
+				return;
+			}
+			case "status": {
+				const identity = readAnchorIdentity(root);
+				if (identity === null) {
+					console.log(
+						json
+							? JSON.stringify({
+									command: "anchor status",
+									success: false,
+									data: { message: "no anchor identity" },
+								})
+							: "No anchor identity. Run `usertrust anchor init` first.",
+					);
+					process.exitCode = 1;
+					return;
+				}
+				const mirrorPath = join(anchorsDir(root), "anchors.jsonl");
+				const mirror = existsSync(mirrorPath)
+					? parseAnchorsContent(readFileSync(mirrorPath, "utf-8"))
+					: { records: [], errors: [] };
+				const tail = mirror.records.sort((a, b) => a.anchorSeq - b.anchorSeq).at(-1) ?? null;
+				const metaPath = join(root, VAULT_DIR, "audit", "events.jsonl.meta");
+				let headSeq = 0;
+				try {
+					headSeq = (JSON.parse(readFileSync(metaPath, "utf-8")) as { sequence: number }).sequence;
+				} catch {
+					/* legacy / empty vault */
+				}
+				const tailEvents = Math.max(0, headSeq - (tail?.treeSize ?? 0));
+				const outboxDir = join(anchorsDir(root), "outbox");
+				let outboxDepth = 0;
+				try {
+					outboxDepth = existsSync(outboxDir)
+						? (await import("node:fs")).readdirSync(outboxDir).filter((f) => f.endsWith(".json"))
+								.length
+						: 0;
+				} catch {
+					/* ignore */
+				}
+				if (json) {
+					console.log(
+						JSON.stringify({
+							command: "anchor status",
+							success: true,
+							data: {
+								vaultId: identity.vaultId,
+								keyId: identity.keyId,
+								lastAnchor: tail,
+								eventsSinceLastAnchor: tailEvents,
+								outboxDepth,
+								mirrorErrors: mirror.errors,
+							},
+						}),
+					);
+					return;
+				}
+				console.log(`vaultId: ${identity.vaultId}`);
+				console.log(`keyId:   ${identity.keyId}`);
+				if (tail) {
+					console.log(
+						`Last anchor: #${tail.anchorSeq} treeSize ${tail.treeSize} (${tail.timestamp})`,
+					);
+				} else {
+					console.log("Last anchor: none");
+				}
+				console.log(`Unanchored tail: ${tailEvents} event(s)`);
+				console.log(`Outbox: ${outboxDepth} pending`);
+				if (mirror.errors.length > 0) {
+					console.log(pc.red(`Mirror parse errors: ${mirror.errors.length}`));
+					process.exitCode = 1;
+				}
+				return;
+			}
+			case "export": {
+				const since = Number.parseInt(flagValue(args, "--since") ?? "0", 10);
+				const mirrorPath = join(anchorsDir(root), "anchors.jsonl");
+				if (!existsSync(mirrorPath)) {
+					console.error("No anchor mirror found.");
+					process.exitCode = 1;
+					return;
+				}
+				const { records, errors } = parseAnchorsContent(readFileSync(mirrorPath, "utf-8"));
+				for (const err of errors) {
+					console.error(`# ${err}`);
+				}
+				for (const r of records.filter((r) => r.anchorSeq > since)) {
+					// Records were persisted canonically; re-serialize the parsed
+					// object canonically for byte-stable output.
+					console.log(JSON.stringify(r));
+				}
+				if (errors.length > 0) process.exitCode = 1;
+				return;
+			}
+			case "rotate": {
+				const identity = readAnchorIdentity(root);
+				if (identity === null) {
+					console.log("No anchor identity. Run `usertrust anchor init` first.");
+					process.exitCode = 1;
+					return;
+				}
+				const successor = mintSuccessorKey(identity.vaultId);
+				const emitter = createAnchorEmitter(root, emitterConfig(args));
+				const result = await emitter.rotate({
+					keyId: successor.keyId,
+					publicKeySpki: successor.publicKeySpki,
+				});
+				await emitter.stop();
+				const rotateStatus = emitter.status();
+				if (!result.emitted) {
+					if (json) {
+						console.log(
+							JSON.stringify({
+								command: "anchor rotate",
+								success: false,
+								data: { reason: result.reason },
+							}),
+						);
+					} else {
+						console.log(pc.red(`Rotation not emitted: ${result.reason}`));
+					}
+					process.exitCode = 1;
+					return;
+				}
+				// The cross-signed record is already fsync'd into the local mirror,
+				// so identity.json MUST advance in lockstep — rolling it back would
+				// desync mirror vs identity. Undelivered-to-sink is surfaced loudly
+				// (exit 1 + recovery path) instead.
+				recordRotatedIdentity(root, {
+					keyId: successor.keyId,
+					publicKeySpki: successor.publicKeySpki,
+				});
+				const rotateDelivered = rotateStatus.outboxDepth === 0;
+				if (json) {
+					console.log(
+						JSON.stringify({
+							command: "anchor rotate",
+							success: rotateDelivered,
+							data: {
+								newKeyId: successor.keyId,
+								keyFile: successor.keyFile,
+								outboxDepth: rotateStatus.outboxDepth,
+								delivered: rotateDelivered,
+							},
+						}),
+					);
+					if (!rotateDelivered) process.exitCode = 1;
+					return;
+				}
+				console.log(pc.green(`Rotation anchored (#${result.record?.anchorSeq}).`));
+				console.log(`  new keyId: ${successor.keyId}`);
+				console.log(`  new private key: ${successor.keyFile}`);
+				console.log("");
+				console.log("New public key (PEM) — distribute the fingerprint OUT-OF-BAND:");
+				console.log(successor.publicKeyPem.trim());
+				console.log("");
+				console.log(pc.bold("IMPORTANT:"));
+				console.log("  - Point USERTRUST_ANCHOR_KEY (or --key-file) at the NEW private key.");
+				console.log("  - Auditors keep pinning the ORIGINAL root key; give them this new");
+				console.log("    fingerprint as a --successor-pin so a hijacked rotation cannot pass.");
+				if (!rotateDelivered) {
+					console.log("");
+					console.log(
+						pc.yellow(
+							`WARNING: the rotation record was NOT delivered to any sink (outbox: ${rotateStatus.outboxDepth} pending).`,
+						),
+					);
+					console.log(
+						pc.yellow(
+							"  The store lacks the trust-chain handoff — anchors signed by the new key will not verify until it ships.",
+						),
+					);
+					console.log(
+						pc.yellow(
+							`  Ship it: usertrust anchor export --since ${(result.record?.anchorSeq ?? 1) - 1}  (then re-run with a reachable sink)`,
+						),
+					);
+					process.exitCode = 1;
+				}
+				return;
+			}
+			case "resume": {
+				const latest = flagValue(args, "--latest");
+				if (latest === undefined) {
+					console.log("Usage: usertrust anchor resume --latest <record.json|->");
+					process.exitCode = 1;
+					return;
+				}
+				const raw = latest === "-" ? readFileSync(0, "utf-8") : readFileSync(latest, "utf-8");
+				const record = resumeAnchorMirror(root, raw);
+				console.log(
+					json
+						? JSON.stringify({
+								command: "anchor resume",
+								success: true,
+								data: { anchorSeq: record.anchorSeq },
+							})
+						: pc.green(`Mirror re-seeded at anchorSeq ${record.anchorSeq}.`),
+				);
+				return;
+			}
+			default: {
+				console.log(`Usage: usertrust anchor <init|now|status|export|rotate|resume>
+
+  init   [--key-file <path>]                 Mint identity + Ed25519 key (outside the vault)
+  now    [--sink-file <p>] [--sink-url <u>]  Snapshot, sign, mirror, publish
+  status                                     Last anchor, unanchored tail, outbox
+  export [--since <anchorSeq>]               Print mirror records (pull-mode shipping)
+  rotate [--key-file <path>]                 Cross-signed key rotation
+  resume --latest <record.json|->            Re-seed a lost mirror from the store`);
+				if (action !== undefined) process.exitCode = 1;
+				return;
+			}
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (json) {
+			console.log(
+				JSON.stringify({ command: `anchor ${action ?? ""}`, success: false, data: { message } }),
+			);
+		} else {
+			console.log(pc.red(message));
+		}
+		process.exitCode = 1;
+	}
+}

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -7,6 +7,7 @@ const COMMANDS = [
 	"inspect",
 	"health",
 	"verify",
+	"anchor",
 	"snapshot",
 	"tb",
 	"pricing",
@@ -80,6 +81,9 @@ switch (command) {
 	case "verify":
 		await import("./verify.js").then((m) => m.run(undefined, { json: jsonFlag }));
 		break;
+	case "anchor":
+		await import("./anchor.js").then((m) => m.run(positional.slice(1), { json: jsonFlag }));
+		break;
 	case "snapshot":
 		await import("./snapshot.js").then((m) => m.run(undefined, { json: jsonFlag }));
 		break;
@@ -114,6 +118,7 @@ Commands:
   inspect       Show trust bank statement
   health        Show entropy diagnostics
   verify        Verify audit chain integrity
+  anchor        External audit anchoring (signed checkpoints)
   snapshot      Create/restore vault snapshots
   tb            Manage TigerBeetle process
   pricing       Show current rate configuration

--- a/packages/core/src/cli/verify.ts
+++ b/packages/core/src/cli/verify.ts
@@ -27,9 +27,13 @@ import {
 import { VAULT_DIR } from "../shared/constants.js";
 import type { CliOptions } from "./init.js";
 
-function parseDurationMs(raw: string): number | undefined {
+function parseDurationMs(raw: string): number {
 	const m = /^(\d+)(ms|s|m|h|d)?$/.exec(raw);
-	if (m === null) return undefined;
+	if (m === null) {
+		// Silently dropping the policy would quietly disable the staleness
+		// gate — the exact fail-open the unknown-flag rejection exists to stop.
+		throw new Error(`Invalid --max-anchor-age: ${raw} (use e.g. 500ms, 30s, 15m, 1h, 7d)`);
+	}
 	const n = Number.parseInt(m[1] as string, 10);
 	const mult = { ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2] ?? "ms"] as number;
 	return n * mult;
@@ -43,7 +47,12 @@ interface AnchorFlags {
 }
 
 const KNOWN_VERIFY_FLAGS = new Set([
+	// Global flags main.ts accepts for every subcommand — rejecting them here
+	// would break existing `usertrust verify --skip-verify`-style invocations.
 	"--json",
+	"--skip-verify",
+	"--reconfigure",
+	// Anchor flags.
 	"--anchor",
 	"--anchors",
 	"--anchor-url",
@@ -103,10 +112,21 @@ async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 		else if (arg === "--require-external-anchor") requireExternalAnchor = true;
 		else if (arg === "--max-anchor-age") {
 			const v = next();
-			if (v !== undefined) maxAnchorAgeMs = parseDurationMs(v);
+			if (v === undefined) throw new Error("--max-anchor-age requires a value");
+			maxAnchorAgeMs = parseDurationMs(v);
 		} else if (arg === "--max-unanchored-events") {
 			const v = next();
-			if (v !== undefined) maxUnanchoredEvents = Number.parseInt(v, 10);
+			maxUnanchoredEvents = Number.parseInt(v ?? "", 10);
+			// parseInt("1O0") === 1 (partial parse) and NaN comparisons are always
+			// false — either typo would silently weaken the staleness gate.
+			// Require the WHOLE value to be a non-negative integer.
+			if (
+				!/^\d+$/.test(v ?? "") ||
+				!Number.isSafeInteger(maxUnanchoredEvents) ||
+				maxUnanchoredEvents < 0
+			) {
+				throw new Error(`Invalid --max-unanchored-events: ${v} (non-negative integer required)`);
+			}
 		} else if (arg === "--vault-id") vaultId = next();
 		else if (arg.startsWith("--") && !KNOWN_VERIFY_FLAGS.has(arg)) {
 			// Reject unknown flags rather than silently ignoring them — a typoed
@@ -120,9 +140,13 @@ async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 	let witness: WitnessInput = { requested: false };
 	if (anchorUrl !== undefined) {
 		const fetched = await fetchAnchorUrl(anchorUrl);
+		// Empty/fully-unparseable body = witness unreachable (inconclusive).
+		// A body with ANY cleanly parsed records IS evidence — keep it whole;
+		// embedded parse errors fail closed downstream instead of discarding
+		// the rollback proof the valid records carry.
 		const parsed =
 			fetched.ok && fetched.body !== undefined ? parseAnchorsContent(fetched.body) : null;
-		if (parsed !== null && parsed.records.length > 0 && parsed.errors.length === 0) {
+		if (parsed !== null && parsed.records.length > 0) {
 			externalAnchorsRaw.push(fetched.body as string);
 			witness = { requested: true, ok: true };
 		} else {

--- a/packages/core/src/cli/verify.ts
+++ b/packages/core/src/cli/verify.ts
@@ -7,19 +7,182 @@
  * Calls verifyVault() on the local vault (anchored to the `.meta` head, spans
  * rotated segments) and displays the result. Sets a nonzero process exit code
  * on a FAILED verdict so CI gates fail on a tampered vault.
+ *
+ * External-anchor flags (spec §7.5) mirror the standalone usertrust-verify
+ * CLI: the caller fetches anchor artifacts and pins the public key
+ * out-of-band; trust is never read from the vault under audit.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import pc from "picocolors";
-import { verifyVault } from "../audit/verify.js";
+import { parseAnchorsContent } from "../audit/anchor-verify.js";
+import {
+	type AnchorVerifyParams,
+	type WitnessInput,
+	exitCodeForAnchored,
+	verifyVault,
+	verifyVaultWithAnchors,
+} from "../audit/verify.js";
 import { VAULT_DIR } from "../shared/constants.js";
 import type { CliOptions } from "./init.js";
+
+function parseDurationMs(raw: string): number | undefined {
+	const m = /^(\d+)(ms|s|m|h|d)?$/.exec(raw);
+	if (m === null) return undefined;
+	const n = Number.parseInt(m[1] as string, 10);
+	const mult = { ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2] ?? "ms"] as number;
+	return n * mult;
+}
+
+interface AnchorFlags {
+	anchorMode: boolean;
+	params: AnchorVerifyParams;
+	requireAnchor: boolean;
+	requireExternalAnchor: boolean;
+}
+
+const KNOWN_VERIFY_FLAGS = new Set([
+	"--json",
+	"--anchor",
+	"--anchors",
+	"--anchor-url",
+	"--pubkey",
+	"--successor-pin",
+	"--require-anchor",
+	"--require-external-anchor",
+	"--max-anchor-age",
+	"--max-unanchored-events",
+	"--vault-id",
+]);
+
+function fetchAnchorUrl(url: string): Promise<{ ok: boolean; body?: string; error?: string }> {
+	return new Promise((resolve) => {
+		import("node:https")
+			.then((https) => {
+				const req = https.get(url, { timeout: 15_000 }, (res) => {
+					const code = res.statusCode ?? 0;
+					if (code < 200 || code >= 300) {
+						res.resume();
+						resolve({ ok: false, error: `HTTP ${code}` });
+						return;
+					}
+					const chunks: Buffer[] = [];
+					res.on("data", (c: Buffer) => chunks.push(c));
+					res.on("end", () => resolve({ ok: true, body: Buffer.concat(chunks).toString("utf-8") }));
+				});
+				req.on("timeout", () => req.destroy(new Error("timeout")));
+				req.on("error", (err) => resolve({ ok: false, error: err.message }));
+			})
+			.catch((err: Error) => resolve({ ok: false, error: err.message }));
+	});
+}
+
+async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
+	const anchorFiles: string[] = [];
+	let anchorUrl: string | undefined;
+	let pubkeyFile: string | undefined;
+	const successorPinFiles: string[] = [];
+	let requireAnchor = false;
+	let requireExternalAnchor = false;
+	let maxAnchorAgeMs: number | undefined;
+	let maxUnanchoredEvents: number | undefined;
+	let vaultId: string | undefined;
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i] as string;
+		const next = (): string | undefined => argv[++i];
+		if (arg === "--anchor" || arg === "--anchors") {
+			const v = next();
+			if (v !== undefined) anchorFiles.push(v);
+		} else if (arg === "--anchor-url") anchorUrl = next();
+		else if (arg === "--pubkey") pubkeyFile = next();
+		else if (arg === "--successor-pin") {
+			const v = next();
+			if (v !== undefined) successorPinFiles.push(v);
+		} else if (arg === "--require-anchor") requireAnchor = true;
+		else if (arg === "--require-external-anchor") requireExternalAnchor = true;
+		else if (arg === "--max-anchor-age") {
+			const v = next();
+			if (v !== undefined) maxAnchorAgeMs = parseDurationMs(v);
+		} else if (arg === "--max-unanchored-events") {
+			const v = next();
+			if (v !== undefined) maxUnanchoredEvents = Number.parseInt(v, 10);
+		} else if (arg === "--vault-id") vaultId = next();
+		else if (arg.startsWith("--") && !KNOWN_VERIFY_FLAGS.has(arg)) {
+			// Reject unknown flags rather than silently ignoring them — a typoed
+			// --require-anchro must not quietly weaken a CI gate.
+			throw new Error(`Unknown flag: ${arg}`);
+		}
+	}
+	const externalAnchorsRaw = anchorFiles.map((f) =>
+		f === "-" ? readFileSync(0, "utf-8") : readFileSync(f, "utf-8"),
+	);
+	let witness: WitnessInput = { requested: false };
+	if (anchorUrl !== undefined) {
+		const fetched = await fetchAnchorUrl(anchorUrl);
+		const parsed =
+			fetched.ok && fetched.body !== undefined ? parseAnchorsContent(fetched.body) : null;
+		if (parsed !== null && parsed.records.length > 0 && parsed.errors.length === 0) {
+			externalAnchorsRaw.push(fetched.body as string);
+			witness = { requested: true, ok: true };
+		} else {
+			witness = {
+				requested: true,
+				ok: false,
+				error: fetched.ok
+					? "witness returned an empty or unparseable body"
+					: (fetched.error ?? "fetch failed"),
+			};
+		}
+	}
+	const anchorMode =
+		anchorFiles.length > 0 ||
+		anchorUrl !== undefined ||
+		pubkeyFile !== undefined ||
+		requireAnchor ||
+		requireExternalAnchor;
+	const trust =
+		pubkeyFile !== undefined
+			? {
+					rootPem: readFileSync(pubkeyFile, "utf-8"),
+					...(successorPinFiles.length > 0
+						? { successorPinsPem: successorPinFiles.map((f) => readFileSync(f, "utf-8")) }
+						: {}),
+				}
+			: undefined;
+	return {
+		anchorMode,
+		requireAnchor,
+		requireExternalAnchor,
+		params: {
+			externalAnchorsRaw,
+			...(trust !== undefined ? { trust } : {}),
+			witness,
+			...(maxAnchorAgeMs !== undefined ? { maxAnchorAgeMs } : {}),
+			...(maxUnanchoredEvents !== undefined ? { maxUnanchoredEvents } : {}),
+			...(vaultId !== undefined ? { expectedVaultId: vaultId } : {}),
+		},
+	};
+}
 
 export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 	const root = rootDir ?? process.cwd();
 	const vaultPath = join(root, VAULT_DIR);
 	const json = opts?.json === true;
+
+	let flags: AnchorFlags;
+	try {
+		flags = await parseAnchorFlags(process.argv.slice(2));
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		if (json) {
+			console.log(JSON.stringify({ command: "verify", success: false, data: { message } }));
+		} else {
+			console.log(pc.red(message));
+		}
+		process.exitCode = 1;
+		return;
+	}
 
 	if (!existsSync(vaultPath)) {
 		if (json) {
@@ -38,8 +201,63 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 		return;
 	}
 
-	const result = verifyVault(vaultPath);
 	const verifiedAt = new Date().toISOString();
+
+	if (flags.anchorMode) {
+		const result = verifyVaultWithAnchors(vaultPath, flags.params);
+		const exitCode = exitCodeForAnchored(result, {
+			requireAnchor: flags.requireAnchor,
+			requireExternalAnchor: flags.requireExternalAnchor,
+		});
+		if (json) {
+			console.log(
+				JSON.stringify({
+					command: "verify",
+					success: result.valid,
+					data: {
+						valid: result.valid,
+						chainLength: result.chainLength,
+						errors: result.errors,
+						merkleRoot: result.merkleRoot,
+						anchorState: result.anchorState,
+						anchoring: result.anchoring,
+						verifiedAt,
+					},
+				}),
+			);
+			if (exitCode !== 0) process.exitCode = exitCode;
+			return;
+		}
+		if (result.valid) {
+			console.log(pc.green(`Chain verified: ${result.chainLength} events, all hashes valid.`));
+		} else {
+			console.log(pc.red(`Chain verification FAILED: ${result.errors.length} error(s) found.`));
+			for (const err of result.errors) {
+				console.log(pc.red(`  - ${err}`));
+			}
+		}
+		console.log(`Anchor state: ${result.anchorState} (source: ${result.anchoring.anchorSource})`);
+		if (result.anchoring.latestAnchor) {
+			const la = result.anchoring.latestAnchor;
+			console.log(`Latest anchor: #${la.anchorSeq} treeSize ${la.treeSize} (${la.timestamp})`);
+		}
+		console.log(`Unanchored tail: ${result.anchoring.unanchoredTail.events} event(s)`);
+		if (result.anchoring.anchorSource === "vault-mirror") {
+			console.log(
+				pc.yellow(
+					"WARNING: anchors verified from the vault-local mirror only — supply an externally fetched copy for deletion protection.",
+				),
+			);
+		}
+		for (const w of result.anchoring.warnings) {
+			console.log(pc.yellow(`WARNING: ${w}`));
+		}
+		console.log(pc.dim(`Verified at: ${verifiedAt}`));
+		if (exitCode !== 0) process.exitCode = exitCode;
+		return;
+	}
+
+	const result = verifyVault(vaultPath);
 
 	if (json) {
 		console.log(
@@ -51,6 +269,7 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 					chainLength: result.chainLength,
 					errors: result.errors,
 					merkleRoot: result.merkleRoot,
+					anchorState: "UNANCHORED",
 					verifiedAt,
 				},
 			}),
@@ -62,6 +281,11 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 	if (result.valid) {
 		console.log(pc.green(`Chain verified: ${result.chainLength} events, all hashes valid.`));
 		if (result.merkleRoot) console.log(`Merkle root: ${pc.dim(result.merkleRoot)}`);
+		console.log(
+			pc.dim(
+				"Anchor state: UNANCHORED — internal consistency only; supply --anchor + --pubkey for independent verification.",
+			),
+		);
 	} else {
 		console.log(pc.red(`Chain verification FAILED: ${result.errors.length} error(s) found.`));
 		console.log(`Events checked: ${result.chainLength}`);

--- a/packages/core/src/ledger/engine.ts
+++ b/packages/core/src/ledger/engine.ts
@@ -71,7 +71,16 @@ function writeDeadLetter(entry: DLQEntry, dlqPath: string): void {
 		// The old HMAC key was derived from the DLQ path (forgeable from
 		// public inputs), and any real key readable at write time is equally
 		// readable by an attacker with host access. See audit/chain.ts.
-		const checksum = createHash("sha256").update(canonicalize(entry)).digest("hex");
+		let checksumSource: string;
+		try {
+			checksumSource = canonicalize(entry);
+		} catch {
+			// canonicalize throws on NaN/Infinity — but a payload carrying NaN
+			// (e.g. a NaN amount) is exactly why the operation failed and MUST
+			// still be dead-lettered. JSON.stringify coerces them to null.
+			checksumSource = JSON.stringify(entry);
+		}
+		const checksum = createHash("sha256").update(checksumSource).digest("hex");
 		const sealed: DLQEntry = { ...entry, checksum, checksumAlg: "sha256" };
 
 		const line = `${JSON.stringify(sealed)}\n`;

--- a/packages/core/src/ledger/engine.ts
+++ b/packages/core/src/ledger/engine.ts
@@ -6,10 +6,11 @@
  * Implements PENDING -> POST/VOID lifecycle for all governed operations.
  */
 
-import { createHash, createHmac } from "node:crypto";
+import { createHash } from "node:crypto";
 import { closeSync, existsSync, fsyncSync, mkdirSync, openSync, writeSync } from "node:fs";
 import { join } from "node:path";
 import { CreateTransferError } from "tigerbeetle-node";
+import { canonicalize } from "../audit/canonical.js";
 import { DEFAULT_HOLD_TTL_MS, VAULT_DIR } from "../shared/constants.js";
 import { InsufficientBalanceError } from "../shared/errors.js";
 import { fnv1a32 } from "../shared/ids.js";
@@ -56,12 +57,8 @@ interface DLQEntry {
 	transferId: string;
 	payload: Record<string, unknown>;
 	error: string;
-	hmac?: string;
-}
-
-/** Derive a DLQ integrity key from the vault base path. */
-function deriveDlqKey(dlqPath: string): string {
-	return createHash("sha256").update(`dlq-integrity:${dlqPath}`).digest("hex");
+	checksum?: string;
+	checksumAlg?: string;
 }
 
 function writeDeadLetter(entry: DLQEntry, dlqPath: string): void {
@@ -70,10 +67,12 @@ function writeDeadLetter(entry: DLQEntry, dlqPath: string): void {
 			mkdirSync(dlqPath, { recursive: true, mode: 0o700 });
 		}
 
-		// Compute HMAC over the entry (excluding the hmac field itself)
-		const key = deriveDlqKey(dlqPath);
-		const hmac = createHmac("sha256", key).update(JSON.stringify(entry)).digest("hex");
-		const sealed: DLQEntry = { ...entry, hmac };
+		// F3: best-effort corruption-detection checksum — NOT tamper-evidence.
+		// The old HMAC key was derived from the DLQ path (forgeable from
+		// public inputs), and any real key readable at write time is equally
+		// readable by an attacker with host access. See audit/chain.ts.
+		const checksum = createHash("sha256").update(canonicalize(entry)).digest("hex");
+		const sealed: DLQEntry = { ...entry, checksum, checksumAlg: "sha256" };
 
 		const line = `${JSON.stringify(sealed)}\n`;
 		const filePath = join(dlqPath, "dead-letter.jsonl");

--- a/packages/core/src/snapshot/checkpoint.ts
+++ b/packages/core/src/snapshot/checkpoint.ts
@@ -52,6 +52,16 @@ const INCLUDED_PATHS = new Set([
 /** Never captured: advisory lock file living inside audit/. */
 const NEVER_CAPTURE = new Set([".audit-writer.lock"]);
 
+/**
+ * Never captured NOR restored: external-anchoring state (mirror of the
+ * append-only anchor store, identity.json with the durable anchorSeq
+ * high-water, outbox). This bookkeeping is MONOTONIC by contract — rolling it
+ * back with a snapshot would make the emitter re-mint anchorSeqs the store
+ * already holds, publishing divergent records at occupied positions:
+ * permanent, undeletable fork evidence that condemns an honest vault.
+ */
+const ANCHORS_REL_DIR = "audit/anchors";
+
 const LOCK_FILE_NAME = ".audit-writer.lock";
 
 // ── Internals ──
@@ -73,6 +83,8 @@ async function collectFiles(basePath: string, currentPath: string): Promise<stri
 		const relPath = relative(basePath, fullPath);
 
 		if (entry.isDirectory()) {
+			// Anchoring state is monotonic — never snapshot it (see ANCHORS_REL_DIR).
+			if (relPath === ANCHORS_REL_DIR) continue;
 			const nested = await collectFiles(basePath, fullPath);
 			results.push(...nested);
 		} else if (entry.isFile()) {
@@ -257,6 +269,11 @@ export async function restoreSnapshot(
 				}
 				// Never restore an advisory lock captured by an older snapshot.
 				if (relPath.split("/").pop() === LOCK_FILE_NAME) continue;
+				// Never restore anchoring state, even from snapshots captured
+				// before this exclusion existed — rolling back the anchorSeq
+				// high-water re-mints occupied store positions (permanent fork
+				// evidence). The live anchors/ dir stays as-is.
+				if (relPath === ANCHORS_REL_DIR || relPath.startsWith(`${ANCHORS_REL_DIR}/`)) continue;
 
 				const fullPath = join(vaultPath, relPath);
 				const resolvedPath = resolve(fullPath);

--- a/packages/core/tests/harden/anchoring/anchor-additive.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-additive.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — ANCHORING IS ADDITIVE (spec §9, AC-2/AC-3/AC-4)
+ *
+ * Anchoring must never change what the writer persists, what the pre-anchor
+ * verifier sees, or the zero-dependency guarantee of packages/verify.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyVault as pkgVerifyVault } from "../../../../verify/src/index.js";
+import {
+	verifyVault as coreVerifyVault,
+	verifyVaultWithAnchors,
+} from "../../../src/audit/verify.js";
+import { VAULT_DIR } from "../../../src/shared/constants.js";
+import { anchorOnce, appendEvents, cleanupAll, makeAnchoredVault, tmp } from "./fixtures.js";
+
+const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..", "..");
+const VERIFY_SRC = join(REPO_ROOT, "packages", "verify", "src");
+
+afterEach(() => {
+	cleanupAll();
+});
+
+describe("HARDEN: anchoring additive proofs", () => {
+	it("1. AC-3.2: anchoring never touches events.jsonl or .meta bytes", async () => {
+		const s = await makeAnchoredVault(5);
+		const logPath = join(s.vaultPath, "audit", "events.jsonl");
+		const metaPath = `${logPath}.meta`;
+		const logBefore = readFileSync(logPath);
+		const metaBefore = readFileSync(metaPath);
+
+		await anchorOnce(s);
+
+		expect(readFileSync(logPath).equals(logBefore)).toBe(true);
+		expect(readFileSync(metaPath).equals(metaBefore)).toBe(true);
+	});
+
+	it("2. AC-3.3: the pre-anchor verifier still passes on an anchored vault; anchors never enter the segment glob", async () => {
+		const s = await makeAnchoredVault(4);
+		const before = coreVerifyVault(s.vaultPath);
+		await anchorOnce(s);
+
+		const core = coreVerifyVault(s.vaultPath);
+		const pkg = pkgVerifyVault(s.vaultPath);
+		expect(core.valid).toBe(true);
+		expect(pkg.valid).toBe(true);
+		expect(core.chainLength).toBe(before.chainLength);
+		expect(core.merkleRoot).toBe(before.merkleRoot);
+
+		// The emitter must never create *.jsonl files directly in audit/ —
+		// the existing verifiers glob those as chain segments (AC-3.3).
+		const auditEntries = readdirSync(join(s.vaultPath, "audit"));
+		const jsonlEntries = auditEntries.filter((e) => e.endsWith(".jsonl"));
+		expect(jsonlEntries).toEqual(["events.jsonl"]);
+		expect(auditEntries).toContain("anchors");
+	});
+
+	it("3. AC-4.1: legacy vault (no anchors, no flags) → valid, UNANCHORED, additive fields present", async () => {
+		const root = tmp("additive-legacy-");
+		await appendEvents(root, 3);
+		const result = verifyVaultWithAnchors(join(root, VAULT_DIR));
+		expect(result.valid).toBe(true);
+		expect(result.anchorState).toBe("UNANCHORED");
+		expect(result.anchoring.anchorSource).toBe("none");
+		// Existing fields keep today's meanings (additive-only result shape).
+		expect(result.chainLength).toBe(3);
+		expect(result.errors).toEqual([]);
+	});
+
+	it("4. AC-2.1: packages/verify dependencies stay exactly {} (no peer/optional smuggling)", () => {
+		const pkg = JSON.parse(
+			readFileSync(join(REPO_ROOT, "packages", "verify", "package.json"), "utf-8"),
+		) as Record<string, unknown>;
+		expect(pkg.dependencies).toEqual({});
+		expect(pkg.peerDependencies).toBeUndefined();
+		expect(pkg.optionalDependencies).toBeUndefined();
+	});
+
+	it("5. AC-2.2: every import in packages/verify/src resolves to node:* or a sibling file", () => {
+		const offenders: string[] = [];
+		for (const file of readdirSync(VERIFY_SRC).filter((f) => f.endsWith(".ts"))) {
+			const source = readFileSync(join(VERIFY_SRC, file), "utf-8");
+			for (const match of source.matchAll(/from\s+"([^"]+)"|import\s*\(\s*"([^"]+)"\s*\)/g)) {
+				const spec = match[1] ?? match[2] ?? "";
+				if (!spec.startsWith("node:") && !spec.startsWith("./")) {
+					offenders.push(`${file}: ${spec}`);
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+
+	it("6. AC-2.2 vendoring guard: packages/verify/src stays within its conscious LOC budget", () => {
+		// The import lint above is structurally blind to vendored source (a
+		// vendored crypto file IS a sibling file). This budget is a tripwire:
+		// growing past it requires consciously editing this number — at which
+		// point the reviewer asks what was added. Current size ~2.6k lines.
+		let total = 0;
+		for (const file of readdirSync(VERIFY_SRC).filter((f) => f.endsWith(".ts"))) {
+			total += readFileSync(join(VERIFY_SRC, file), "utf-8").split("\n").length;
+		}
+		expect(total).toBeLessThan(3200);
+	});
+
+	it("7. mirror parity: anchor-verify.ts is byte-identical across packages modulo import paths", () => {
+		const strip = (s: string): string =>
+			s
+				.split("\n")
+				.filter((l) => !l.includes('from "'))
+				.join("\n");
+		const pkgCopy = readFileSync(join(VERIFY_SRC, "anchor-verify.ts"), "utf-8");
+		const coreCopy = readFileSync(
+			join(REPO_ROOT, "packages", "core", "src", "audit", "anchor-verify.ts"),
+			"utf-8",
+		);
+		expect(strip(coreCopy)).toBe(strip(pkgCopy));
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-cli.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-cli.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — anchor CLI regressions: `anchor now --json` and `anchor rotate`
+ * must report failure (exit 1) when a record is emitted but never delivered
+ * to any sink (spec §5.3); the core `verify` CLI rejects unknown flags so a
+ * typo cannot silently weaken a CI gate (spec §7.5).
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { run as anchorRun } from "../../../src/cli/anchor.js";
+import { run as verifyRun } from "../../../src/cli/verify.js";
+import { appendEvents, cleanupAll, makeAnchoredVault, tmp } from "./fixtures.js";
+
+const origCwd = process.cwd();
+const origArgv = process.argv;
+
+afterEach(() => {
+	process.chdir(origCwd);
+	process.argv = origArgv;
+	process.exitCode = 0;
+	vi.restoreAllMocks();
+	cleanupAll();
+});
+
+function captureLog(): { lines: string[]; restore: () => void } {
+	const lines: string[] = [];
+	const spy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+		lines.push(a.map(String).join(" "));
+	});
+	return { lines, restore: () => spy.mockRestore() };
+}
+
+describe("HARDEN: `anchor now --json` is delivery-gated", () => {
+	it("reports success:false and exit 1 when every sink fails (record stranded in outbox)", async () => {
+		const s = await makeAnchoredVault(3);
+		process.chdir(s.root);
+		process.env.USERTRUST_ANCHOR_KEY = s.keyFile;
+		const unwritable = "/proc/nonexistent/anchors.jsonl"; // guaranteed write failure
+		const { lines, restore } = captureLog();
+		try {
+			await anchorRun(["now", "--sink-file", unwritable, "--publish-retries", "1"], { json: true });
+		} finally {
+			restore();
+		}
+		const out = JSON.parse(lines.at(-1) as string);
+		expect(out.command).toBe("anchor now");
+		expect(out.success).toBe(false);
+		expect(out.data.delivered).toBe(false);
+		expect(out.data.outboxDepth).toBeGreaterThan(0);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("HARDEN: `anchor rotate` is delivery-gated", () => {
+	it("reports success:false and exit 1 when the rotation record never reaches a sink", async () => {
+		const s = await makeAnchoredVault(3);
+		await appendEvents(s.root, 1, 4);
+		process.chdir(s.root);
+		process.env.USERTRUST_ANCHOR_KEY = s.keyFile;
+		const unwritable = "/proc/nonexistent/anchors.jsonl";
+		const { lines, restore } = captureLog();
+		try {
+			await anchorRun(["rotate", "--sink-file", unwritable, "--publish-retries", "1"], {
+				json: true,
+			});
+		} finally {
+			restore();
+		}
+		const out = JSON.parse(lines.at(-1) as string);
+		expect(out.command).toBe("anchor rotate");
+		expect(out.success).toBe(false);
+		expect(out.data.delivered).toBe(false);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("HARDEN: core `verify` CLI rejects unknown flags", () => {
+	it("a typoed --require-anchro fails loudly instead of silently weakening the gate", async () => {
+		const root = tmp("verify-flag-");
+		await appendEvents(root, 2);
+		process.argv = ["node", "usertrust", "verify", "--require-anchro"];
+		const { lines, restore } = captureLog();
+		try {
+			await verifyRun(root, { json: false });
+		} finally {
+			restore();
+		}
+		expect(lines.join("\n")).toMatch(/Unknown flag: --require-anchro/);
+		expect(process.exitCode).toBe(1);
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-corpus.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-corpus.test.ts
@@ -1,0 +1,652 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — EXTERNAL ANCHORING ADVERSARIAL CORPUS (spec §10, constraints §5.11)
+ *
+ * Every attack asserts the exact FAIL state + reason code. Fixtures are built
+ * by the real writer + emitter, then mutated. Row numbers reference
+ * docs/superpowers/specs/2026-07-26-external-anchoring-design.md §10.
+ */
+
+import { rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyTransaction as pkgVerifyTransaction } from "../../../../verify/src/index.js";
+import { anchorPayloadHash } from "../../../src/audit/anchor-verify.js";
+import { createAnchorEmitter } from "../../../src/audit/anchor.js";
+import { canonicalize } from "../../../src/audit/canonical.js";
+import { exitCodeForAnchored } from "../../../src/audit/verify.js";
+import {
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	computeRoot,
+	makeAnchoredVault,
+	mutateAndRechain,
+	nextPayload,
+	pubPemFromKeyFile,
+	restoreVault,
+	rotateOnce,
+	signRecord,
+	snapshotVault,
+	storeRaw,
+	storeRecords,
+	truncateVault,
+	verify,
+} from "./fixtures.js";
+
+afterEach(() => {
+	cleanupAll();
+});
+
+describe("HARDEN: anchoring corpus — mutation / deletion / rollback (rows 1-5)", () => {
+	it("1. F1 KILL: mutate anchored event + full re-chain + .meta rewrite → ANCHOR_MISMATCH/root-mismatch; --tx never prints INCLUSION VERIFIED", async () => {
+		const s = await makeAnchoredVault(5);
+		await anchorOnce(s);
+		mutateAndRechain(s, 1);
+
+		// The pre-anchor verifier is blind to this by construction: the chain
+		// is internally consistent again. The anchor closes exactly this hole.
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("root-mismatch");
+		expect(result.valid).toBe(false);
+		expect(exitCodeForAnchored(result, {})).toBe(1);
+
+		// AC-5.1: the receipt must not overclaim either.
+		const tx = pkgVerifyTransaction(s.vaultPath, "tr_2", {
+			externalAnchorsRaw: [storeRaw(s)],
+			trust: s.trust,
+			witness: { requested: false },
+		});
+		expect(tx.receipt).not.toContain("INCLUSION VERIFIED");
+		expect(tx.valid).toBe(false);
+	});
+
+	it("2. F2 KILL: delete the ENTIRE audit tree; external anchor supplied → ANCHOR_MISMATCH/deletion, exit 1", async () => {
+		const s = await makeAnchoredVault(5);
+		await anchorOnce(s);
+		rmSync(join(s.vaultPath, "audit"), { recursive: true, force: true });
+
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("deletion");
+		expect(result.valid).toBe(false);
+		expect(exitCodeForAnchored(result, {})).toBe(1);
+	});
+
+	it("3. tail truncation below latest treeSize + .meta rewrite → ANCHOR_MISMATCH/rollback", async () => {
+		const s = await makeAnchoredVault(6);
+		await anchorOnce(s);
+		truncateVault(s, 3);
+
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("rollback");
+	});
+
+	it("4. rollback to an older internally-valid snapshot → ANCHOR_MISMATCH/rollback (AC-1.3)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		const snap = snapshotVault(s);
+		await appendEvents(s.root, 3, 4);
+		await anchorOnce(s);
+		restoreVault(s, snap);
+
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("rollback");
+	});
+
+	it("5. fork: rewrite events ≤ treeSize, regrow chain → root-mismatch + consistency-failure (AC-1.4, row 17)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 3, 4);
+		await anchorOnce(s);
+		mutateAndRechain(s, 1);
+
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("root-mismatch");
+		// The consistency proof is BOUND to the signed roots — the bare
+		// verifyConsistencyProof call would pass on the re-chained leaves.
+		expect(result.anchoring.reasons).toContain("consistency-failure");
+	});
+});
+
+describe("HARDEN: anchoring corpus — forged trust material (rows 6-7)", () => {
+	it("6. attacker keypair re-signs full history; auditor pins the real root → ANCHOR_INVALID (AC-6.3)", async () => {
+		const s = await makeAnchoredVault(4);
+		await anchorOnce(s);
+		const real = storeRecords(s)[0] as NonNullable<ReturnType<typeof storeRecords>[0]>;
+
+		// Attacker: own keypair, correct roots, re-signed records.
+		const attacker = await makeAnchoredVault(1); // just for its keypair
+		const forged = signRecord(
+			{
+				v: 1,
+				vaultId: real.vaultId,
+				anchorSeq: 1,
+				prevAnchorHash: real.prevAnchorHash,
+				treeSize: real.treeSize,
+				lastHash: real.lastHash,
+				merkleRoot: real.merkleRoot,
+				timestamp: real.timestamp,
+				keyId: (await import("../../../src/audit/anchor-verify.js")).keyIdFromKeyObject(
+					(await import("node:crypto")).createPublicKey(
+						(await import("node:crypto")).createPrivateKey(
+							(await import("node:fs")).readFileSync(attacker.keyFile, "utf-8"),
+						),
+					),
+				),
+			},
+			attacker.keyFile,
+		);
+		// Attacker also wipes the vault mirror (they own the vault).
+		writeFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "");
+
+		const result = verify(s, { external: [`${canonicalize(forged)}\n`] });
+		expect(result.anchorState).toBe("ANCHOR_INVALID");
+		expect(result.anchoring.reasons).toContain("sig-invalid");
+	});
+
+	it("7. key swap inside the vault: doctored identity.json + attacker-signed mirror → ANCHOR_INVALID (pinned root governs)", async () => {
+		const s = await makeAnchoredVault(4);
+		await anchorOnce(s);
+		const real = storeRecords(s)[0] as NonNullable<ReturnType<typeof storeRecords>[0]>;
+
+		const attacker = await makeAnchoredVault(1);
+		const attackerPub = pubPemFromKeyFile(attacker.keyFile);
+		const { keyIdFromKeyObject, publicKeyFromPem } = await import(
+			"../../../src/audit/anchor-verify.js"
+		);
+		const attackerKeyId = keyIdFromKeyObject(
+			publicKeyFromPem(attackerPub) as NonNullable<ReturnType<typeof publicKeyFromPem>>,
+		);
+		const forged = signRecord(
+			{
+				v: 1,
+				vaultId: real.vaultId,
+				anchorSeq: 1,
+				prevAnchorHash: real.prevAnchorHash,
+				treeSize: real.treeSize,
+				lastHash: real.lastHash,
+				merkleRoot: real.merkleRoot,
+				timestamp: real.timestamp,
+				keyId: attackerKeyId,
+			},
+			attacker.keyFile,
+		);
+		// Attacker rewrites mirror + identity.json inside the vault.
+		writeFileSync(
+			join(s.vaultPath, "audit", "anchors", "anchors.jsonl"),
+			`${canonicalize(forged)}\n`,
+		);
+		writeFileSync(
+			join(s.vaultPath, "audit", "anchors", "identity.json"),
+			JSON.stringify({
+				v: 1,
+				vaultId: real.vaultId,
+				keyId: attackerKeyId,
+				publicKeySpki: "x",
+				createdAt: "now",
+			}),
+		);
+
+		// Auditor supplies NO external artifacts (mirror-only) but pins the
+		// REAL root key — the vault-resident key material must be ignored.
+		const result = verify(s, { external: [] });
+		expect(result.anchorState).toBe("ANCHOR_INVALID");
+		expect(result.anchoring.reasons).toContain("sig-invalid");
+	});
+});
+
+describe("HARDEN: anchoring corpus — anchor-history integrity (rows 8-14)", () => {
+	it("8. gap: middle record deleted from the supplied set (mirror wiped) → anchor-chain-gap (AC-1.5)", async () => {
+		const s = await makeAnchoredVault(2);
+		await anchorOnce(s);
+		await appendEvents(s.root, 2, 3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 2, 5);
+		await anchorOnce(s);
+		const records = storeRecords(s);
+		expect(records.length).toBe(3);
+		const withGap = [records[0], records[2]].map((r) => canonicalize(r as object)).join("\n");
+		writeFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "");
+
+		const result = verify(s, { external: [withGap] });
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("anchor-chain-gap");
+	});
+
+	it("9. monotonicity: decreasing treeSize across records → ANCHOR_MISMATCH", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		// Key-holder signs a syntactically valid successor with SMALLER treeSize.
+		const shrunk = signRecord(
+			nextPayload(s, r1, {
+				treeSize: 2,
+				lastHash: (await import("../../../src/audit/anchor-verify.js")).gatherOrderedEventHashes(
+					s.vaultPath,
+				)[1] as string,
+				merkleRoot: computeRoot(s, 2),
+			}),
+			s.keyFile,
+		);
+		const result = verify(s, { external: [`${storeRaw(s)}${canonicalize(shrunk)}\n`] });
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("rollback");
+	});
+
+	it("10. fork evidence: same prevAnchorHash, same key, DIVERGENT content → ANCHOR_MISMATCH/fork", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		await appendEvents(s.root, 2, 4);
+		const a = signRecord(nextPayload(s, r1), s.keyFile);
+		const b = signRecord(
+			nextPayload(s, r1, {
+				treeSize: 4,
+				lastHash: (await import("../../../src/audit/anchor-verify.js")).gatherOrderedEventHashes(
+					s.vaultPath,
+				)[3] as string,
+				merkleRoot: computeRoot(s, 4),
+			}),
+			s.keyFile,
+		);
+		const result = verify(s, {
+			external: [`${canonicalize(r1)}\n${canonicalize(a)}\n${canonicalize(b)}\n`],
+		});
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("fork");
+	});
+
+	it("11. benign duplicate: identical modulo timestamp/sig → ANCHORED_VERIFIED + duplicate-anchor warning", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const { sig: _sig, ...payload } = r1;
+		const dup = signRecord(
+			{ ...payload, timestamp: new Date(Date.now() + 5000).toISOString() },
+			s.keyFile,
+		);
+		const result = verify(s, { external: [`${canonicalize(r1)}\n${canonicalize(dup)}\n`] });
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.warnings).toContain("duplicate-anchor");
+		expect(result.valid).toBe(true);
+	});
+
+	it("12. emitter race with the lock: exactly one record minted, loser skips", async () => {
+		const s = await makeAnchoredVault(3);
+		const mk = () =>
+			createAnchorEmitter(s.root, {
+				signer: { type: "pem", file: s.keyFile },
+				sinks: [{ type: "file", path: s.storeFile }],
+			});
+		const e1 = mk();
+		const e2 = mk();
+		const [r1, r2] = await Promise.all([e1.anchorNow(), e2.anchorNow()]);
+		await e1.stop();
+		await e2.stop();
+		const emitted = [r1, r2].filter((r) => r.emitted);
+		const skipped = [r1, r2].filter((r) => !r.emitted);
+		expect(emitted.length).toBe(1);
+		expect(skipped.length).toBe(1);
+		expect(["locked", "no-new-events"]).toContain(skipped[0]?.reason);
+		expect(storeRecords(s).length).toBe(1);
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+	});
+
+	it("13. mirror↔external disagreement at one anchorSeq → ANCHOR_MISMATCH/mirror-disagreement; external governs (AC-1.2)", async () => {
+		const s = await makeAnchoredVault(4);
+		const r1 = await anchorOnce(s);
+		// Key-holding attacker rewrites the MIRROR copy with a different root.
+		const { sig: _sig, ...payload } = r1;
+		const doctored = signRecord(
+			{
+				...payload,
+				merkleRoot: computeRoot(s, 2),
+				treeSize: 2,
+				lastHash: (await import("../../../src/audit/anchor-verify.js")).gatherOrderedEventHashes(
+					s.vaultPath,
+				)[1] as string,
+			},
+			s.keyFile,
+		);
+		writeFileSync(
+			join(s.vaultPath, "audit", "anchors", "anchors.jsonl"),
+			`${canonicalize(doctored)}\n`,
+		);
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("mirror-disagreement");
+	});
+
+	it("14. cross-vault replay: valid record from another vaultId → ANCHOR_MISMATCH/vault-id-mismatch", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		const other = await makeAnchoredVault(3);
+		const foreign = await anchorOnce(other);
+		const result = verify(s, {
+			external: [`${storeRaw(s)}${canonicalize(foreign)}\n`],
+		});
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("vault-id-mismatch");
+
+		// expectedVaultId pinning also rejects a wholesale-substituted set.
+		const pinned = verify(s, {
+			external: [canonicalize(foreign)],
+			expectedVaultId: storeRecords(s)[0]?.vaultId as string,
+		});
+		expect(pinned.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(pinned.anchoring.reasons).toContain("vault-id-mismatch");
+	});
+});
+
+describe("HARDEN: anchoring corpus — malformed / degenerate records (rows 15-16)", () => {
+	it("15. corrupt JSON and unknown extra fields → ANCHOR_INVALID (fail-closed)", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const corrupt = verify(s, { external: ["{not json"] });
+		expect(corrupt.anchorState).toBe("ANCHOR_INVALID");
+
+		const extra = { ...JSON.parse(canonicalize(r1)), smuggled: true };
+		const withExtra = verify(s, { external: [JSON.stringify(extra)] });
+		expect(withExtra.anchorState).toBe("ANCHOR_INVALID");
+		expect(withExtra.anchoring.reasons).toContain("malformed-anchor");
+	});
+
+	it("16. degenerate numerics (treeSize 0 / negative / float / unsafe) → ANCHOR_INVALID/range-invalid, NO throw", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const base = JSON.parse(canonicalize(r1)) as Record<string, unknown>;
+		for (const bad of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 2]) {
+			const record = { ...base, treeSize: bad };
+			const result = verify(s, { external: [JSON.stringify(record)] });
+			expect(result.anchorState).toBe("ANCHOR_INVALID");
+			expect(result.anchoring.reasons).toContain("range-invalid");
+		}
+	});
+});
+
+describe("HARDEN: anchoring corpus — freshness / trust-material states (rows 18-23)", () => {
+	it("18. stale beyond thresholds → ANCHOR_STALE; exit 0 default, 1 strict", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 5, 4);
+		const result = verify(s, { maxUnanchoredEvents: 2 });
+		expect(result.anchorState).toBe("ANCHOR_STALE");
+		expect(result.valid).toBe(true);
+		expect(exitCodeForAnchored(result, {})).toBe(0);
+		expect(exitCodeForAnchored(result, { requireAnchor: true })).toBe(1);
+
+		const aged = verify(s, { maxAnchorAgeMs: 1, nowMs: Date.now() + 3_600_000 });
+		expect(aged.anchorState).toBe("ANCHOR_STALE");
+	});
+
+	it("19. future-dated timestamp on the newest anchor → future-timestamp warning; event threshold still fires", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const result = verify(s, { nowMs: Date.parse(r1.timestamp) - 60_000 });
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.warnings).toContain("future-timestamp");
+
+		// Clock gaming cannot defuse the clock-independent control.
+		await appendEvents(s.root, 5, 4);
+		const stale = verify(s, {
+			nowMs: Date.parse(r1.timestamp) - 60_000,
+			maxUnanchoredEvents: 2,
+		});
+		expect(stale.anchorState).toBe("ANCHOR_STALE");
+	});
+
+	it("20. anchors present, no trust material → ANCHOR_UNVERIFIABLE/no-trust-material; exit 0 default, 1 strict", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		const result = verify(s, { trust: undefined });
+		expect(result.anchorState).toBe("ANCHOR_UNVERIFIABLE");
+		expect(result.anchoring.reasons).toContain("no-trust-material");
+		expect(result.valid).toBe(true);
+		expect(exitCodeForAnchored(result, {})).toBe(0);
+		expect(exitCodeForAnchored(result, { requireAnchor: true })).toBe(1);
+	});
+
+	it("21. legacy vault, no anchors anywhere → UNANCHORED; exit 0 default, 1 strict (AC-4.1)", async () => {
+		const root = (await import("./fixtures.js")).tmp("anchor-legacy-");
+		await appendEvents(root, 3);
+		const { verifyVaultWithAnchors } = await import("../../../src/audit/verify.js");
+		const { VAULT_DIR } = await import("../../../src/shared/constants.js");
+		const result = verifyVaultWithAnchors(join(root, VAULT_DIR));
+		expect(result.anchorState).toBe("UNANCHORED");
+		expect(result.valid).toBe(true);
+		expect(exitCodeForAnchored(result, {})).toBe(0);
+		expect(exitCodeForAnchored(result, { requireAnchor: true })).toBe(1);
+	});
+
+	it("22. witness unreachable → ANCHOR_UNVERIFIABLE/witness-unreachable; NEVER ANCHORED_VERIFIED from the mirror (AC-2.4)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		// Mirror intact + trust supplied — without the witness rule this would
+		// be mirror-only ANCHORED_VERIFIED. The failed fetch caps it.
+		const result = verify(s, {
+			external: [],
+			witness: { requested: true, ok: false, error: "ECONNREFUSED" },
+		});
+		expect(result.anchorState).toBe("ANCHOR_UNVERIFIABLE");
+		expect(result.anchoring.reasons).toContain("witness-unreachable");
+		expect(result.anchoring.witness.status).toBe("unreachable");
+		expect(result.valid).toBe(true);
+		expect(exitCodeForAnchored(result, {})).toBe(0);
+		expect(exitCodeForAnchored(result, { requireAnchor: true })).toBe(1);
+	});
+
+	it("23. witness disagrees: fetched record contradicts the vault → ANCHOR_MISMATCH, always exit 1", async () => {
+		const s = await makeAnchoredVault(4);
+		const r1 = await anchorOnce(s);
+		const { sig: _sig, ...payload } = r1;
+		const contradicting = signRecord(
+			{
+				...payload,
+				merkleRoot: computeRoot(s, 2),
+				treeSize: 2,
+				lastHash: (await import("../../../src/audit/anchor-verify.js")).gatherOrderedEventHashes(
+					s.vaultPath,
+				)[1] as string,
+			},
+			s.keyFile,
+		);
+		const result = verify(s, {
+			external: [canonicalize(contradicting)],
+			witness: { requested: true, ok: true },
+		});
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.witness.status).toBe("disagrees");
+		expect(exitCodeForAnchored(result, {})).toBe(1);
+	});
+});
+
+describe("HARDEN: anchoring corpus — rotation (rows 24-28)", () => {
+	it("24. records after a rotation still signed by the superseded key → ANCHOR_MISMATCH/rotation-continuity", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		await rotateOnce(s);
+		await appendEvents(s.root, 1, 5);
+		const rotation = storeRecords(s).at(-1) as NonNullable<ReturnType<typeof storeRecords>[0]>;
+		// Old key signs a post-rotation record (keyId still the OLD key's).
+		const stale = signRecord({ ...nextPayload(s, rotation), keyId: rotation.keyId }, s.keyFile);
+		const result = verify(s, { external: [`${storeRaw(s)}${canonicalize(stale)}\n`] });
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("rotation-continuity");
+	});
+
+	it("25. genesis under a successor pin instead of the root → ANCHOR_MISMATCH (valid sig, wrong position)", async () => {
+		const s = await makeAnchoredVault(3);
+		const other = await makeAnchoredVault(3);
+		// "Successor" key = other vault's key, supplied as a pin. A history
+		// rooted at the PIN (not the root) must not verify from genesis.
+		const otherPub = pubPemFromKeyFile(other.keyFile);
+		const foreignSigned = await anchorOnce(other);
+		const rewritten = {
+			...foreignSigned,
+			vaultId: storeRecords(s)[0]?.vaultId ?? foreignSigned.vaultId,
+		};
+		void rewritten;
+		// Simplest concrete form: vault s's genesis anchor re-signed by the
+		// pin key (attacker compromised an old successor pin).
+		const real = await anchorOnce(s);
+		const { sig: _s2, ...payload } = real;
+		const { keyIdFromKeyObject, publicKeyFromPem } = await import(
+			"../../../src/audit/anchor-verify.js"
+		);
+		const pinKeyId = keyIdFromKeyObject(
+			publicKeyFromPem(otherPub) as NonNullable<ReturnType<typeof publicKeyFromPem>>,
+		);
+		const resigned = signRecord({ ...payload, keyId: pinKeyId }, other.keyFile);
+		writeFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "");
+		const result = verify(s, {
+			external: [canonicalize(resigned)],
+			trust: { rootPem: s.rootPem, successorPinsPem: [otherPub] },
+		});
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("rotation-continuity");
+	});
+
+	it("26. rotation hijack with pins supplied: rotation to an unpinned key → ANCHOR_MISMATCH/rotation-unpinned", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		const attacker = await rotateOnce(s); // rotation to a key the auditor did NOT pin
+		void attacker;
+		const legit = await makeAnchoredVault(1); // unrelated key the auditor pinned
+		const result = verify(s, {
+			trust: { rootPem: s.rootPem, successorPinsPem: [pubPemFromKeyFile(legit.keyFile)] },
+		});
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("rotation-unpinned");
+	});
+
+	it("27. rotation without pins: accepted + prominent rotation-unpinned warning; successor chain verifies", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		const successor = await rotateOnce(s);
+		await appendEvents(s.root, 1, 5);
+		await anchorOnce(s, successor.keyFile);
+
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.warnings).toContain("rotation-unpinned");
+
+		// With the successor properly pinned: clean pass, no warning.
+		const pinned = verify(s, {
+			trust: { rootPem: s.rootPem, successorPinsPem: [successor.publicKeyPem] },
+		});
+		expect(pinned.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(pinned.anchoring.warnings).not.toContain("rotation-unpinned");
+	});
+
+	it("28. competing rotations extending the same predecessor → ANCHOR_MISMATCH/fork", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const attacker = await makeAnchoredVault(1);
+		const attackerSpki = (await import("node:crypto"))
+			.createPublicKey(
+				(await import("node:crypto")).createPrivateKey(
+					(await import("node:fs")).readFileSync(attacker.keyFile, "utf-8"),
+				),
+			)
+			.export({ type: "spki", format: "der" }) as Buffer;
+		const { keyIdFromSpkiDer } = await import("../../../src/audit/anchor-verify.js");
+		const rotA = signRecord(
+			{
+				...nextPayload(s, r1),
+				rotation: {
+					nextKeyId: keyIdFromSpkiDer(attackerSpki),
+					nextPublicKeySpki: attackerSpki.toString("base64"),
+				},
+			},
+			s.keyFile,
+		);
+		const legit = await mintKeyFor(s);
+		const rotB = signRecord(
+			{
+				...nextPayload(s, r1),
+				timestamp: new Date(Date.now() + 1000).toISOString(),
+				rotation: legit,
+			},
+			s.keyFile,
+		);
+		const result = verify(s, {
+			external: [`${canonicalize(r1)}\n${canonicalize(rotA)}\n${canonicalize(rotB)}\n`],
+		});
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("fork");
+	});
+});
+
+async function mintKeyFor(s: Awaited<ReturnType<typeof makeAnchoredVault>>): Promise<{
+	nextKeyId: string;
+	nextPublicKeySpki: string;
+}> {
+	const { readAnchorIdentity, mintSuccessorKey } = await import("../../../src/audit/anchor.js");
+	const identity = readAnchorIdentity(s.root);
+	if (identity === null) throw new Error("no identity");
+	const k = mintSuccessorKey(identity.vaultId);
+	return { nextKeyId: k.keyId, nextPublicKeySpki: k.publicKeySpki };
+}
+
+describe("HARDEN: anchoring corpus — strict gates + happy paths (rows 29-30)", () => {
+	it("29. mirror-only + --require-external-anchor → exit 1 (state stays ANCHORED_VERIFIED)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		const result = verify(s, { external: [] });
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.anchorSource).toBe("vault-mirror");
+		expect(exitCodeForAnchored(result, {})).toBe(0);
+		expect(exitCodeForAnchored(result, { requireExternalAnchor: true })).toBe(1);
+	});
+
+	it("30. happy paths: single anchor / full history / grown chain / post-rotation keyring → ANCHORED_VERIFIED", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 3, 4);
+		await anchorOnce(s);
+
+		// Full history.
+		const full = verify(s);
+		expect(full.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(full.anchoring.anchorSource).toBe("external");
+		expect(full.valid).toBe(true);
+		expect(exitCodeForAnchored(full, { requireAnchor: true, requireExternalAnchor: true })).toBe(0);
+
+		// Single latest checkpoint (mirror supplies linkage).
+		const latest = storeRecords(s).at(-1) as NonNullable<ReturnType<typeof storeRecords>[0]>;
+		const single = verify(s, { external: [canonicalize(latest)] });
+		expect(single.anchorState).toBe("ANCHORED_VERIFIED");
+
+		// Grown chain: unanchored tail reported, consistency binding holds.
+		await appendEvents(s.root, 2, 7);
+		const grown = verify(s);
+		expect(grown.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(grown.anchoring.unanchoredTail.events).toBe(2);
+
+		// Anchored --tx receipt renders the honest INCLUSION line.
+		const tx = pkgVerifyTransaction(s.vaultPath, "tr_2", {
+			externalAnchorsRaw: [storeRaw(s)],
+			trust: s.trust,
+			witness: { requested: false },
+		});
+		expect(tx.valid).toBe(true);
+		expect(tx.receipt).toContain("INCLUSION VERIFIED (anchor #");
+
+		// Tail event: honest label, never "verified".
+		const tail = pkgVerifyTransaction(s.vaultPath, "tr_8", {
+			externalAnchorsRaw: [storeRaw(s)],
+			trust: s.trust,
+			witness: { requested: false },
+		});
+		expect(tail.receipt).toContain("IN UNANCHORED TAIL");
+		expect(tail.receipt).not.toContain("INCLUSION VERIFIED");
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-differential.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-differential.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — ANCHOR DIFFERENTIAL. The core verifier and the zero-dep verify
+ * package must return identical anchor verdicts for the same vault + trust
+ * inputs — the anchoring extension of the existing differential guarantee
+ * (any change to the anchor record format / state machine must land in BOTH
+ * packages or this test breaks).
+ */
+
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	type AnchorVerifyParams as PkgParams,
+	verifyVaultWithAnchors as pkgVerify,
+} from "../../../../verify/src/index.js";
+import {
+	type AnchorVerifyParams as CoreParams,
+	verifyVaultWithAnchors as coreVerify,
+} from "../../../src/audit/verify.js";
+import {
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	mutateAndRechain,
+	storeRaw,
+} from "./fixtures.js";
+
+afterEach(() => {
+	cleanupAll();
+});
+
+function verdict(result: {
+	valid: boolean;
+	anchorState: string;
+	anchoring: {
+		reasons: string[];
+		warnings: string[];
+		anchorCount: number;
+		anchorSource: string;
+		unanchoredTail: { events: number };
+	};
+	chainLength: number;
+}): string {
+	return JSON.stringify({
+		valid: result.valid,
+		anchorState: result.anchorState,
+		reasons: [...result.anchoring.reasons].sort(),
+		warnings: [...result.anchoring.warnings].sort(),
+		anchorCount: result.anchoring.anchorCount,
+		anchorSource: result.anchoring.anchorSource,
+		tail: result.anchoring.unanchoredTail.events,
+		chainLength: result.chainLength,
+	});
+}
+
+function assertAgree(vaultPath: string, params: CoreParams & PkgParams): string {
+	const core = coreVerify(vaultPath, params);
+	const pkg = pkgVerify(vaultPath, params);
+	expect(verdict(core)).toBe(verdict(pkg));
+	return core.anchorState;
+}
+
+describe("HARDEN: core vs verify pkg produce identical ANCHOR verdicts", () => {
+	it("agrees across the state machine: verified / stale / unverifiable / mismatch / deletion / unanchored", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 3, 4);
+		await anchorOnce(s);
+
+		const base = { externalAnchorsRaw: [storeRaw(s)], trust: s.trust };
+
+		// 1. Happy path.
+		expect(assertAgree(s.vaultPath, base)).toBe("ANCHORED_VERIFIED");
+
+		// 2. Stale under a caller-supplied freshness policy.
+		await appendEvents(s.root, 4, 7);
+		expect(assertAgree(s.vaultPath, { ...base, maxUnanchoredEvents: 1 })).toBe("ANCHOR_STALE");
+
+		// 3. Unverifiable: artifacts, no trust.
+		expect(assertAgree(s.vaultPath, { externalAnchorsRaw: [storeRaw(s)] })).toBe(
+			"ANCHOR_UNVERIFIABLE",
+		);
+
+		// 4. Witness unreachable cap.
+		expect(
+			assertAgree(s.vaultPath, {
+				...base,
+				witness: { requested: true, ok: false, error: "timeout" },
+			}),
+		).toBe("ANCHOR_UNVERIFIABLE");
+
+		// 5. F1-style mutation + full re-chain.
+		mutateAndRechain(s, 1);
+		expect(assertAgree(s.vaultPath, base)).toBe("ANCHOR_MISMATCH");
+
+		// 6. Whole-vault deletion (F2).
+		rmSync(join(s.vaultPath, "audit"), { recursive: true, force: true });
+		expect(assertAgree(s.vaultPath, base)).toBe("ANCHOR_MISMATCH");
+
+		// 7. Legacy: nothing anchor-related at all.
+		const legacy = await makeAnchoredVault(2); // identity exists but no anchors emitted...
+		rmSync(join(legacy.vaultPath, "audit", "anchors"), { recursive: true, force: true });
+		expect(assertAgree(legacy.vaultPath, {})).toBe("UNANCHORED");
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-emitter-hardening.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-emitter-hardening.test.ts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — EMITTER ROBUSTNESS regressions for the implementation review
+ * findings (scheduler crash, outbox redelivery, corrupt/emptied-mirror guard,
+ * signer epoch guard). These are honest-operator failure modes that would
+ * otherwise silently poison the append-only store or crash the host process.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseAnchorsContent } from "../../../src/audit/anchor-verify.js";
+import {
+	type AnchorSink,
+	createAnchorEmitter,
+	initAnchorIdentity,
+	readAnchorIdentity,
+} from "../../../src/audit/anchor.js";
+import {
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	storeRecords,
+	tmp,
+} from "./fixtures.js";
+
+afterEach(() => {
+	cleanupAll();
+});
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("HARDEN: emitter — scheduler never crashes the host process (blocker)", () => {
+	it("a rejecting signer in the scheduler surfaces as degraded+lastEmitError, not an unhandled rejection", async () => {
+		const root = tmp("emit-crash-");
+		await appendEvents(root, 3);
+		// External signer whose sign() always rejects (simulated KMS outage).
+		const { publicKeySpki, keyId } = mintExternalIdentity(root);
+		const emitter = createAnchorEmitter(root, {
+			signer: {
+				type: "external",
+				keyId,
+				publicKeySpki,
+				sign: () => Promise.reject(new Error("KMS unavailable")),
+			},
+			cadence: { everyMs: 1, everyEvents: 1 },
+			sinks: [],
+		});
+
+		const rejections: unknown[] = [];
+		const onRejection = (err: unknown) => rejections.push(err);
+		process.on("unhandledRejection", onRejection);
+		try {
+			emitter.start();
+			// The scheduler's internal interval is clamped to a 250ms floor;
+			// wait past it so at least one tick fires and rejects.
+			await sleep(600);
+			await emitter.stop();
+			await sleep(50);
+		} finally {
+			process.off("unhandledRejection", onRejection);
+		}
+
+		expect(rejections).toEqual([]);
+		const status = emitter.status();
+		expect(status.degraded).toBe(true);
+		expect(status.lastEmitError).toContain("KMS unavailable");
+	});
+});
+
+describe("HARDEN: emitter — outbox redelivery (no permanent store gaps)", () => {
+	it("a stranded record is republished on the next cycle; store history has no anchorSeq gap", async () => {
+		const s = await makeAnchoredVault(3);
+		let failNext = true;
+		const flaky: AnchorSink = {
+			name: "flaky",
+			publish: async (record) => {
+				if (failNext) {
+					failNext = false;
+					throw new Error("sink down");
+				}
+				const line = `${JSON.stringify(record)}\n`;
+				const { appendFileSync } = await import("node:fs");
+				appendFileSync(s.storeFile, line);
+			},
+		};
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [flaky],
+			publishRetries: 1,
+		});
+		const r1 = await emitter.anchorNow(); // publish of #1 fails → stranded in outbox
+		expect(r1.emitted).toBe(true);
+		await emitter.stop();
+		expect(emitter.status().outboxDepth).toBe(1);
+		expect(emitter.status().degraded).toBe(true);
+
+		await appendEvents(s.root, 2, 4);
+		const r2 = await emitter.anchorNow(); // drains #1 then publishes #2
+		expect(r2.emitted).toBe(true);
+		await emitter.stop();
+
+		const stored = parseAnchorsContent(readFileSync(s.storeFile, "utf-8")).records.sort(
+			(a, b) => a.anchorSeq - b.anchorSeq,
+		);
+		expect(stored.map((r) => r.anchorSeq)).toEqual([1, 2]); // no gap
+		expect(emitter.status().outboxDepth).toBe(0);
+		expect(emitter.status().degraded).toBe(false);
+	});
+});
+
+describe("HARDEN: emitter — mirror-loss guards (no permanent fork evidence)", () => {
+	it("emptied-but-present mirror refuses to re-mint a GENESIS anchorSeq 1 (durable high-water)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s); // mirror + identity high-water now at seq 1
+		const mirrorPath = join(s.vaultPath, "audit", "anchors", "anchors.jsonl");
+		writeFileSync(mirrorPath, ""); // accidental truncation / bad restore
+		await appendEvents(s.root, 2, 4);
+
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const result = await emitter.anchorNow();
+		await emitter.stop();
+		expect(result.emitted).toBe(false);
+		expect(result.reason).toMatch(/mirror-behind-highwater/);
+		// The store still holds exactly one record (no divergent second seq 1).
+		expect(storeRecords(s).map((r) => r.anchorSeq)).toEqual([1]);
+	});
+
+	it("corrupt-but-present mirror refuses to emit", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		const mirrorPath = join(s.vaultPath, "audit", "anchors", "anchors.jsonl");
+		writeFileSync(mirrorPath, "{ not json\n");
+		await appendEvents(s.root, 2, 4);
+
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const result = await emitter.anchorNow();
+		await emitter.stop();
+		expect(result.emitted).toBe(false);
+		expect(result.reason).toMatch(/mirror-corrupt/);
+	});
+});
+
+describe("HARDEN: emitter — signer epoch guard", () => {
+	it("anchoring with a superseded key after rotation refuses (stale-signer-key)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		// Rotate to a fresh key.
+		const { mintSuccessorKey, recordRotatedIdentity } = await import(
+			"../../../src/audit/anchor.js"
+		);
+		const identity = readAnchorIdentity(s.root);
+		if (identity === null) throw new Error("no identity");
+		const successor = mintSuccessorKey(identity.vaultId);
+		const rotator = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const rot = await rotator.rotate({
+			keyId: successor.keyId,
+			publicKeySpki: successor.publicKeySpki,
+		});
+		await rotator.stop();
+		expect(rot.emitted).toBe(true);
+		recordRotatedIdentity(s.root, {
+			keyId: successor.keyId,
+			publicKeySpki: successor.publicKeySpki,
+		});
+		await appendEvents(s.root, 1, 5);
+
+		// The old key is still at s.keyFile; a cron `anchor now` resolving it
+		// must refuse rather than mint permanent rotation-continuity evidence.
+		const stale = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const result = await stale.anchorNow();
+		await stale.stop();
+		expect(result.emitted).toBe(false);
+		expect(result.reason).toMatch(/stale-signer-key/);
+
+		// The successor key emits cleanly.
+		const good = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: successor.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const ok = await good.anchorNow();
+		await good.stop();
+		expect(ok.emitted).toBe(true);
+	});
+});
+
+/** Mint an identity whose key is an external (non-file) signer for crash tests. */
+function mintExternalIdentity(root: string): { publicKeySpki: string; keyId: string } {
+	const store = tmp("emit-extkey-");
+	const keyFile = join(store, "k.pem");
+	const { identity } = initAnchorIdentity(root, { keyFile });
+	return { publicKeySpki: identity.publicKeySpki, keyId: identity.keyId };
+}

--- a/packages/core/tests/harden/anchoring/anchor-review-regressions.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-review-regressions.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — VERIFIER/GLUE/CLI regressions for the implementation review
+ * findings: signature-blind dedup (order-dependent verdict), post-rotation
+ * --tx inclusion, lone-checkpoint false-mismatch, witness empty-body bypass,
+ * and the result-shape contract (unanchoredTail.sinceTimestampMs).
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyTransaction as pkgVerifyTransaction } from "../../../../verify/src/index.js";
+import { canonicalize } from "../../../src/audit/canonical.js";
+import {
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	rotateOnce,
+	signRecord,
+	storeRaw,
+	storeRecords,
+	verify,
+} from "./fixtures.js";
+
+afterEach(() => {
+	cleanupAll();
+});
+
+describe("HARDEN: benign-duplicate dedup is signature-checked (order-independent)", () => {
+	it("a committed-equal twin with a BAD signature is ANCHOR_INVALID regardless of record order", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const { sig: _sig, ...payload } = r1;
+		// Same committed content, different timestamp, GARBAGE signature.
+		const badTwin = {
+			...payload,
+			timestamp: new Date(Date.parse(r1.timestamp) + 1000).toISOString(),
+			sig: Buffer.from("not-a-valid-signature").toString("base64"),
+		};
+		// Order A: valid first, bad twin second.
+		const a = verify(s, { external: [`${canonicalize(r1)}\n${canonicalize(badTwin)}\n`] });
+		expect(a.anchorState).toBe("ANCHOR_INVALID");
+		expect(a.anchoring.reasons).toContain("sig-invalid");
+		// Order B: bad twin first, valid second — verdict must not flip.
+		const b = verify(s, { external: [`${canonicalize(badTwin)}\n${canonicalize(r1)}\n`] });
+		expect(b.anchorState).toBe("ANCHOR_INVALID");
+		expect(b.anchoring.reasons).toContain("sig-invalid");
+	});
+
+	it("a committed-equal twin with a VALID signature stays a benign duplicate", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const { sig: _sig, ...payload } = r1;
+		const goodTwin = signRecord(
+			{ ...payload, timestamp: new Date(Date.parse(r1.timestamp) + 1000).toISOString() },
+			s.keyFile,
+		);
+		const result = verify(s, { external: [`${canonicalize(r1)}\n${canonicalize(goodTwin)}\n`] });
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.warnings).toContain("duplicate-anchor");
+	});
+});
+
+describe("HARDEN: post-rotation --tx inclusion (no false INCLUSION FAILED)", () => {
+	it("an event covered only by a post-rotation anchor verifies with root-key trust alone", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		const successor = await rotateOnce(s);
+		await appendEvents(s.root, 2, 5); // events 5,6 under the new epoch
+		await anchorOnce(s, successor.keyFile); // covers up to treeSize 6
+
+		// Vault verdict is ANCHORED_VERIFIED with only the root pinned (§6/row 27).
+		const vault = verify(s);
+		expect(vault.anchorState).toBe("ANCHORED_VERIFIED");
+
+		// A tx in the post-rotation region must NOT report INCLUSION FAILED just
+		// because its covering anchor was signed by the in-chain successor key.
+		const tx = pkgVerifyTransaction(s.vaultPath, "tr_5", {
+			externalAnchorsRaw: [storeRaw(s)],
+			trust: s.trust, // root only — no successor pin supplied
+			witness: { requested: false },
+		});
+		expect(tx.valid).toBe(true);
+		expect(tx.receipt).toContain("INCLUSION VERIFIED (anchor #");
+	});
+});
+
+describe("HARDEN: lone external checkpoint (partial history, not tampered)", () => {
+	it("a single anchorSeq>1 checkpoint with no mirror is ANCHORED_VERIFIED + partial-history warning", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 2, 4);
+		await anchorOnce(s);
+		const latest = storeRecords(s).at(-1) as NonNullable<ReturnType<typeof storeRecords>[0]>;
+		expect(latest.anchorSeq).toBe(2);
+		// Wipe the mirror so no local linkage back to genesis is available.
+		writeFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "");
+
+		const result = verify(s, { external: [canonicalize(latest)] });
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.warnings).toContain("partial-history");
+		expect(result.valid).toBe(true);
+	});
+
+	it("a GAP between two present records is still a hard ANCHOR_MISMATCH", async () => {
+		const s = await makeAnchoredVault(2);
+		await anchorOnce(s);
+		await appendEvents(s.root, 2, 3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 2, 5);
+		await anchorOnce(s);
+		const recs = storeRecords(s);
+		const gapped = [recs[0], recs[2]].map((r) => canonicalize(r as object)).join("\n");
+		writeFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "");
+		const result = verify(s, { external: [gapped] });
+		expect(result.anchorState).toBe("ANCHOR_MISMATCH");
+		expect(result.anchoring.reasons).toContain("anchor-chain-gap");
+	});
+});
+
+describe("HARDEN: witness external-source gating (AC-2.4 defense in depth)", () => {
+	it("witnessOk with zero parsed external records does not launder mirror into anchorSource=external", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		// Simulate a 200-empty-body witness: witness.ok true but no external
+		// records supplied. Mirror is intact and valid.
+		const result = verify(s, {
+			external: [],
+			witness: { requested: true, ok: true },
+		});
+		expect(result.anchoring.anchorSource).toBe("vault-mirror");
+	});
+});
+
+describe("HARDEN: result-shape contract (spec §7.3)", () => {
+	it("unanchoredTail exposes sinceTimestampMs as a number|null, not an ISO string", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const result = verify(s);
+		const tail = result.anchoring.unanchoredTail as unknown as Record<string, unknown>;
+		expect("sinceTimestampMs" in tail).toBe(true);
+		expect("sinceTimestamp" in tail).toBe(false);
+		expect(typeof result.anchoring.unanchoredTail.sinceTimestampMs).toBe("number");
+		expect(result.anchoring.unanchoredTail.sinceTimestampMs).toBe(Date.parse(r1.timestamp));
+	});
+});
+
+// touch: keep readFileSync imported for potential future fixtures
+void readFileSync;

--- a/packages/core/tests/harden/anchoring/anchor-unit.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-unit.test.ts
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Unit coverage for emitter/verifier helpers not exercised by the adversarial
+ * corpus: signer resolution, sink construction, identity/resume error paths,
+ * legacy-vault snapshots, the scheduler happy path, and the alg-agile
+ * signature helper (spec reconciliation R2 — ECDSA P-256 for Phase 2).
+ */
+
+import {
+	createPrivateKey,
+	createPublicKey,
+	sign as cryptoSign,
+	generateKeyPairSync,
+} from "node:crypto";
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	keyIdFromKeyObject,
+	publicKeyFromPem,
+	publicKeyFromSpkiBase64,
+	verifySignatureRaw,
+} from "../../../src/audit/anchor-verify.js";
+import {
+	createAnchorEmitter,
+	createSink,
+	defaultKeyPath,
+	initAnchorIdentity,
+	mintSuccessorKey,
+	readAnchorIdentity,
+	resolveSigner,
+	resumeAnchorMirror,
+} from "../../../src/audit/anchor.js";
+import { canonicalize } from "../../../src/audit/canonical.js";
+import { VAULT_DIR } from "../../../src/shared/constants.js";
+import {
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	storeRecords,
+	tmp,
+} from "./fixtures.js";
+
+afterEach(() => {
+	// vi.stubEnv/unstubAllEnvs actually REMOVE the vars again — a plain
+	// `process.env.X = undefined` would store the string "undefined" and
+	// poison later signer resolution.
+	vi.unstubAllEnvs();
+	cleanupAll();
+});
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("resolveSigner", () => {
+	function pemPair(): { privatePem: string; keyId: string } {
+		const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+		return {
+			privatePem: privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+			keyId: keyIdFromKeyObject(publicKey),
+		};
+	}
+
+	it("resolves an inline PEM from the default env var", async () => {
+		const { privatePem, keyId } = pemPair();
+		vi.stubEnv("USERTRUST_ANCHOR_KEY", privatePem);
+		const signer = resolveSigner({ type: "pem" });
+		expect(signer.keyId).toBe(keyId);
+		const sig = await signer.sign("payload");
+		expect(Buffer.from(sig, "base64").length).toBe(64);
+	});
+
+	it("resolves a key-file path from a custom env var", () => {
+		const { privatePem, keyId } = pemPair();
+		const dir = tmp("signer-env-");
+		const file = join(dir, "k.pem");
+		writeFileSync(file, privatePem);
+		vi.stubEnv("TEST_ANCHOR_KEY_ALT", file);
+		const signer = resolveSigner({ type: "pem", env: "TEST_ANCHOR_KEY_ALT" });
+		expect(signer.keyId).toBe(keyId);
+	});
+
+	it("throws a helpful error when no key source exists", () => {
+		vi.stubEnv("USERTRUST_ANCHOR_KEY", undefined);
+		expect(() => resolveSigner({ type: "pem" })).toThrow(/USERTRUST_ANCHOR_KEY/);
+	});
+
+	it("external signer: keyId must match its publicKeySpki (defense against misconfig)", async () => {
+		const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+		const spki = (publicKey.export({ type: "spki", format: "der" }) as Buffer).toString("base64");
+		const keyId = keyIdFromKeyObject(publicKey);
+		expect(() =>
+			resolveSigner({
+				type: "external",
+				keyId: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+				publicKeySpki: spki,
+				sign: () => Promise.resolve(new Uint8Array(64)),
+			}),
+		).toThrow(/does not match/);
+
+		const ok = resolveSigner({
+			type: "external",
+			keyId,
+			publicKeySpki: spki,
+			sign: (pre) => Promise.resolve(cryptoSign(null, Buffer.from(pre), privateKey)),
+		});
+		expect(ok.keyId).toBe(keyId);
+		const sig = await ok.sign("data");
+		expect(verifySignatureRaw("ed25519", "data", publicKey, sig)).toBe(true);
+	});
+});
+
+describe("sinks", () => {
+	it("command sink pipes the canonical record to stdin and honors exit codes", async () => {
+		const s = await makeAnchoredVault(2);
+		const r1 = await anchorOnce(s);
+		const dir = tmp("cmd-sink-");
+		const out = join(dir, "out.jsonl");
+		const okSink = createSink({ type: "command", argv: ["/bin/sh", "-c", `cat >> ${out}`] });
+		await okSink.publish(r1);
+		expect(readFileSync(out, "utf-8").trim()).toBe(canonicalize(r1));
+
+		const failSink = createSink({ type: "command", argv: ["/bin/sh", "-c", "exit 3"] });
+		await expect(failSink.publish(r1)).rejects.toThrow(/exited 3/);
+
+		// A command that exits 0 WITHOUT reading stdin must still resolve —
+		// the stdin EPIPE is a symptom, never the verdict (and never an
+		// unhandled error).
+		const earlyExit = createSink({ type: "command", argv: ["/bin/sh", "-c", "exit 0"] });
+		await earlyExit.publish(r1);
+
+		const emptySink = createSink({ type: "command", argv: [] });
+		await expect(emptySink.publish(r1)).rejects.toThrow(/empty argv/);
+	});
+
+	it("file sink appends canonical lines", async () => {
+		const s = await makeAnchoredVault(2);
+		const r1 = await anchorOnce(s);
+		const dir = tmp("file-sink-");
+		const out = join(dir, "a.jsonl");
+		const sink = createSink({ type: "file", path: out });
+		await sink.publish(r1);
+		await sink.publish(r1);
+		expect(readFileSync(out, "utf-8").trim().split("\n").length).toBe(2);
+	});
+});
+
+describe("identity / resume", () => {
+	it("init refuses a second identity and a key path inside the vault", async () => {
+		const s = await makeAnchoredVault(1);
+		expect(() => initAnchorIdentity(s.root)).toThrow(/already exists/);
+		const fresh = tmp("init-invault-");
+		await appendEvents(fresh, 1);
+		expect(() => initAnchorIdentity(fresh, { keyFile: join(fresh, VAULT_DIR, "k.pem") })).toThrow(
+			/inside the vault/,
+		);
+	});
+
+	it("readAnchorIdentity returns null for corrupt identity.json", async () => {
+		const s = await makeAnchoredVault(1);
+		writeFileSync(join(s.vaultPath, "audit", "anchors", "identity.json"), "{corrupt");
+		expect(readAnchorIdentity(s.root)).toBeNull();
+	});
+
+	it("defaultKeyPath is namespaced by vaultId", () => {
+		expect(defaultKeyPath("abc")).toMatch(/abc\.anchor\.pem$/);
+	});
+
+	it("resume validates the supplied record and re-seeds the mirror tail", async () => {
+		const s = await makeAnchoredVault(2);
+		const r1 = await anchorOnce(s);
+		expect(() => resumeAnchorMirror(s.root, "{nope")).toThrow(/invalid/);
+		const other = await makeAnchoredVault(1);
+		const foreign = await anchorOnce(other);
+		expect(() => resumeAnchorMirror(s.root, canonicalize(foreign))).toThrow(/vaultId/);
+		expect(() => resumeAnchorMirror(s.root, canonicalize(r1))).toThrow(/already at anchorSeq/);
+
+		// Simulate mirror loss, then re-seed from the store's newest record.
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		const seeded = resumeAnchorMirror(s.root, canonicalize(r1));
+		expect(seeded.anchorSeq).toBe(1);
+		// Emission resumes cleanly after re-seeding.
+		await appendEvents(s.root, 1, 3);
+		const r2 = await anchorOnce(s);
+		expect(r2.anchorSeq).toBe(2);
+	});
+
+	it("mintSuccessorKey writes the new private key outside the vault", () => {
+		const successor = mintSuccessorKey("some-vault");
+		expect(successor.keyId).toMatch(/^sha256:/);
+		const priv = createPrivateKey(readFileSync(successor.keyFile, "utf-8"));
+		expect(keyIdFromKeyObject(createPublicKey(priv))).toBe(successor.keyId);
+		unlinkSync(successor.keyFile);
+	});
+});
+
+describe("emitter edge paths", () => {
+	it("legacy vault without .meta anchors from the ordered segment tail", async () => {
+		const s = await makeAnchoredVault(3);
+		unlinkSync(join(s.vaultPath, "audit", "events.jsonl.meta"));
+		const r1 = await anchorOnce(s);
+		expect(r1.treeSize).toBe(3);
+	});
+
+	it("empty vault is a no-op; rotate on an empty vault refuses", async () => {
+		const root = tmp("empty-vault-");
+		const store = tmp("empty-store-");
+		const keyFile = join(store, "k.pem");
+		initAnchorIdentity(root, { keyFile });
+		const emitter = createAnchorEmitter(root, { signer: { type: "pem", file: keyFile } });
+		const result = await emitter.anchorNow();
+		expect(result.emitted).toBe(false);
+		expect(result.reason).toBe("empty");
+		await emitter.stop();
+	});
+
+	it("unreadable .meta (zero-length) skips the cycle after retries", async () => {
+		const s = await makeAnchoredVault(2);
+		writeFileSync(join(s.vaultPath, "audit", "events.jsonl.meta"), "");
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+		});
+		const result = await emitter.anchorNow();
+		await emitter.stop();
+		expect(result.emitted).toBe(false);
+		expect(result.reason).toBe("snapshot-unstable");
+		expect(emitter.status().anchorSkips).toBeGreaterThan(0);
+	});
+
+	it("scheduler emits on the everyEvents trigger and stop() is idempotent", async () => {
+		const s = await makeAnchoredVault(3);
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+			// The internal tick interval is max(250, min(everyMs, 5000)) — keep
+			// everyMs small so a tick fires within the test window.
+			cadence: { everyEvents: 1, everyMs: 300 },
+		});
+		emitter.start();
+		emitter.start(); // second start is a no-op
+		await sleep(900); // past the 250ms tick floor
+		await emitter.stop();
+		await emitter.stop();
+		expect(storeRecords(s).length).toBeGreaterThanOrEqual(1);
+		expect(emitter.exportSince(0).length).toBeGreaterThanOrEqual(1);
+		expect(emitter.exportSince(999)).toEqual([]);
+	});
+
+	it("no-sinks (pull mode) leaves no outbox residue; status reports the tail", async () => {
+		const s = await makeAnchoredVault(2);
+		const emitter = createAnchorEmitter(s.root, { signer: { type: "pem", file: s.keyFile } });
+		const r = await emitter.anchorNow();
+		await emitter.stop();
+		expect(r.emitted).toBe(true);
+		const status = emitter.status();
+		expect(status.outboxDepth).toBe(0);
+		expect(status.lastAnchor?.anchorSeq).toBe(1);
+		expect(status.eventsSinceLastAnchor).toBe(0);
+		expect(status.msSinceLastAnchor).not.toBeNull();
+	});
+});
+
+describe("verifySignatureRaw alg agility (R2)", () => {
+	it("verifies ECDSA P-256 (Phase 2 transparency-log checkpoints) and rejects garbage", () => {
+		const { publicKey, privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+		const data = "checkpoint body";
+		const sigDer = cryptoSign("sha256", Buffer.from(data), { key: privateKey, dsaEncoding: "der" });
+		expect(verifySignatureRaw("ecdsa-p256", data, publicKey, sigDer.toString("base64"))).toBe(true);
+		const sigP1363 = cryptoSign("sha256", Buffer.from(data), {
+			key: privateKey,
+			dsaEncoding: "ieee-p1363",
+		});
+		expect(verifySignatureRaw("ecdsa-p256", data, publicKey, sigP1363.toString("base64"))).toBe(
+			true,
+		);
+		expect(verifySignatureRaw("ecdsa-p256", "tampered", publicKey, sigDer.toString("base64"))).toBe(
+			false,
+		);
+		expect(verifySignatureRaw("ecdsa-p256", data, publicKey, "")).toBe(false);
+	});
+
+	it("key-parsing helpers fail closed on garbage", () => {
+		expect(publicKeyFromPem("not a pem")).toBeNull();
+		expect(publicKeyFromSpkiBase64("bm90IGEga2V5")).toBeNull();
+	});
+});
+
+describe("parseAnchorRecord strictness matrix (both packages)", () => {
+	it("rejects every malformed-field variant with a code-prefixed error, in core AND verify copies", async () => {
+		const { parseAnchorRecord: coreParse, verifyAnchorSignature } = await import(
+			"../../../src/audit/anchor-verify.js"
+		);
+		const { parseAnchorRecord: pkgParse } = await import("../../../../verify/src/index.js");
+		const s = await makeAnchoredVault(2);
+		const r1 = await anchorOnce(s);
+		const base = JSON.parse(canonicalize(r1)) as Record<string, unknown>;
+		const variants: [Record<string, unknown> | string, RegExp][] = [
+			["not json", /malformed-anchor/],
+			['["array"]', /malformed-anchor/],
+			[{ ...base, v: 2 }, /unsupported version/],
+			[{ ...base, vaultId: "" }, /vaultId/],
+			[{ ...base, prevAnchorHash: "xyz" }, /prevAnchorHash/],
+			[{ ...base, lastHash: "short" }, /lastHash/],
+			[{ ...base, merkleRoot: 42 }, /merkleRoot/],
+			[{ ...base, timestamp: "" }, /timestamp/],
+			[{ ...base, keyId: "md5:abc" }, /keyId/],
+			[{ ...base, sig: "" }, /sig/],
+			[{ ...base, rotation: "not-an-object" }, /rotation must be an object/],
+			[
+				{ ...base, rotation: { nextKeyId: r1.keyId, nextPublicKeySpki: "x", extra: 1 } },
+				/unknown rotation field/,
+			],
+			[{ ...base, rotation: { nextKeyId: "bad", nextPublicKeySpki: "aGk=" } }, /nextKeyId/],
+			[{ ...base, rotation: { nextKeyId: r1.keyId, nextPublicKeySpki: "" } }, /nextPublicKeySpki/],
+		];
+		for (const [variant, pattern] of variants) {
+			const raw = typeof variant === "string" ? variant : JSON.stringify(variant);
+			for (const parse of [coreParse, pkgParse]) {
+				const { record, error } = parse(raw);
+				expect(record, raw).toBeNull();
+				expect(error, raw).toMatch(pattern);
+			}
+		}
+		// A well-formed record still parses in both copies.
+		expect(coreParse(canonicalize(r1)).record).not.toBeNull();
+		expect(pkgParse(canonicalize(r1)).record).not.toBeNull();
+
+		// verifyAnchorSignature error paths: unparseable candidate, no keyId match.
+		const noMatch = verifyAnchorSignature(r1, ["-----BEGIN GARBAGE-----"]);
+		expect(noMatch.ok).toBe(false);
+		expect(noMatch.errors.join(" ")).toMatch(/no candidate key matches/);
+		const other = await makeAnchoredVault(1);
+		const wrongKey = verifyAnchorSignature(r1, [other.rootPem]);
+		expect(wrongKey.ok).toBe(false);
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-xreview-regressions.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-xreview-regressions.test.ts
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — regressions for the xhigh code-review findings on PR #51:
+ * CLI strict-gate fail-opens, adversarial timestamp/freshness bypasses,
+ * benign-twin linkage, post-rotation partial history, emitter crash-window
+ * self-heal, vault-behind guard, resume validation, snapshot/anchor
+ * isolation, key-path guard, and the DLQ NaN drop.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	parseAnchorRecord as pkgParseAnchorRecord,
+	verifyTransaction as pkgVerifyTransaction,
+} from "../../../../verify/src/index.js";
+import { anchorPayloadHash, parseAnchorRecord } from "../../../src/audit/anchor-verify.js";
+import {
+	createAnchorEmitter,
+	initAnchorIdentity,
+	readAnchorIdentity,
+	resumeAnchorMirror,
+} from "../../../src/audit/anchor.js";
+import { canonicalize } from "../../../src/audit/canonical.js";
+import { createAuditWriter } from "../../../src/audit/chain.js";
+import { exitCodeForAnchored } from "../../../src/audit/verify.js";
+import { run as verifyRun } from "../../../src/cli/verify.js";
+import { VAULT_DIR } from "../../../src/shared/constants.js";
+import { createSnapshot, restoreSnapshot } from "../../../src/snapshot/checkpoint.js";
+import {
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	nextPayload,
+	pubPemFromKeyFile,
+	rotateOnce,
+	signRecord,
+	storeRaw,
+	storeRecords,
+	tmp,
+	verify,
+} from "./fixtures.js";
+
+const origCwd = process.cwd();
+const origArgv = process.argv;
+
+afterEach(() => {
+	process.chdir(origCwd);
+	process.argv = origArgv;
+	process.exitCode = 0;
+	vi.restoreAllMocks();
+	cleanupAll();
+});
+
+describe("finding 0: --tx mode enforces strict gates", () => {
+	it("verifyTransaction exposes anchorState/anchoring so strict gates compose", async () => {
+		const s = await makeAnchoredVault(3);
+		// No anchors emitted, strict-gate params supplied.
+		const tx = pkgVerifyTransaction(s.vaultPath, "tr_2", {
+			externalAnchorsRaw: [],
+			trust: s.trust,
+			witness: { requested: false },
+		});
+		expect(tx.valid).toBe(true);
+		expect(tx.anchorState).toBe("UNANCHORED");
+		expect(tx.anchoring).toBeDefined();
+		const gate = exitCodeForAnchored(
+			{
+				valid: true,
+				anchorState: tx.anchorState as NonNullable<typeof tx.anchorState>,
+				anchoring: tx.anchoring as NonNullable<typeof tx.anchoring>,
+			},
+			{ requireExternalAnchor: true },
+		);
+		expect(gate).toBe(1);
+	});
+
+	it("CLI: --tx --require-external-anchor exits 1 on an unanchored vault (and 0 without the flag)", async () => {
+		const s = await makeAnchoredVault(3);
+		const repoRoot = join(import.meta.dirname, "..", "..", "..", "..", "..");
+		const cli = join(repoRoot, "packages", "verify", "src", "cli.ts");
+		const strict = spawnSync(
+			"npx",
+			["tsx", cli, s.vaultPath, "--tx", "tr_2", "--require-external-anchor"],
+			{ cwd: repoRoot, encoding: "utf-8" },
+		);
+		expect(strict.status).toBe(1);
+		const lax = spawnSync("npx", ["tsx", cli, s.vaultPath, "--tx", "tr_2"], {
+			cwd: repoRoot,
+			encoding: "utf-8",
+		});
+		expect(lax.status).toBe(0);
+	}, 30_000);
+});
+
+describe("finding 1/14: freshness-policy values fail loudly; global flags stay accepted", () => {
+	function captureLog(): { lines: string[]; restore: () => void } {
+		const lines: string[] = [];
+		const spy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+			lines.push(a.map(String).join(" "));
+		});
+		return { lines, restore: () => spy.mockRestore() };
+	}
+
+	it("typo'd --max-unanchored-events / --max-anchor-age exit 1 instead of silently disabling the gate", async () => {
+		const root = tmp("flags-");
+		await appendEvents(root, 2);
+		for (const argv of [
+			["--require-anchor", "--max-unanchored-events", "1O0"],
+			["--max-anchor-age", "15min"],
+		]) {
+			process.exitCode = 0;
+			process.argv = ["node", "usertrust", "verify", ...argv];
+			const { lines, restore } = captureLog();
+			try {
+				await verifyRun(root, { json: false });
+			} finally {
+				restore();
+			}
+			expect(lines.join("\n"), argv.join(" ")).toMatch(/Invalid --max/);
+			expect(process.exitCode, argv.join(" ")).toBe(1);
+		}
+	});
+
+	it("global flags (--skip-verify, --reconfigure) are not rejected", async () => {
+		const root = tmp("flags-global-");
+		await appendEvents(root, 2);
+		process.argv = ["node", "usertrust", "verify", "--skip-verify", "--reconfigure"];
+		const { lines, restore } = captureLog();
+		try {
+			await verifyRun(root, { json: false });
+		} finally {
+			restore();
+		}
+		expect(lines.join("\n")).not.toMatch(/Unknown flag/);
+		expect(process.exitCode).toBe(0);
+	});
+});
+
+describe("finding 2: relative --key-file cannot land the signing key inside the vault", () => {
+	it("initAnchorIdentity resolves the key path before the inside-vault guard", async () => {
+		const root = tmp("keyguard-");
+		await appendEvents(root, 1);
+		process.chdir(root);
+		expect(() => initAnchorIdentity(root, { keyFile: `${VAULT_DIR}/keys/anchor.pem` })).toThrow(
+			/inside the vault/,
+		);
+		expect(existsSync(join(root, VAULT_DIR, "keys", "anchor.pem"))).toBe(false);
+	});
+});
+
+describe("finding 3 (downstream): witness evidence with embedded garbage fails closed, not open", () => {
+	it("a body of valid records + one garbage line yields a FAIL state, never a silent pass", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		const body = `${storeRaw(s)}{garbage\n`;
+		const result = verify(s, { external: [body], witness: { requested: true, ok: true } });
+		expect(["ANCHOR_INVALID", "ANCHOR_MISMATCH"]).toContain(result.anchorState);
+		expect(result.valid).toBe(false);
+	});
+});
+
+describe("finding 4: signed-but-unparseable timestamps are rejected at parse", () => {
+	it("timestamp 'n/a' is malformed-anchor in BOTH packages (age gate cannot be defused)", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const doctored = { ...JSON.parse(canonicalize(r1)), timestamp: "n/a" };
+		for (const parse of [parseAnchorRecord, pkgParseAnchorRecord]) {
+			const { record, error } = parse(JSON.stringify(doctored));
+			expect(record).toBeNull();
+			expect(error).toMatch(/timestamp/);
+		}
+	});
+});
+
+describe("finding 5: benign committed-equal twins do not break successor linkage", () => {
+	it("a successor linking to the DROPPED twin still verifies (order-independent)", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const { sig: _s1, ...p1 } = r1;
+		const twin = signRecord(
+			{ ...p1, timestamp: new Date(Date.parse(r1.timestamp) + 1000).toISOString() },
+			s.keyFile,
+		);
+		await appendEvents(s.root, 2, 4);
+		// Successor minted against the TWIN as predecessor.
+		const r2 = signRecord({ ...nextPayload(s, twin) }, s.keyFile);
+		expect(r2.prevAnchorHash).toBe(anchorPayloadHash(twin));
+		for (const order of [
+			[r1, twin, r2],
+			[twin, r1, r2],
+		]) {
+			const result = verify(s, {
+				external: [order.map((r) => canonicalize(r)).join("\n")],
+			});
+			expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+			expect(result.anchoring.warnings).toContain("duplicate-anchor");
+		}
+	});
+});
+
+describe("finding 6: partial history starting after a rotation verifies under a pinned successor", () => {
+	it("lone post-rotation checkpoint + root & successor pin → ANCHORED_VERIFIED (partial-history)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		const successor = await rotateOnce(s);
+		await appendEvents(s.root, 1, 5);
+		await anchorOnce(s, successor.keyFile);
+		const latest = storeRecords(s).at(-1) as NonNullable<ReturnType<typeof storeRecords>[0]>;
+		expect(latest.keyId).toBe(successor.keyId);
+		// Auditor holds ONLY the newest checkpoint; mirror unavailable.
+		writeFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "");
+		const result = verify(s, {
+			external: [canonicalize(latest)],
+			trust: { rootPem: s.rootPem, successorPinsPem: [successor.publicKeyPem] },
+		});
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.warnings).toContain("partial-history");
+	});
+});
+
+describe("finding 7: outbox-first ordering + orphan self-heal (no permanent store gaps)", () => {
+	it("an outbox record missing from the mirror is re-appended, then emission continues", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		await appendEvents(s.root, 2, 4);
+		// Simulate the crash window: a fully minted seq-2 record durably in the
+		// outbox, absent from the mirror (outbox is written first now).
+		const orphan = signRecord(nextPayload(s, r1), s.keyFile);
+		writeFileSync(
+			join(s.vaultPath, "audit", "anchors", "outbox", "000000000002.json"),
+			canonicalize(orphan),
+			{ mode: 0o600 },
+		);
+		await appendEvents(s.root, 1, 6);
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const r3 = await emitter.anchorNow();
+		await emitter.stop();
+		expect(r3.emitted).toBe(true);
+		expect(r3.record?.anchorSeq).toBe(3);
+		// Mirror healed: 1,2,3 contiguous; store received the orphan too.
+		const mirrorSeqs = readFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "utf-8")
+			.trim()
+			.split("\n")
+			.map((l) => (JSON.parse(l) as { anchorSeq: number }).anchorSeq);
+		expect(mirrorSeqs).toEqual([1, 2, 3]);
+		expect(
+			storeRecords(s)
+				.map((r) => r.anchorSeq)
+				.sort(),
+		).toEqual([1, 2, 3]);
+		expect(verify(s).anchorState).toBe("ANCHORED_VERIFIED");
+	});
+
+	it("an INVALID outbox orphan refuses emission instead of forking", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		const attacker = await makeAnchoredVault(1);
+		const real = storeRecords(s)[0] as NonNullable<ReturnType<typeof storeRecords>[0]>;
+		const forged = signRecord({ ...nextPayload(s, real), vaultId: real.vaultId }, attacker.keyFile);
+		writeFileSync(
+			join(s.vaultPath, "audit", "anchors", "outbox", "000000000002.json"),
+			canonicalize(forged),
+			{ mode: 0o600 },
+		);
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const result = await emitter.anchorNow();
+		await emitter.stop();
+		expect(result.emitted).toBe(false);
+		expect(result.reason).toMatch(/outbox-orphan-invalid/);
+	});
+});
+
+describe("finding 8: stale-lock reclaim is single-winner (no unlink TOCTOU)", () => {
+	it("a dead-pid lock is reclaimed atomically and emission proceeds once", async () => {
+		const s = await makeAnchoredVault(3);
+		const lockPath = join(s.vaultPath, "audit", "anchors", ".anchor-writer.lock");
+		writeFileSync(lockPath, JSON.stringify({ pid: 999999, startedAt: "x" }), { mode: 0o600 });
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const result = await emitter.anchorNow();
+		await emitter.stop();
+		expect(result.emitted).toBe(true);
+		expect(existsSync(lockPath)).toBe(false);
+		// No stray reclaim artifacts left behind.
+		const strays = readdirSync(join(s.vaultPath, "audit", "anchors")).filter((f) =>
+			f.includes(".reclaim-"),
+		);
+		expect(strays).toEqual([]);
+	});
+});
+
+describe("finding 9: snapshots never capture nor restore anchoring state", () => {
+	it("capture excludes audit/anchors; restore preserves the live high-water", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		// Satisfy the pre-existing money/audit desync guard on restore.
+		writeFileSync(join(s.vaultPath, "spend-ledger.json"), "{}");
+		await createSnapshot(s.vaultPath, "pre");
+		const payload = JSON.parse(
+			readFileSync(join(s.vaultPath, "snapshots", "pre.json"), "utf-8"),
+		) as { entries: Record<string, string> };
+		expect(Object.keys(payload.entries).filter((p) => p.startsWith("audit/anchors"))).toEqual([]);
+
+		// Even a snapshot that DOES carry anchors entries (older format /
+		// tampered) must not roll the live state back.
+		payload.entries["audit/anchors/identity.json"] = Buffer.from("{}").toString("base64");
+		payload.entries["audit/anchors/anchors.jsonl"] = Buffer.from("").toString("base64");
+		writeFileSync(join(s.vaultPath, "snapshots", "pre.json"), JSON.stringify(payload));
+
+		await appendEvents(s.root, 2, 4);
+		await anchorOnce(s); // high-water now 2
+		await restoreSnapshot(s.vaultPath, "pre", { forceLedgerDesync: true });
+
+		const identity = readAnchorIdentity(s.root);
+		expect(identity?.lastAnchorSeq).toBe(2);
+		const mirrorSeqs = readFileSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"), "utf-8")
+			.trim()
+			.split("\n")
+			.map((l) => (JSON.parse(l) as { anchorSeq: number }).anchorSeq);
+		expect(mirrorSeqs).toEqual([1, 2]);
+	});
+});
+
+describe("finding 10: vault-behind guard refuses decreasing-treeSize anchors", () => {
+	it("events restored below the anchored head refuse emission (no rollback evidence minted)", async () => {
+		const s = await makeAnchoredVault(6);
+		await anchorOnce(s); // treeSize 6
+		// Partial event restore: truncate events+meta to 3 while anchors stay.
+		const logPath = join(s.vaultPath, "audit", "events.jsonl");
+		const lines = readFileSync(logPath, "utf-8").trim().split("\n").slice(0, 3);
+		const last = JSON.parse(lines[2] as string) as { hash: string };
+		writeFileSync(logPath, `${lines.join("\n")}\n`);
+		writeFileSync(`${logPath}.meta`, JSON.stringify({ lastHash: last.hash, sequence: 3 }));
+
+		const emitter = createAnchorEmitter(s.root, {
+			signer: { type: "pem", file: s.keyFile },
+			sinks: [{ type: "file", path: s.storeFile }],
+		});
+		const result = await emitter.anchorNow();
+		await emitter.stop();
+		expect(result.emitted).toBe(false);
+		expect(result.reason).toMatch(/vault-behind-anchors/);
+		expect(storeRecords(s).length).toBe(1);
+	});
+});
+
+describe("finding 11: resume validates the supplied record cryptographically", () => {
+	it("rejects a record signed by a different key even with the right vaultId", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const attacker = await makeAnchoredVault(1);
+		const { sig: _s2, ...payload } = r1;
+		const forged = signRecord({ ...payload }, attacker.keyFile);
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		expect(() => resumeAnchorMirror(s.root, canonicalize(forged))).toThrow(
+			/does not verify under this vault's current anchor key/,
+		);
+	});
+
+	it("rejects a record older than the durable high-water", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		await appendEvents(s.root, 2, 4);
+		await anchorOnce(s); // high-water 2
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		expect(() => resumeAnchorMirror(s.root, canonicalize(r1))).toThrow(/high-water/);
+	});
+});
+
+describe("finding 12: identity.json writes are atomic", () => {
+	it("no temp files linger after emissions and the identity stays parseable", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await appendEvents(s.root, 1, 4);
+		await anchorOnce(s);
+		const files = readdirSync(join(s.vaultPath, "audit", "anchors"));
+		expect(files.filter((f) => f.includes(".tmp-"))).toEqual([]);
+		expect(readAnchorIdentity(s.root)?.lastAnchorSeq).toBe(2);
+	});
+});
+
+describe("finding 13: DLQ persists dead letters carrying NaN payloads", () => {
+	it("appendEvent with NaN data still writes the dead letter (canonicalize fallback)", async () => {
+		const root = tmp("dlq-nan-");
+		const w = createAuditWriter(root);
+		try {
+			await expect(
+				w.appendEvent({ kind: "llm_call", actor: "sys", data: { amount: Number.NaN } }),
+			).rejects.toThrow();
+		} finally {
+			w.release();
+		}
+		const dlqPath = join(root, VAULT_DIR, "dlq", "dead-letters.jsonl");
+		expect(existsSync(dlqPath)).toBe(true);
+		const entry = JSON.parse(readFileSync(dlqPath, "utf-8").trim().split("\n")[0] as string) as {
+			source: string;
+			checksum?: string;
+		};
+		expect(entry.source).toContain("appendEvent");
+		expect(entry.checksum).toHaveLength(64);
+	});
+});

--- a/packages/core/tests/harden/anchoring/fixtures.ts
+++ b/packages/core/tests/harden/anchoring/fixtures.ts
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Shared fixture builders for the external-anchoring adversarial corpus
+ * (spec §10). Every fixture is built by REAL writer + emitter code, then
+ * mutated by the test — no hand-crafted fantasy vaults.
+ */
+
+import { createHash, createPrivateKey, createPublicKey, sign as cryptoSign } from "node:crypto";
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { verifyVaultWithAnchors as pkgVerifyVaultWithAnchors } from "../../../../verify/src/index.js";
+import {
+	type AnchorRecord,
+	type AnchorTrust,
+	anchorPayloadHash,
+	gatherOrderedEventHashes,
+	parseAnchorsContent,
+} from "../../../src/audit/anchor-verify.js";
+import {
+	createAnchorEmitter,
+	initAnchorIdentity,
+	mintSuccessorKey,
+	readAnchorIdentity,
+	recordRotatedIdentity,
+} from "../../../src/audit/anchor.js";
+import { canonicalize } from "../../../src/audit/canonical.js";
+import { createAuditWriter } from "../../../src/audit/chain.js";
+import { buildMerkleTree } from "../../../src/audit/merkle.js";
+import {
+	type AnchorVerifyParams,
+	type AnchoredVaultVerificationResult,
+	verifyVaultWithAnchors,
+} from "../../../src/audit/verify.js";
+import { GENESIS_HASH, VAULT_DIR } from "../../../src/shared/constants.js";
+
+const tracked: string[] = [];
+
+export function tmp(prefix: string): string {
+	const d = mkdtempSync(join(tmpdir(), prefix));
+	tracked.push(d);
+	return d;
+}
+
+export function cleanupAll(): void {
+	for (const d of tracked.splice(0)) {
+		rmSync(d, { recursive: true, force: true });
+	}
+}
+
+export async function appendEvents(root: string, n: number, start = 1): Promise<void> {
+	const w = createAuditWriter(root);
+	try {
+		for (let i = 0; i < n; i++) {
+			await w.appendEvent({
+				kind: "llm_call",
+				actor: "sys",
+				data: { cost: 1, transferId: `tr_${start + i}` },
+			});
+		}
+	} finally {
+		w.release();
+	}
+}
+
+export interface AnchoredSetup {
+	root: string;
+	vaultPath: string;
+	storeDir: string;
+	storeFile: string;
+	keyFile: string;
+	rootPem: string;
+	trust: AnchorTrust;
+}
+
+/** Fresh vault with `events` events, anchor identity, and a file-sink store. */
+export async function makeAnchoredVault(events: number): Promise<AnchoredSetup> {
+	const root = tmp("anchor-fix-");
+	const storeDir = tmp("anchor-store-");
+	const storeFile = join(storeDir, "anchors.jsonl");
+	writeFileSync(storeFile, "");
+	const keyFile = join(storeDir, "key.pem");
+	await appendEvents(root, events);
+	const { publicKeyPem } = initAnchorIdentity(root, { keyFile });
+	return {
+		root,
+		vaultPath: join(root, VAULT_DIR),
+		storeDir,
+		storeFile,
+		keyFile,
+		rootPem: publicKeyPem,
+		trust: { rootPem: publicKeyPem },
+	};
+}
+
+/** One emit cycle through the real emitter (publishes to the file sink). */
+export async function anchorOnce(s: AnchoredSetup, keyFile = s.keyFile): Promise<AnchorRecord> {
+	const emitter = createAnchorEmitter(s.root, {
+		signer: { type: "pem", file: keyFile },
+		sinks: [{ type: "file", path: s.storeFile }],
+	});
+	const result = await emitter.anchorNow();
+	await emitter.stop();
+	if (!result.emitted || result.record === undefined) {
+		throw new Error(`fixture anchor failed: ${result.reason}`);
+	}
+	return result.record;
+}
+
+/** Cross-signed rotation via the real emitter; returns the successor key. */
+export async function rotateOnce(
+	s: AnchoredSetup,
+	currentKeyFile = s.keyFile,
+): Promise<{ keyId: string; publicKeyPem: string; publicKeySpki: string; keyFile: string }> {
+	const identity = readAnchorIdentity(s.root);
+	if (identity === null) throw new Error("fixture: no identity");
+	const successor = mintSuccessorKey(identity.vaultId);
+	const emitter = createAnchorEmitter(s.root, {
+		signer: { type: "pem", file: currentKeyFile },
+		sinks: [{ type: "file", path: s.storeFile }],
+	});
+	const result = await emitter.rotate({
+		keyId: successor.keyId,
+		publicKeySpki: successor.publicKeySpki,
+	});
+	await emitter.stop();
+	if (!result.emitted) throw new Error(`fixture rotate failed: ${result.reason}`);
+	recordRotatedIdentity(s.root, {
+		keyId: successor.keyId,
+		publicKeySpki: successor.publicKeySpki,
+	});
+	return successor;
+}
+
+export function storeRecords(s: AnchoredSetup): AnchorRecord[] {
+	return parseAnchorsContent(readFileSync(s.storeFile, "utf-8")).records;
+}
+
+export function storeRaw(s: AnchoredSetup): string {
+	return readFileSync(s.storeFile, "utf-8");
+}
+
+/**
+ * Verify via BOTH packages' glue and assert their verdicts agree — every
+ * corpus scenario doubles as a core↔verify differential test (the anchoring
+ * extension of the lockstep guarantee). Returns the core result.
+ * `external` entries are RAW artifact contents.
+ */
+export function verify(
+	s: AnchoredSetup,
+	opts?: Partial<AnchorVerifyParams> & { external?: string[] },
+): AnchoredVaultVerificationResult {
+	const { external, ...rest } = opts ?? {};
+	const params = {
+		externalAnchorsRaw: external ?? [storeRaw(s)],
+		trust: s.trust,
+		witness: { requested: false },
+		...rest,
+	};
+	const core = verifyVaultWithAnchors(s.vaultPath, params);
+	const pkg = pkgVerifyVaultWithAnchors(s.vaultPath, params);
+	const project = (r: AnchoredVaultVerificationResult): string =>
+		JSON.stringify({
+			valid: r.valid,
+			anchorState: r.anchorState,
+			reasons: [...r.anchoring.reasons].sort(),
+			warnings: [...r.anchoring.warnings].sort(),
+			anchorCount: r.anchoring.anchorCount,
+			anchorSource: r.anchoring.anchorSource,
+			tail: r.anchoring.unanchoredTail.events,
+			chainLength: r.chainLength,
+		});
+	const coreVerdict = project(core);
+	const pkgVerdict = project(pkg as unknown as AnchoredVaultVerificationResult);
+	if (coreVerdict !== pkgVerdict) {
+		throw new Error(
+			`core↔verify anchor verdict divergence:\ncore: ${coreVerdict}\npkg:  ${pkgVerdict}`,
+		);
+	}
+	return core;
+}
+
+/** Sign an arbitrary anchor payload with a PEM key (attacker/key-holder sim). */
+export function signRecord(payload: Omit<AnchorRecord, "sig">, keyFile: string): AnchorRecord {
+	const key = createPrivateKey(readFileSync(keyFile, "utf-8"));
+	const sig = cryptoSign(null, Buffer.from(canonicalize(payload), "utf8"), key).toString("base64");
+	return { ...payload, sig } as AnchorRecord;
+}
+
+export function pubPemFromKeyFile(keyFile: string): string {
+	const pub = createPublicKey(createPrivateKey(readFileSync(keyFile, "utf-8")));
+	return pub.export({ type: "spki", format: "pem" }) as string;
+}
+
+export function computeRoot(s: AnchoredSetup, treeSize: number): string {
+	const hashes = gatherOrderedEventHashes(s.vaultPath);
+	const { root } = buildMerkleTree(hashes.slice(0, treeSize));
+	if (root === undefined) throw new Error("empty tree");
+	return root;
+}
+
+export function vaultHashes(s: AnchoredSetup): string[] {
+	return gatherOrderedEventHashes(s.vaultPath);
+}
+
+/** Next-record payload continuing the real chain (for handcrafted attacks). */
+export function nextPayload(
+	s: AnchoredSetup,
+	prev: AnchorRecord,
+	over: Partial<Omit<AnchorRecord, "sig">> = {},
+): Omit<AnchorRecord, "sig"> {
+	const hashes = vaultHashes(s);
+	const treeSize = (over.treeSize as number | undefined) ?? hashes.length;
+	return {
+		v: 1,
+		vaultId: prev.vaultId,
+		anchorSeq: prev.anchorSeq + 1,
+		prevAnchorHash: anchorPayloadHash(prev),
+		treeSize,
+		lastHash: hashes[treeSize - 1] as string,
+		merkleRoot: computeRoot(s, treeSize),
+		timestamp: new Date().toISOString(),
+		keyId: prev.rotation?.nextKeyId ?? prev.keyId,
+		...over,
+	} as Omit<AnchorRecord, "sig">;
+}
+
+/**
+ * THE F1 mutation: change one event's data, then recompute EVERY hash,
+ * previousHash link, and the .meta sidecar so the chain is internally
+ * consistent again. Invisible to the pre-anchor verifier by construction.
+ */
+export function mutateAndRechain(s: AnchoredSetup, eventIndex: number): void {
+	const logPath = join(s.vaultPath, "audit", "events.jsonl");
+	const lines = readFileSync(logPath, "utf-8").trim().split("\n");
+	const events = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+	const target = events[eventIndex] as Record<string, unknown> & { data: Record<string, unknown> };
+	target.data = { ...target.data, n: "TAMPERED" };
+	let prev = GENESIS_HASH;
+	const rechained: string[] = [];
+	let lastHash = "";
+	for (const e of events) {
+		const { hash: _h, ...rest } = e;
+		(rest as Record<string, unknown>).previousHash = prev;
+		const hash = createHash("sha256").update(canonicalize(rest)).digest("hex");
+		rechained.push(canonicalize({ ...rest, hash }));
+		prev = hash;
+		lastHash = hash;
+	}
+	writeFileSync(logPath, `${rechained.join("\n")}\n`);
+	writeFileSync(`${logPath}.meta`, JSON.stringify({ lastHash, sequence: events.length }));
+}
+
+/** Truncate the log to `keep` events and rewrite .meta to match (rollback). */
+export function truncateVault(s: AnchoredSetup, keep: number): void {
+	const logPath = join(s.vaultPath, "audit", "events.jsonl");
+	const lines = readFileSync(logPath, "utf-8").trim().split("\n").slice(0, keep);
+	const last = JSON.parse(lines[lines.length - 1] as string) as { hash: string };
+	writeFileSync(logPath, `${lines.join("\n")}\n`);
+	writeFileSync(`${logPath}.meta`, JSON.stringify({ lastHash: last.hash, sequence: keep }));
+}
+
+export function snapshotVault(s: AnchoredSetup): string {
+	const snap = tmp("anchor-snap-");
+	cpSync(s.vaultPath, join(snap, VAULT_DIR), { recursive: true });
+	return snap;
+}
+
+export function restoreVault(s: AnchoredSetup, snapRoot: string): void {
+	rmSync(s.vaultPath, { recursive: true, force: true });
+	cpSync(join(snapRoot, VAULT_DIR), s.vaultPath, { recursive: true });
+}

--- a/packages/core/tests/ledger/engine.test.ts
+++ b/packages/core/tests/ledger/engine.test.ts
@@ -327,14 +327,17 @@ describe("TrustEngine", () => {
 			expect(mockWriteSync).toHaveBeenCalled();
 			expect(mockFsyncSync).toHaveBeenCalled();
 			expect(mockCloseSync).toHaveBeenCalled();
-			// Verify the DLQ entry contains proper data + HMAC
+			// Verify the DLQ entry contains proper data + corruption checksum
+			// (F3: the path-derived "integrity" HMAC was replaced with an
+			// honest best-effort checksum — no key, no integrity claim)
 			const writtenData = mockWriteSync.mock.calls[0]?.[1] as string;
 			const dlqEntry = JSON.parse(writtenData.trim());
 			expect(dlqEntry.source).toBe("engine.postPendingSpend.ambiguous");
 			expect(dlqEntry.transferId).toBe("42");
-			expect(dlqEntry.hmac).toBeDefined();
-			expect(typeof dlqEntry.hmac).toBe("string");
-			expect(dlqEntry.hmac.length).toBe(64); // SHA-256 hex
+			expect(dlqEntry.checksum).toBeDefined();
+			expect(typeof dlqEntry.checksum).toBe("string");
+			expect(dlqEntry.checksum.length).toBe(64); // SHA-256 hex
+			expect(dlqEntry.checksumAlg).toBe("sha256");
 		});
 
 		it("creates DLQ directory with restricted permissions if it does not exist", async () => {

--- a/packages/verify/README.md
+++ b/packages/verify/README.md
@@ -22,6 +22,25 @@ All hashes: valid (847/847)
 - **Head anchor** — the fsync'd `events.jsonl.meta` sidecar records the last hash and the total event count. The verifier fails if the log has been **truncated or deleted** (a shorter-but-internally-consistent chain no longer passes).
 - **Segment continuity** — a rotated vault (multiple `*.jsonl` segments) is verified as one continuous chain by sequence number; a missing whole segment is detected as a sequence gap.
 - **Merkle root** — recomputes the RFC 6962 root over the event hashes.
+- **External anchors** (optional) — binds the vault to Ed25519-signed checkpoints held in an append-only store the vault operator cannot rewrite. This upgrades the guarantee from *tamper-evident if you trust the operator's files* to **independently verifiable**: even a fully re-hashed, internally-consistent rewrite fails against the externally-held root.
+
+## Verify against external anchors
+
+You fetch the checkpoint(s) from the operator's append-only store yourself (`aws s3 cp`, `git show`, a SIEM export) and pin the vault's public key **out-of-band** — the verifier deliberately never reads trust material from the vault under audit, and works fully offline.
+
+```bash
+# Full checkpoint history (strongest)
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem
+
+# Single checkpoint via stdin
+aws s3 cp s3://…/000000000042.json - | usertrust-verify .usertrust --anchor - --pubkey root.pem
+
+# CI gate: externally anchored, fresh, verified — or exit 1
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
+  --require-anchor --require-external-anchor --max-unanchored-events 5000
+```
+
+Result states: `ANCHORED_VERIFIED`, `UNANCHORED` (legacy vaults — valid, weaker, labeled), `ANCHOR_UNVERIFIABLE`, `ANCHOR_STALE`, and the hard failures `ANCHOR_INVALID` / `ANCHOR_MISMATCH` (rewrite, rollback, deletion, or fork against the signed checkpoints — always exit 1). After a key rotation, keep pinning the original root key and pass the announced successor fingerprints with `--successor-pin`. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md) for the operator side.
 
 ## Exit codes (CI-safe)
 
@@ -53,6 +72,18 @@ if (!result.valid) {
   console.error(result.errors);
   process.exit(exitCodeFor(result)); // 1
 }
+```
+
+With external anchors:
+
+```typescript
+import { verifyVaultWithAnchors, exitCodeForAnchored } from "usertrust-verify";
+
+const result = verifyVaultWithAnchors(".usertrust", {
+  externalAnchorsRaw: [anchorsJsonl],        // fetched by YOU, not by the verifier
+  trust: { rootPem: pinnedPublicKeyPem },    // pinned out-of-band, never from the vault
+});
+process.exit(exitCodeForAnchored(result, { requireExternalAnchor: true }));
 ```
 
 `verifyVault` re-implements canonicalization and hashing independently of `usertrust` and must stay byte-for-byte identical to the writer — a differential test in the repo pins that invariant.

--- a/packages/verify/src/anchor-verify.ts
+++ b/packages/verify/src/anchor-verify.ts
@@ -1,0 +1,975 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * External Anchor Verification — Zero-dependency standalone
+ *
+ * INTENTIONAL DUPLICATION: this file exists byte-for-byte in BOTH
+ * packages/verify/src/anchor-verify.ts and
+ * packages/core/src/audit/anchor-verify.ts — only the import paths differ.
+ * The anchor differential/parity tests pin the two together; any change must
+ * land in both packages.
+ *
+ * Verifies signed anchor checkpoints (spec: docs/superpowers/specs/
+ * 2026-07-26-external-anchoring-design.md) against a caller-pinned trust root:
+ *  - strict record parsing (unknown fields / range violations are INVALID)
+ *  - Ed25519 signature verification via node:crypto (ECDSA P-256 helper kept
+ *    alg-agile for Phase 2 transparency-log checkpoints)
+ *  - anchor-chain verification: prevAnchorHash linkage, anchorSeq contiguity,
+ *    key epochs via cross-signed rotation records, fork/duplicate semantics
+ *  - vault binding: Merkle root / head hash at each anchored treeSize, with
+ *    externally-bound consistency proofs between anchors
+ *  - the spec §7.2 state machine (UNANCHORED / ANCHORED_VERIFIED / ANCHOR_STALE
+ *    / ANCHOR_UNVERIFIABLE / ANCHOR_INVALID / ANCHOR_MISMATCH)
+ *
+ * Trust NEVER comes from the vault under audit: the caller pins the genesis
+ * root key (and optional rotation-successor pins) out-of-band.
+ */
+
+import { type KeyObject, createHash, createPublicKey, verify as cryptoVerify } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { canonicalize } from "./canonical.js";
+import { GENESIS_HASH } from "./constants.js";
+import {
+	type MerkleInclusionProof,
+	buildMerkleTree,
+	generateConsistencyProof,
+	verifyConsistencyProof,
+	verifyInclusionProof,
+} from "./verify.js";
+
+// ── Types ──
+
+export interface AnchorRotation {
+	readonly nextKeyId: string;
+	readonly nextPublicKeySpki: string;
+}
+
+export interface AnchorRecord {
+	readonly v: 1;
+	readonly vaultId: string;
+	readonly anchorSeq: number;
+	readonly prevAnchorHash: string;
+	readonly treeSize: number;
+	readonly lastHash: string;
+	readonly merkleRoot: string;
+	readonly timestamp: string;
+	readonly keyId: string;
+	readonly rotation?: AnchorRotation;
+	readonly sig: string;
+}
+
+/** Caller-pinned trust material. NEVER read from the vault under audit. */
+export interface AnchorTrust {
+	/** THE pinned genesis root key (PEM). anchorSeq 1 MUST verify under it. */
+	readonly rootPem: string;
+	/** Optional out-of-band pins for rotation successors. */
+	readonly successorPinsPem?: readonly string[];
+}
+
+export type AnchorState =
+	| "UNANCHORED"
+	| "ANCHORED_VERIFIED"
+	| "ANCHOR_STALE"
+	| "ANCHOR_UNVERIFIABLE"
+	| "ANCHOR_INVALID"
+	| "ANCHOR_MISMATCH";
+
+export type AnchorSource = "external" | "vault-mirror" | "none";
+export type WitnessStatus = "agrees" | "disagrees" | "unreachable" | "not-consulted";
+
+export interface WitnessInput {
+	readonly requested: boolean;
+	readonly ok?: boolean;
+	readonly error?: string;
+}
+
+export interface AnchorEvaluationOptions {
+	readonly maxAnchorAgeMs?: number;
+	readonly maxUnanchoredEvents?: number;
+	readonly expectedVaultId?: string;
+	/** Injectable clock for tests. Defaults to Date.now(). */
+	readonly nowMs?: number;
+}
+
+export interface AnchorEvaluationInput {
+	/** Globally sequence-ordered stored event hashes (verifyVault ordering). */
+	readonly orderedHashes: readonly string[];
+	/** Caller-fetched external anchor records (already parsed). */
+	readonly externalAnchors: readonly AnchorRecord[];
+	/** Parse errors from caller-supplied artifacts (fail-closed). */
+	readonly externalErrors: readonly string[];
+	/** Records from the vault-local mirror — CACHE, never a trust root alone. */
+	readonly mirrorAnchors: readonly AnchorRecord[];
+	readonly mirrorErrors: readonly string[];
+	readonly trust: AnchorTrust | null;
+	readonly witness: WitnessInput;
+	readonly opts?: AnchorEvaluationOptions;
+}
+
+export interface AnchorEvaluation {
+	anchorState: AnchorState;
+	/** false only on ANCHOR_INVALID / ANCHOR_MISMATCH. */
+	anchorsValid: boolean;
+	anchorSource: AnchorSource;
+	anchorCount: number;
+	latestAnchor: {
+		anchorSeq: number;
+		treeSize: number;
+		lastHash: string;
+		keyId: string;
+		timestamp: string;
+	} | null;
+	unanchoredTail: { events: number; sinceTimestampMs: number | null };
+	witness: { requested: boolean; status: WitnessStatus; error?: string };
+	reasons: string[];
+	warnings: string[];
+	errors: string[];
+}
+
+function nullIfNaN(n: number): number | null {
+	return Number.isFinite(n) ? n : null;
+}
+
+// ── Reason-code classes (see spec §7.2) ──
+
+const INVALID_REASONS = new Set(["malformed-anchor", "range-invalid", "sig-invalid"]);
+const NON_FAIL_REASONS = new Set(["no-trust-material", "witness-unreachable"]);
+
+// ── Strict parsing ──
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const KEY_ID = /^sha256:[0-9a-f]{64}$/;
+const RECORD_KEYS = new Set([
+	"v",
+	"vaultId",
+	"anchorSeq",
+	"prevAnchorHash",
+	"treeSize",
+	"lastHash",
+	"merkleRoot",
+	"timestamp",
+	"keyId",
+	"rotation",
+	"sig",
+]);
+const ROTATION_KEYS = new Set(["nextKeyId", "nextPublicKeySpki"]);
+
+function isSafePositiveInt(n: unknown): n is number {
+	return typeof n === "number" && Number.isSafeInteger(n) && n >= 1;
+}
+
+/**
+ * Strict parse of a single anchor record. Unknown fields, missing fields, and
+ * range violations are all rejected (fail-closed — spec §3 strict-parse rules;
+ * range checks run BEFORE any Merkle primitive so a validly-signed-but-
+ * degenerate record yields a deterministic verdict, never a throw).
+ * Returns `{ record }` or `{ error }` with a code-prefixed message.
+ */
+export function parseAnchorRecord(raw: string): {
+	record: AnchorRecord | null;
+	error: string | null;
+} {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return { record: null, error: "malformed-anchor: not valid JSON" };
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { record: null, error: "malformed-anchor: not an object" };
+	}
+	const obj = parsed as Record<string, unknown>;
+	for (const key of Object.keys(obj)) {
+		if (!RECORD_KEYS.has(key)) {
+			return { record: null, error: `malformed-anchor: unknown field "${key}"` };
+		}
+	}
+	if (obj.v !== 1) {
+		return { record: null, error: "malformed-anchor: unsupported version" };
+	}
+	if (typeof obj.vaultId !== "string" || obj.vaultId.length === 0) {
+		return { record: null, error: "malformed-anchor: missing vaultId" };
+	}
+	if (!isSafePositiveInt(obj.anchorSeq)) {
+		return { record: null, error: "range-invalid: anchorSeq must be a safe integer >= 1" };
+	}
+	if (!isSafePositiveInt(obj.treeSize)) {
+		return { record: null, error: "range-invalid: treeSize must be a safe integer >= 1" };
+	}
+	if (typeof obj.prevAnchorHash !== "string" || !HEX64.test(obj.prevAnchorHash)) {
+		return { record: null, error: "malformed-anchor: prevAnchorHash must be 64-hex" };
+	}
+	if (typeof obj.lastHash !== "string" || !HEX64.test(obj.lastHash)) {
+		return { record: null, error: "malformed-anchor: lastHash must be 64-hex" };
+	}
+	if (typeof obj.merkleRoot !== "string" || !HEX64.test(obj.merkleRoot)) {
+		return { record: null, error: "malformed-anchor: merkleRoot must be 64-hex" };
+	}
+	if (typeof obj.timestamp !== "string" || obj.timestamp.length === 0) {
+		return { record: null, error: "malformed-anchor: missing timestamp" };
+	}
+	if (typeof obj.keyId !== "string" || !KEY_ID.test(obj.keyId)) {
+		return { record: null, error: "malformed-anchor: keyId must be sha256:<64-hex>" };
+	}
+	if (typeof obj.sig !== "string" || obj.sig.length === 0) {
+		return { record: null, error: "malformed-anchor: missing sig" };
+	}
+	if (obj.rotation !== undefined) {
+		const rot = obj.rotation;
+		if (rot === null || typeof rot !== "object" || Array.isArray(rot)) {
+			return { record: null, error: "malformed-anchor: rotation must be an object" };
+		}
+		const rotObj = rot as Record<string, unknown>;
+		for (const key of Object.keys(rotObj)) {
+			if (!ROTATION_KEYS.has(key)) {
+				return { record: null, error: `malformed-anchor: unknown rotation field "${key}"` };
+			}
+		}
+		if (typeof rotObj.nextKeyId !== "string" || !KEY_ID.test(rotObj.nextKeyId)) {
+			return {
+				record: null,
+				error: "malformed-anchor: rotation.nextKeyId must be sha256:<64-hex>",
+			};
+		}
+		if (
+			typeof rotObj.nextPublicKeySpki !== "string" ||
+			Buffer.from(rotObj.nextPublicKeySpki, "base64").length === 0
+		) {
+			return {
+				record: null,
+				error: "malformed-anchor: rotation.nextPublicKeySpki must be base64",
+			};
+		}
+	}
+	return { record: obj as unknown as AnchorRecord, error: null };
+}
+
+/** Parse a JSONL (or single-JSON) anchors artifact. Every line must parse. */
+export function parseAnchorsContent(content: string): {
+	records: AnchorRecord[];
+	errors: string[];
+} {
+	const records: AnchorRecord[] = [];
+	const errors: string[] = [];
+	const lines = content
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l.length > 0);
+	for (let i = 0; i < lines.length; i++) {
+		const { record, error } = parseAnchorRecord(lines[i] as string);
+		if (record) {
+			records.push(record);
+		} else {
+			errors.push(`anchor line ${i + 1}: ${error}`);
+		}
+	}
+	return { records, errors };
+}
+
+// ── Crypto helpers ──
+
+/** Signing pre-image = canonicalize(record − sig). Spec §3. */
+export function anchorSigningPreimage(record: AnchorRecord): string {
+	const { sig: _sig, ...rest } = record;
+	return canonicalize(rest);
+}
+
+/** sha256 hex of the signing pre-image — what the successor's prevAnchorHash carries. */
+export function anchorPayloadHash(record: AnchorRecord): string {
+	return createHash("sha256").update(anchorSigningPreimage(record), "utf8").digest("hex");
+}
+
+export function keyIdFromSpkiDer(der: Buffer): string {
+	return `sha256:${createHash("sha256").update(der).digest("hex")}`;
+}
+
+export function publicKeyFromPem(pem: string): KeyObject | null {
+	try {
+		return createPublicKey(pem);
+	} catch {
+		return null;
+	}
+}
+
+export function publicKeyFromSpkiBase64(b64: string): KeyObject | null {
+	try {
+		return createPublicKey({ key: Buffer.from(b64, "base64"), format: "der", type: "spki" });
+	} catch {
+		return null;
+	}
+}
+
+export function keyIdFromKeyObject(key: KeyObject): string {
+	return keyIdFromSpkiDer(key.export({ type: "spki", format: "der" }) as Buffer);
+}
+
+/**
+ * Raw signature verification over UTF-8 data. Ed25519 for usertrust anchor
+ * records; ECDSA P-256 kept alg-agile for Phase 2 transparency-log checkpoints
+ * (Rekor signs with ECDSA — spec reconciliation R2). Never throws.
+ */
+export function verifySignatureRaw(
+	alg: "ed25519" | "ecdsa-p256",
+	dataUtf8: string,
+	publicKey: KeyObject,
+	sigBase64: string,
+): boolean {
+	const data = Buffer.from(dataUtf8, "utf8");
+	const sig = Buffer.from(sigBase64, "base64");
+	if (sig.length === 0) return false;
+	try {
+		if (alg === "ed25519") {
+			return cryptoVerify(null, data, publicKey, sig);
+		}
+		return (
+			cryptoVerify("sha256", data, { key: publicKey, dsaEncoding: "ieee-p1363" }, sig) ||
+			cryptoVerify("sha256", data, { key: publicKey, dsaEncoding: "der" }, sig)
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Verify one record's Ed25519 signature against explicit candidate keys.
+ * The candidate whose keyId matches the record's keyId is used; a record whose
+ * keyId matches none of the candidates fails with a distinct error.
+ */
+export function verifyAnchorSignature(
+	record: AnchorRecord,
+	candidateKeysPem: readonly string[],
+): { ok: boolean; keyId: string; errors: string[] } {
+	const errors: string[] = [];
+	for (const pem of candidateKeysPem) {
+		const key = publicKeyFromPem(pem);
+		if (key === null) {
+			errors.push("sig-invalid: unparseable candidate public key");
+			continue;
+		}
+		if (keyIdFromKeyObject(key) !== record.keyId) continue;
+		if (verifySignatureRaw("ed25519", anchorSigningPreimage(record), key, record.sig)) {
+			return { ok: true, keyId: record.keyId, errors: [] };
+		}
+		errors.push(`sig-invalid: signature does not verify under keyId ${record.keyId}`);
+		return { ok: false, keyId: record.keyId, errors };
+	}
+	errors.push(`sig-invalid: no candidate key matches keyId ${record.keyId}`);
+	return { ok: false, keyId: record.keyId, errors };
+}
+
+// ── Duplicate / fork semantics (spec §7.2) ──
+
+/** Committed-field equality: everything except timestamp and sig. */
+export function committedFieldsEqual(a: AnchorRecord, b: AnchorRecord): boolean {
+	const strip = (r: AnchorRecord): string => {
+		const { sig: _s, timestamp: _t, ...rest } = r;
+		return canonicalize(rest);
+	};
+	return strip(a) === strip(b);
+}
+
+/**
+ * Collapse same-anchorSeq records WITHIN one stream (store or mirror):
+ * identical committed content = benign duplicate (warn, keep first);
+ * divergent committed content = fork evidence (MISMATCH).
+ */
+export function dedupeAnchorSet(records: readonly AnchorRecord[]): {
+	unique: AnchorRecord[];
+	/** Committed-equal twins collapsed out — still signature-checked by the walk. */
+	dropped: AnchorRecord[];
+	warnings: string[];
+	errors: string[];
+	mismatchReasons: string[];
+} {
+	const warnings: string[] = [];
+	const errors: string[] = [];
+	const mismatchReasons: string[] = [];
+	const dropped: AnchorRecord[] = [];
+	const bySeq = new Map<number, AnchorRecord>();
+	for (const r of records) {
+		const existing = bySeq.get(r.anchorSeq);
+		if (existing === undefined) {
+			bySeq.set(r.anchorSeq, r);
+		} else if (committedFieldsEqual(existing, r)) {
+			// Benign duplicate ONLY if its signature also verifies — the walk
+			// re-checks every dropped twin under its epoch key (spec §7.2
+			// "both signatures valid"). Order must not decide the verdict.
+			warnings.push("duplicate-anchor");
+			dropped.push(r);
+		} else {
+			errors.push(
+				`fork: divergent records at anchorSeq ${r.anchorSeq} (same position, different committed content)`,
+			);
+			mismatchReasons.push("fork");
+		}
+	}
+	const unique = [...bySeq.values()].sort((a, b) => a.anchorSeq - b.anchorSeq);
+	return { unique, dropped, warnings, errors, mismatchReasons };
+}
+
+// ── Anchor chain verification ──
+
+export interface AnchorChainResult {
+	/** anchorSeq-ordered records that entered the walk. */
+	records: AnchorRecord[];
+	errors: string[];
+	/** ANCHOR_INVALID-class reason codes. */
+	invalidReasons: string[];
+	/** ANCHOR_MISMATCH-class reason codes. */
+	mismatchReasons: string[];
+	warnings: string[];
+}
+
+/**
+ * Verify the anchor stream as its own hash chain under the pinned trust root:
+ * signatures per key epoch (rotations walked forward from the root),
+ * prevAnchorHash linkage from GENESIS, anchorSeq contiguity from 1, treeSize
+ * monotonicity, single vaultId, and — when event hashes are supplied —
+ * consistency binding between consecutive anchored roots. The proof's
+ * firstRoot/secondRoot are compared to the SIGNED roots before
+ * verifyConsistencyProof is called: the bare call checks only internal proof
+ * consistency and passes unconditionally on locally generated proofs
+ * (spec §7.2 — omitting the binding recreates F1).
+ *
+ * Callers pass a set already deduped per stream (dedupeAnchorSet); same-seq
+ * survivors here are treated as forks.
+ */
+export function verifyAnchorChain(
+	records: readonly AnchorRecord[],
+	trust: AnchorTrust,
+	eventHashes?: readonly string[],
+): AnchorChainResult {
+	const errors: string[] = [];
+	const invalidReasons: string[] = [];
+	const mismatchReasons: string[] = [];
+	const warnings: string[] = [];
+
+	const rootKey = publicKeyFromPem(trust.rootPem);
+	if (rootKey === null) {
+		errors.push("trust root public key is not a parseable PEM");
+		invalidReasons.push("sig-invalid");
+		return { records: [], errors, invalidReasons, mismatchReasons, warnings };
+	}
+	const pinKeyIds = new Set<string>();
+	const knownKeys = new Map<string, KeyObject>();
+	const rootKeyId = keyIdFromKeyObject(rootKey);
+	knownKeys.set(rootKeyId, rootKey);
+	for (const pem of trust.successorPinsPem ?? []) {
+		const k = publicKeyFromPem(pem);
+		if (k !== null) {
+			const id = keyIdFromKeyObject(k);
+			pinKeyIds.add(id);
+			knownKeys.set(id, k);
+		}
+	}
+
+	// A mixed-vaultId set is rejected wholesale, BEFORE dedup can collapse a
+	// replayed foreign record into a same-seq group (cross-vault replay).
+	const vaultIds = new Set(records.map((r) => r.vaultId));
+	if (vaultIds.size > 1) {
+		errors.push(`vault-id-mismatch: anchor set mixes ${vaultIds.size} distinct vaultIds`);
+		mismatchReasons.push("vault-id-mismatch");
+	}
+
+	const dedup = dedupeAnchorSet(records);
+	warnings.push(...dedup.warnings);
+	errors.push(...dedup.errors);
+	mismatchReasons.push(...dedup.mismatchReasons);
+	const ordered = dedup.unique;
+	const droppedBySeq = new Map<number, AnchorRecord[]>();
+	for (const d of dedup.dropped) {
+		const list = droppedBySeq.get(d.anchorSeq) ?? [];
+		list.push(d);
+		droppedBySeq.set(d.anchorSeq, list);
+	}
+
+	let epochKeyId = rootKeyId;
+	let epochKey: KeyObject | null = rootKey;
+	let prev: AnchorRecord | null = null;
+
+	for (let i = 0; i < ordered.length; i++) {
+		const r = ordered[i] as AnchorRecord;
+
+		if (i === 0 && r.anchorSeq !== 1) {
+			// A supplied history that simply does not START at genesis (e.g. the
+			// documented single-checkpoint bind, §7.5) is PARTIAL, not tampered:
+			// the missing prefix is unprovable, not proof of deletion, and every
+			// present record still binds to the vault content. A gap BETWEEN two
+			// present records (checked below) remains a hard MISMATCH.
+			warnings.push("partial-history");
+		}
+		if (prev !== null && r.anchorSeq !== prev.anchorSeq + 1) {
+			errors.push(`anchor-chain-gap: anchorSeq ${r.anchorSeq} follows ${prev.anchorSeq}`);
+			mismatchReasons.push("anchor-chain-gap");
+		}
+		if (r.anchorSeq === 1 && r.prevAnchorHash !== GENESIS_HASH) {
+			errors.push("anchor-chain-gap: anchorSeq 1 prevAnchorHash must be GENESIS");
+			mismatchReasons.push("anchor-chain-gap");
+		}
+		if (prev !== null && r.anchorSeq === prev.anchorSeq + 1) {
+			if (r.prevAnchorHash !== anchorPayloadHash(prev)) {
+				errors.push(
+					`anchor-chain-gap: anchorSeq ${r.anchorSeq} prevAnchorHash does not link to its predecessor`,
+				);
+				mismatchReasons.push("anchor-chain-gap");
+			}
+		}
+		if (prev !== null && r.treeSize < prev.treeSize) {
+			errors.push(
+				`anchor monotonicity violation: treeSize ${r.treeSize} at anchorSeq ${r.anchorSeq} decreases from ${prev.treeSize}`,
+			);
+			mismatchReasons.push("rollback");
+		}
+		if (prev !== null && r.vaultId !== prev.vaultId) {
+			errors.push(`vault-id-mismatch: mixed vaultId in anchor set at anchorSeq ${r.anchorSeq}`);
+			mismatchReasons.push("vault-id-mismatch");
+		}
+
+		// Signature under the current epoch key. A cryptographically valid
+		// signature under a trusted key that is WRONG for this chain position
+		// is MISMATCH (key/rotation continuity); a signature no trusted key
+		// verifies is INVALID (spec §7.1 rule).
+		let sigOk = false;
+		if (r.keyId === epochKeyId && epochKey !== null) {
+			if (verifySignatureRaw("ed25519", anchorSigningPreimage(r), epochKey, r.sig)) {
+				sigOk = true;
+			} else {
+				errors.push(`sig-invalid: anchorSeq ${r.anchorSeq} signature fails under keyId ${r.keyId}`);
+				invalidReasons.push("sig-invalid");
+			}
+		} else {
+			const candidate = knownKeys.get(r.keyId);
+			if (
+				candidate !== undefined &&
+				verifySignatureRaw("ed25519", anchorSigningPreimage(r), candidate, r.sig)
+			) {
+				errors.push(
+					`rotation-continuity: anchorSeq ${r.anchorSeq} signed by keyId ${r.keyId}, expected epoch key ${epochKeyId}`,
+				);
+				mismatchReasons.push("rotation-continuity");
+			} else {
+				errors.push(
+					`sig-invalid: anchorSeq ${r.anchorSeq} signed by untrusted or failing keyId ${r.keyId}`,
+				);
+				invalidReasons.push("sig-invalid");
+			}
+		}
+
+		// A committed-equal twin dropped by dedup must ALSO verify (spec §7.2
+		// "both signatures valid") — otherwise record order would decide the
+		// verdict. keyId is a committed field, so the twin resolves to the
+		// same epoch/known key as its survivor.
+		for (const twin of droppedBySeq.get(r.anchorSeq) ?? []) {
+			const twinKey = twin.keyId === epochKeyId ? epochKey : (knownKeys.get(twin.keyId) ?? null);
+			if (
+				twinKey === null ||
+				!verifySignatureRaw("ed25519", anchorSigningPreimage(twin), twinKey, twin.sig)
+			) {
+				errors.push(
+					`sig-invalid: duplicate record at anchorSeq ${r.anchorSeq} has a signature that does not verify under keyId ${twin.keyId}`,
+				);
+				invalidReasons.push("sig-invalid");
+			}
+		}
+
+		// Rotation: cross-signed successor introduction. Only a record whose
+		// own signature verified in its epoch may advance the epoch — a forged
+		// rotation must never install a key.
+		if (r.rotation !== undefined && sigOk) {
+			const nextKey = publicKeyFromSpkiBase64(r.rotation.nextPublicKeySpki);
+			if (nextKey === null || keyIdFromKeyObject(nextKey) !== r.rotation.nextKeyId) {
+				errors.push(
+					`malformed-anchor: rotation at anchorSeq ${r.anchorSeq} — nextKeyId does not match nextPublicKeySpki`,
+				);
+				invalidReasons.push("malformed-anchor");
+			} else {
+				if (pinKeyIds.size > 0 && !pinKeyIds.has(r.rotation.nextKeyId)) {
+					errors.push(
+						`rotation-unpinned: rotation at anchorSeq ${r.anchorSeq} to keyId ${r.rotation.nextKeyId} not in the supplied successor pins`,
+					);
+					mismatchReasons.push("rotation-unpinned");
+				} else if (pinKeyIds.size === 0) {
+					warnings.push("rotation-unpinned");
+				}
+				knownKeys.set(r.rotation.nextKeyId, nextKey);
+				epochKeyId = r.rotation.nextKeyId;
+				epochKey = nextKey;
+			}
+		}
+
+		// Consistency binding between consecutive anchored roots (spec §7.2).
+		if (
+			eventHashes !== undefined &&
+			prev !== null &&
+			prev.treeSize >= 1 &&
+			r.treeSize <= eventHashes.length &&
+			prev.treeSize <= r.treeSize
+		) {
+			if (prev.treeSize === r.treeSize) {
+				if (prev.merkleRoot !== r.merkleRoot) {
+					errors.push(
+						`consistency-failure: anchorSeq ${prev.anchorSeq}->${r.anchorSeq} same treeSize, different roots`,
+					);
+					mismatchReasons.push("consistency-failure");
+				}
+			} else {
+				const proof = generateConsistencyProof(prev.treeSize, r.treeSize, [...eventHashes]);
+				if (
+					proof.firstRoot !== prev.merkleRoot ||
+					proof.secondRoot !== r.merkleRoot ||
+					!verifyConsistencyProof(proof)
+				) {
+					errors.push(
+						`consistency-failure: anchored root at treeSize ${prev.treeSize} is not a prefix of the tree at ${r.treeSize}`,
+					);
+					mismatchReasons.push("consistency-failure");
+				}
+			}
+		}
+
+		prev = r;
+	}
+
+	return { records: ordered, errors, invalidReasons, mismatchReasons, warnings };
+}
+
+// ── Vault gathering ──
+
+/**
+ * Gather the globally sequence-ordered stored event hashes of a vault, using
+ * the exact segment-gathering and ordering semantics of verifyVault
+ * (events.jsonl first, then every other *.jsonl sorted; order by persisted
+ * global `sequence` when every event has one, else file order). Malformed
+ * lines are skipped here — chain-level errors are verifyVault's job, not the
+ * anchor evaluator's.
+ */
+export function gatherOrderedEventHashes(vaultPath: string): string[] {
+	const auditDir = join(vaultPath, "audit");
+	const segmentFiles: string[] = [];
+	const mainLog = join(auditDir, "events.jsonl");
+	if (existsSync(mainLog)) {
+		segmentFiles.push(mainLog);
+	}
+	if (existsSync(auditDir)) {
+		try {
+			for (const entry of readdirSync(auditDir).sort()) {
+				if (entry.endsWith(".jsonl") && entry !== "events.jsonl") {
+					segmentFiles.push(join(auditDir, entry));
+				}
+			}
+		} catch {
+			// Directory read failure — non-fatal
+		}
+	}
+	const events: { hash: string; sequence?: number | undefined }[] = [];
+	for (const segmentFile of segmentFiles) {
+		let content: string;
+		try {
+			content = readFileSync(segmentFile, "utf-8").trim();
+		} catch {
+			continue;
+		}
+		if (content === "") continue;
+		for (const raw of content.split("\n").filter((l) => l.trim())) {
+			try {
+				const parsed = JSON.parse(raw) as Record<string, unknown>;
+				events.push({
+					hash: typeof parsed.hash === "string" ? parsed.hash : "",
+					sequence: typeof parsed.sequence === "number" ? parsed.sequence : undefined,
+				});
+			} catch {
+				// skip malformed line
+			}
+		}
+	}
+	const allHaveSeq = events.every((e) => typeof e.sequence === "number");
+	const ordered = allHaveSeq
+		? [...events].sort((a, b) => (a.sequence as number) - (b.sequence as number))
+		: events;
+	return ordered.map((e) => e.hash);
+}
+
+/** Read the vault-local anchor mirror (cache, never a trust root alone). */
+export function readAnchorMirror(vaultPath: string): {
+	records: AnchorRecord[];
+	errors: string[];
+} {
+	const mirrorPath = join(vaultPath, "audit", "anchors", "anchors.jsonl");
+	if (!existsSync(mirrorPath)) return { records: [], errors: [] };
+	try {
+		return parseAnchorsContent(readFileSync(mirrorPath, "utf-8"));
+	} catch {
+		return { records: [], errors: ["malformed-anchor: anchor mirror unreadable"] };
+	}
+}
+
+// ── State machine ──
+
+const STATE_SEVERITY: Record<AnchorState, number> = {
+	ANCHORED_VERIFIED: 0,
+	UNANCHORED: 1,
+	ANCHOR_UNVERIFIABLE: 2,
+	ANCHOR_STALE: 3,
+	ANCHOR_INVALID: 4,
+	ANCHOR_MISMATCH: 5,
+};
+
+function worseState(a: AnchorState, b: AnchorState): AnchorState {
+	return (STATE_SEVERITY[a] ?? 0) >= (STATE_SEVERITY[b] ?? 0) ? a : b;
+}
+
+/**
+ * The spec §7.2 state machine. Pure function over gathered inputs so both
+ * packages (and the differential test) evaluate identically. Evaluation order
+ * per constraints §4.2: discover → trust check → parse/signature → content
+ * cross-checks → freshness; worst state wins. The witness-fetch-failure rule
+ * (AC-2.4) caps the state below ANCHORED_VERIFIED without discarding
+ * caller-supplied artifacts.
+ */
+export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvaluation {
+	const opts = input.opts ?? {};
+	const nowMs = opts.nowMs ?? Date.now();
+	const reasons: string[] = [];
+	const warnings: string[] = [];
+	const errors: string[] = [];
+
+	const witnessRequested = input.witness.requested;
+	const witnessOk = input.witness.ok === true;
+	const witnessFailed = witnessRequested && !witnessOk;
+
+	const observed = input.orderedHashes.length;
+	const anchorsPresent =
+		input.externalAnchors.length > 0 ||
+		input.mirrorAnchors.length > 0 ||
+		input.externalErrors.length > 0 ||
+		input.mirrorErrors.length > 0;
+
+	// "external" requires at least one PARSED external record (or a parse error
+	// to fail on) — a witness that returned 2xx with an empty/zero-record body
+	// must not launder vault-mirror-only evidence into "external" and slip past
+	// --require-external-anchor (AC-2.4 defense in depth).
+	const hasExternal = input.externalAnchors.length > 0 || input.externalErrors.length > 0;
+	const anchorSource: AnchorSource = hasExternal
+		? "external"
+		: anchorsPresent
+			? "vault-mirror"
+			: "none";
+
+	const finish = (state: AnchorState, records: readonly AnchorRecord[]): AnchorEvaluation => {
+		// Witness-unreachable cap: inconclusive, never a silent downgrade
+		// (AC-2.4). MISMATCH/INVALID/STALE from remaining inputs still win;
+		// ANCHORED_VERIFIED and UNANCHORED are capped to UNVERIFIABLE.
+		let finalState = state;
+		if (witnessFailed) {
+			reasons.push("witness-unreachable");
+			finalState = worseState(finalState, "ANCHOR_UNVERIFIABLE");
+			errors.push(`witness-unreachable: ${input.witness.error ?? "anchor URL fetch failed"}`);
+		}
+		let witness: { requested: boolean; status: WitnessStatus; error?: string };
+		if (!witnessRequested) {
+			witness = { requested: false, status: "not-consulted" };
+		} else if (!witnessOk) {
+			witness =
+				input.witness.error !== undefined
+					? { requested: true, status: "unreachable", error: input.witness.error }
+					: { requested: true, status: "unreachable" };
+		} else {
+			const disagrees = finalState === "ANCHOR_MISMATCH" || finalState === "ANCHOR_INVALID";
+			witness = { requested: true, status: disagrees ? "disagrees" : "agrees" };
+		}
+		const latest =
+			records.length > 0 ? ([...records].sort((a, b) => b.treeSize - a.treeSize)[0] ?? null) : null;
+		const tailEvents = latest === null ? observed : Math.max(0, observed - latest.treeSize);
+		return {
+			anchorState: finalState,
+			anchorsValid: finalState !== "ANCHOR_INVALID" && finalState !== "ANCHOR_MISMATCH",
+			anchorSource,
+			anchorCount: records.length,
+			latestAnchor:
+				latest === null
+					? null
+					: {
+							anchorSeq: latest.anchorSeq,
+							treeSize: latest.treeSize,
+							lastHash: latest.lastHash,
+							keyId: latest.keyId,
+							timestamp: latest.timestamp,
+						},
+			unanchoredTail: {
+				events: tailEvents,
+				sinceTimestampMs: latest === null ? null : nullIfNaN(Date.parse(latest.timestamp)),
+			},
+			witness,
+			reasons: [...new Set(reasons)],
+			warnings: [...new Set(warnings)],
+			errors,
+		};
+	};
+
+	// Step 2 — discovery.
+	if (!anchorsPresent) {
+		return finish("UNANCHORED", []);
+	}
+
+	// Step 3 — trust material (before parse escalation, per constraints §4.2).
+	if (input.trust === null) {
+		reasons.push("no-trust-material");
+		errors.push("anchor artifacts present but no trust material supplied (pin the public key)");
+		return finish("ANCHOR_UNVERIFIABLE", [...input.externalAnchors, ...input.mirrorAnchors]);
+	}
+
+	// Step 4 — parse failures are fail-closed (mirrors the `.meta` precedent).
+	for (const e of [...input.externalErrors, ...input.mirrorErrors]) {
+		errors.push(e);
+		reasons.push(e.includes("range-invalid") ? "range-invalid" : "malformed-anchor");
+	}
+
+	// Cross-vault replay: a mixed-vaultId union is rejected BEFORE dedup can
+	// collapse a replayed foreign record into a same-seq group.
+	const allVaultIds = new Set(
+		[...input.externalAnchors, ...input.mirrorAnchors].map((r) => r.vaultId),
+	);
+	if (allVaultIds.size > 1) {
+		errors.push(`vault-id-mismatch: anchor set mixes ${allVaultIds.size} distinct vaultIds`);
+		reasons.push("vault-id-mismatch");
+	}
+
+	// Dedup within each stream (racing-emitter duplicates live in ONE stream),
+	// then merge external over mirror. A mirror copy of an external record is
+	// expected, not a duplicate; divergence at one anchorSeq is MISMATCH
+	// (AC-1.2 — the external copy governs).
+	const ext = dedupeAnchorSet(input.externalAnchors);
+	const mir = dedupeAnchorSet(input.mirrorAnchors);
+	for (const set of [ext, mir]) {
+		warnings.push(...set.warnings);
+		errors.push(...set.errors);
+		reasons.push(...set.mismatchReasons);
+	}
+	const extBySeq = new Map(ext.unique.map((r) => [r.anchorSeq, r]));
+	const mergedBySeq = new Map(extBySeq);
+	for (const m of mir.unique) {
+		const e = extBySeq.get(m.anchorSeq);
+		if (e === undefined) {
+			mergedBySeq.set(m.anchorSeq, m);
+		} else if (!committedFieldsEqual(e, m)) {
+			errors.push(
+				`mirror-disagreement: vault mirror and external copy differ at anchorSeq ${m.anchorSeq} (external governs)`,
+			);
+			reasons.push("mirror-disagreement");
+		}
+	}
+	const mergedRecords = [...mergedBySeq.values()].sort((a, b) => a.anchorSeq - b.anchorSeq);
+
+	// Steps 4-5 — signatures, chain linkage, consistency binding. Per-stream
+	// dropped twins are re-appended so the walk signature-checks them too
+	// (spec §7.2 "both signatures valid" — a bad-sig committed-equal twin is
+	// ANCHOR_INVALID regardless of record order).
+	const chain = verifyAnchorChain(
+		[...mergedRecords, ...ext.dropped, ...mir.dropped],
+		input.trust,
+		input.orderedHashes,
+	);
+	errors.push(...chain.errors);
+	reasons.push(...chain.invalidReasons, ...chain.mismatchReasons);
+	warnings.push(...chain.warnings);
+	const records = chain.records;
+
+	// Step 5 — vault binding per record.
+	for (const r of records) {
+		if (opts.expectedVaultId !== undefined && r.vaultId !== opts.expectedVaultId) {
+			errors.push(
+				`vault-id-mismatch: anchorSeq ${r.anchorSeq} carries vaultId ${r.vaultId}, expected ${opts.expectedVaultId}`,
+			);
+			reasons.push("vault-id-mismatch");
+		}
+		if (r.treeSize > observed) {
+			if (observed === 0) {
+				errors.push(
+					`deletion: anchor anchorSeq ${r.anchorSeq} attests ${r.treeSize} event(s); vault presents 0 (deletion detected)`,
+				);
+				reasons.push("deletion");
+			} else {
+				errors.push(
+					`rollback: anchor anchorSeq ${r.anchorSeq} attests ${r.treeSize} event(s); vault presents ${observed}`,
+				);
+				reasons.push("rollback");
+			}
+			continue;
+		}
+		const tree = buildMerkleTree(input.orderedHashes.slice(0, r.treeSize));
+		if (tree.root === undefined || tree.root !== r.merkleRoot) {
+			errors.push(
+				`root-mismatch: recomputed Merkle root at treeSize ${r.treeSize} does not match anchorSeq ${r.anchorSeq}`,
+			);
+			reasons.push("root-mismatch");
+		}
+		if (input.orderedHashes[r.treeSize - 1] !== r.lastHash) {
+			errors.push(
+				`head-mismatch: stored hash at sequence ${r.treeSize} does not match anchorSeq ${r.anchorSeq} lastHash`,
+			);
+			reasons.push("head-mismatch");
+		}
+	}
+
+	// Classify: MISMATCH ≥ INVALID (constraints §4.2 severity).
+	const hasMismatch = reasons.some((c) => !INVALID_REASONS.has(c) && !NON_FAIL_REASONS.has(c));
+	const hasInvalid = reasons.some((c) => INVALID_REASONS.has(c));
+	if (hasMismatch) {
+		return finish("ANCHOR_MISMATCH", records);
+	}
+	if (hasInvalid) {
+		return finish("ANCHOR_INVALID", records);
+	}
+
+	// Step 6 — freshness (caller-supplied policy only; tail always reported).
+	const latest = [...records].sort((a, b) => b.treeSize - a.treeSize)[0];
+	if (latest !== undefined) {
+		const ts = Date.parse(latest.timestamp);
+		if (Number.isFinite(ts) && ts > nowMs) {
+			// Operator-claimed time is in the auditor's future — clock gaming
+			// (buyer-rejection §5.13). --max-unanchored-events is the
+			// clock-independent control.
+			warnings.push("future-timestamp");
+		}
+		const tail = Math.max(0, observed - latest.treeSize);
+		if (opts.maxUnanchoredEvents !== undefined && tail > opts.maxUnanchoredEvents) {
+			errors.push(
+				`stale: ${tail} event(s) since the newest anchor exceed the supplied threshold ${opts.maxUnanchoredEvents}`,
+			);
+			return finish("ANCHOR_STALE", records);
+		}
+		if (
+			opts.maxAnchorAgeMs !== undefined &&
+			Number.isFinite(ts) &&
+			nowMs - ts > opts.maxAnchorAgeMs &&
+			observed > latest.treeSize
+		) {
+			errors.push(
+				"stale: newest anchor is older than the supplied --max-anchor-age (operator-claimed time)",
+			);
+			return finish("ANCHOR_STALE", records);
+		}
+	}
+
+	return finish("ANCHORED_VERIFIED", records);
+}
+
+// ── Inclusion against an external anchor (the F1 fix) ──
+
+/**
+ * Verify a Merkle inclusion proof against a SIGNED EXTERNAL anchor record —
+ * root and treeSize come from the record, never recomputed from the events
+ * under check (spec §7.1; closes F1). The record must verify under the pinned
+ * root or a supplied successor pin.
+ */
+export function verifyInclusionAgainstAnchor(
+	proof: MerkleInclusionProof,
+	record: AnchorRecord,
+	trust: AnchorTrust,
+): boolean {
+	const sig = verifyAnchorSignature(record, [trust.rootPem, ...(trust.successorPinsPem ?? [])]);
+	if (!sig.ok) return false;
+	return verifyInclusionProof(proof, record.merkleRoot, record.treeSize);
+}

--- a/packages/verify/src/anchor-verify.ts
+++ b/packages/verify/src/anchor-verify.ts
@@ -207,8 +207,15 @@ export function parseAnchorRecord(raw: string): {
 	if (typeof obj.merkleRoot !== "string" || !HEX64.test(obj.merkleRoot)) {
 		return { record: null, error: "malformed-anchor: merkleRoot must be 64-hex" };
 	}
-	if (typeof obj.timestamp !== "string" || obj.timestamp.length === 0) {
-		return { record: null, error: "malformed-anchor: missing timestamp" };
+	if (
+		typeof obj.timestamp !== "string" ||
+		obj.timestamp.length === 0 ||
+		!Number.isFinite(Date.parse(obj.timestamp))
+	) {
+		// A signed-but-unparseable timestamp would make the --max-anchor-age
+		// staleness gate silently fail open (Date.parse → NaN) — an
+		// adversary-controlled bypass of the caller's freshness policy.
+		return { record: null, error: "malformed-anchor: timestamp must be a parseable date-time" };
 	}
 	if (typeof obj.keyId !== "string" || !KEY_ID.test(obj.keyId)) {
 		return { record: null, error: "malformed-anchor: keyId must be sha256:<64-hex>" };
@@ -489,6 +496,20 @@ export function verifyAnchorChain(
 	let epochKey: KeyObject | null = rootKey;
 	let prev: AnchorRecord | null = null;
 
+	// A partial history may legitimately START in a later key epoch — the
+	// documented lone-checkpoint bind (§7.5) fetched after a rotation. When
+	// the first record's key is a caller-TRUSTED key (root or successor pin),
+	// adopt it as the starting epoch instead of condemning the unprovable
+	// prefix; an untrusted key stays fail-closed (sig-invalid below).
+	const firstRecord = ordered[0];
+	if (firstRecord !== undefined && firstRecord.anchorSeq !== 1 && firstRecord.keyId !== rootKeyId) {
+		const pinnedStart = knownKeys.get(firstRecord.keyId);
+		if (pinnedStart !== undefined) {
+			epochKeyId = firstRecord.keyId;
+			epochKey = pinnedStart;
+		}
+	}
+
 	for (let i = 0; i < ordered.length; i++) {
 		const r = ordered[i] as AnchorRecord;
 
@@ -509,7 +530,13 @@ export function verifyAnchorChain(
 			mismatchReasons.push("anchor-chain-gap");
 		}
 		if (prev !== null && r.anchorSeq === prev.anchorSeq + 1) {
-			if (r.prevAnchorHash !== anchorPayloadHash(prev)) {
+			// The predecessor may exist as several benign committed-equal twins
+			// (differing only in timestamp/sig — racing-emitter duplicates), and
+			// timestamp IS part of the signing pre-image: the successor
+			// legitimately links to WHICHEVER twin its emitter had as the mirror
+			// tail, so linkage accepts any twin's payload hash.
+			const prevTwins = [prev, ...(droppedBySeq.get(prev.anchorSeq) ?? [])];
+			if (!prevTwins.some((t) => r.prevAnchorHash === anchorPayloadHash(t))) {
 				errors.push(
 					`anchor-chain-gap: anchorSeq ${r.anchorSeq} prevAnchorHash does not link to its predecessor`,
 				);

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -2,32 +2,208 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Usertools, Inc.
 
-import { exitCodeFor, verifyTransaction, verifyVault } from "./index.js";
+/**
+ * usertrust-verify CLI.
+ *
+ * Anchor contract (spec §7.5): the CALLER fetches anchor artifacts (aws s3
+ * cp, git show, SIEM export) and passes them as files/stdin; trust material
+ * (--pubkey = THE pinned genesis root, --successor-pin = rotation pins) is
+ * pinned out-of-band and NEVER read from the vault under audit. --anchor-url
+ * is an opt-in convenience (bare node:https GET); offline is the primary path.
+ */
+
+import { readFileSync } from "node:fs";
+import { parseAnchorsContent } from "./anchor-verify.js";
+import {
+	type AnchorVerifyParams,
+	type AnchoredVaultVerificationResult,
+	type WitnessInput,
+	exitCodeFor,
+	exitCodeForAnchored,
+	verifyTransaction,
+	verifyVault,
+	verifyVaultWithAnchors,
+} from "./index.js";
 
 const args = process.argv.slice(2);
 
-// Parse --tx flag
+function usage(): never {
+	console.log(`Usage: npx usertrust-verify <path-to-.usertrust> [options]
+
+Options:
+  --tx <transferId>              Verify a single transaction (receipt)
+  --anchor <file|->              Caller-fetched anchor artifact (repeatable; - = stdin)
+  --anchors <file>               Anchor history file (JSONL; repeatable)
+  --anchor-url <url>             Opt-in: fetch one anchor artifact over HTTPS
+  --pubkey <pem-file>            PINNED genesis root public key (out-of-band)
+  --successor-pin <pem-file>     Pinned rotation-successor key (repeatable)
+  --vault-id <uuid>              Expected vaultId
+  --require-anchor               Strict: UNANCHORED/UNVERIFIABLE/STALE exit 1
+  --require-external-anchor      Strict: exit 0 only for externally anchored
+  --max-anchor-age <dur>         Freshness policy, e.g. 1h, 30m (operator-claimed time)
+  --max-unanchored-events <n>    Freshness policy (clock-independent; preferred)`);
+	process.exit(1);
+}
+
+function parseDurationMs(raw: string): number {
+	const m = /^(\d+)(ms|s|m|h|d)?$/.exec(raw);
+	if (m === null) {
+		console.error(`Invalid duration: ${raw} (use e.g. 500ms, 30s, 15m, 1h, 7d)`);
+		process.exit(1);
+	}
+	const n = Number.parseInt(m[1] as string, 10);
+	const mult = { ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[m[2] ?? "ms"] as number;
+	return n * mult;
+}
+
+function readArtifact(pathOrDash: string): string {
+	if (pathOrDash === "-") return readFileSync(0, "utf-8");
+	return readFileSync(pathOrDash, "utf-8");
+}
+
+function fetchAnchorUrl(url: string): Promise<{ ok: boolean; body?: string; error?: string }> {
+	return new Promise((resolve) => {
+		import("node:https")
+			.then((https) => {
+				const req = https.get(url, { timeout: 15_000 }, (res) => {
+					const code = res.statusCode ?? 0;
+					if (code < 200 || code >= 300) {
+						res.resume();
+						resolve({ ok: false, error: `HTTP ${code}` });
+						return;
+					}
+					const chunks: Buffer[] = [];
+					res.on("data", (c: Buffer) => chunks.push(c));
+					res.on("end", () => resolve({ ok: true, body: Buffer.concat(chunks).toString("utf-8") }));
+				});
+				req.on("timeout", () => req.destroy(new Error("timeout")));
+				req.on("error", (err) => resolve({ ok: false, error: err.message }));
+			})
+			.catch((err: Error) => resolve({ ok: false, error: err.message }));
+	});
+}
+
+// ── Parse flags ──
+
 let vaultPath: string | undefined;
 let txId: string | undefined;
+const anchorFiles: string[] = [];
+let anchorUrl: string | undefined;
+let pubkeyFile: string | undefined;
+const successorPinFiles: string[] = [];
+let vaultId: string | undefined;
+let requireAnchor = false;
+let requireExternalAnchor = false;
+let maxAnchorAgeMs: number | undefined;
+let maxUnanchoredEvents: number | undefined;
 
 for (let i = 0; i < args.length; i++) {
 	const arg = args[i] as string;
-	if (arg === "--tx" && i + 1 < args.length) {
-		txId = args[i + 1] as string;
-		i++; // skip next arg
-	} else if (!arg.startsWith("--")) {
-		vaultPath = arg;
-	}
+	const next = (): string => {
+		const v = args[i + 1];
+		if (v === undefined) usage();
+		i++;
+		return v;
+	};
+	if (arg === "--tx") txId = next();
+	else if (arg === "--anchor" || arg === "--anchors") anchorFiles.push(next());
+	else if (arg === "--anchor-url") anchorUrl = next();
+	else if (arg === "--pubkey") pubkeyFile = next();
+	else if (arg === "--successor-pin") successorPinFiles.push(next());
+	else if (arg === "--vault-id") vaultId = next();
+	else if (arg === "--require-anchor") requireAnchor = true;
+	else if (arg === "--require-external-anchor") requireExternalAnchor = true;
+	else if (arg === "--max-anchor-age") maxAnchorAgeMs = parseDurationMs(next());
+	else if (arg === "--max-unanchored-events") maxUnanchoredEvents = Number.parseInt(next(), 10);
+	else if (arg === "--help" || arg === "-h") usage();
+	else if (!arg.startsWith("--")) vaultPath = arg;
+	else usage();
 }
 
-if (!vaultPath) {
-	console.log("Usage: npx usertrust-verify <path-to-.usertrust> [--tx <transferId>]");
-	process.exit(1);
+if (!vaultPath) usage();
+
+const anchorMode =
+	anchorFiles.length > 0 ||
+	anchorUrl !== undefined ||
+	pubkeyFile !== undefined ||
+	requireAnchor ||
+	requireExternalAnchor;
+
+async function buildAnchorParams(): Promise<AnchorVerifyParams> {
+	const externalAnchorsRaw: string[] = anchorFiles.map(readArtifact);
+	let witness: WitnessInput = { requested: false };
+	if (anchorUrl !== undefined) {
+		const fetched = await fetchAnchorUrl(anchorUrl);
+		// AC-2.4: a 2xx with an empty or unparseable body is NOT a consulted
+		// witness — treat it as unreachable (inconclusive), never a hard fail,
+		// and never let it launder mirror-only evidence into anchorSource
+		// "external". Only a cleanly-parsing body counts.
+		const parsed =
+			fetched.ok && fetched.body !== undefined ? parseAnchorsContent(fetched.body) : null;
+		if (parsed !== null && parsed.records.length > 0 && parsed.errors.length === 0) {
+			externalAnchorsRaw.push(fetched.body as string);
+			witness = { requested: true, ok: true };
+		} else {
+			witness = {
+				requested: true,
+				ok: false,
+				error: fetched.ok
+					? "witness returned an empty or unparseable body"
+					: (fetched.error ?? "fetch failed"),
+			};
+		}
+	}
+	const trust =
+		pubkeyFile !== undefined
+			? {
+					rootPem: readFileSync(pubkeyFile, "utf-8"),
+					...(successorPinFiles.length > 0
+						? { successorPinsPem: successorPinFiles.map((f) => readFileSync(f, "utf-8")) }
+						: {}),
+				}
+			: undefined;
+	return {
+		externalAnchorsRaw,
+		...(trust !== undefined ? { trust } : {}),
+		witness,
+		...(maxAnchorAgeMs !== undefined ? { maxAnchorAgeMs } : {}),
+		...(maxUnanchoredEvents !== undefined ? { maxUnanchoredEvents } : {}),
+		...(vaultId !== undefined ? { expectedVaultId: vaultId } : {}),
+	};
+}
+
+function printAnchorSection(result: AnchoredVaultVerificationResult): void {
+	const a = result.anchoring;
+	if (result.anchorState === "UNANCHORED") {
+		console.log(
+			"Anchor state: UNANCHORED — internal consistency only; supply --anchor + --pubkey for independent verification",
+		);
+		return;
+	}
+	console.log(`Anchor state: ${result.anchorState} (source: ${a.anchorSource})`);
+	if (a.latestAnchor) {
+		console.log(
+			`Latest anchor: #${a.latestAnchor.anchorSeq} treeSize ${a.latestAnchor.treeSize} keyId ${a.latestAnchor.keyId.slice(0, 19)}… (${a.latestAnchor.timestamp})`,
+		);
+	}
+	console.log(`Unanchored tail: ${a.unanchoredTail.events} event(s)`);
+	if (a.witness.requested) {
+		console.log(`Witness: ${a.witness.status}${a.witness.error ? ` (${a.witness.error})` : ""}`);
+	}
+	if (a.anchorSource === "vault-mirror") {
+		console.log(
+			"WARNING: anchors verified from the VAULT-LOCAL mirror only — a vault-writing attacker can truncate mirror and events together. Supply an externally fetched copy.",
+		);
+	}
+	for (const w of a.warnings) {
+		console.log(`WARNING: ${w}`);
+	}
 }
 
 // ── Single transaction mode ──
 if (txId !== undefined) {
-	const result = verifyTransaction(vaultPath, txId);
+	const params = anchorMode ? await buildAnchorParams() : undefined;
+	const result = verifyTransaction(vaultPath, txId, params);
 	console.log(result.receipt);
 	// Exit 0: verified, 1: tampered/corrupted, 2: not found
 	if (!result.found) process.exit(2);
@@ -35,24 +211,45 @@ if (txId !== undefined) {
 }
 
 // ── Full vault verification ──
-const result = verifyVault(vaultPath);
+if (!anchorMode) {
+	const result = verifyVault(vaultPath);
+	if (result.valid) {
+		console.log("Vault integrity: VERIFIED (UNANCHORED — internal consistency only)");
+	} else {
+		console.log("Vault integrity: FAILED");
+		for (const error of result.errors) {
+			console.log(`  - ${error}`);
+		}
+	}
+	console.log(`Chain length: ${result.chainLength} events`);
+	console.log(`Merkle root: ${result.merkleRoot ?? "N/A"}`);
+	console.log("Hash algorithm: SHA-256");
+	if (result.firstEvent) console.log(`First event: ${result.firstEvent}`);
+	if (result.lastEvent) console.log(`Last event: ${result.lastEvent}`);
+	if (result.chainLength > 0) {
+		console.log(`All hashes: valid (${result.validHashes}/${result.chainLength})`);
+	}
+	process.exit(exitCodeFor(result));
+}
 
+const result = verifyVaultWithAnchors(vaultPath, await buildAnchorParams());
 if (result.valid) {
-	console.log("Vault integrity: VERIFIED");
+	console.log(
+		result.anchorState === "ANCHORED_VERIFIED"
+			? `Vault integrity: VERIFIED (${result.anchoring.anchorSource === "external" ? "externally anchored" : "vault-mirror anchors only"})`
+			: `Vault integrity: VERIFIED (${result.anchorState})`,
+	);
 } else {
-	console.log("Vault integrity: FAILED");
+	console.log(`Vault integrity: FAILED (${result.anchorState})`);
 	for (const error of result.errors) {
 		console.log(`  - ${error}`);
 	}
 }
+printAnchorSection(result);
 console.log(`Chain length: ${result.chainLength} events`);
 console.log(`Merkle root: ${result.merkleRoot ?? "N/A"}`);
 console.log("Hash algorithm: SHA-256");
-if (result.firstEvent) console.log(`First event: ${result.firstEvent}`);
-if (result.lastEvent) console.log(`Last event: ${result.lastEvent}`);
 if (result.chainLength > 0) {
 	console.log(`All hashes: valid (${result.validHashes}/${result.chainLength})`);
 }
-
-// Exit nonzero on a FAILED verdict so CI gates fail on a tampered vault.
-process.exit(exitCodeFor(result));
+process.exit(exitCodeForAnchored(result, { requireAnchor, requireExternalAnchor }));

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -114,8 +114,20 @@ for (let i = 0; i < args.length; i++) {
 	else if (arg === "--require-anchor") requireAnchor = true;
 	else if (arg === "--require-external-anchor") requireExternalAnchor = true;
 	else if (arg === "--max-anchor-age") maxAnchorAgeMs = parseDurationMs(next());
-	else if (arg === "--max-unanchored-events") maxUnanchoredEvents = Number.parseInt(next(), 10);
-	else if (arg === "--help" || arg === "-h") usage();
+	else if (arg === "--max-unanchored-events") {
+		const rawEvents = next();
+		maxUnanchoredEvents = Number.parseInt(rawEvents, 10);
+		// parseInt("1O0") === 1 (partial parse) and NaN comparisons are always
+		// false — either typo would silently weaken the staleness gate.
+		if (
+			!/^\d+$/.test(rawEvents) ||
+			!Number.isSafeInteger(maxUnanchoredEvents) ||
+			maxUnanchoredEvents < 0
+		) {
+			console.error("Invalid --max-unanchored-events: must be a non-negative integer");
+			process.exit(1);
+		}
+	} else if (arg === "--help" || arg === "-h") usage();
 	else if (!arg.startsWith("--")) vaultPath = arg;
 	else usage();
 }
@@ -134,13 +146,16 @@ async function buildAnchorParams(): Promise<AnchorVerifyParams> {
 	let witness: WitnessInput = { requested: false };
 	if (anchorUrl !== undefined) {
 		const fetched = await fetchAnchorUrl(anchorUrl);
-		// AC-2.4: a 2xx with an empty or unparseable body is NOT a consulted
-		// witness — treat it as unreachable (inconclusive), never a hard fail,
-		// and never let it launder mirror-only evidence into anchorSource
-		// "external". Only a cleanly-parsing body counts.
+		// AC-2.4: a 2xx with an empty or fully-unparseable body is NOT a
+		// consulted witness — treat it as unreachable (inconclusive) and never
+		// let it launder mirror-only evidence into anchorSource "external".
+		// But a body with ANY cleanly parsed records IS evidence: keep the
+		// whole body (embedded parse errors fail closed downstream) — throwing
+		// away 50 valid records over one truncated line would discard the very
+		// rollback proof the witness exists to provide.
 		const parsed =
 			fetched.ok && fetched.body !== undefined ? parseAnchorsContent(fetched.body) : null;
-		if (parsed !== null && parsed.records.length > 0 && parsed.errors.length === 0) {
+		if (parsed !== null && parsed.records.length > 0) {
 			externalAnchorsRaw.push(fetched.body as string);
 			witness = { requested: true, ok: true };
 		} else {
@@ -207,7 +222,19 @@ if (txId !== undefined) {
 	console.log(result.receipt);
 	// Exit 0: verified, 1: tampered/corrupted, 2: not found
 	if (!result.found) process.exit(2);
-	process.exit(result.valid ? 0 : 1);
+	if (!result.valid) process.exit(1);
+	// Strict gates apply in --tx mode too — the flags turned anchorMode on,
+	// so silently ignoring them here would let an UNANCHORED receipt pass a
+	// --require-external-anchor pipeline.
+	if (result.anchorState !== undefined && result.anchoring !== undefined) {
+		process.exit(
+			exitCodeForAnchored(
+				{ valid: true, anchorState: result.anchorState, anchoring: result.anchoring },
+				{ requireAnchor, requireExternalAnchor },
+			),
+		);
+	}
+	process.exit(0);
 }
 
 // ── Full vault verification ──

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -6,6 +6,21 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { basename, join } from "node:path";
+import {
+	type AnchorRecord,
+	type AnchorSource,
+	type AnchorState,
+	type AnchorTrust,
+	type WitnessInput,
+	type WitnessStatus,
+	dedupeAnchorSet,
+	evaluateAnchoredVault,
+	gatherOrderedEventHashes,
+	parseAnchorsContent,
+	publicKeyFromSpkiBase64,
+	readAnchorMirror,
+	verifyInclusionAgainstAnchor,
+} from "./anchor-verify.js";
 import { canonicalize } from "./canonical.js";
 import { GENESIS_HASH } from "./constants.js";
 import {
@@ -44,6 +59,36 @@ export {
 	type MerkleInclusionProof,
 	type MerkleConsistencyProof,
 } from "./verify.js";
+export {
+	type AnchorChainResult,
+	type AnchorEvaluation,
+	type AnchorEvaluationInput,
+	type AnchorEvaluationOptions,
+	type AnchorRecord,
+	type AnchorRotation,
+	type AnchorSource,
+	type AnchorState,
+	type AnchorTrust,
+	type WitnessInput,
+	type WitnessStatus,
+	anchorPayloadHash,
+	anchorSigningPreimage,
+	committedFieldsEqual,
+	dedupeAnchorSet,
+	evaluateAnchoredVault,
+	gatherOrderedEventHashes,
+	keyIdFromKeyObject,
+	keyIdFromSpkiDer,
+	parseAnchorRecord,
+	parseAnchorsContent,
+	publicKeyFromPem,
+	publicKeyFromSpkiBase64,
+	readAnchorMirror,
+	verifyAnchorChain,
+	verifyAnchorSignature,
+	verifyInclusionAgainstAnchor,
+	verifySignatureRaw,
+} from "./anchor-verify.js";
 
 // ── Vault Verification ──
 
@@ -261,6 +306,125 @@ export function exitCodeFor(result: { valid: boolean }): number {
 	return result.valid ? 0 : 1;
 }
 
+// ── Anchored Vault Verification (spec §7) ──
+
+export interface AnchorVerifyParams {
+	/** Raw contents of caller-fetched anchor artifacts (single JSON or JSONL). */
+	readonly externalAnchorsRaw?: readonly string[] | undefined;
+	/** Caller-pinned trust material — NEVER read from the vault under audit. */
+	readonly trust?: AnchorTrust | undefined;
+	readonly witness?: WitnessInput | undefined;
+	readonly maxAnchorAgeMs?: number | undefined;
+	readonly maxUnanchoredEvents?: number | undefined;
+	readonly expectedVaultId?: string | undefined;
+	readonly nowMs?: number | undefined;
+}
+
+export interface AnchoringReport {
+	anchorSource: AnchorSource;
+	anchorCount: number;
+	latestAnchor: {
+		anchorSeq: number;
+		treeSize: number;
+		lastHash: string;
+		keyId: string;
+		timestamp: string;
+	} | null;
+	unanchoredTail: { events: number; sinceTimestampMs: number | null };
+	witness: { requested: boolean; status: WitnessStatus; error?: string };
+	reasons: string[];
+	warnings: string[];
+}
+
+export interface AnchoredVaultVerificationResult extends VaultVerificationResult {
+	anchorState: AnchorState;
+	anchoring: AnchoringReport;
+}
+
+/**
+ * verifyVault + the spec §7.2 anchor state machine. Existing chain semantics
+ * are UNCHANGED (verifyVault runs as-is); anchor evaluation is layered on
+ * top additively. IDENTICAL function body in packages/core/src/audit/verify.ts
+ * — the anchor differential test pins the two.
+ */
+export function verifyVaultWithAnchors(
+	vaultPath: string,
+	params: AnchorVerifyParams = {},
+): AnchoredVaultVerificationResult {
+	const base = verifyVault(vaultPath);
+	const externalRecords: AnchorRecord[] = [];
+	const externalErrors: string[] = [];
+	for (const raw of params.externalAnchorsRaw ?? []) {
+		const parsed = parseAnchorsContent(raw);
+		externalRecords.push(...parsed.records);
+		externalErrors.push(...parsed.errors);
+	}
+	const mirror = readAnchorMirror(vaultPath);
+	const evaluation = evaluateAnchoredVault({
+		orderedHashes: gatherOrderedEventHashes(vaultPath),
+		externalAnchors: externalRecords,
+		externalErrors,
+		mirrorAnchors: mirror.records,
+		mirrorErrors: mirror.errors,
+		trust: params.trust ?? null,
+		witness: params.witness ?? { requested: false },
+		opts: {
+			...(params.maxAnchorAgeMs !== undefined ? { maxAnchorAgeMs: params.maxAnchorAgeMs } : {}),
+			...(params.maxUnanchoredEvents !== undefined
+				? { maxUnanchoredEvents: params.maxUnanchoredEvents }
+				: {}),
+			...(params.expectedVaultId !== undefined ? { expectedVaultId: params.expectedVaultId } : {}),
+			...(params.nowMs !== undefined ? { nowMs: params.nowMs } : {}),
+		},
+	});
+	return {
+		...base,
+		valid: base.valid && evaluation.anchorsValid,
+		errors: [...base.errors, ...evaluation.errors],
+		anchorState: evaluation.anchorState,
+		anchoring: {
+			anchorSource: evaluation.anchorSource,
+			anchorCount: evaluation.anchorCount,
+			latestAnchor: evaluation.latestAnchor,
+			unanchoredTail: evaluation.unanchoredTail,
+			witness: evaluation.witness,
+			reasons: evaluation.reasons,
+			warnings: evaluation.warnings,
+		},
+	};
+}
+
+/**
+ * Exit-code policy for anchored verification. Exit codes stay 0/1
+ * (constraints §4.3); `--require-anchor` and `--require-external-anchor` are
+ * new INPUTS, not changed defaults.
+ */
+export function exitCodeForAnchored(
+	result: {
+		valid: boolean;
+		anchorState: AnchorState;
+		anchoring: { anchorSource: AnchorSource };
+	},
+	opts?: { requireAnchor?: boolean; requireExternalAnchor?: boolean },
+): number {
+	if (!result.valid) return 1;
+	if (
+		opts?.requireAnchor === true &&
+		(result.anchorState === "UNANCHORED" ||
+			result.anchorState === "ANCHOR_UNVERIFIABLE" ||
+			result.anchorState === "ANCHOR_STALE")
+	) {
+		return 1;
+	}
+	if (
+		opts?.requireExternalAnchor === true &&
+		(result.anchorState !== "ANCHORED_VERIFIED" || result.anchoring.anchorSource !== "external")
+	) {
+		return 1;
+	}
+	return 0;
+}
+
 // ── Single Transaction Verification ──
 
 export interface TransactionVerificationResult {
@@ -273,11 +437,18 @@ export interface TransactionVerificationResult {
 /**
  * Verify a single transaction and return a formatted receipt.
  *
- * Finds the event matching `txId` (by `data.transferId`), verifies the
- * hash chain up to that event, generates a Merkle inclusion proof, and
- * returns a terminal-formatted receipt string.
+ * Finds the event matching `txId` (by `data.transferId`) and verifies the
+ * hash chain. WITHOUT anchor inputs the receipt claims chain consistency
+ * only — the historical self-referential inclusion check (proof verified
+ * against a root recomputed from the same events, F1) is retired (AC-5.2).
+ * WITH anchor inputs the §7.2 state machine runs over the whole vault first
+ * (AC-5.4) and inclusion is proven against the SIGNED EXTERNAL anchor root.
  */
-export function verifyTransaction(vaultPath: string, txId: string): TransactionVerificationResult {
+export function verifyTransaction(
+	vaultPath: string,
+	txId: string,
+	anchorParams?: AnchorVerifyParams,
+): TransactionVerificationResult {
 	const auditDir = join(vaultPath, "audit");
 	const mainLog = join(auditDir, "events.jsonl");
 
@@ -328,16 +499,94 @@ export function verifyTransaction(vaultPath: string, txId: string): TransactionV
 	const chainResult = verifyChain(mainLog);
 	const chainVerified = chainResult.valid;
 
-	// Build Merkle tree and generate inclusion proof
+	// Merkle root over the stored hashes — informational display only. The
+	// self-referential inclusion check (F1: proof AND root computed from the
+	// same allHashes) is retired; inclusion is only ever claimed against a
+	// verified EXTERNAL anchor root below (AC-5.2).
 	const allHashes = events.map((e) => e.hash);
 	const tree = buildMerkleTree(allHashes);
-	const merkleRoot = tree.root ?? "";
+	let merkleRoot = tree.root ?? "";
 	const leafIndex = events.indexOf(targetEvent);
 
-	let merkleVerified = false;
-	if (tree.root !== undefined && leafIndex >= 0) {
-		const proof = generateInclusionProof(leafIndex, allHashes, "events.jsonl");
-		merkleVerified = verifyInclusionProof(proof, tree.root, allHashes.length);
+	let merkleVerified: boolean;
+	let merkleLabel: string;
+	let anchorsValid = true;
+	const anchorErrors: string[] = [];
+
+	if (anchorParams === undefined) {
+		merkleVerified = chainVerified;
+		merkleLabel = chainVerified ? "CHAIN CONSISTENT (UNANCHORED)" : "CHAIN INCONSISTENT";
+	} else {
+		// AC-5.4: the anchor state machine runs over the WHOLE vault first —
+		// an ANCHOR_INVALID / ANCHOR_MISMATCH vault must never render
+		// "INCLUSION VERIFIED", whatever the single-event proof says.
+		const vaultResult = verifyVaultWithAnchors(vaultPath, anchorParams);
+		anchorsValid = vaultResult.valid;
+		anchorErrors.push(...vaultResult.anchoring.reasons.map((r) => `anchor: ${r}`));
+		const state = vaultResult.anchorState;
+		if (state === "ANCHORED_VERIFIED" || state === "ANCHOR_STALE") {
+			const orderedHashes = gatherOrderedEventHashes(vaultPath);
+			const pos = typeof targetEvent.sequence === "number" ? targetEvent.sequence : leafIndex + 1;
+			const candidates: AnchorRecord[] = [];
+			for (const raw of anchorParams.externalAnchorsRaw ?? []) {
+				candidates.push(...parseAnchorsContent(raw).records);
+			}
+			candidates.push(...readAnchorMirror(vaultPath).records);
+			const uniqueAnchors = dedupeAnchorSet(candidates).unique;
+			const covering = uniqueAnchors
+				.filter((r) => r.treeSize >= pos)
+				.sort((a, b) => a.treeSize - b.treeSize)[0];
+			if (covering === undefined) {
+				// Honest tail label — never "verified" for unanchored events.
+				merkleVerified = chainVerified;
+				merkleLabel = "IN UNANCHORED TAIL";
+			} else if (
+				anchorParams.trust !== undefined &&
+				pos >= 1 &&
+				covering.treeSize <= orderedHashes.length
+			) {
+				const proof = generateInclusionProof(
+					pos - 1,
+					orderedHashes.slice(0, covering.treeSize),
+					"events.jsonl",
+				);
+				// §7.1: resolve the covering record's epoch key the way the chain
+				// walk does — root + caller pins + in-chain rotation successors.
+				// This branch is gated on ANCHORED_VERIFIED/ANCHOR_STALE, so every
+				// rotation here was already validated; a forged rotation never
+				// reaches this point. Without this, a post-rotation-covered event
+				// falsely reports INCLUSION FAILED (the state machine accepted it).
+				const inChainSuccessorPems = uniqueAnchors.flatMap((r) => {
+					if (r.rotation === undefined) return [];
+					const k = publicKeyFromSpkiBase64(r.rotation.nextPublicKeySpki);
+					return k === null ? [] : [k.export({ type: "spki", format: "pem" }) as string];
+				});
+				const ok = verifyInclusionAgainstAnchor(proof, covering, {
+					...anchorParams.trust,
+					successorPinsPem: [
+						...(anchorParams.trust.successorPinsPem ?? []),
+						...inChainSuccessorPems,
+					],
+				});
+				merkleVerified = ok;
+				merkleRoot = covering.merkleRoot;
+				merkleLabel = ok
+					? `INCLUSION VERIFIED (anchor #${covering.anchorSeq})`
+					: "INCLUSION FAILED (anchored root)";
+			} else {
+				merkleVerified = false;
+				merkleLabel = "INCLUSION UNVERIFIABLE";
+			}
+		} else if (state === "UNANCHORED") {
+			merkleVerified = chainVerified;
+			merkleLabel = chainVerified ? "CHAIN CONSISTENT (UNANCHORED)" : "CHAIN INCONSISTENT";
+		} else if (state === "ANCHOR_UNVERIFIABLE") {
+			merkleVerified = chainVerified;
+			merkleLabel = "INCLUSION UNVERIFIABLE";
+		} else {
+			merkleVerified = false;
+			merkleLabel = "INCLUSION UNVERIFIABLE";
+		}
 	}
 
 	// Compute cumulative spend up to and including this event
@@ -357,13 +606,14 @@ export function verifyTransaction(vaultPath: string, txId: string): TransactionV
 		chainVerified,
 		cumulativeSpend,
 		verifiedAt: new Date(),
+		merkleLabel,
 	};
 
-	const allErrors = [...parseErrors, ...chainResult.errors];
+	const allErrors = [...parseErrors, ...chainResult.errors, ...anchorErrors];
 
 	return {
 		found: true,
-		valid: chainVerified && merkleVerified,
+		valid: chainVerified && merkleVerified && anchorsValid,
 		receipt: renderReceipt(receiptData),
 		errors: allErrors,
 	};

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -432,6 +432,11 @@ export interface TransactionVerificationResult {
 	readonly valid: boolean;
 	readonly receipt: string;
 	readonly errors: string[];
+	/** Present when anchor inputs were supplied: the §7.2 vault-level state,
+	 * so CLI strict gates (--require-anchor / --require-external-anchor) can
+	 * be enforced in --tx mode too. */
+	readonly anchorState?: AnchorState | undefined;
+	readonly anchoring?: AnchoringReport | undefined;
 }
 
 /**
@@ -511,6 +516,8 @@ export function verifyTransaction(
 	let merkleVerified: boolean;
 	let merkleLabel: string;
 	let anchorsValid = true;
+	let anchorState: AnchorState | undefined;
+	let anchoring: AnchoringReport | undefined;
 	const anchorErrors: string[] = [];
 
 	if (anchorParams === undefined) {
@@ -522,6 +529,8 @@ export function verifyTransaction(
 		// "INCLUSION VERIFIED", whatever the single-event proof says.
 		const vaultResult = verifyVaultWithAnchors(vaultPath, anchorParams);
 		anchorsValid = vaultResult.valid;
+		anchorState = vaultResult.anchorState;
+		anchoring = vaultResult.anchoring;
 		anchorErrors.push(...vaultResult.anchoring.reasons.map((r) => `anchor: ${r}`));
 		const state = vaultResult.anchorState;
 		if (state === "ANCHORED_VERIFIED" || state === "ANCHOR_STALE") {
@@ -616,5 +625,7 @@ export function verifyTransaction(
 		valid: chainVerified && merkleVerified && anchorsValid,
 		receipt: renderReceipt(receiptData),
 		errors: allErrors,
+		...(anchorState !== undefined ? { anchorState } : {}),
+		...(anchoring !== undefined ? { anchoring } : {}),
 	};
 }

--- a/packages/verify/src/receipt.ts
+++ b/packages/verify/src/receipt.ts
@@ -35,6 +35,13 @@ export interface ReceiptData {
 	readonly chainVerified: boolean;
 	readonly cumulativeSpend: number;
 	readonly verifiedAt: Date;
+	/**
+	 * Honest Merkle-row label. "INCLUSION VERIFIED" may ONLY be passed when
+	 * the proof was checked against a verified EXTERNAL anchor root — never
+	 * from a root recomputed out of the same events (the retired F1 path).
+	 * Absent → the truthful unanchored default is rendered.
+	 */
+	readonly merkleLabel?: string | undefined;
 }
 
 // ── Formatting helpers ──
@@ -243,7 +250,11 @@ export function renderReceipt(data: ReceiptData): string {
 	lines.push(row(`${dotted("  Hash", truncHash(event.hash), WIDTH - 1)} `));
 	lines.push(row(`${dotted("  Prev", truncHash(event.previousHash), WIDTH - 1)} `));
 
-	const merkleStatus = merkleVerified ? "INCLUSION VERIFIED" : "INCLUSION FAILED";
+	// AC-5.3: without an external anchor the truthful claim is chain
+	// consistency, not inclusion — the old unconditional "INCLUSION VERIFIED"
+	// came from a self-referential proof and is retired.
+	const merkleStatus =
+		data.merkleLabel ?? (merkleVerified ? "CHAIN CONSISTENT (UNANCHORED)" : "INCLUSION FAILED");
 	lines.push(row(`${dotted("  Merkle", merkleStatus, WIDTH - 1)} `));
 
 	lines.push(blank());

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
 		coverage: {
 			provider: "v8",
 			include: ["packages/*/src/**/*.ts"],
-			exclude: ["packages/*/src/cli/**"],
+			// CLI entrypoints are process-level scripts (parse argv, print,
+			// process.exit) — excluded from unit coverage. verify's CLI is a
+			// single file rather than a cli/ directory.
+			exclude: ["packages/*/src/cli/**", "packages/verify/src/cli.ts"],
 			thresholds: {
 				lines: 92,
 				branches: 84,


### PR DESCRIPTION
## What

External anchoring for the audit chain: the writer periodically emits an **Ed25519-signed checkpoint** of the chain head (Merkle root + treeSize + lastHash, hash-chained to the previous checkpoint — the Certificate-Transparency STH pattern) to an **append-only store the vault operator cannot silently rewrite**. The zero-dependency verifier binds the vault to caller-fetched checkpoints under a caller-pinned public key, fully offline.

This turns "tamper-evident *if you trust the operator's files*" into **independently verifiable**: hashing has no secret input, so before this a vault owner could rewrite an event, recompute every hash + `.meta`, and pass verification cleanly. Now that exact attack is the first pinned test.

## Closes the three audit findings

- **F1** — the self-referential Merkle inclusion check (`INCLUSION VERIFIED` printed from a root recomputed out of the same events) is retired; inclusion is only ever claimed against a verified **external** anchor root.
- **F2** — deleting the entire audit tree is now detected: the store's checkpoint attests N events against a vault presenting 0.
- **F3** — both path-derived DLQ "integrity" HMACs (`audit/chain.ts` **and** `ledger/engine.ts`) replaced with an honest corruption checksum (a host-resident MAC key adds nothing against the primary adversary; no verifier ever consumed them).

## Surface

- **Mirrored verifier** (`anchor-verify.ts`, byte-identical in `packages/verify` + `packages/core`, pinned by a parity test): strict record parsing, key epochs with cross-signed rotation + `--successor-pin`, anchor-chain linkage, externally-bound consistency proofs, and the `UNANCHORED / ANCHORED_VERIFIED / ANCHOR_STALE / ANCHOR_UNVERIFIABLE / ANCHOR_INVALID / ANCHOR_MISMATCH` state machine. Legacy vaults stay valid (labeled `UNANCHORED`).
- **Emitter** (`packages/core/src/audit/anchor.ts`): advisory-locked snapshot, durable anchorSeq high-water, outbox with redelivery (a transient sink outage cannot leave a permanent store gap), file/https/command/custom sinks, PEM or external (KMS-style) signer, and a cadence scheduler that surfaces failures as `degraded`/`lastEmitError` instead of crashing the host process.
- **CLIs**: `usertrust anchor init|now|status|export|rotate|resume` (delivery-gated exits); `--anchor/--anchors/--anchor-url/--pubkey/--successor-pin/--require-anchor/--require-external-anchor/--max-anchor-age/--max-unanchored-events/--vault-id` on both verify CLIs.
- **Docs**: [`docs/anchoring.md`](https://github.com/usertools-ai/usertrust/blob/feat/external-anchoring/docs/anchoring.md) — the deployment invariant (*the identity that writes the vault gets append-only store access*), S3 Object Lock / protected-branch / SIEM recipes, the staleness monitor rule, key ceremony, pull-mode caveat.

## Guarantees preserved (additive-only)

- `canonicalize`, event hashing, and the `.meta` format are untouched; `events.jsonl`/`.meta` bytes are byte-identical with anchoring on vs off (pinned test).
- The pre-existing differential test passes **unchanged**; a new anchor differential suite pins core↔verify verdict parity.
- `packages/verify` stays `"dependencies": {}` — enforced by a test, plus an import lint and a LOC-budget tripwire against vendored source.

## Tests

52 new anchoring tests (full suite 1957 green, tsc + biome clean):
- **30-row adversarial corpus** — mutate + full re-chain, whole-vault deletion, rollback/truncation, forks, forged/substituted keys, rotation hijack (pinned + unpinned), degenerate numeric records (no throws), witness unreachable vs disagrees, benign duplicates vs fork evidence, cross-vault replay, strict-gate behavior.
- **Additive proofs**, **differential parity**, **emitter hardening** (scheduler crash, outbox redelivery, corrupt/emptied mirror, stale signer key), and **CLI gates** (delivery-gated `--json`, unknown-flag rejection).

The design and the implementation each went through a 13-agent adversarial review (find → refute); all confirmed findings are fixed and regression-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)