### PR TITLE
feat(ui): terminal-thermal design pass — the ledger is a receipt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,6 +1003,16 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@fontsource/jetbrains-mono": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.3.0.tgz",
+			"integrity": "sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==",
+			"dev": true,
+			"license": "OFL-1.1",
+			"funding": {
+				"url": "https://github.com/sponsors/ayuhito"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -4736,6 +4746,7 @@
 				"usertrust-ui": "dist/server/main.js"
 			},
 			"devDependencies": {
+				"@fontsource/jetbrains-mono": "^5.1.0",
 				"@tailwindcss/vite": "^4.0.0",
 				"@tanstack/react-virtual": "^3.13.0",
 				"@types/react": "^19.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -39,6 +39,7 @@
 		"usertrust-verify": "*"
 	},
 	"devDependencies": {
+		"@fontsource/jetbrains-mono": "^5.1.0",
 		"@tailwindcss/vite": "^4.0.0",
 		"@tanstack/react-virtual": "^3.13.0",
 		"@types/react": "^19.0.0",

--- a/packages/ui/src/app/app.tsx
+++ b/packages/ui/src/app/app.tsx
@@ -14,7 +14,7 @@ import { Trends } from "./trends.js";
 export type View = "audit" | "trends";
 
 export function App(): React.JSX.Element {
-	const { rows, summary, live } = useLedger();
+	const { rows, summary, live, liveIds } = useLedger();
 	const [view, setView] = useState<View>("audit");
 	const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
 	const [open, setOpen] = useState<LedgerRow | null>(null);
@@ -23,28 +23,30 @@ export function App(): React.JSX.Element {
 	return (
 		<div className="mx-auto flex h-screen max-w-[1400px] flex-col gap-3 p-4">
 			<SummaryStrip summary={summary} live={live} />
-			<nav className="flex gap-2">
+			<nav
+				aria-label="view"
+				className="reveal reveal-2 inline-flex gap-0.5 self-start rounded-md border border-[var(--border)] bg-[var(--panel)] p-0.5"
+			>
 				{(["audit", "trends"] as const).map((v) => (
 					<button
 						key={v}
 						type="button"
 						onClick={() => setView(v)}
-						className={`rounded px-3 py-1 text-sm capitalize ${view === v ? "bg-[var(--panel)] text-[var(--text)]" : "text-[var(--muted)]"}`}
+						aria-pressed={view === v}
+						className={`rounded px-3 py-1 text-xs uppercase tracking-wider transition-colors duration-100 ${view === v ? "bg-[var(--panel-2)] text-[var(--text)]" : "text-[var(--muted)] hover:text-[var(--text)]"}`}
 					>
 						{v}
 					</button>
 				))}
 			</nav>
+			{/* P6: reveal stays on chrome — the table/scroll surface never animates */}
+			<div className="reveal reveal-3">
+				<FilterBar rows={rows} filters={filters} onChange={setFilters} />
+			</div>
 			{view === "audit" ? (
-				<>
-					<FilterBar rows={rows} filters={filters} onChange={setFilters} />
-					<AuditTable rows={filtered} onOpen={setOpen} />
-				</>
+				<AuditTable rows={filtered} liveIds={liveIds} onOpen={setOpen} />
 			) : (
-				<>
-					<FilterBar rows={rows} filters={filters} onChange={setFilters} />
-					<Trends rows={filtered} />
-				</>
+				<Trends rows={filtered} />
 			)}
 			{open && <RowPanel row={open} onClose={() => setOpen(null)} />}
 		</div>

--- a/packages/ui/src/app/audit-table.tsx
+++ b/packages/ui/src/app/audit-table.tsx
@@ -6,12 +6,13 @@ import { useMemo, useRef, useState } from "react";
 import { type LedgerRow, statusOf } from "../shared/rows.js";
 
 type SortKey = "seq" | "ts" | "kind" | "actor" | "model" | "costUt";
+type ColumnKey = SortKey | "status" | "integrity" | "transferId";
 const COLUMNS: Array<{
-	key: SortKey | "status" | "integrity" | "transferId";
+	key: ColumnKey;
 	label: string;
 	width: string;
 }> = [
-	{ key: "ts", label: "Time", width: "w-44" },
+	{ key: "ts", label: "Time", width: "w-32" },
 	{ key: "kind", label: "Kind", width: "w-32" },
 	{ key: "actor", label: "Actor", width: "w-28" },
 	{ key: "model", label: "Model", width: "w-44" },
@@ -20,6 +21,15 @@ const COLUMNS: Array<{
 	{ key: "integrity", label: "Integrity", width: "w-28" },
 	{ key: "transferId", label: "Tx", width: "flex-1" },
 ];
+
+function isSortKey(key: ColumnKey): key is SortKey {
+	return key !== "status" && key !== "integrity" && key !== "transferId";
+}
+
+/** Display-only reformat (P6): "MM-DD HH:mm:ss" — the full ISO stays in `title`. */
+function formatTs(iso: string): string {
+	return `${iso.slice(5, 10)} ${iso.slice(11, 19)}`;
+}
 
 function compare(a: LedgerRow, b: LedgerRow, key: SortKey): number {
 	if (key === "seq") return (a.seq ?? 0) - (b.seq ?? 0);
@@ -31,23 +41,26 @@ function compare(a: LedgerRow, b: LedgerRow, key: SortKey): number {
 
 function StatusBadge(props: { row: LedgerRow }): React.JSX.Element {
 	const status = statusOf(props.row);
+	// Settling is normal, not a celebration — neutral text. Green is earned
+	// by verification only (integrity column).
 	const color =
 		status === "settled"
-			? "text-[var(--accent)]"
+			? "text-[var(--text)]"
 			: status === "failed"
 				? "text-[var(--danger)]"
-				: "text-[var(--muted)]";
+				: "text-[var(--amber)]";
 	return <span className={`text-xs uppercase ${color}`}>{status}</span>;
 }
 
 function IntegrityBadge(props: { row: LedgerRow }): React.JSX.Element {
 	if (props.row.integrity === "verified")
-		return <span className="text-xs text-[var(--accent)]">✓ verified</span>;
+		return <span className="text-xs text-[var(--verify)]">✓ verified</span>;
 	return <span className="text-xs text-[var(--danger)]">⚠ after break</span>;
 }
 
 export function AuditTable(props: {
 	rows: LedgerRow[];
+	liveIds?: Set<string>;
 	onOpen(row: LedgerRow): void;
 }): React.JSX.Element {
 	const [sortKey, setSortKey] = useState<SortKey>("seq");
@@ -75,61 +88,79 @@ export function AuditTable(props: {
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col rounded border border-[var(--border)]">
-			<div className="flex border-b border-[var(--border)] bg-[var(--panel)] px-2 py-1.5 text-xs font-medium text-[var(--muted)]">
-				{COLUMNS.map((c) => (
-					<button
-						key={c.key}
-						type="button"
-						className={`${c.width} shrink-0 text-left`}
-						onClick={() => {
-							if (c.key !== "status" && c.key !== "integrity" && c.key !== "transferId")
-								sortBy(c.key);
-						}}
-					>
-						{c.label}
-						{c.key === sortKey ? (desc ? " ↓" : " ↑") : ""}
-					</button>
-				))}
+			<div className="flex border-b border-[var(--border)] bg-[var(--panel)] px-2 py-1.5 text-[10px] uppercase tracking-wider text-[var(--faint)] [font-family:var(--font-sans)]">
+				{COLUMNS.map((c) =>
+					isSortKey(c.key) ? (
+						<button
+							key={c.key}
+							type="button"
+							className={`${c.width} shrink-0 text-left`}
+							onClick={() => sortBy(c.key as SortKey)}
+						>
+							{c.label}{" "}
+							<span
+								aria-hidden="true"
+								className={c.key === sortKey ? "text-[var(--text)]" : "text-[var(--faint)]"}
+							>
+								{c.key === sortKey ? (desc ? "↓" : "↑") : "↕"}
+							</span>
+						</button>
+					) : (
+						<span key={c.key} className={`${c.width} shrink-0 text-left`}>
+							{c.label}
+						</span>
+					),
+				)}
 			</div>
 			<div ref={parentRef} className="min-h-0 flex-1 overflow-auto">
-				<div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
-					{virtualizer.getVirtualItems().map((item) => {
-						const row = sorted[item.index] as LedgerRow;
-						return (
-							<button
-								type="button"
-								key={row.id}
-								onClick={() => props.onOpen(row)}
-								className="absolute left-0 flex w-full border-b border-[var(--border)] px-2 py-2 text-left text-xs hover:bg-[var(--panel)]"
-								style={{ top: 0, transform: `translateY(${item.start}px)` }}
-							>
-								<span className="w-44 shrink-0 text-[var(--muted)]">
-									{row.ts.replace("T", " ").slice(0, 19)}
-								</span>
-								<span className="w-32 shrink-0">{row.kind}</span>
-								<span className="w-28 shrink-0 text-[var(--muted)]">{row.actor}</span>
-								<span className="w-44 shrink-0">{row.model ?? "—"}</span>
-								<span className="w-28 shrink-0">
-									{row.costUt !== undefined ? `${row.costUt} UT` : "—"}
-									{row.costUsd !== undefined && (
-										<span className="text-[var(--muted)]"> ${row.costUsd.toFixed(4)}</span>
-									)}
-								</span>
-								<span className="w-24 shrink-0">
-									<StatusBadge row={row} />
-								</span>
-								<span className="w-28 shrink-0">
-									<IntegrityBadge row={row} />
-								</span>
-								<span className="flex-1 truncate font-mono text-[var(--muted)]">
-									{row.transferId ?? row.id}
-								</span>
-							</button>
-						);
-					})}
-				</div>
+				{sorted.length === 0 ? (
+					<div className="flex h-full items-center justify-center p-8 text-xs text-[var(--faint)] [font-family:var(--font-sans)]">
+						no matching transactions — clear filters
+					</div>
+				) : (
+					<div style={{ height: virtualizer.getTotalSize(), position: "relative" }}>
+						{virtualizer.getVirtualItems().map((item) => {
+							const row = sorted[item.index] as LedgerRow;
+							return (
+								<button
+									type="button"
+									key={row.id}
+									onClick={() => props.onOpen(row)}
+									className={`absolute left-0 flex w-full border-b border-[var(--border)]/50 px-2 py-2 text-left text-xs tabular-nums transition-colors duration-100 hover:bg-[var(--panel-2)]${props.liveIds?.has(row.id) ? " row-live" : ""}`}
+									style={{ top: 0, transform: `translateY(${item.start}px)` }}
+								>
+									<span className="w-32 shrink-0 text-[var(--muted)]" title={row.ts}>
+										{formatTs(row.ts)}
+									</span>
+									<span className="w-32 shrink-0">{row.kind}</span>
+									<span className="w-28 shrink-0 truncate text-[var(--muted)]" title={row.actor}>
+										{row.actor}
+									</span>
+									<span className="w-44 shrink-0 truncate" title={row.model}>
+										{row.model ?? "—"}
+									</span>
+									<span className="w-28 shrink-0">
+										{row.costUt !== undefined ? `${row.costUt} UT` : "—"}
+										{row.costUsd !== undefined && (
+											<span className="text-[var(--muted)]"> ${row.costUsd.toFixed(4)}</span>
+										)}
+									</span>
+									<span className="w-24 shrink-0">
+										<StatusBadge row={row} />
+									</span>
+									<span className="w-28 shrink-0">
+										<IntegrityBadge row={row} />
+									</span>
+									<span className="flex-1 truncate text-[var(--muted)]">
+										{row.transferId ?? row.id}
+									</span>
+								</button>
+							);
+						})}
+					</div>
+				)}
 			</div>
-			<div className="border-t border-[var(--border)] px-2 py-1 text-xs text-[var(--muted)]">
+			<div className="border-t border-[var(--border)] px-2 py-1 text-xs text-[var(--muted)] tabular-nums">
 				{sorted.length} transactions
 			</div>
 		</div>

--- a/packages/ui/src/app/filter-bar.tsx
+++ b/packages/ui/src/app/filter-bar.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Usertools, Inc.
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { EMPTY_FILTERS, type FilterState, isFiltering } from "../shared/filters.js";
 import { type LedgerRow, statusOf } from "../shared/rows.js";
 
@@ -9,28 +9,92 @@ function distinct(values: Array<string | undefined>): string[] {
 	return [...new Set(values.filter((v): v is string => v !== undefined))].sort();
 }
 
-function FacetSelect(props: {
+/** Shared field chrome: 32px tall, mono 12px, panel fill, dark-scheme native pickers. */
+const FIELD_CLASSES =
+	"h-8 rounded-md border border-[var(--border)] bg-[var(--panel)] px-2 font-mono text-xs text-[var(--text)] [color-scheme:dark] placeholder:text-[var(--faint)]";
+
+function FacetPill(props: {
 	label: string;
 	options: string[];
 	selected: string[];
 	onChange(next: string[]): void;
 }): React.JSX.Element {
+	const { label, options, selected, onChange } = props;
+	const [open, setOpen] = useState(false);
+	const rootRef = useRef<HTMLDivElement | null>(null);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+	useEffect(() => {
+		if (!open) return;
+		const onPointerDown = (e: PointerEvent) => {
+			if (rootRef.current !== null && !rootRef.current.contains(e.target as Node)) {
+				setOpen(false);
+			}
+		};
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				setOpen(false);
+				triggerRef.current?.focus();
+			}
+		};
+		document.addEventListener("pointerdown", onPointerDown);
+		document.addEventListener("keydown", onKeyDown);
+		return () => {
+			document.removeEventListener("pointerdown", onPointerDown);
+			document.removeEventListener("keydown", onKeyDown);
+		};
+	}, [open]);
+
+	const active = selected.length > 0;
 	return (
-		<label className="flex items-center gap-1 text-xs text-[var(--muted)]">
-			{props.label}
-			<select
-				multiple
-				value={props.selected}
-				onChange={(e) => props.onChange([...e.currentTarget.selectedOptions].map((o) => o.value))}
-				className="max-w-40 rounded border border-[var(--border)] bg-[var(--panel)] p-1 text-[var(--text)]"
+		<div ref={rootRef} className="relative">
+			<button
+				ref={triggerRef}
+				type="button"
+				aria-haspopup="true"
+				aria-expanded={open}
+				onClick={() => setOpen((o) => !o)}
+				title={active ? `${label}: ${selected.join(", ")}` : label}
+				className={`h-8 max-w-[220px] truncate rounded-md border bg-[var(--panel)] px-3 font-mono text-xs ${
+					active
+						? "border-[var(--text)] text-[var(--text)]"
+						: "border-[var(--border)] text-[var(--muted)]"
+				}`}
 			>
-				{props.options.map((o) => (
-					<option key={o} value={o}>
-						{o}
-					</option>
-				))}
-			</select>
-		</label>
+				{active ? `${label} · ${selected.length}` : label}
+			</button>
+			{open && (
+				<div
+					className="absolute top-full left-0 z-20 mt-1 max-h-60 min-w-40 max-w-[260px] overflow-y-auto rounded-md border border-[var(--border)] bg-[var(--panel-2)] p-1"
+					style={{ boxShadow: "var(--shadow)" }}
+				>
+					{options.length === 0 ? (
+						<div className="px-2 py-1.5 font-mono text-[11px] text-[var(--faint)]">no values</div>
+					) : (
+						options.map((o) => (
+							<label
+								key={o}
+								className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 font-mono text-xs text-[var(--text)] hover:bg-[var(--border)]"
+							>
+								<input
+									type="checkbox"
+									checked={selected.includes(o)}
+									onChange={(e) =>
+										onChange(
+											e.currentTarget.checked ? [...selected, o] : selected.filter((x) => x !== o),
+										)
+									}
+									className="accent-[var(--chart)]"
+								/>
+								<span className="max-w-[220px] truncate" title={o}>
+									{o}
+								</span>
+							</label>
+						))
+					)}
+				</div>
+			)}
+		</div>
 	);
 }
 
@@ -89,33 +153,33 @@ export function FilterBar(props: {
 
 	return (
 		<div className="flex flex-col gap-2">
-			<div className="flex flex-wrap items-center gap-3">
+			<div className="flex flex-wrap items-center gap-2">
 				<input
 					type="search"
 					placeholder="Search transactions…"
 					value={filters.search}
 					onChange={(e) => onChange({ ...filters, search: e.currentTarget.value })}
-					className="w-64 rounded border border-[var(--border)] bg-[var(--panel)] px-2 py-1 text-sm"
+					className={`${FIELD_CLASSES} w-[260px]`}
 				/>
-				<FacetSelect
+				<FacetPill
 					label="kind"
 					options={kinds}
 					selected={filters.kinds}
 					onChange={(v) => onChange({ ...filters, kinds: v })}
 				/>
-				<FacetSelect
+				<FacetPill
 					label="model"
 					options={models}
 					selected={filters.models}
 					onChange={(v) => onChange({ ...filters, models: v })}
 				/>
-				<FacetSelect
+				<FacetPill
 					label="actor"
 					options={actors}
 					selected={filters.actors}
 					onChange={(v) => onChange({ ...filters, actors: v })}
 				/>
-				<FacetSelect
+				<FacetPill
 					label="status"
 					options={statuses}
 					selected={filters.statuses}
@@ -123,18 +187,23 @@ export function FilterBar(props: {
 				/>
 				<input
 					type="date"
+					aria-label="from date"
+					title="from"
 					value={filters.from ?? ""}
 					onChange={(e) => onChange({ ...filters, from: e.currentTarget.value || undefined })}
-					className="rounded border border-[var(--border)] bg-[var(--panel)] px-1 py-1 text-xs"
+					className={FIELD_CLASSES}
 				/>
 				<input
 					type="date"
+					aria-label="to date"
+					title="to"
 					value={filters.to ?? ""}
 					onChange={(e) => onChange({ ...filters, to: e.currentTarget.value || undefined })}
-					className="rounded border border-[var(--border)] bg-[var(--panel)] px-1 py-1 text-xs"
+					className={FIELD_CLASSES}
 				/>
 				<input
 					type="number"
+					aria-label="min cost (UT)"
 					placeholder="min UT"
 					value={filters.costMin ?? ""}
 					onChange={(e) =>
@@ -143,10 +212,11 @@ export function FilterBar(props: {
 							costMin: e.currentTarget.value === "" ? undefined : Number(e.currentTarget.value),
 						})
 					}
-					className="w-20 rounded border border-[var(--border)] bg-[var(--panel)] px-1 py-1 text-xs"
+					className={`${FIELD_CLASSES} w-20`}
 				/>
 				<input
 					type="number"
+					aria-label="max cost (UT)"
 					placeholder="max UT"
 					value={filters.costMax ?? ""}
 					onChange={(e) =>
@@ -155,7 +225,7 @@ export function FilterBar(props: {
 							costMax: e.currentTarget.value === "" ? undefined : Number(e.currentTarget.value),
 						})
 					}
-					className="w-20 rounded border border-[var(--border)] bg-[var(--panel)] px-1 py-1 text-xs"
+					className={`${FIELD_CLASSES} w-20`}
 				/>
 			</div>
 			{isFiltering(filters) && (
@@ -165,15 +235,18 @@ export function FilterBar(props: {
 							key={c.label}
 							type="button"
 							onClick={c.clear}
-							className="rounded-full border border-[var(--border)] bg-[var(--panel)] px-2 py-0.5 text-xs text-[var(--muted)]"
+							title={c.label}
+							aria-label={`clear ${c.label}`}
+							className="flex max-w-[220px] items-center gap-1 rounded-full border border-[var(--faint)] bg-[var(--panel)] px-2 py-0.5 font-mono text-[11px] text-[var(--muted)] hover:text-[var(--text)]"
 						>
-							{c.label} ✕
+							<span className="truncate">{c.label}</span>
+							<span aria-hidden="true">×</span>
 						</button>
 					))}
 					<button
 						type="button"
 						onClick={() => onChange(EMPTY_FILTERS)}
-						className="px-2 text-xs text-[var(--accent)]"
+						className="px-2 font-mono text-[11px] text-[var(--muted)] hover:text-[var(--text)]"
 					>
 						clear all
 					</button>

--- a/packages/ui/src/app/index.html
+++ b/packages/ui/src/app/index.html
@@ -3,6 +3,11 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link
+			rel="icon"
+			type="image/svg+xml"
+			href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%230f0f2a' d='M4 4q0-2 2-2h12q2 0 2 2v15l-2 2-2-2-2 2-2-2-2 2-2-2-2 2-2-2z'/%3E%3Crect x='7' y='7.5' width='10' height='1.5' rx='.75' fill='%234ade80'/%3E%3Crect x='7' y='11' width='10' height='1.5' rx='.75' fill='%234ade80'/%3E%3Crect x='7' y='14.5' width='6' height='1.5' rx='.75' fill='%234ade80'/%3E%3C/svg%3E"
+		/>
 		<title>usertrust — visual ledger</title>
 	</head>
 	<body>

--- a/packages/ui/src/app/main.tsx
+++ b/packages/ui/src/app/main.tsx
@@ -4,6 +4,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./app.js";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "@fontsource/jetbrains-mono/700.css";
 import "./styles.css";
 
 createRoot(document.getElementById("root") as HTMLElement).render(

--- a/packages/ui/src/app/row-panel.tsx
+++ b/packages/ui/src/app/row-panel.tsx
@@ -171,9 +171,31 @@ export function RowPanel(props: { row: LedgerRow; onClose(): void }): React.JSX.
 		};
 	}, []);
 
+	const panelRef = useRef<HTMLElement>(null);
+
 	useEffect(() => {
 		const onKey = (e: KeyboardEvent): void => {
-			if (e.key === "Escape") onClose();
+			if (e.key === "Escape") {
+				onClose();
+				return;
+			}
+			// aria-modal promises modality: keep Tab cycling inside the panel.
+			if (e.key === "Tab" && panelRef.current) {
+				const focusables = panelRef.current.querySelectorAll<HTMLElement>(
+					"button, [href], input, [tabindex]:not([tabindex='-1'])",
+				);
+				if (focusables.length === 0) return;
+				const first = focusables[0] as HTMLElement;
+				const last = focusables[focusables.length - 1] as HTMLElement;
+				const active = document.activeElement;
+				if (e.shiftKey && (active === first || !panelRef.current.contains(active))) {
+					e.preventDefault();
+					last.focus();
+				} else if (!e.shiftKey && (active === last || !panelRef.current.contains(active))) {
+					e.preventDefault();
+					first.focus();
+				}
+			}
 		};
 		document.addEventListener("keydown", onKey);
 		return () => document.removeEventListener("keydown", onKey);
@@ -211,6 +233,7 @@ export function RowPanel(props: { row: LedgerRow; onClose(): void }): React.JSX.
 				onClick={onClose}
 			/>
 			<aside
+				ref={panelRef}
 				className="rp-panel"
 				role="dialog"
 				aria-modal="true"

--- a/packages/ui/src/app/row-panel.tsx
+++ b/packages/ui/src/app/row-panel.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Usertools, Inc.
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { type LedgerRow, statusOf } from "../shared/rows.js";
 
 interface VerifyResponse {
@@ -11,15 +11,123 @@ interface VerifyResponse {
 	errors: string[];
 }
 
+/**
+ * Local styles for the drill-in panel: scrim, slide-in, dotted leaders,
+ * thermal receipt frame, delayed verdict reveal. Tokens only — no raw colors
+ * (P3). Keyframes are file-local; `.receipt-line` comes from styles.css.
+ */
+const PANEL_CSS = `
+@keyframes rp-scrim-in {
+	from { opacity: 0; }
+}
+@keyframes rp-panel-in {
+	from { transform: translateX(24px); opacity: 0; }
+}
+@keyframes rp-verdict-in {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+.rp-scrim {
+	position: fixed;
+	inset: 0;
+	z-index: 40;
+	border: 0;
+	margin: 0;
+	padding: 0;
+	background: var(--scrim);
+	backdrop-filter: blur(2px);
+	-webkit-backdrop-filter: blur(2px);
+	animation: rp-scrim-in 240ms ease-out both;
+	cursor: default;
+}
+.rp-panel {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 50;
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+	width: 440px;
+	max-width: calc(100vw - 24px);
+	overflow-y: auto;
+	background: var(--panel);
+	border-left: 1px solid var(--border);
+	box-shadow: var(--shadow);
+	padding: 16px;
+	animation: rp-panel-in 240ms cubic-bezier(0.32, 0.72, 0, 1) both;
+}
+.rp-field {
+	display: flex;
+	align-items: baseline;
+}
+.rp-label {
+	flex: none;
+	white-space: nowrap;
+	font-family: var(--font-sans);
+	font-size: 10px;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--muted);
+}
+.rp-leader {
+	flex: 1;
+	min-width: 16px;
+	border-bottom: 1px dotted var(--faint);
+	margin: 0 6px 4px;
+}
+.rp-value {
+	max-width: 62%;
+	font-size: 12px;
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+	overflow-wrap: anywhere;
+}
+.rp-value--hash {
+	font-size: 11px;
+	word-break: break-all;
+}
+.rp-receipt {
+	overflow-x: auto;
+	border-radius: 2px;
+	background: var(--bg);
+	box-shadow: 0 0 0 1px var(--border), var(--shadow);
+	padding: 10px 12px;
+	font-family: var(--font-mono);
+	font-size: 10px;
+	line-height: 1.45;
+}
+.rp-verdict {
+	font-size: 13px;
+	font-weight: 700;
+	letter-spacing: 0.06em;
+	opacity: 0;
+	animation: rp-verdict-in 240ms ease-out forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+	.rp-verdict {
+		opacity: 1;
+	}
+}
+`;
+
 function Field(props: {
 	label: string;
 	value: React.ReactNode;
-	mono?: boolean;
+	hash?: boolean;
+	tone?: string;
 }): React.JSX.Element {
 	return (
-		<div className="flex flex-col gap-0.5">
-			<dt className="text-[10px] uppercase tracking-wide text-[var(--muted)]">{props.label}</dt>
-			<dd className={`break-all text-xs ${props.mono ? "font-mono" : ""}`}>{props.value}</dd>
+		<div className="rp-field">
+			<dt className="rp-label">{props.label}</dt>
+			<span className="rp-leader" aria-hidden="true" />
+			<dd
+				className={`rp-value${props.hash ? " rp-value--hash" : ""}${props.tone ? ` ${props.tone}` : ""}`}
+			>
+				{props.value}
+			</dd>
 		</div>
 	);
 }
@@ -29,18 +137,20 @@ function CopyHash(props: { label: string; hash: string }): React.JSX.Element {
 	return (
 		<Field
 			label={props.label}
-			mono
+			hash
 			value={
 				<button
 					type="button"
-					className="text-left hover:text-[var(--accent)]"
+					title="copy to clipboard"
+					className="cursor-pointer text-right underline decoration-[var(--faint)] decoration-dotted underline-offset-2 hover:decoration-[var(--muted)]"
 					onClick={() => {
 						navigator.clipboard.writeText(props.hash).catch(() => {});
 						setCopied(true);
 						setTimeout(() => setCopied(false), 1200);
 					}}
 				>
-					{props.hash} {copied ? "✓ copied" : ""}
+					{props.hash}
+					{copied && <span className="text-[var(--muted)]"> ✓ copied</span>}
 				</button>
 			}
 		/>
@@ -48,8 +158,26 @@ function CopyHash(props: { label: string; hash: string }): React.JSX.Element {
 }
 
 export function RowPanel(props: { row: LedgerRow; onClose(): void }): React.JSX.Element {
-	const { row } = props;
+	const { row, onClose } = props;
 	const [verify, setVerify] = useState<VerifyResponse | "loading" | "error" | null>(null);
+	const closeRef = useRef<HTMLButtonElement>(null);
+
+	// Initial focus moves into the panel; on close it returns to the invoking row.
+	useEffect(() => {
+		const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+		closeRef.current?.focus();
+		return () => {
+			if (opener?.isConnected) opener.focus();
+		};
+	}, []);
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent): void => {
+			if (e.key === "Escape") onClose();
+		};
+		document.addEventListener("keydown", onKey);
+		return () => document.removeEventListener("keydown", onKey);
+	}, [onClose]);
 
 	const runVerify = async (): Promise<void> => {
 		if (!row.transferId) return;
@@ -62,62 +190,106 @@ export function RowPanel(props: { row: LedgerRow; onClose(): void }): React.JSX.
 		}
 	};
 
+	const status = statusOf(row);
+	const statusTone =
+		status === "failed"
+			? "text-[var(--danger)]"
+			: status === "pending"
+				? "text-[var(--amber)]"
+				: undefined;
+	const result = verify !== null && verify !== "loading" && verify !== "error" ? verify : null;
+	const lines = result ? result.receipt.split("\n") : [];
+
 	return (
-		<aside className="fixed inset-y-0 right-0 z-10 flex w-[420px] flex-col gap-3 overflow-y-auto border-l border-[var(--border)] bg-[var(--panel)] p-4">
-			<div className="flex items-center justify-between">
-				<h2 className="text-sm font-semibold">
-					{row.kind} · seq {row.seq ?? "?"}
-				</h2>
-				<button
-					type="button"
-					onClick={props.onClose}
-					className="text-[var(--muted)] hover:text-[var(--text)]"
-				>
-					✕
-				</button>
-			</div>
-			<dl className="flex flex-col gap-2">
-				<Field label="Timestamp" value={row.ts} mono />
-				<Field label="Actor" value={row.actor} />
-				{row.model && <Field label="Model" value={`${row.model} (${row.provider})`} />}
-				{row.costUt !== undefined && (
-					<Field label="Cost" value={`${row.costUt} UT · $${(row.costUsd ?? 0).toFixed(4)}`} />
-				)}
-				<Field label="Status" value={statusOf(row)} />
-				<Field label="Integrity" value={row.integrity} />
-				{row.transferId && <Field label="Transfer" value={row.transferId} mono />}
-				{row.error && <Field label="Error" value={row.error} />}
-				<CopyHash label="Hash" hash={row.hash} />
-				<CopyHash label="Previous hash" hash={row.previousHash} />
-				<Field label="Event id" value={row.id} mono />
-			</dl>
+		<>
+			<style>{PANEL_CSS}</style>
 			<button
 				type="button"
-				onClick={runVerify}
-				disabled={!row.transferId || verify === "loading"}
-				className="rounded border border-[var(--accent)] px-3 py-1.5 text-sm text-[var(--accent)] disabled:opacity-40"
+				className="rp-scrim"
+				aria-hidden="true"
+				tabIndex={-1}
+				onClick={onClose}
+			/>
+			<aside
+				className="rp-panel"
+				role="dialog"
+				aria-modal="true"
+				aria-label={`event detail — ${row.kind} seq ${row.seq ?? "?"}`}
 			>
-				{verify === "loading" ? "Verifying…" : "Verify this transaction"}
-			</button>
-			{verify === "error" && (
-				<span className="text-sm font-semibold text-[var(--danger)]">
-					verification request failed
-				</span>
-			)}
-			{verify !== null && verify !== "loading" && verify !== "error" && (
-				<div className="flex flex-col gap-2">
-					<span
-						className={`text-sm font-semibold ${verify.valid ? "text-[var(--accent)]" : "text-[var(--danger)]"}`}
+				<header className="flex items-start justify-between gap-2">
+					<h2 className="text-[13px] font-semibold tracking-wide">
+						{row.kind} · seq {row.seq ?? "?"}
+					</h2>
+					<button
+						ref={closeRef}
+						type="button"
+						onClick={onClose}
+						aria-label="close detail panel"
+						className="-m-1 cursor-pointer p-1 text-[var(--muted)] hover:text-[var(--text)]"
 					>
-						{verify.valid
-							? "VERIFIED"
-							: `FAILED${verify.errors.length ? `: ${verify.errors[0]}` : ""}`}
+						✕
+					</button>
+				</header>
+				<dl className="flex flex-col gap-2">
+					<Field label="Timestamp" value={row.ts} />
+					<Field label="Actor" value={row.actor} />
+					{row.model && <Field label="Model" value={`${row.model} (${row.provider})`} />}
+					{row.costUt !== undefined && (
+						<Field label="Cost" value={`${row.costUt} UT · $${(row.costUsd ?? 0).toFixed(4)}`} />
+					)}
+					<Field label="Status" value={status} tone={statusTone} />
+					<Field
+						label="Integrity"
+						value={row.integrity}
+						tone={row.integrity === "verified" ? "text-[var(--verify)]" : "text-[var(--danger)]"}
+					/>
+					{row.transferId && <Field label="Transfer" value={row.transferId} hash />}
+					{row.error && <Field label="Error" value={row.error} tone="text-[var(--danger)]" />}
+					<CopyHash label="Hash" hash={row.hash} />
+					<CopyHash label="Previous hash" hash={row.previousHash} />
+					<Field label="Event id" value={row.id} hash />
+				</dl>
+				{row.transferId ? (
+					<button
+						type="button"
+						onClick={runVerify}
+						disabled={verify === "loading"}
+						aria-busy={verify === "loading"}
+						className="cursor-pointer rounded border border-[var(--verify)] px-3 py-1.5 text-xs text-[var(--verify)] hover:bg-[var(--panel-2)] disabled:cursor-default disabled:opacity-40"
+					>
+						{verify === "loading" ? "verifying…" : "verify this transaction"}
+					</button>
+				) : (
+					<span className="text-[11px] text-[var(--faint)] italic">
+						no transfer id — nothing to verify
 					</span>
-					<pre className="overflow-x-auto rounded bg-[var(--bg)] p-2 font-mono text-[10px] leading-tight">
-						{verify.receipt}
+				)}
+				{result && (
+					<pre className="rp-receipt">
+						{lines.map((line, i) => (
+							// biome-ignore lint/suspicious/noArrayIndexKey: receipt lines are static per response and never reorder
+							<span key={i} className="receipt-line" style={{ animationDelay: `${i * 26}ms` }}>
+								{`${line}\n`}
+							</span>
+						))}
 					</pre>
+				)}
+				<div aria-live="polite">
+					{verify === "error" && (
+						<span className="rp-verdict text-[var(--danger)]">verification request failed</span>
+					)}
+					{result && (
+						<span
+							className={`rp-verdict ${result.valid ? "text-[var(--verify)]" : "text-[var(--danger)]"}`}
+							style={{ animationDelay: `${lines.length * 26 + 150}ms` }}
+						>
+							{result.valid
+								? "VERIFIED"
+								: `FAILED${result.errors.length ? `: ${result.errors[0]}` : ""}`}
+						</span>
+					)}
 				</div>
-			)}
-		</aside>
+			</aside>
+		</>
 	);
 }

--- a/packages/ui/src/app/store.ts
+++ b/packages/ui/src/app/store.ts
@@ -9,6 +9,13 @@ export interface LedgerData {
 	rows: LedgerRow[];
 	summary: SummaryPayload | null;
 	live: boolean;
+	/**
+	 * Ephemeral UI state (P6): ids that just arrived over SSE, kept for
+	 * ~1.6s so the table can one-shot flash them. Never persisted — reset
+	 * on resync, pruned by per-batch timers so virtualization remounts
+	 * cannot re-trigger the flash.
+	 */
+	liveIds: Set<string>;
 }
 
 async function fetchAll(): Promise<{ rows: LedgerRow[]; summary: SummaryPayload }> {
@@ -19,14 +26,22 @@ async function fetchAll(): Promise<{ rows: LedgerRow[]; summary: SummaryPayload 
 }
 
 export function useLedger(): LedgerData {
-	const [data, setData] = useState<LedgerData>({ rows: [], summary: null, live: false });
+	const [data, setData] = useState<LedgerData>({
+		rows: [],
+		summary: null,
+		live: false,
+		liveIds: new Set(),
+	});
 
 	useEffect(() => {
 		let cancelled = false;
+		const flashTimers = new Set<ReturnType<typeof setTimeout>>();
 		const resync = (): void => {
 			fetchAll()
 				.then(({ rows, summary }) => {
-					if (!cancelled) setData((d) => ({ ...d, rows, summary }));
+					// liveIds is flash state for SSE arrivals only — a resync
+					// replaces the row set wholesale, so it starts clean.
+					if (!cancelled) setData((d) => ({ ...d, rows, summary, liveIds: new Set<string>() }));
 				})
 				.catch((err: unknown) => {
 					// Amendment A6: never leave an unhandled rejection; drop the
@@ -52,8 +67,25 @@ export function useLedger(): LedgerData {
 				// fetch and redeliver rows the fetch already returned.
 				const seen = new Set(d.rows.map((r) => r.id));
 				const novel = fresh.filter((r) => !seen.has(r.id));
-				return novel.length > 0 ? { ...d, rows: [...d.rows, ...novel] } : d;
+				if (novel.length === 0) return d;
+				const liveIds = new Set(d.liveIds);
+				for (const r of novel) liveIds.add(r.id);
+				return { ...d, rows: [...d.rows, ...novel], liveIds };
 			});
+			// One-shot flash (P6): drop this batch's ids once the row-flash
+			// animation window has passed, so remounted virtual rows stay quiet.
+			const ids = fresh.map((r) => r.id);
+			const timer = setTimeout(() => {
+				flashTimers.delete(timer);
+				setData((d) => {
+					if (d.liveIds.size === 0) return d;
+					const liveIds = new Set(d.liveIds);
+					let changed = false;
+					for (const id of ids) changed = liveIds.delete(id) || changed;
+					return changed ? { ...d, liveIds } : d;
+				});
+			}, 1600);
+			flashTimers.add(timer);
 		});
 		source.addEventListener("summary", (e) => {
 			const summary = JSON.parse((e as MessageEvent).data) as SummaryPayload;
@@ -63,6 +95,7 @@ export function useLedger(): LedgerData {
 
 		return () => {
 			cancelled = true;
+			for (const timer of flashTimers) clearTimeout(timer);
 			source.close();
 		};
 	}, []);

--- a/packages/ui/src/app/styles.css
+++ b/packages/ui/src/app/styles.css
@@ -138,14 +138,14 @@ body::after {
 	animation: row-flash 1.2s ease-out;
 }
 
+/* Staggered opacity only — transforms don't apply to inline boxes in the
+   receipt <pre>, and thermal print is an appear, not a slide. */
 @keyframes print-line {
 	from {
 		opacity: 0;
-		transform: translateY(-2px);
 	}
 	to {
 		opacity: 1;
-		transform: none;
 	}
 }
 

--- a/packages/ui/src/app/styles.css
+++ b/packages/ui/src/app/styles.css
@@ -1,17 +1,169 @@
 @import "tailwindcss";
 
+/*
+ * terminal-thermal foundation — "The Ledger Is a Receipt"
+ * These tokens are the ONLY colors in the app. Green (--verify) is EARNED
+ * by verification: verified/integrity badges, the Verify button, the
+ * VERIFIED verdict, and focus rings. Chart marks are --chart, never green.
+ * Font weights 400/500/700 are imported in main.tsx (@fontsource, bundled).
+ */
+
 :root {
-	--bg: #0a0a0b;
-	--panel: #131316;
-	--border: #26262b;
-	--text: #e7e7ea;
-	--muted: #8b8b93;
-	--accent: #4ade80;
-	--danger: #f87171;
+	/* substrate — matches site brand (#0a0a1a bg, #0f0f2a cards) */
+	--bg: #0a0a1a;
+	--panel: #0f0f2a;
+	--panel-2: #14143a; /* hover wash / raised */
+	--border: #23234a;
+	--text: #e8e8f0;
+	--muted: #9a9ab0; /* contrast-bumped from #8b8b93 */
+	--faint: #6a6a88;
+	/* semantics — green is EARNED by verification only */
+	--verify: #4ade80; /* verified badges, integrity, VERIFIED verdict, live dot */
+	--amber: #fbbf24; /* pending */
+	--danger: #f87171; /* failed, integrity failure */
+	--chart: #7c8cf8; /* ALL chart marks — never green */
+	--chart-dim: #3d478f;
+	--shadow: 0 8px 24px rgb(0 0 0 / 0.5);
+	--scrim: rgb(5 5 16 / 0.55);
+	--font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+	--font-sans: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+	color-scheme: dark;
 }
 
 body {
 	background: var(--bg);
 	color: var(--text);
-	font-family: ui-sans-serif, system-ui, sans-serif;
+	font-family: var(--font-mono);
+}
+
+/* grain — fixed paper-texture layer beneath the app surface (no blend mode) */
+body::after {
+	content: "";
+	position: fixed;
+	inset: 0;
+	z-index: 0;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23n)'/%3E%3C/svg%3E");
+	opacity: 0.02;
+	pointer-events: none;
+}
+
+/* all app content rides above the grain */
+#root {
+	position: relative;
+	z-index: 1;
+}
+
+/* scrollbars — thin, quiet */
+* {
+	scrollbar-width: thin;
+	scrollbar-color: var(--border) transparent;
+}
+
+::-webkit-scrollbar {
+	width: 8px;
+	height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+	background: var(--border);
+	border-radius: 4px;
+}
+
+::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+::selection {
+	/* plain fallback first; color-mix wins where supported */
+	background: var(--verify);
+	background: color-mix(in oklab, var(--verify) 30%, transparent);
+}
+
+:focus-visible {
+	outline: 1.5px solid var(--verify);
+	outline-offset: 2px;
+}
+
+/* receipt texture — punched tear-off edge */
+.perforation {
+	height: 10px;
+	background-color: var(--panel);
+	background-image: radial-gradient(
+		circle at 5px 5px,
+		var(--bg) 3px,
+		transparent 3px
+	);
+	background-size: 14px 10px;
+	background-repeat: repeat-x;
+	border-radius: 0 0 6px 6px;
+}
+
+/* motion — exactly three moments: load reveal, live-row flash, thermal print */
+
+@keyframes reveal {
+	from {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+}
+
+.reveal {
+	animation: reveal 320ms ease-out both;
+}
+
+.reveal-1 {
+	animation-delay: 0ms;
+}
+
+.reveal-2 {
+	animation-delay: 60ms;
+}
+
+.reveal-3 {
+	animation-delay: 120ms;
+}
+
+@keyframes row-flash {
+	0% {
+		/* plain fallback first; color-mix wins where supported */
+		background-color: var(--panel-2);
+		background-color: color-mix(in oklab, var(--verify) 16%, transparent);
+	}
+	100% {
+		background-color: transparent;
+	}
+}
+
+.row-live {
+	animation: row-flash 1.2s ease-out;
+}
+
+@keyframes print-line {
+	from {
+		opacity: 0;
+		transform: translateY(-2px);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}
+
+.receipt-line {
+	opacity: 0;
+	animation: print-line 100ms steps(2, end) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation: none !important;
+		transition: none !important;
+	}
+
+	/* the animation carried this reveal — restore visibility without it */
+	.receipt-line {
+		opacity: 1;
+	}
 }

--- a/packages/ui/src/app/summary-strip.tsx
+++ b/packages/ui/src/app/summary-strip.tsx
@@ -3,21 +3,34 @@
 
 import type { SummaryPayload } from "../shared/api.js";
 
+// Local motion: live-connectivity pulse only. Disabled globally by the
+// prefers-reduced-motion override in styles.css (stylesheet !important wins).
+const stripCss = `
+@keyframes strip-pulse {
+	0%, 100% { opacity: 1; }
+	50% { opacity: 0.4; }
+}
+.live-pulse { animation: strip-pulse 2s ease-in-out infinite; }
+`;
+
 function Stat(props: {
 	label: string;
 	value: React.ReactNode;
 	tone?: "ok" | "bad";
 }): React.JSX.Element {
+	// Green is EARNED by verification — "ok" is used only by the Integrity stat.
 	const tone =
 		props.tone === "ok"
-			? "text-[var(--accent)]"
+			? "text-[var(--verify)]"
 			: props.tone === "bad"
 				? "text-[var(--danger)]"
 				: "";
 	return (
-		<div className="flex flex-col">
-			<span className="text-[10px] uppercase tracking-wide text-[var(--muted)]">{props.label}</span>
-			<span className={`text-sm font-semibold ${tone}`}>{props.value}</span>
+		<div className="flex flex-col gap-0.5">
+			<span className="text-[10px] uppercase tracking-wide text-[var(--muted)] [font-family:var(--font-sans)]">
+				{props.label}
+			</span>
+			<span className={`text-[15px] font-medium tabular-nums ${tone}`}>{props.value}</span>
 		</div>
 	);
 }
@@ -27,11 +40,22 @@ export function SummaryStrip(props: {
 	live: boolean;
 }): React.JSX.Element {
 	const s = props.summary;
-	if (!s) return <div className="h-14 rounded border border-[var(--border)] bg-[var(--panel)]" />;
+	if (!s)
+		return (
+			<div className="reveal reveal-1">
+				<div className="h-16 rounded-t-md border border-b-0 border-[var(--border)] bg-[var(--panel)]" />
+				<div className="perforation" />
+			</div>
+		);
 	const pct = s.budget > 0 ? Math.max(0, Math.min(100, (s.remainingUt / s.budget) * 100)) : 0;
+	// Healthy budget is --chart (connectivity-neutral), never green: amber under
+	// 20% remaining, danger under 5%.
+	const frac = s.budget > 0 ? s.remainingUt / s.budget : 0;
+	const budgetFill = frac > 0.2 ? "var(--chart)" : frac >= 0.05 ? "var(--amber)" : "var(--danger)";
 
 	return (
-		<div className="flex flex-col gap-2">
+		<div className="reveal reveal-1 flex flex-col gap-2">
+			<style>{stripCss}</style>
 			{!s.chain.valid && (
 				<div className="flex flex-col gap-1 rounded border border-[var(--danger)] bg-[var(--danger)]/10 px-3 py-2 text-sm text-[var(--danger)]">
 					<span>
@@ -39,7 +63,7 @@ export function SummaryStrip(props: {
 						{s.chain.breakIndex !== null && ` (break at chain position ${s.chain.breakIndex + 1})`}
 					</span>
 					{s.chain.errors.slice(0, 3).map((err) => (
-						<span key={err} className="font-mono text-xs opacity-90">
+						<span key={err} className="text-[11px] opacity-90">
 							{err}
 						</span>
 					))}
@@ -54,32 +78,56 @@ export function SummaryStrip(props: {
 					events.
 				</div>
 			)}
-			<div className="flex items-center gap-6 rounded border border-[var(--border)] bg-[var(--panel)] px-4 py-2">
-				<Stat
-					label="Spend"
-					value={`${s.spentUt.toLocaleString()} UT · $${(s.spentUt * 0.0001).toFixed(2)}`}
-				/>
-				<div className="flex w-48 flex-col gap-1">
-					<span className="text-[10px] uppercase tracking-wide text-[var(--muted)]">
-						Budget remaining {s.budget > 0 ? `${pct.toFixed(1)}%` : "—"}
+			<div>
+				<div className="rounded-t-md border border-b-0 border-[var(--border)] bg-[var(--panel)] px-4 pt-2.5 pb-3">
+					<span className="text-[10px] tracking-[0.3em] text-[var(--faint)]">
+						USERTRUST · LEDGER
 					</span>
-					<div className="h-1.5 rounded bg-[var(--bg)]">
-						<div className="h-1.5 rounded bg-[var(--accent)]" style={{ width: `${pct}%` }} />
+					<div className="mt-2 flex items-center gap-6">
+						<Stat
+							label="Spend"
+							value={`${s.spentUt.toLocaleString()} UT · $${(s.spentUt * 0.0001).toFixed(2)}`}
+						/>
+						<div className="flex w-48 flex-col gap-1">
+							<span className="text-[10px] uppercase tracking-wide text-[var(--muted)] [font-family:var(--font-sans)]">
+								Budget remaining{s.budget > 0 ? ` ${pct.toFixed(1)}%` : ""}
+							</span>
+							{s.budget > 0 ? (
+								<div className="h-1.5 rounded bg-[var(--bg)]">
+									<div
+										className="h-1.5 rounded"
+										style={{ width: `${pct}%`, background: budgetFill }}
+									/>
+								</div>
+							) : (
+								<span className="text-xs italic text-[var(--faint)]">no budget set</span>
+							)}
+						</div>
+						<Stat label="Chain" value={`${s.chain.events.toLocaleString()} events`} />
+						<Stat
+							label="Integrity"
+							value={s.chain.valid ? "verified" : "BROKEN"}
+							tone={s.chain.valid ? "ok" : "bad"}
+						/>
+						<Stat
+							label="Anchor"
+							value={
+								<span className="rounded-full border border-[var(--border)] bg-[var(--panel-2)] px-2 py-0.5 text-[11px] font-normal text-[var(--muted)]">
+									{s.anchorState}
+								</span>
+							}
+						/>
+						<div className="ml-auto flex items-center gap-1.5 text-[11px] text-[var(--muted)]">
+							<span
+								className={`inline-block h-2 w-2 rounded-full ${
+									props.live ? "live-pulse bg-[var(--chart)]" : "bg-[var(--faint)]"
+								}`}
+							/>
+							{props.live ? "live" : "offline"}
+						</div>
 					</div>
 				</div>
-				<Stat label="Chain" value={`${s.chain.events.toLocaleString()} events`} />
-				<Stat
-					label="Integrity"
-					value={s.chain.valid ? "verified" : "BROKEN"}
-					tone={s.chain.valid ? "ok" : "bad"}
-				/>
-				<Stat label="Anchor" value={s.anchorState} />
-				<div className="ml-auto flex items-center gap-1 text-xs text-[var(--muted)]">
-					<span
-						className={`inline-block h-2 w-2 rounded-full ${props.live ? "bg-[var(--accent)]" : "bg-[var(--muted)]"}`}
-					/>
-					{props.live ? "live" : "offline"}
-				</div>
+				<div className="perforation" />
 			</div>
 		</div>
 	);

--- a/packages/ui/src/app/trends.tsx
+++ b/packages/ui/src/app/trends.tsx
@@ -12,11 +12,42 @@ import {
 } from "../shared/aggregate.js";
 import type { LedgerRow } from "../shared/rows.js";
 
-function Tile(props: { label: string; value: string }): React.JSX.Element {
+type Granularity = "day" | "hour";
+
+function pad2(n: number): string {
+	return String(n).padStart(2, "0");
+}
+
+/** Axis tick: `MM-DD` (day) / `MM-DD HH:mm` (hour). Buckets are UTC — format in UTC. */
+function formatTickUtc(t: number, granularity: Granularity): string {
+	const d = new Date(t);
+	const md = `${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+	return granularity === "day" ? md : `${md} ${pad2(d.getUTCHours())}:${pad2(d.getUTCMinutes())}`;
+}
+
+/** Tooltip label: reconstruct the full bucket string (`YYYY-MM-DD` / `YYYY-MM-DD HH:00`). */
+function formatBucketUtc(t: number, granularity: Granularity): string {
+	const d = new Date(t);
+	const ymd = `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+	return granularity === "day" ? ymd : `${ymd} ${pad2(d.getUTCHours())}:00`;
+}
+
+/** Display-only compaction of a full ISO timestamp: `YYYY-MM-DD HH:mm`. */
+function formatIsoCompact(ts: string): string {
+	return ts.slice(0, 16).replace("T", " ");
+}
+
+function Tile(props: { label: string; value: string; danger?: boolean }): React.JSX.Element {
 	return (
-		<div className="flex flex-1 flex-col rounded border border-[var(--border)] bg-[var(--panel)] p-3">
-			<span className="text-[10px] uppercase tracking-wide text-[var(--muted)]">{props.label}</span>
-			<span className="text-lg font-semibold">{props.value}</span>
+		<div className="flex flex-1 flex-col gap-1 rounded border border-[var(--border)] bg-[var(--panel)] p-3">
+			<span className="text-[10px] uppercase tracking-wide text-[var(--muted)] [font-family:var(--font-sans)]">
+				{props.label}
+			</span>
+			<span
+				className={`text-[18px] font-medium tabular-nums ${props.danger ? "text-[var(--danger)]" : ""}`}
+			>
+				{props.value}
+			</span>
 		</div>
 	);
 }
@@ -24,35 +55,60 @@ function Tile(props: { label: string; value: string }): React.JSX.Element {
 function BarList(props: { title: string; totals: KeyTotal[] }): React.JSX.Element {
 	const max = props.totals[0]?.costUt ?? 1;
 	return (
-		<div className="flex flex-1 flex-col gap-2 rounded border border-[var(--border)] bg-[var(--panel)] p-3">
-			<h3 className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
+		<div className="flex flex-col gap-2 rounded border border-[var(--border)] bg-[var(--panel)] p-3">
+			<h3 className="text-[10px] uppercase tracking-wide text-[var(--muted)] [font-family:var(--font-sans)]">
 				{props.title}
 			</h3>
 			{props.totals.slice(0, 8).map((t) => (
 				<div key={t.key} className="flex items-center gap-2 text-xs">
-					<span className="w-36 truncate">{t.key}</span>
-					<div className="h-2 flex-1 rounded bg-[var(--bg)]">
+					<span className="w-36 truncate" title={t.key}>
+						{t.key}
+					</span>
+					<div className="h-1 flex-1 rounded-[1px] bg-[var(--bg)]">
 						<div
-							className="h-2 rounded bg-[var(--accent)]"
+							className="h-1 rounded-[1px] bg-[var(--chart)]"
 							style={{ width: `${max > 0 ? (t.costUt / max) * 100 : 0}%` }}
 						/>
 					</div>
-					<span className="w-20 text-right text-[var(--muted)]">
-						{t.costUt} UT · {t.count}
+					<span className="w-28 shrink-0 whitespace-nowrap text-right text-[11px] tabular-nums text-[var(--muted)]">
+						{t.costUt.toLocaleString()} UT · {t.count}×
 					</span>
 				</div>
 			))}
+			{props.totals.length > 8 && (
+				<span className="text-[10px] text-[var(--faint)]">top 8 of {props.totals.length}</span>
+			)}
 			{props.totals.length === 0 && (
-				<span className="text-xs text-[var(--muted)]">no data in filter</span>
+				<span className="text-xs text-[var(--faint)]">no data in filter</span>
 			)}
 		</div>
 	);
 }
 
 export function Trends(props: { rows: LedgerRow[] }): React.JSX.Element {
-	const [granularity, setGranularity] = useState<"day" | "hour">("day");
-	const series = useMemo(() => spendOverTime(props.rows, granularity), [props.rows, granularity]);
+	const [granularity, setGranularity] = useState<Granularity>("day");
+	const series = useMemo(
+		() =>
+			spendOverTime(props.rows, granularity)
+				.map((b) => ({
+					...b,
+					t: Date.parse(
+						granularity === "day" ? `${b.bucket}T00:00:00Z` : `${b.bucket.replace(" ", "T")}:00Z`,
+					),
+				}))
+				.filter((b) => !Number.isNaN(b.t)),
+		[props.rows, granularity],
+	);
 	const tiles = useMemo(() => statTiles(props.rows), [props.rows]);
+	const window = useMemo(() => {
+		let first: string | undefined;
+		let last: string | undefined;
+		for (const r of props.rows) {
+			if (first === undefined || r.ts < first) first = r.ts;
+			if (last === undefined || r.ts > last) last = r.ts;
+		}
+		return first !== undefined && last !== undefined ? { first, last } : undefined;
+	}, [props.rows]);
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
@@ -60,41 +116,93 @@ export function Trends(props: { rows: LedgerRow[] }): React.JSX.Element {
 				<Tile label="Total spend" value={`${tiles.totalCostUt.toLocaleString()} UT`} />
 				<Tile label="Events" value={tiles.calls.toLocaleString()} />
 				<Tile label="Avg cost" value={`${tiles.avgCostUt.toFixed(1)} UT`} />
-				<Tile label="Error rate" value={`${(tiles.errorRate * 100).toFixed(1)}%`} />
+				<Tile
+					label="Error rate"
+					value={`${(tiles.errorRate * 100).toFixed(1)}%`}
+					danger={tiles.errorRate > 0}
+				/>
 			</div>
-			<div className="rounded border border-[var(--border)] bg-[var(--panel)] p-3">
-				<div className="mb-2 flex items-center justify-between">
-					<h3 className="text-xs font-medium uppercase tracking-wide text-[var(--muted)]">
-						Spend over time
-					</h3>
-					<div className="flex gap-1 text-xs">
-						{(["day", "hour"] as const).map((g) => (
-							<button
-								key={g}
-								type="button"
-								onClick={() => setGranularity(g)}
-								className={`rounded px-2 py-0.5 ${granularity === g ? "bg-[var(--bg)] text-[var(--text)]" : "text-[var(--muted)]"}`}
-							>
-								{g}
-							</button>
-						))}
+			<div className="reveal reveal-3 flex flex-col gap-3">
+				<div className="rounded border border-[var(--border)] bg-[var(--panel)] p-3">
+					<div className="mb-2 flex items-center justify-between">
+						<h3 className="text-[10px] uppercase tracking-wide text-[var(--muted)] [font-family:var(--font-sans)]">
+							Spend over time
+						</h3>
+						<div className="flex gap-1">
+							{(["day", "hour"] as const).map((g) => (
+								<button
+									key={g}
+									type="button"
+									aria-pressed={granularity === g}
+									onClick={() => setGranularity(g)}
+									className={`rounded px-2 py-0.5 text-[10px] uppercase tracking-wide ${granularity === g ? "bg-[var(--panel-2)] text-[var(--text)]" : "text-[var(--muted)] hover:text-[var(--text)]"}`}
+								>
+									{g}
+								</button>
+							))}
+						</div>
 					</div>
+					{series.length === 0 ? (
+						<div className="flex h-[240px] items-center justify-center text-xs text-[var(--faint)]">
+							no data in filter
+						</div>
+					) : (
+						<ResponsiveContainer width="100%" height={240}>
+							<BarChart data={series}>
+								<CartesianGrid stroke="var(--border)" strokeOpacity={0.4} vertical={false} />
+								<XAxis
+									dataKey="t"
+									type="number"
+									scale="time"
+									domain={["dataMin", "dataMax"]}
+									padding={{ left: 16, right: 16 }}
+									tickFormatter={(t: number) => formatTickUtc(t, granularity)}
+									tick={{ fill: "var(--muted)", fontSize: 10, fontFamily: "var(--font-mono)" }}
+									tickLine={false}
+									axisLine={{ stroke: "var(--border)" }}
+								/>
+								<YAxis
+									width={44}
+									tickFormatter={(v: number) => v.toLocaleString()}
+									tick={{ fill: "var(--muted)", fontSize: 10, fontFamily: "var(--font-mono)" }}
+									tickLine={false}
+									axisLine={false}
+								/>
+								<Tooltip
+									cursor={{ fill: "var(--panel-2)" }}
+									contentStyle={{
+										background: "var(--panel-2)",
+										border: "1px solid var(--border)",
+										borderRadius: 6,
+										boxShadow: "var(--shadow)",
+										fontFamily: "var(--font-mono)",
+										fontSize: 11,
+									}}
+									labelStyle={{ color: "var(--muted)" }}
+									itemStyle={{ color: "var(--text)" }}
+									labelFormatter={(label) => formatBucketUtc(Number(label), granularity)}
+									formatter={(value) => [`${Number(value).toLocaleString()} UT`, "cost"]}
+								/>
+								<Bar
+									dataKey="costUt"
+									name="cost"
+									fill="var(--chart)"
+									barSize={12}
+									radius={[2, 2, 0, 0]}
+								/>
+							</BarChart>
+						</ResponsiveContainer>
+					)}
 				</div>
-				<ResponsiveContainer width="100%" height={220}>
-					<BarChart data={series}>
-						<CartesianGrid stroke="var(--border)" vertical={false} />
-						<XAxis dataKey="bucket" stroke="var(--muted)" fontSize={10} />
-						<YAxis stroke="var(--muted)" fontSize={10} />
-						<Tooltip
-							contentStyle={{ background: "var(--panel)", border: "1px solid var(--border)" }}
-						/>
-						<Bar dataKey="costUt" fill="var(--accent)" radius={[2, 2, 0, 0]} />
-					</BarChart>
-				</ResponsiveContainer>
-			</div>
-			<div className="flex gap-3">
-				<BarList title="Cost by task type" totals={costByKind(props.rows)} />
-				<BarList title="Cost by model" totals={costByModel(props.rows)} />
+				<div className="grid grid-cols-2 gap-3">
+					<BarList title="Cost by task type" totals={costByKind(props.rows)} />
+					<BarList title="Cost by model" totals={costByModel(props.rows)} />
+				</div>
+				<div className="pb-2 text-[11px] text-[var(--faint)]">
+					{props.rows.length.toLocaleString()} events
+					{window &&
+						` · window ${formatIsoCompact(window.first)} — ${formatIsoCompact(window.last)}`}
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
Design-only pass over the visual ledger SPA implementing the audited "terminal-thermal" direction:
- **Brand substrate**: site-navy tokens (`#0a0a1a`/`#0f0f2a`), JetBrains Mono as the data voice (bundled via @fontsource, build-time only), receipt texture — perforated summary strip, dotted leaders, subtle grain, receipt favicon
- **Semantic color**: phosphor green now EARNED only by verification (badges, verify action, verdict); statuses go neutral/amber/danger; charts and budget/live indicators use indigo `--chart`
- **Filter bar**: broken native multi-selects replaced with accessible facet-pill popovers (aria-expanded, Escape-returns-focus, pointerdown dismiss)
- **Motion, exactly three moments**: staggered chrome reveal, one-shot live-row flash (SSE), thermal-print receipt reveal with AT-visible verdict (`aria-live`); all reduced-motion-safe
- **Drill-in**: dialog semantics (role/aria-modal/focus trap/focus return), scrim + slide-in
- **Trends**: truthful time-scaled axis (UTC, NaN-guarded), flat bar-lists, intentional footer

No behavior/API/data changes — `src/server/**` and the pinned pure modules (`filters.ts`/`aggregate.ts`/`rows.ts`) are byte-identical to master (hash-verified in review).

## Review audit trail (pre-push)
- GPT-5.4 plan review: 15 amendments adopted (incl. a caught green-token contradiction), scope-cuts rejected
- Code review: PASS — 2 P2 + 1 P3, focus trap + keyframe fixed in `ebd65c1`, within-flash-window remount replay deferred (cosmetic, self-corrects in 1.6s)
- Security (in-house): PASS 6/6 — no injection sinks, font dep integrity-pinned/no scripts/fully local, no new network/storage
- Security (Trail of Bits): PASS — 2 P3 hygiene notes on keeping constant `<style>` blocks non-interpolated

## Test plan
- Full suite green (2098 tests — pure modules pinned), typecheck + biome clean, vite build clean
- Before/after screenshots of all three states captured against the real vault (attached in handoff comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)