### PR TITLE
docs(gtm): LIMITATIONS, AGT comparison, local-model + schema docs, local-first site copy

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -9,24 +9,29 @@ moves, this document moves with it.
 
 ## 1. The governance surface is the wrapped SDK methods — nothing else
 
-`trust()` intercepts exactly three entry points:
+`trust()` governs a specific set of SDK methods, not "the network." Governed
+today:
 
-- Anthropic: `client.messages.create()`
-- OpenAI: `client.chat.completions.create()`
+- Anthropic: `client.messages.create()`, `client.messages.stream()`, and
+  `client.beta.messages.{create,stream,parse}()`
+- OpenAI: `client.chat.completions.create()` and `client.responses.create()`
 - Google: `client.models.generateContent()`
 
-Streaming through those methods (`stream: true`) is governed, including mid-stream
-anomaly cutoff. Everything else on the client bypasses governance, audit, and
-budget enforcement entirely: Anthropic's `client.messages.stream()` helper and
-`client.beta.*`, OpenAI's Responses API and legacy `client.completions.create()`,
-and any other alternative surface.
+Streaming through any governed method is governed end to end, including
+mid-stream anomaly cutoff and settle-or-void on completion. A few alternative
+surfaces are still ungoverned pass-throughs — they reach the provider without a
+budget hold, policy check, or audit entry: OpenAI's `responses.stream()` /
+`responses.parse()` helpers and legacy `completions.create()`, Anthropic's
+`messages.batches` and `beta.models` / `beta.files`, and Google's alternative
+methods. usertrust never pretends to govern these — the exact, current boundary
+is enumerated at the source in `packages/core/src/detect.ts`.
 
 **Why:** usertrust detects clients by duck typing and wraps them with a JS Proxy.
 That is what makes it a one-line integration with zero SDK dependencies across
-SDK versions — and it means the governed surface is a specific set of methods,
-not "the network." If your code relies on an ungoverned method, route it through
-a governed entry point or bring your own controls. The exact boundary is
-documented at the source in `packages/core/src/detect.ts`.
+SDK versions — and it means the governed surface is a set of methods we
+explicitly cover, not an interception of all traffic. If your code relies on an
+ungoverned method, route it through a governed entry point or bring your own
+controls.
 
 ## 2. Endpoint classification is a trusted-operator decision
 

--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,141 @@
+# Limitations
+
+usertrust is a trust layer. A trust layer that overstates itself is worse than none,
+so this document is part of the product: what usertrust deliberately does not do,
+where its boundaries sit, and why each boundary is where it is.
+
+Every statement below is true of the code in this repository. When a limitation
+moves, this document moves with it.
+
+## 1. The governance surface is the wrapped SDK methods — nothing else
+
+`trust()` intercepts exactly three entry points:
+
+- Anthropic: `client.messages.create()`
+- OpenAI: `client.chat.completions.create()`
+- Google: `client.models.generateContent()`
+
+Streaming through those methods (`stream: true`) is governed, including mid-stream
+anomaly cutoff. Everything else on the client bypasses governance, audit, and
+budget enforcement entirely: Anthropic's `client.messages.stream()` helper and
+`client.beta.*`, OpenAI's Responses API and legacy `client.completions.create()`,
+and any other alternative surface.
+
+**Why:** usertrust detects clients by duck typing and wraps them with a JS Proxy.
+That is what makes it a one-line integration with zero SDK dependencies across
+SDK versions — and it means the governed surface is a specific set of methods,
+not "the network." If your code relies on an ungoverned method, route it through
+a governed entry point or bring your own controls. The exact boundary is
+documented at the source in `packages/core/src/detect.ts`.
+
+## 2. Endpoint classification is a trusted-operator decision
+
+`classifyEndpoint()` decides whether a call settles at local or cloud rates from
+`endpoints[]` matchers, per-call overrides, and loopback autodetect. All three
+inputs belong to the operator. If any of them is plumbed from end-user or
+request input, an attacker chooses their own settlement regime — the same trust
+boundary as `budget` and `customRates`, where the config author already controls
+billing entirely.
+
+Two specifics worth knowing:
+
+- **Loopback autodetect is workstation mode.** On servers and in containers, set
+  `local.autoDetectLoopback: false` and classify via explicit `endpoints[]` —
+  loopback inside a container can be a forwarding sidecar to a paid API.
+- **Classification happens once, at wrap time,** from the client's `baseURL`.
+  Per-request baseURL overrides are not re-classified. Absent or malformed
+  baseURLs classify as cloud — fail-expensive, because over-charging at cloud
+  rates is recoverable and under-charging a paid endpoint is not.
+
+## 3. Local-server usage reports are trusted for settlement
+
+For local endpoints, usertrust prefers server-reported usage (it auto-injects
+`stream_options: { include_usage: true }` into local OpenAI-compatible streams).
+A compromised or lying local server can under-report its own usage, and
+usertrust does not independently re-count tokens for arbitrary local runtimes.
+
+**Why receipts still hold up:** every receipt stamps `usageSource`
+(`"provider"` or `"estimated"`) and `meter.rateSource`, so the provenance of
+every settled number is explicit and auditable. usertrust does not pretend to
+verify what it cannot; it makes the trust relationship visible in the ledger
+instead.
+
+## 4. Hard budget atomicity applies to full mode, not `dryRun`
+
+`dryRun: true` (or `USERTRUST_DRY_RUN=true`) skips TigerBeetle entirely and runs
+audit-chain-only. It exists as the explicit, honest way to bypass financial
+enforcement — in tests, in evaluation. Every claim about atomic budget
+enforcement (an over-budget PENDING hold rejected by the ledger before the
+provider is called) applies to full mode with a live TigerBeetle instance.
+
+One caveat from our own release history: CI validates live-ledger enforcement
+against a stateful `tigerbeetle-node` fake that implements real double-entry
+balance math and `debits_must_not_exceed_credits` (see
+`packages/core/tests/harden/ledger-funded-wallet.test.ts`) — a behavioral test
+against real ledger semantics, not a mock asserting a mock. It is still a fake.
+Validate against a real TigerBeetle cluster before relying on enforcement in
+production.
+
+## 5. One audit writer per vault, one process at a time
+
+The audit chain is a linear SHA-256 hash chain. Two concurrent writers would
+fork it, which is precisely the tampering the chain exists to make evident — so
+usertrust enforces single-writer semantics with an advisory file lock plus an
+in-process mutex. A second process opening the same vault gets a hard error, not
+a silent fork. Stale locks from crashed processes are reclaimed; live ones are
+never stolen.
+
+If you need multiple concurrent workers, give each its own vault. Merging or
+centralizing chains is a control-plane concern, not something the core SDK
+pretends to solve today.
+
+## 6. Anomaly governance ships conservative defaults and expects calibration
+
+Anomaly detection is opt-in (`anomaly.enabled: true`) and tuned to catch
+sustained runaway behavior, not brief spikes: 500 tok/s over three consecutive
+2-second windows, $1.00/min spend velocity over a 10-second rolling window,
+3 injection signals in 60 seconds. Local endpoints get local-calibrated
+thresholds (5,000 tok/s; 10,000 nominal usertokens/min) because fast local GPU
+inference legitimately exceeds cloud rates.
+
+One behavior is by design, not a gap: with the default local rate of `{0,0}`,
+per-call nominal cost floors at 1 usertoken, so spend velocity cannot trip on
+default local config — **token rate is the primary local signal**. Velocity
+becomes meaningful on local endpoints when you set nonzero amortized rates.
+Whatever your workload looks like, the defaults are a starting point; calibrate
+them against your own traffic before trusting the trip wire.
+
+## 7. The Board of Directors is heuristic, not an LLM
+
+The board's two directors review decisions with six pattern-matching concern
+detectors (hallucination, bias, safety, scope creep, resource abuse, policy
+violation). No LLM calls are made.
+
+**Why:** deterministic review is auditable, free, adds no latency, and cannot be
+prompt-injected. The trade is real — heuristics will not catch what a model
+reviewer might. Treat board verdicts as a cheap tripwire layered under your
+policy rules, not as semantic judgment.
+
+## 8. No third-party certification
+
+usertrust has no SOC 2 report, no ISO 27001 certificate, no third-party
+attestation of any kind. The audit chain — hash-chained events, RFC 6962 Merkle
+proofs, a zero-dependency offline verifier — is designed to produce evidence an
+auditor can check without trusting us or this codebase. That is the deliberate
+division of labor: usertrust generates the receipts; certifying a deployment
+that uses them is the deployer's work with their own auditors.
+
+## 9. Proxy mode was deleted rather than shipped as theater
+
+Early versions carried a proxy-mode stub for remote governance that returned
+hardcoded success for every spend, settle, and void — which made the entire
+two-phase lifecycle theater and was, in effect, a governance bypass. Under
+AUD-456 we removed it: `connectProxy()` now throws, and passing `proxy` to
+`trust()` fails fast with the reason. If proxy mode ships in the future it will
+ship with real financial enforcement behind it. Until then: `dryRun` for
+explicit bypass in testing, a real TigerBeetle for production.
+
+---
+
+Found a boundary we haven't documented? That is a bug in this file — open an
+issue, or see [SECURITY.md](SECURITY.md) if it has security impact.

--- a/site/app/components/built-for.tsx
+++ b/site/app/components/built-for.tsx
@@ -6,8 +6,8 @@ const useCases = [
 		detail: "Ship with spend controls from day one",
 	},
 	{
-		role: "Enterprise teams",
-		detail: "Audit-ready governance without vendor lock-in",
+		role: "Fleet operators",
+		detail: "Govern agent fleets from one control plane — budgets and audit per tenant",
 	},
 	{
 		role: "Agent builders",

--- a/site/app/components/byok.tsx
+++ b/site/app/components/byok.tsx
@@ -6,6 +6,9 @@ const providers = [
 	{ name: "Google", detail: "Gemini SDK" },
 	{ name: "xAI", detail: "Grok SDK" },
 	{ name: "Groq", detail: "Fast inference" },
+	{ name: "Ollama", detail: "Local models" },
+	{ name: "vLLM", detail: "Your GPUs" },
+	{ name: "LM Studio", detail: "Local models" },
 ];
 
 export function BYOK() {
@@ -18,7 +21,7 @@ export function BYOK() {
 							className="text-3xl sm:text-4xl font-bold leading-tight"
 							style={{ textShadow: "0 0 40px rgba(52,211,153,0.1)" }}
 						>
-							Your keys. Your billing.
+							Your keys. Your billing. Your GPUs.
 							<br />
 							Our trust layer.
 						</h2>
@@ -26,8 +29,9 @@ export function BYOK() {
 					<ScrollReveal delay={0.1}>
 						<p className="text-base text-white/60 leading-relaxed">
 							<code className="font-mono text-ut">trust()</code> wraps your existing provider
-							client. No proxy. No routing. No new accounts. Just trust on top of what you already
-							use.
+							client. No proxy. No routing. No new accounts. Local endpoints — Ollama, vLLM, LM
+							Studio — get classified and metered at nominal rates, with the same receipts as every
+							cloud call.
 						</p>
 					</ScrollReveal>
 				</div>

--- a/site/app/components/hero.tsx
+++ b/site/app/components/hero.tsx
@@ -10,8 +10,8 @@ import { CopyCommand } from "./copy-command";
 // later rotations never produce a bigger paint area and LCP stays anchored to
 // the initial (server-rendered, CSS-revealed) tagline instead of a rotation.
 const taglines = [
-	"Hash-chained receipts. Tamper-evident by construction. Zero vendor lock-in.",
-	"Budget holds, audit trails, and spend limits for every LLM call.",
+	"Hash-chained receipts with Merkle proofs — verifiable offline, zero dependencies.",
+	"Ollama and local models, governed with real receipts at nominal rates.",
 	"Your API keys. Your billing. Your provider. We add the trust layer.",
 	"Like a credit card hold — but for AI spend. Settled or voided, never lost.",
 ];

--- a/site/content/docs/compare/agent-governance-toolkit.mdx
+++ b/site/content/docs/compare/agent-governance-toolkit.mdx
@@ -1,0 +1,101 @@
+---
+title: Agent Governance Toolkit
+description: Run AGT's stateless policy decisions on top of usertrust's stateful enforcement — pre-spend holds, double-entry settlement, and offline-verifiable receipts.
+---
+
+Microsoft's [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) (AGT) and usertrust sit on opposite sides of the same boundary. AGT's Agent Control Specification defines a deliberately stateless, deterministic policy runtime: it evaluates an action and returns a verdict, and its spec assigns every stateful obligation — enforcing the verdict, holding budget state, persisting audit records, resolving approvals — to the host. usertrust is that stateful side: a budget ledger with two-phase holds, settlement, and receipts your finance team can verify offline.
+
+So the honest comparison is not "which one" — it is "which layer". If AGT decides, something still has to enforce, meter, and account. Run them together.
+
+## Run Them Together
+
+AGT's own integration docs describe a composite-evaluator pattern for pairing its stateless decision layer with an external budget ledger: the policy decides first, and only allowed actions consume a reservation. `usertrust-acs-adapter` implements that slot with the usertrust ledger behind it.
+
+```ts
+import { createGovernor } from "usertrust/headless";
+import { CompositeEvaluator, type PolicyDecider } from "usertrust-acs-adapter";
+
+// 1. Your stateless decision layer — bridge to your AGT policy
+//    evaluation, or any decider returning an ACS-style verdict.
+const policy: PolicyDecider = async (action, { inputIdentity, budgets }) => {
+	const verdict = await evaluateWithAgt(action, budgets); // your AGT bridge
+	return { decision: verdict.decision, reason: verdict.reason };
+};
+
+// 2. The stateful enforcement layer — budget ledger, settlement, receipts.
+const governor = await createGovernor({ budget: 100_000 });
+const composite = new CompositeEvaluator({ policy, governor });
+
+// 3. Decision first, then an atomic PENDING hold.
+//    A denied action never consumes a reservation.
+const result = await composite.evaluate({
+	kind: "model_call",
+	model: "claude-sonnet-4-6",
+	estimatedInputTokens: 500,
+	maxOutputTokens: 4096,
+});
+
+if (result.authorization) {
+	try {
+		const response = await callModel(/* ... */);
+		// 4. POST the hold at actual usage. The receipt is offline-verifiable.
+		const receipt = await composite.settle(result, {
+			inputTokens: response.usage.input_tokens,
+			outputTokens: response.usage.output_tokens,
+		});
+	} catch (err) {
+		// 5. VOID the hold — reserved tokens return to the budget.
+		await composite.abort(result, err);
+		throw err;
+	}
+}
+```
+
+The adapter speaks AGT's decision vocabulary in both directions: a malformed policy verdict fails closed (deny) with a reserved `runtime_error:*` reason, and a ledger budget denial comes back as `budget_cost_usd_exceeded` — so the decision layer sees a coherent picture.
+
+## Where Each Layer Stops
+
+Every AGT-side statement below links to the exact line in AGT's own specs and design records, pinned to commit `179843b`.
+
+| Concern | AGT (decision layer) | usertrust (enforcement layer) |
+| --- | --- | --- |
+| Role | Stateless policy verdicts (allow / warn / deny / escalate / transform); enforcement is a documented host obligation | Stateful enforcement: ledger holds, settlement, audit, receipts |
+| Budget check timing | Post-action cost governance; its ADR accepts a one-action overshoot | Pre-spend `PENDING` hold; an over-budget call is denied before it executes |
+| Stream governance | Evaluates assembled snapshots; token/chunk-level enforcement is outside its model | Per-chunk hook can cut a stream off mid-flight on anomaly signals |
+| Audit | SHA-256 hash-linked entry chain; several decision-context fields sit outside the canonical hash in spec v1.0 | SHA-256 hash chain + RFC 6962 Merkle proofs + zero-dependency offline verifier |
+| Spend accounting | In-process budget tracking over host-supplied cost estimates and counters | Double-entry two-phase TigerBeetle ledger (`PENDING → POST / VOID`), 7 transfer codes |
+| Local models | n/a in the materials cited on this page | Nominal metering for local endpoints (v1.5.0) |
+
+## Budget Timing: Post-Action vs Pre-Spend
+
+AGT's cost-governance ADR is candid about its post-action design. Among the tradeoffs it lists: "the action that crosses the hard cap still executes (one action overshoot)" ([ADR-0012, line 115](https://github.com/microsoft/agent-governance-toolkit/blob/179843b16eadd48bc9666c05f33a38f009542be1/docs/adr/0012-cost-governance-observability-policies.md#L115)). That is a reasonable tradeoff for an observability-first design — cost data is measured, not estimated — but it means the budget is a rearview mirror at the moment it matters most.
+
+usertrust checks before the money moves. `authorize()` evaluates the policy gate against `budget_remaining_after` — the balance as it would be *after* this call — and denies a single overshooting call pre-spend. If the policy gate passes, the `PENDING` hold itself is enforced by TigerBeetle: the holding account is created with `debits_must_not_exceed_credits`, so an over-budget reservation is rejected atomically by the ledger and surfaced as a hard deny, never forwarded to the provider. See [Two-Phase Spend](/docs/concepts/two-phase-spend).
+
+## Streams: Assemble-Then-Judge vs Mid-Stream Cutoff
+
+AGT's specification is explicit that it evaluates whole snapshots: a host must assemble streamed output before the post-call intervention point, and "Enforcement at the token or chunk level is outside this model" ([Agent Control Specification §18, line 406](https://github.com/microsoft/agent-governance-toolkit/blob/179843b16eadd48bc9666c05f33a38f009542be1/policy-engine/spec/SPECIFICATION.md#L406)). By the time the verdict lands, the stream has already been paid for.
+
+usertrust governs the stream while it is running. The streaming wrapper fires a hook on every chunk, and the anomaly detector (token-rate, spend-velocity, and injection-cascade signals) can throw from that hook to abort the stream mid-flight and trip the circuit breaker. The pending hold is then voided — a runaway stream stops costing you tokens at the chunk where it was caught, not at the end.
+
+## Audit: What the Hash Actually Covers
+
+Both projects hash-chain their audit logs with SHA-256. The difference is what the hash covers and who can check it.
+
+AGT's audit spec (v1.0) keeps its canonical hash over a fixed field set for chain compatibility, and places newer decision-context fields — `policy_version`, `approver_did`, `arguments_hash` — outside it. The spec says so plainly: "a tampering party can mutate them without invalidating `entry_hash`" ([AUDIT-COMPLIANCE-1.0 §4.3.1, line 251](https://github.com/microsoft/agent-governance-toolkit/blob/179843b16eadd48bc9666c05f33a38f009542be1/docs/specs/AUDIT-COMPLIANCE-1.0.md#L251)), and instructs verifiers not to rely on those fields for tamper detection in v1.0. Spec v1.1 plans to close this.
+
+AGT's limitations doc also draws its own scope line: it is an "audit trail of actions", not an "audit trail of outcomes" ([LIMITATIONS.md, line 135](https://github.com/microsoft/agent-governance-toolkit/blob/179843b16eadd48bc9666c05f33a38f009542be1/docs/LIMITATIONS.md#L135)).
+
+usertrust's audit chain records settled outcomes — actual tokens, actual cost, `settled` status — because settlement is the event. Every event chains from the previous via deterministic canonicalization, Merkle roots follow RFC 6962 with inclusion and consistency proofs, and [`usertrust-verify`](/docs/verify) is a zero-dependency verifier: an auditor can check the whole vault offline, with no usertrust install and nothing to trust but the math.
+
+## Spend Accounting: Who Holds the Ledger
+
+AGT v5 removed a set of Public Preview surfaces precisely because they implied enforcement that did not exist — in its own words, "the ledger always admitted, slashing and quarantine recorded events but enforced nothing" ([BREAKING_CHANGES.md, lines 228–229](https://github.com/microsoft/agent-governance-toolkit/blob/179843b16eadd48bc9666c05f33a38f009542be1/BREAKING_CHANGES.md#L228-L229)). That cleanup is to AGT's credit, and it sharpened the architecture: the ledger is not AGT's job. Its SpendGuard integration guide makes the same point in table form, listing compliance evidence for its in-process `CostGuard` as "None" while pointing at an external cryptographically-audited ledger for that role ([spendguard-integration.md, line 27](https://github.com/microsoft/agent-governance-toolkit/blob/179843b16eadd48bc9666c05f33a38f009542be1/docs/integrations/spendguard-integration.md#L27)).
+
+usertrust is built as that ledger role, natively: real double-entry accounting in TigerBeetle, seven transfer codes, and a two-phase lifecycle where every token is either settled or voided — never lost in limbo. For local models, where there is no provider invoice, v1.5.0 meters calls in nominal usertokens so the same ledger, anomaly signals, and receipts govern your fleet's local endpoints too.
+
+## Scope and Disclosure
+
+Comparisons on this page reference the Agent Governance Toolkit at commit [`179843b`](https://github.com/microsoft/agent-governance-toolkit/tree/179843b16eadd48bc9666c05f33a38f009542be1) (v5.0.0), retrieved 2026-07-26, and usertrust v1.5.0. Every AGT-side claim links to the exact line at that commit. AGT moves fast; if a statement here has gone stale, [open an issue](https://github.com/usertools-ai/usertrust/issues).
+
+The Agent Governance Toolkit is MIT-licensed. `usertrust-acs-adapter` adapts its documented decision vocabulary and composite-evaluator integration point under that license — see the usertrust repository `NOTICE` file for attribution. Microsoft and Agent Governance Toolkit are referenced for identification purposes only; usertrust is an independent project of Usertools, Inc. and is not affiliated with, endorsed by, or sponsored by Microsoft.

--- a/site/content/docs/compare/meta.json
+++ b/site/content/docs/compare/meta.json
@@ -1,0 +1,4 @@
+{
+	"title": "Compare",
+	"pages": ["agent-governance-toolkit"]
+}

--- a/site/content/docs/concepts/local-models.mdx
+++ b/site/content/docs/concepts/local-models.mdx
@@ -1,0 +1,96 @@
+---
+title: Local Models
+description: How usertrust classifies local endpoints and meters Ollama, vLLM, and LM Studio at nominal rates.
+---
+
+usertrust governs local (self-hosted) inference with the same two-phase spend, audit chain, and receipts as cloud calls. The *endpoint* -- not the model string -- picks the settlement regime: a call to Ollama on localhost settles at nominal local rates, a call to a paid API settles at cloud rates. Renaming a local model (`ollama cp llama3.2 gpt-4o`) cannot change the regime in either direction.
+
+Free inference stays inside governance, not exempt from it.
+
+## Endpoint Classification
+
+Every governed client is classified `local` or `cloud` by inspecting its `baseURL`. Classification runs in a fixed order -- the first rule that applies wins:
+
+1. **Explicit override** -- an override passed by the caller wins over everything.
+2. **No readable `baseURL`** -- absent or malformed URLs classify as cloud. Never throws.
+3. **`endpoints[]` matchers** -- first matching config entry wins.
+4. **Loopback autodetect** -- `localhost`, `127.0.0.1`, `::1`, and the IPv4-mapped IPv6 loopback classify as local when `local.autoDetectLoopback` is `true` (the default). The port hints the runtime: `11434` = ollama, `1234` = lmstudio, `8000` = vllm, anything else = openai-compat.
+5. **Cloud default** -- anything unmatched is cloud.
+
+The default is **fail-expensive** by design: over-charging free inference at cloud rates is recoverable; under-charging a paid endpoint is not.
+
+### Endpoint Matchers
+
+Each `endpoints[]` entry matches the client's `baseURL` in exactly one of three forms -- never raw string prefixing:
+
+| Form | Example | Semantics |
+|------|---------|-----------|
+| Scheme URL | `http://gpu-box:8000` | Origin equality; path, query, and trailing slash ignored |
+| Leading star | `*.gpu.internal` | Hostname suffix; matches `a.gpu.internal`, not `gpu.internal` itself |
+| Bare hostname | `gpu-box` | Case-insensitive hostname equality, any port |
+
+```jsonc
+// .usertrust/usertrust.config.json
+{
+	"budget": 500000,
+	"endpoints": [
+		{ "match": "http://gpu-box:8000", "class": "local", "runtime": "vllm" },
+		{ "match": "*.gpu.internal", "class": "local" }
+	]
+}
+```
+
+Origin equality is deliberate: prefix matching would let `http://gpu-box:8000.evil.com` or `http://gpu-box:8000@evil.com` classify as local. Origin comparison kills both shapes.
+
+## Nominal Metering
+
+Local-scope rate resolution never touches the cloud pricing table:
+
+1. `local.models` exact match
+2. Longest trailing-star glob (`"llama3.3*"`, `"*"`)
+3. `local.defaultRate` -- `{ inputPer1k: 0, outputPer1k: 0 }` by default
+
+Every call cost is floored at 1 usertoken -- zero-amount ledger transfers are invalid -- so a `{0,0}`-rate local call settles at **exactly 1 nominal usertoken**. Real token counts are still metered: for local OpenAI-compatible streams, `stream_options: { include_usage: true }` is auto-injected (`local.injectUsageOptions`, default `true`) so settlement uses server-truth counts instead of estimates.
+
+### Why Budgets Still Bind
+
+Nominal metering is not an exemption. Every local call still places a PENDING hold, settles at least 1 usertoken, and lands on the audit chain -- so runaway loops burn budget, anomaly governance still fires, and every call has a receipt. The receipt carries the provenance:
+
+| Receipt field | Local value |
+|---------------|-------------|
+| `endpoint` | `{ class: "local", runtime: "ollama" \| "vllm" \| "lmstudio" \| "openai-compat" }` |
+| `meter.costBasis` | `"nominal"` (or `"usd-proxy"` with `rateClass: "amortized-usd"`) |
+| `meter.rateSource` | `"local-model"` or `"local-default"` |
+| `usageSource` | `"provider"` or `"estimated"` |
+
+For GPU showback, set `local.rateClass: "amortized-usd"` and per-model rates in `local.models` -- local calls then settle at your amortized chargeback rate (1 usertoken = $0.0001, as usual) instead of the nominal floor.
+
+## unknownModelPolicy
+
+Only cloud-scope calls can hit an unknown model -- local scope always resolves to local rates. When a model misses `customRates`, the pricing table, and prefix matching, `unknownModelPolicy` decides:
+
+| Policy | Behavior |
+|--------|----------|
+| `"fallback"` | Silent sonnet-class fallback rate (legacy behavior) |
+| `"warn"` (default) | Same rate, one-time console warning per model per process, `meter.rateSource: "fallback"` on the receipt |
+| `"deny"` | `PolicyDeniedError` thrown before any PENDING hold is placed |
+
+## Security Posture
+
+Endpoint classification -- config matchers, overrides, and loopback autodetect -- is a **trusted-operator decision**. Never wire it to end-user or request input. This is the same trust boundary as `budget` and `customRates`: the config author already controls billing entirely.
+
+<Callout type="warn">
+In server and multi-tenant deployments, set `local.autoDetectLoopback: false` and classify via explicit `endpoints[]` config. Loopback inside a container can be a forwarding sidecar to a paid API.
+</Callout>
+
+A compromised local server can under-report usage. Receipts expose `usageSource` and `meter.rateSource` precisely so that this is auditable.
+
+## Try It
+
+The [`examples/ollama-local-governance`](https://github.com/usertools-ai/usertrust/tree/master/examples/ollama-local-governance) demo shows the before/after -- frontier fallback billing vs. nominal local settlement -- plus the model-spoofing defense. It works against a live Ollama on `localhost:11434` or an inline mock server, in `dryRun` mode against throwaway temp vaults. No TigerBeetle needed.
+
+```sh
+npm install
+cd examples/ollama-local-governance
+npx tsx run.ts
+```

--- a/site/content/docs/concepts/meta.json
+++ b/site/content/docs/concepts/meta.json
@@ -4,6 +4,7 @@
 		"two-phase-spend",
 		"audit-trail",
 		"merkle-proofs",
+		"local-models",
 		"policy-engine",
 		"pattern-memory",
 		"circuit-breaker"

--- a/site/content/docs/meta.json
+++ b/site/content/docs/meta.json
@@ -10,6 +10,9 @@
 		"api",
 		"cli",
 		"policy",
-		"verify"
+		"verify",
+		"schemas",
+		"---Compare---",
+		"compare"
 	]
 }

--- a/site/content/docs/schemas.mdx
+++ b/site/content/docs/schemas.mdx
@@ -1,0 +1,43 @@
+---
+title: JSON Schemas
+description: Published JSON Schemas for trust receipts and audit chain events, with stable $ids.
+---
+
+usertrust publishes JSON Schema (draft 2020-12) definitions for its two public interop shapes: the receipt returned by every governed call, and one persisted line of the hash-chained audit log. The `$id` URLs are stable — pin them in validators, CI checks, or any tool that consumes receipts or audit logs.
+
+| Schema | `$id` | Describes |
+|--------|-------|-----------|
+| Trust Receipt v1 | [receipt.v1.schema.json](https://usertrust.ai/schemas/receipt.v1.schema.json) | The `TrustReceipt` returned by every governed call |
+| Audit Event v1 | [audit-event.v1.schema.json](https://usertrust.ai/schemas/audit-event.v1.schema.json) | One line of the audit chain (`.usertrust/audit/*.jsonl`) |
+
+## Versioning
+
+- **v1 is frozen.** Once published, a versioned schema never changes meaning. Description wording may improve; the validated shape does not.
+- **Changes ship as a new version.** Additive or breaking changes become `receipt.v2.schema.json` at a new URL. v1 URLs keep working and keep meaning the same thing.
+- **Both schemas are open.** Receipts may carry additional diagnostic fields, and audit events may carry extra fields that are covered by the chain hash. Validators must ignore unknown fields, not reject them.
+
+## Validating a receipt
+
+With [ajv](https://ajv.js.org/) v8 (`npm install ajv ajv-formats`):
+
+```typescript
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+const schema = await fetch("https://usertrust.ai/schemas/receipt.v1.schema.json").then((r) =>
+  r.json(),
+);
+
+const ajv = addFormats(new Ajv2020());
+const validate = ajv.compile(schema);
+
+if (!validate(receipt)) {
+  console.error(validate.errors);
+}
+```
+
+No validator handy? The schemas are plain static JSON — fetch one and read `required` / `properties` directly. String formats (`date-time`, `uuid`) are annotations; `ajv-formats` enforces them, other validators may not.
+
+<Callout type="info">
+Schema validation checks shape, not integrity. To prove an audit log is untampered — hash chain, sequence continuity, Merkle root — run the zero-dependency [usertrust-verify](/docs/verify) package against the vault. It works offline.
+</Callout>

--- a/site/public/schemas/audit-event.v1.schema.json
+++ b/site/public/schemas/audit-event.v1.schema.json
@@ -1,0 +1,49 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://usertrust.ai/schemas/audit-event.v1.schema.json",
+	"title": "AuditEvent",
+	"description": "One persisted line of the usertrust hash-chained audit log ('<vault>/.usertrust/audit/events.jsonl' plus rotated '*.jsonl' segments). Each line is one event serialized as canonical JSON: object keys sorted alphabetically at every nesting level, undefined stripped, null preserved, array order kept. The event's hash is the SHA-256 of its canonical JSON with the 'hash' field removed; 'previousHash' links to the prior event's hash, and the first event in a vault chains from the genesis hash (64 zeros). Unknown fields are permitted: any extra field is part of the hash pre-image, so verifiers hash the full line minus 'hash' rather than a fixed field list.",
+	"type": "object",
+	"required": ["id", "timestamp", "previousHash", "hash", "kind", "actor", "data", "sequence"],
+	"properties": {
+		"id": {
+			"type": "string",
+			"format": "uuid",
+			"description": "Random UUID identifying the event."
+		},
+		"timestamp": {
+			"type": "string",
+			"format": "date-time",
+			"description": "ISO 8601 timestamp when the event was appended."
+		},
+		"previousHash": {
+			"type": "string",
+			"pattern": "^[a-f0-9]{64}$",
+			"description": "SHA-256 hash (hex) of the previous event in the chain. The first event in a vault uses the genesis hash: 64 zeros."
+		},
+		"hash": {
+			"type": "string",
+			"pattern": "^[a-f0-9]{64}$",
+			"description": "SHA-256 hash (hex) of this event's canonical JSON with the 'hash' field removed. Recompute it to verify the line; any edit to any field changes it."
+		},
+		"kind": {
+			"type": "string",
+			"description": "Event kind. Open-ended; kinds emitted today include 'llm_call', 'stream_partial_delivery', 'anomaly_detected', and 'settlement_ambiguous'."
+		},
+		"actor": {
+			"type": "string",
+			"description": "Actor identity that produced the event (defaults to 'local')."
+		},
+		"data": {
+			"type": "object",
+			"description": "Event payload. Open-ended by design: each kind carries its own fields, and all of them are covered by the hash.",
+			"additionalProperties": true
+		},
+		"sequence": {
+			"type": "integer",
+			"minimum": 1,
+			"description": "1-based global sequence number, continuous across rotated segments. Gaps indicate segment or event deletion. Legacy segments written before sequence numbering omit this field; the verifier accepts them, but every line the current writer persists includes it."
+		}
+	},
+	"additionalProperties": true
+}

--- a/site/public/schemas/receipt.v1.schema.json
+++ b/site/public/schemas/receipt.v1.schema.json
@@ -1,0 +1,148 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://usertrust.ai/schemas/receipt.v1.schema.json",
+	"title": "TrustReceipt",
+	"description": "The receipt returned by every governed call in usertrust. Each receipt links a two-phase ledger transfer (PENDING → POST/VOID) to its hash-chained audit event. Receipts may carry additional diagnostic fields beyond this schema (e.g. proxy stub markers); v1 validators must ignore unknown fields rather than reject them.",
+	"type": "object",
+	"required": [
+		"transferId",
+		"cost",
+		"budgetRemaining",
+		"auditHash",
+		"chainPath",
+		"receiptUrl",
+		"settled",
+		"model",
+		"provider",
+		"timestamp"
+	],
+	"properties": {
+		"transferId": {
+			"type": "string",
+			"description": "Unique id of the two-phase ledger transfer (PENDING → POST/VOID) this receipt settles. Typically of the form 'tx_<base36 time>_<8 hex chars>'."
+		},
+		"cost": {
+			"type": "number",
+			"description": "Cost of the call in usertokens. Denomination is given by meter.costBasis when present: 'usd-proxy' (1 usertoken = $0.0001) or 'nominal' (bookkeeping units for local endpoints). On a streaming estimated receipt this is the pre-call estimate until the stream settles."
+		},
+		"budgetRemaining": {
+			"type": "number",
+			"description": "Budget remaining after this call, in usertokens: configured budget minus settled spend minus in-flight holds."
+		},
+		"auditHash": {
+			"description": "SHA-256 hex digest linking this receipt to the audit chain. Usually the hash of the audit event written for this call; on a streaming estimated receipt it is a placeholder digest until settlement. The sentinel 'AUDIT_DEGRADED' when the audit write failed (see auditDegraded).",
+			"oneOf": [
+				{
+					"type": "string",
+					"pattern": "^[a-f0-9]{64}$"
+				},
+				{
+					"const": "AUDIT_DEGRADED"
+				}
+			]
+		},
+		"chainPath": {
+			"type": "string",
+			"description": "Vault-relative path to the audit chain directory (currently '.usertrust/audit')."
+		},
+		"receiptUrl": {
+			"type": ["string", "null"],
+			"description": "Hosted receipt URL. Currently always null: the only code path that populates it requires proxy mode, which was removed under AUD-456 and fails fast today. Retained for forward compatibility."
+		},
+		"settled": {
+			"type": "boolean",
+			"description": "Whether the pending ledger hold was settled (POST). False when settlement failed (settlement_ambiguous) or, for streaming calls, on the estimated receipt issued before the stream is consumed."
+		},
+		"model": {
+			"type": "string",
+			"description": "Model id the call was made with. For governed non-LLM actions, the action name (e.g. 'file_read', 'curl')."
+		},
+		"provider": {
+			"type": "string",
+			"description": "Provider/client kind (e.g. 'anthropic', 'openai', 'google'). For governed non-LLM actions, the action kind; 'headless' for headless metering."
+		},
+		"timestamp": {
+			"type": "string",
+			"format": "date-time",
+			"description": "ISO 8601 timestamp when the receipt was issued."
+		},
+		"auditDegraded": {
+			"type": "boolean",
+			"description": "Present and true when the audit chain write failed (failure mode 15.3). The failed event is written to the dead-letter queue."
+		},
+		"usageSource": {
+			"type": "string",
+			"enum": ["provider", "estimated"],
+			"description": "Whether cost came from provider-reported usage or the pre-call estimate."
+		},
+		"chunksDelivered": {
+			"type": "number",
+			"minimum": 0,
+			"description": "Number of chunks delivered to the consumer (streaming calls only)."
+		},
+		"actionKind": {
+			"type": "string",
+			"enum": ["llm_call", "tool_use", "file_access", "shell_command", "api_request"],
+			"description": "Action kind for governed non-LLM actions. Absent for LLM calls (backward compatibility)."
+		},
+		"endpoint": {
+			"type": "object",
+			"description": "Endpoint classification for this call. Absent on pre-M2 receipts.",
+			"required": ["class", "runtime"],
+			"properties": {
+				"class": {
+					"type": "string",
+					"enum": ["local", "cloud"],
+					"description": "Settlement scope of the endpoint: local (self-hosted) or cloud (metered provider)."
+				},
+				"runtime": {
+					"type": "string",
+					"enum": ["ollama", "vllm", "lmstudio", "openai-compat", "unknown"],
+					"description": "Best-effort runtime label for a local endpoint (receipt/UX metadata only)."
+				}
+			},
+			"additionalProperties": false
+		},
+		"meter": {
+			"type": "object",
+			"description": "Metering provenance: denomination and rate origin of the settled cost. Absent on pre-M2 receipts.",
+			"required": ["costBasis", "rateSource"],
+			"properties": {
+				"costBasis": {
+					"type": "string",
+					"enum": ["usd-proxy", "nominal"],
+					"description": "Denomination of the settled cost: real-dollar proxy or nominal bookkeeping units."
+				},
+				"rateSource": {
+					"type": "string",
+					"enum": ["table", "custom", "local-model", "local-default", "fallback"],
+					"description": "Where the applied rates came from during resolution."
+				},
+				"computeMs": {
+					"type": "number",
+					"minimum": 0,
+					"description": "Compute wall-time in milliseconds. Present only when a compute-time source was available."
+				}
+			},
+			"additionalProperties": false
+		}
+	},
+	"additionalProperties": true,
+	"examples": [
+		{
+			"transferId": "tx_mdl3k9q2_1f3c9d2e",
+			"cost": 42,
+			"budgetRemaining": 49958,
+			"auditHash": "9b3c2f6e8a1d4c5b7e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d",
+			"chainPath": ".usertrust/audit",
+			"receiptUrl": null,
+			"settled": true,
+			"model": "claude-sonnet-4-5",
+			"provider": "anthropic",
+			"timestamp": "2026-07-26T12:00:00.000Z",
+			"usageSource": "provider",
+			"endpoint": { "class": "cloud", "runtime": "unknown" },
+			"meter": { "costBasis": "usd-proxy", "rateSource": "table" }
+		}
+	]
+}


### PR DESCRIPTION
GTM refresh — the public-facing pieces from the July recon, updated to post-#48 reality. **Draft for your review — nothing here auto-merges.**

## What's in it
- **LIMITATIONS.md** — 'transparency is a feature' doc, 9 honest boundaries. §1 now reflects #48's full-surface governance (messages.stream/beta/parse + responses.create governed; only responses.stream/parse, batches, beta.models/files remain ungoverned). §3 (provider-usage trust) stays **open** — the divergence detector was deferred to #50, so this is honest, not a claimed fix.
- **AGT comparison page** (`/docs/compare/agent-governance-toolkit`) — complementary-first (usertrust is the stateful ledger behind AGT's stateless policy layer), then the capability table. Every competitor clause is a commit-pinned permalink to AGT's own repo, quotes ≤12 words. The mid-stream-cutoff row is now *strengthened* by #48's cross-surface-consistent anomaly abort.
- **local-models concept doc** + **published JSON schemas** (`receipt.v1`, `audit-event.v1` at real usertrust.ai/schemas URLs — plants the interop namespace flag while AGT's $ids are still `.test` placeholders).
- **Site copy** — local-first hero tagline (preserves the LCP longest-first invariant), 'Your GPUs.' in the BYOK story, fleet-operator persona.

## Vocabulary discipline (from the verified a16z + market recon)
No 'AI safety' / 'trust & safety' / 'guardrails' as framing; no 'SOC2 ready'; no Ed25519/S3-anchoring claims usertrust doesn't have. Control-plane / fleet / audit / receipts throughout.

## Test plan
- `npm run build` (fumadocs) compiles clean; biome clean on docs.
- Every usertrust-side claim verified against packages/core; every AGT citation verified against the pinned commit 179843b.

## Review notes for you
- **Brand:** usertrust leads (your call). No investor language on the site (that's the internal one-pager in the stealth repo).
- The schema $id URLs only resolve once this deploys to usertrust.ai — confirm before announcing the interop namespace.
- Comparison page pins 'retrieved 2026-07-26' — refresh if it lands much later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)