### PR TITLE
feat(anchor): Phase 1.5 + 2 — S3 sink, store doctor, Rekor witness verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ usertrust init          # Create .usertrust/ vault
 usertrust inspect       # Vault bank statement
 usertrust health        # Entropy diagnostics (6 signals, 0-100 score)
 usertrust verify        # Verify audit chain integrity (+ external anchors)
-usertrust anchor        # External anchoring: init|now|status|export|rotate|resume
+usertrust anchor        # External anchoring: init|now|status|doctor|export|export-bundle|rotate|resume
 usertrust snapshot      # Checkpoint/restore vault state
 usertrust tb            # TigerBeetle process management
 usertrust completions   # Shell completions (bash, zsh, fish)
@@ -190,7 +190,7 @@ const config = defineConfig({
 
 **Merkle proofs (RFC 6962)** — Inclusion and consistency proofs for public verifiability. Any third party can verify a specific event existed in the chain.
 
-**External anchoring** — Ed25519-signed chain-head checkpoints pushed to an append-only store the vault operator cannot rewrite (S3 Object Lock, protected git branch, SIEM). Even a fully re-hashed, internally-consistent rewrite fails verification against the externally-held root. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md).
+**External anchoring** — Ed25519-signed chain-head checkpoints pushed to an append-only store the vault operator cannot rewrite (S3 Object Lock, protected git branch, SIEM). Even a fully re-hashed, internally-consistent rewrite fails verification against the externally-held root. Ships a native SigV4 S3 sink (no AWS SDK), an experimental [Rekor](https://docs.sigstore.dev/logging/overview/) transparency-log witness that publishes digests only, `anchor doctor` to probe whether the writer identity can actually delete or overwrite in the store, and `anchor export-bundle` to hand an auditor the records and receipts in one file. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md).
 
 **Policy engine** — 12 field operators (`eq`, `gt`, `in`, `regex`, etc.) with soft/hard enforcement. Block specific models, cap costs, require approvals.
 
@@ -263,6 +263,10 @@ With [external anchoring](https://github.com/usertools-ai/usertrust/blob/master/
 ```bash
 usertrust anchor init                                     # once: mint identity, pin the key
 usertrust anchor now --sink-file /mnt/worm/anchors.jsonl  # from cron/CI, or in-process
+
+# or publish straight to S3, after checking the store really refuses deletes
+usertrust anchor doctor --sink-s3 bucket=audit-anchors,region=us-east-1
+usertrust anchor now    --sink-s3 bucket=audit-anchors,region=us-east-1
 
 npx usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem --require-external-anchor
 ```

--- a/docs/anchoring.md
+++ b/docs/anchoring.md
@@ -234,6 +234,15 @@ usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
   --rekor-receipts receipts.jsonl --rekor-pubkey rekor-internal.pem
 ```
 
+**Keyring scope.** The keyring is flat: any pinned key may vouch for any log host appearing in the
+receipt set, and a checkpoint carrying several signatures (a log plus its witnesses) passes as soon
+as *one* of them verifies under *one* pinned key. So pin only keys you would trust to attest
+inclusion for any receipt in the run — pinning a partner's internal log key alongside
+rekor.sigstore.dev lets either key speak for either host. Host-scoped pinning (`--rekor-pubkey
+host=file`) is a possible future refinement; today, split the runs instead if the distinction
+matters. Supplying `--rekor-pubkey` material that turns out to be empty or unusable is an error,
+never a silent fall back to the embedded key.
+
 **Attested time.** A verified receipt upgrades `--max-anchor-age` from the operator-claimed
 `timestamp` field to the log's `integratedTime`. Staleness is then measured against a third
 party's clock, so backdating records no longer buys freshness. Without receipts, keep preferring

--- a/docs/anchoring.md
+++ b/docs/anchoring.md
@@ -243,13 +243,21 @@ host=file`) is a possible future refinement; today, split the runs instead if th
 matters. Supplying `--rekor-pubkey` material that turns out to be empty or unusable is an error,
 never a silent fall back to the embedded key.
 
-**Attested time.** A verified receipt upgrades `--max-anchor-age` from the operator-claimed
-`timestamp` field to the log's `integratedTime`. Staleness is then measured against a third
-party's clock, so backdating records no longer buys freshness. Without receipts, keep preferring
-`--max-unanchored-events`: event counts are not clock-dependent.
+**Attested time.** Staleness is measured against the log's **signed entry timestamp** (SET) — the
+log's own signature over `{body, integratedTime, logID, logIndex}`, and the only signature that
+covers `integratedTime` at all. When a receipt carries a SET that verifies under the same pinned
+log key as the checkpoint, `--max-anchor-age` is measured against that time instead of the
+operator-claimed `timestamp` field, so backdating records no longer buys freshness. Receipts
+*without* a SET still prove inclusion, but fall back to operator-claimed time for freshness: an
+unsigned `integratedTime` is a number the party under audit could have chosen. A SET that is
+present and does **not** verify fails the receipt closed — supplied evidence has to verify. A
+forward-dated operator `timestamp` still raises the `future-timestamp` warning whether or not a
+witness also attested the anchor. Without receipts, keep preferring `--max-unanchored-events`:
+event counts are not clock-dependent.
 
-**Checkpoint-replay caveat.** Offline verification proves the entry was included in the log *at
-`integratedTime`*, under a checkpoint signed by the pinned key. It does **not** prove that
+**Checkpoint-replay caveat.** Offline verification proves the entry was included in the log — *at
+`integratedTime`* only when a SET vouches for that time — under a checkpoint signed by the pinned
+key. It does **not** prove that
 checkpoint is consistent with the log's current head — a forked or rewound log would need a
 consistency proof against a checkpoint you fetched yourself. Read a receipt as "the log attested
 this at time T", not "the log is honest today"; for the public instance, the witness and monitor

--- a/docs/anchoring.md
+++ b/docs/anchoring.md
@@ -59,7 +59,7 @@ already run. The writer role gets `PutObject` only:
 
 No `s3:DeleteObject*`, no `s3:PutBucketPolicy`, no `s3:BypassGovernanceRetention`. Create the
 bucket with Object Lock enabled (compliance mode + retention period). Ship records with the
-command sink:
+native S3 sink (next section), or shell out:
 
 ```bash
 usertrust anchor now --sink-file /tmp/latest.json && \
@@ -79,6 +79,81 @@ credentials are inherently append-only.
 **File on a different mount/principal** (`--sink-file`) — weakest option; acceptable only when
 the path is owned by a different principal with append-only ACLs. Prefer the others.
 
+### S3 sink (native SigV4)
+
+Publish straight to S3 — no AWS SDK, no CLI on the box, no shell hop. Requests are signed with
+SigV4 built on `node:crypto`:
+
+```bash
+usertrust anchor now --sink-s3 bucket=audit-anchors,region=us-east-1
+usertrust anchor now --sink-s3 bucket=audit-anchors,region=us-east-1,prefix=anchors
+```
+
+`--sink-s3` takes a `k=v` CSV. `bucket` and `region` are required (either missing is a hard
+error); `prefix` defaults to `anchors`; `endpoint` targets an S3-compatible store. The SDK form
+is the same shape:
+
+```ts
+sinks: [{ type: "s3", bucket: "audit-anchors", region: "us-east-1", prefix: "anchors" }]
+```
+
+- **One object per record**, key `<prefix>/<vaultId>/<anchorSeq padded to 12>.json`, body = the
+  canonical record JSON. Anchor records are a few hundred bytes — a single `PUT`, never a
+  multipart upload.
+- **Credentials come from the environment**: `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`, plus
+  `AWS_SESSION_TOKEN` when you are on temporary credentials (it is signed as
+  `x-amz-security-token`). Missing credentials fail the publish, which keeps the record in the
+  outbox for redelivery rather than dropping it. Use the `PutObject`-only policy above.
+- **Addressing**: virtual-host style (`<bucket>.s3.<region>.amazonaws.com`) against AWS;
+  path-style (`<endpoint>/<bucket>/<key>`) when `endpoint=` is set, since S3-compatible stores
+  rarely serve bucket subdomains.
+- **Endpoint scheme rules**: `endpoint` must include a scheme, and it must be `https:` — SigV4
+  authenticates a request but does not encrypt it, so plaintext would put credential-bearing
+  headers on the wire. The one exception is `http://localhost` / `http://127.0.0.1`, for dev
+  MinIO and LocalStack.
+- Any 2xx is success. Anything else throws with the status and a ≤120-character body snippet;
+  request headers are never included in an error, so a failure is safe to paste into a ticket.
+
+### `anchor doctor` — permission probes
+
+```bash
+usertrust anchor doctor --sink-s3 bucket=audit-anchors,region=us-east-1
+usertrust anchor doctor --sink-file /mnt/worm/anchors.jsonl --json
+```
+
+Doctor writes a throwaway **probe object** to the store and reports whether *this identity, with
+the credentials in this environment, could delete or overwrite that probe object right now*. It
+exits 1 if any check fails.
+
+Read that sentence literally, because it is the whole claim. Doctor is a **permission probe, not
+proof of immutability**. A store can deny these operations today and allow them tomorrow, deny
+them for this identity and allow them for an admin one, or accept an overwrite as a new object
+version. WORM guarantees come from the store's own configuration — S3 Object Lock compliance-mode
+retention, POSIX ownership, an appliance's WORM mode. What doctor catches is the failure worth
+catching before an audit: a configuration that is not doing anything at all.
+
+| Sink | Probe |
+|---|---|
+| `--sink-file` | creates `.doctor-probe-<pid>` in the store's directory, then attempts `unlink` (`delete-denied`) and in-place truncation (`overwrite-denied`). Denied ⇒ pass, succeeded ⇒ fail, could not even create the probe ⇒ `info`. |
+| `--sink-s3` | `PUT`s `<prefix>/doctor-probe/<pid>-<timestamp>.json`, then attempts `DELETE` and an overwrite `PUT` of that key. `403` ⇒ pass, 2xx ⇒ fail, other statuses ⇒ `info` (inconclusive). |
+| `--sink-url`, `--sink-rekor`, `command` | `info` — no probe is possible from here; verify the append-only property at the receiving system. |
+
+Two caveats that change how you read the output:
+
+- **POSIX directory semantics.** Deletion is governed by write permission on the *directory*;
+  in-place truncation is governed by permission on the *file*. A store can deny one and allow the
+  other, so the two checks are independent and are reported independently. A `--sink-file` path in
+  a directory the vault writer owns will (correctly) fail `delete-denied` — that is the deployment
+  invariant telling you a local file sink is the weakest option.
+- **Versioned buckets.** An overwrite that returns 2xx with `x-amz-version-id` is neither a
+  refusal nor a true overwrite, so it reports as `info`: the new version does not remove the
+  previous one, but you must confirm Object Lock retention denies deletion of *individual
+  versions*.
+
+When the store denies deletion, the probe object is left behind — that is the store working as
+intended. Its key is named in every check detail, so it can be reconciled or aged out by a
+lifecycle rule.
+
 ## Monitor the cadence (do not skip this)
 
 An attacker's cheapest move is to *stop anchoring* and tamper later. The absence of expected
@@ -91,6 +166,113 @@ can't suppress it. One rule:
 That is a two-line CloudWatch metric filter on `PutObject` events, or a scheduled SIEM search on
 the ingest index. Writer-side, `usertrust anchor status` reports the unanchored tail, outbox
 depth, and a `degraded` flag; scheduled emitters also surface `lastEmitError`.
+
+## Rekor transparency-log witness (EXPERIMENTAL)
+
+> **EXPERIMENTAL.** The sink is exercised against synthetic responses only — the live Rekor API
+> is untested in CI — and the entry `apiVersion` is pinned to `0.0.1`. Treat it as an additional
+> witness alongside an append-only store, not as a replacement for one.
+
+A public transparency log is the strongest form of "the operator cannot un-publish it": the
+witness is a third party with its own Merkle tree, its own signing key, and its own monitors.
+
+```bash
+usertrust anchor now --sink-rekor                          # https://rekor.sigstore.dev
+usertrust anchor now --sink-rekor=https://rekor.internal   # self-hosted; SINGLE token, "=" form
+```
+
+`--sink-rekor` never consumes the next argv token — pass a custom URL as `--sink-rekor=<url>`, not
+as a separate argument. The SDK form is `{ type: "rekor", url?: string }`.
+
+### What actually goes public
+
+The entry is a `hashedrekord` carrying exactly three things: **sha256 of the anchor's signing
+pre-image, the record's Ed25519 signature, and the vault's public key**. Nothing else is
+transmitted.
+
+That is safe by construction rather than by policy: anchor records carry digests and counters
+only (spec §3) — a Merkle root, a tree size, a previous-record hash, a sequence number, a
+timestamp. There is no event data, no payload, no transaction content in a record, so there is
+none in the entry either, and the log receives no business data even in principle. Anchor keys are
+**per vault**, which bounds public correlation: an observer of the log sees one key per vault, not
+one identity across your whole estate.
+
+### Receipts
+
+A successful publish writes an inclusion receipt to
+`<vault>/audit/anchors/rekor/<anchorSeq padded to 12>.json` (fsync'd, mode 0600). Receipts live in
+their own files because the anchor record schema is **frozen** — a transparency log must not
+become a field inside the thing it witnesses. Any non-201, `409` included, fails the publish and
+leaves the record in the outbox; no receipt is written from a response that was not fully
+validated first.
+
+### Verifying receipts
+
+```bash
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
+  --rekor-receipts .usertrust/audit/anchors/rekor/000000000042.json
+```
+
+`--rekor-receipts` is repeatable and takes a file (one receipt JSON, or JSONL of receipts) or `-`
+for stdin. Verification is offline and zero-dependency: the signed-note checkpoint is parsed and
+its ECDSA P-256 signature checked, inclusion is proven by an RFC 9162 index-based path walk, and
+the stored entry is bound to *your* record by payload hash and by decoded signature bytes.
+
+It is **fail-closed**: every receipt you supply must verify. Any failure produces
+`ANCHOR_INVALID` with reason `rekor-receipt-invalid` and exit 1 — supplying evidence that does not
+check out is a worse signal than supplying none.
+
+**Key pinning.** With no `--rekor-pubkey`, the embedded rekor.sigstore.dev v1 log key is used —
+and *only* when the receipt's log host is exactly `rekor.sigstore.dev`. Any other log without an
+explicit key is refused with `rekor-receipt-invalid: custom log requires --rekor-pubkey`, because
+an unpinned receipt from an operator-chosen log is self-certifying. `--rekor-pubkey` is repeatable
+and forms a keyring — any pinned key that verifies the checkpoint passes — so a self-hosted or
+witnessed log uses the same verifier with no code change:
+
+```bash
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
+  --rekor-receipts receipts.jsonl --rekor-pubkey rekor-internal.pem
+```
+
+**Attested time.** A verified receipt upgrades `--max-anchor-age` from the operator-claimed
+`timestamp` field to the log's `integratedTime`. Staleness is then measured against a third
+party's clock, so backdating records no longer buys freshness. Without receipts, keep preferring
+`--max-unanchored-events`: event counts are not clock-dependent.
+
+**Checkpoint-replay caveat.** Offline verification proves the entry was included in the log *at
+`integratedTime`*, under a checkpoint signed by the pinned key. It does **not** prove that
+checkpoint is consistent with the log's current head — a forked or rewound log would need a
+consistency proof against a checkpoint you fetched yourself. Read a receipt as "the log attested
+this at time T", not "the log is honest today"; for the public instance, the witness and monitor
+network is what closes that gap.
+
+## Auditor bundles
+
+`export-bundle` packages the anchor records and their Rekor receipts into one file for handoff:
+
+```bash
+usertrust anchor export-bundle > audit-bundle.json
+usertrust anchor export-bundle --since 41 > incremental.json
+
+usertrust-verify .usertrust --bundle audit-bundle.json --pubkey root.pem
+usertrust anchor export-bundle | usertrust-verify .usertrust --bundle - --pubkey root.pem
+```
+
+The shape is `{"v":1,"records":[…],"rekorReceipts":[…]}`; `--since <anchorSeq>` filters both lists
+to entries after that sequence. Parsing on the verify side is strict — unknown top-level fields, a
+version other than 1, non-array members, or more than 10 000 records or receipts are all errors
+that exit 1.
+
+Both ends **fail closed**. If any receipt in the vault fails to parse, `export-bundle` writes
+diagnostics to stderr and exits 1 with **empty stdout** — a bundle on stdout is always a complete,
+valid bundle, never a partial one. On the verify side, every record and every receipt in the
+bundle must verify.
+
+A bundle is convenience packaging, not a trust upgrade: it is operator-supplied evidence, so
+signatures still verify against your out-of-band `--pubkey`, but only checkpoints *you* fetch from
+the append-only store prove the operator did not omit the ones that contradict them. The strongest
+posture is unchanged — fetch checkpoints yourself with `--anchors`, and use the bundle for the
+receipts.
 
 ## Pull mode (zero-egress runtimes)
 
@@ -125,6 +307,55 @@ honest export of an earlier head exists. Push mode with the monitor rule above i
   records at the same position in the append-only store are cryptographic fork evidence. Rotate
   immediately, re-pin out-of-band, re-anchor from a trusted snapshot.
 
+## External signers (KMS/HSM)
+
+The `external` signer keeps the private key off the vault host entirely: usertrust hands the
+backend the record's signing pre-image and gets a signature back. The key never touches disk, and
+`anchor init`'s PEM file is never created.
+
+```ts
+import { createAnchorEmitter, type AnchoringConfig } from "usertrust";
+
+const config: AnchoringConfig = {
+  signer: {
+    type: "external",
+    // sha256:<hex of the SPKI DER> — the same keyId `anchor init` prints.
+    keyId: "sha256:9f2c…",
+    publicKeySpki: "MCowBQYDK2VwAyEA…",   // base64 SPKI DER of the Ed25519 public key
+    async sign(preimage: Uint8Array): Promise<Uint8Array> {
+      const res = await fetch(`${process.env.VAULT_ADDR}/v1/transit/sign/usertrust-anchor`, {
+        method: "POST",
+        headers: { "X-Vault-Token": token, "content-type": "application/json" },
+        body: JSON.stringify({ input: Buffer.from(preimage).toString("base64") }),
+      });
+      if (!res.ok) throw new Error(`vault transit: HTTP ${res.status}`);
+      const { data } = (await res.json()) as { data: { signature: string } };
+      // "vault:v1:<base64 signature>"
+      return Buffer.from(data.signature.split(":").pop() as string, "base64");
+    },
+  },
+  sinks: [{ type: "s3", bucket: "audit-anchors", region: "us-east-1" }],
+};
+
+const emitter = createAnchorEmitter(process.cwd(), config);
+```
+
+Create the transit key as `ed25519` (`vault write -f transit/keys/usertrust-anchor type=ed25519`)
+and give the vault-writer role `update` on `transit/sign/usertrust-anchor` only — never `export`.
+`keyId` must be the fingerprint of `publicKeySpki`; a mismatch is refused when the signer is
+resolved, so a misconfigured backend fails at startup rather than producing records no auditor can
+attribute.
+
+**Hosted-KMS adapters are deferred.** There is no AWS KMS or GCP KMS adapter here: neither service
+signs Ed25519 for this shape, and supporting them requires algorithm agility in the record schema
+(an algorithm identifier plus verifier dispatch) — a future phase, not a flag. Any backend that
+*can* sign Ed25519 — Vault transit, a PKCS#11 HSM, a YubiHSM — works through the interface above
+today, unchanged.
+
+Scope it honestly: an external signer bounds key **exfiltration**. It does not defeat an attacker
+who can drive the backend as a signing oracle — they can still sign a forked history. The
+append-only witness, not the key custody, is the control for that.
+
 ## Verifying (the auditor side)
 
 The contract is **caller fetches, verifier checks**: you fetch the checkpoint(s) from the store
@@ -144,6 +375,13 @@ usertrust-verify .usertrust --tx tr_123 --anchor latest.json --pubkey root.pem
 # CI gate: must be externally anchored, fresh, and verified — or exit 1
 usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
   --require-anchor --require-external-anchor --max-unanchored-events 5000
+
+# With transparency-log receipts (freshness measured against the log's clock)
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
+  --rekor-receipts receipts.jsonl --max-anchor-age 24h
+
+# One operator-supplied handoff file
+usertrust-verify .usertrust --bundle audit-bundle.json --pubkey root.pem
 ```
 
 | State | Meaning | Exit (default / strict) |
@@ -159,8 +397,9 @@ Prefer `--max-unanchored-events` over `--max-anchor-age` for freshness policy: r
 are operator-claimed, event counts are not.
 
 The core CLI (`usertrust verify`) accepts the same flags. `usertrust anchor` subcommands:
-`init`, `now`, `status`, `export`, `rotate`, `resume` (re-seed a lost local mirror from the
-store's newest record).
+`init`, `now`, `status`, `doctor` (probe a sink's delete/overwrite permissions), `export`,
+`export-bundle` (records + receipts for an auditor), `rotate`, `resume` (re-seed a lost local
+mirror from the store's newest record).
 
 ## What each attack looks like
 

--- a/docs/anchoring.md
+++ b/docs/anchoring.md
@@ -169,9 +169,17 @@ depth, and a `degraded` flag; scheduled emitters also surface `lastEmitError`.
 
 ## Rekor transparency-log witness (EXPERIMENTAL)
 
-> **EXPERIMENTAL.** The sink is exercised against synthetic responses only — the live Rekor API
-> is untested in CI — and the entry `apiVersion` is pinned to `0.0.1`. Treat it as an additional
-> witness alongside an append-only store, not as a replacement for one.
+> **EXPERIMENTAL — does not yet work against the public `rekor.sigstore.dev`.** The sink is
+> exercised against synthetic responses only (the live API is untested in CI), the entry
+> `apiVersion` is pinned to `0.0.1`, and there is a **known incompatibility**: anchor records are
+> signed with pure Ed25519, while a `hashedrekord` entry asks the log to verify a signature given
+> only the artifact's sha256 digest — something pure Ed25519 cannot do (the log expects `ed25519ph`
+> or an algorithm that signs a prehash). Proposals to the public log are therefore rejected today.
+> Closing this needs signing-algorithm agility in the anchor record schema, which is deliberately
+> out of scope here. What ships now is the complete, tested verification path — receipt schema,
+> signed-note checkpoints, RFC 9162 inclusion, SET-verified attested time — plus a sink that works
+> against any log accepting these entries. Treat Rekor as an additional witness alongside an
+> append-only store, never as a replacement for one.
 
 A public transparency log is the strongest form of "the operator cannot un-publish it": the
 witness is a third party with its own Merkle tree, its own signing key, and its own monitors.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,7 +113,7 @@ usertrust init          # Create .usertrust/ vault
 usertrust inspect       # Vault bank statement
 usertrust health        # Entropy diagnostics (6 signals, 0-100 score)
 usertrust verify        # Verify audit chain integrity (+ external anchors)
-usertrust anchor        # External anchoring: init|now|status|export|rotate|resume
+usertrust anchor        # External anchoring: init|now|status|doctor|export|export-bundle|rotate|resume
 usertrust snapshot      # Checkpoint/restore vault state
 usertrust tb            # TigerBeetle process management
 usertrust completions   # Shell completions (bash, zsh, fish)
@@ -190,7 +190,7 @@ const config = defineConfig({
 
 **Merkle proofs (RFC 6962)** — Inclusion and consistency proofs for public verifiability. Any third party can verify a specific event existed in the chain.
 
-**External anchoring** — Ed25519-signed chain-head checkpoints pushed to an append-only store the vault operator cannot rewrite (S3 Object Lock, protected git branch, SIEM). Even a fully re-hashed, internally-consistent rewrite fails verification against the externally-held root. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md).
+**External anchoring** — Ed25519-signed chain-head checkpoints pushed to an append-only store the vault operator cannot rewrite (S3 Object Lock, protected git branch, SIEM). Even a fully re-hashed, internally-consistent rewrite fails verification against the externally-held root. Ships a native SigV4 S3 sink (no AWS SDK), an experimental [Rekor](https://docs.sigstore.dev/logging/overview/) transparency-log witness that publishes digests only, `anchor doctor` to probe whether the writer identity can actually delete or overwrite in the store, and `anchor export-bundle` to hand an auditor the records and receipts in one file. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md).
 
 **Policy engine** — 12 field operators (`eq`, `gt`, `in`, `regex`, etc.) with soft/hard enforcement. Block specific models, cap costs, require approvals.
 
@@ -263,6 +263,10 @@ With [external anchoring](https://github.com/usertools-ai/usertrust/blob/master/
 ```bash
 usertrust anchor init                                     # once: mint identity, pin the key
 usertrust anchor now --sink-file /mnt/worm/anchors.jsonl  # from cron/CI, or in-process
+
+# or publish straight to S3, after checking the store really refuses deletes
+usertrust anchor doctor --sink-s3 bucket=audit-anchors,region=us-east-1
+usertrust anchor now    --sink-s3 bucket=audit-anchors,region=us-east-1
 
 npx usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem --require-external-anchor
 ```

--- a/packages/core/src/audit/anchor-doctor.ts
+++ b/packages/core/src/audit/anchor-doctor.ts
@@ -324,6 +324,14 @@ function probeTarget(cfg: S3ProbeConfig, prefix: string): ProbeTarget {
 	return { host, path: `/${encoded}`, url: `https://${host}/${encoded}`, key };
 }
 
+/**
+ * Endpoint for an S3-compatible store, under the SAME rule as the sink
+ * (rekor.ts / s3-sink): plaintext is refused off-loopback. The doctor's probes
+ * are SigV4-signed like any other request, so an http endpoint on the network
+ * would put the credential-bearing headers on the wire — and a diagnostic
+ * command is exactly where an operator would paste an attacker-suggested URL.
+ * Loopback stays allowed for dev MinIO/LocalStack.
+ */
 function parseEndpoint(endpoint: string): URL {
 	let url: URL;
 	try {
@@ -331,8 +339,11 @@ function parseEndpoint(endpoint: string): URL {
 	} catch {
 		throw new Error(`s3 doctor: endpoint must include a scheme, got "${endpoint.slice(0, 60)}"`);
 	}
-	if (url.protocol !== "https:" && url.protocol !== "http:") {
-		throw new Error(`s3 doctor: endpoint scheme must be http(s), got "${url.protocol}"`);
+	const loopback = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+	if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+		throw new Error(
+			`s3 doctor: endpoint must be https (http is allowed only for localhost/127.0.0.1), got "${url.protocol}//${url.host}"`,
+		);
 	}
 	return url;
 }

--- a/packages/core/src/audit/anchor-doctor.ts
+++ b/packages/core/src/audit/anchor-doctor.ts
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * `anchor doctor` — append-only store PERMISSION PROBES.
+ *
+ * What this module establishes is narrow and worth stating precisely: it writes
+ * a throwaway probe object to the store and reports whether THIS identity, with
+ * the credentials in THIS environment, could delete or overwrite that object
+ * RIGHT NOW. It does not prove the store is append-only. A store can deny these
+ * operations today and allow them tomorrow, deny them for this identity and
+ * allow them for an admin one, or accept an overwrite as a new object version.
+ * Immutability comes from the store's own configuration (S3 Object Lock
+ * retention, POSIX directory permissions, an appliance's WORM mode) — the
+ * doctor only tells an operator whether their configuration is doing anything
+ * at all, which is the failure mode worth catching before an audit.
+ *
+ * The two probes are independent on purpose: on POSIX, deletion is governed by
+ * write permission on the DIRECTORY while in-place truncation is governed by
+ * permission on the FILE, so a store can deny one and allow the other.
+ *
+ * The S3 probe leaves its probe object behind whenever the store denies
+ * deletion — that is the store working as intended, not a leak, and the probe
+ * key is named in every check detail so it can be reconciled or lifecycled.
+ *
+ * Never in the output: credentials, the `authorization` header, or the session
+ * token — a diagnostic that gets pasted into an issue tracker must be safe to
+ * paste (plan delta D6).
+ */
+
+import { closeSync, openSync, unlinkSync, writeSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { type SigV4Credentials, sigV4Headers } from "./sigv4.js";
+
+export interface DoctorCheck {
+	name: string;
+	status: "pass" | "fail" | "info";
+	detail: string;
+}
+
+export interface DoctorReport {
+	sink: string;
+	checks: DoctorCheck[];
+	failed: boolean;
+}
+
+/**
+ * Injectable HTTP transport — the probe's only impure edge, so tests script
+ * store responses instead of reaching the network. Response `headers` are
+ * optional because only the S3 versioning probe reads one.
+ */
+export type HttpTransport = (opts: {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	body: Buffer;
+}) => Promise<{ status: number; body: string; headers?: Record<string, string> }>;
+
+export interface S3ProbeConfig {
+	bucket: string;
+	region: string;
+	prefix?: string;
+	endpoint?: string;
+}
+
+const PROBE_BODY = Buffer.from(
+	`${JSON.stringify({ probe: "usertrust-anchor-doctor", note: "safe to delete" })}\n`,
+	"utf8",
+);
+
+// ── Report helpers ──
+
+const pass = (name: string, detail: string): DoctorCheck => ({ name, status: "pass", detail });
+const fail = (name: string, detail: string): DoctorCheck => ({ name, status: "fail", detail });
+const info = (name: string, detail: string): DoctorCheck => ({ name, status: "info", detail });
+
+function report(sink: string, checks: DoctorCheck[]): DoctorReport {
+	return { sink, checks, failed: checks.some((c) => c.status === "fail") };
+}
+
+/**
+ * Untrusted text (store error bodies, transport error messages) on its way into
+ * a check detail. Anything that could carry a signed header is dropped to the
+ * end of its line rather than partially masked — a diagnostic is worth less
+ * than a credential.
+ */
+function redact(text: string): string {
+	const scrubbed = text
+		.replace(/authorization[^\n]*/gi, "[redacted]")
+		.replace(/x-amz-security-token[^\n]*/gi, "[redacted]")
+		.replace(/AWS4-HMAC-SHA256[^\n]*/g, "[redacted]")
+		.replace(/Credential=[^\s,]*/g, "[redacted]")
+		.replace(/Signature=[^\s,]*/g, "[redacted]")
+		.replace(/\s+/g, " ")
+		.trim();
+	return scrubbed.length > 120 ? `${scrubbed.slice(0, 120)}…` : scrubbed;
+}
+
+const messageOf = (err: unknown): string =>
+	redact(err instanceof Error ? err.message : String(err));
+
+const errnoOf = (err: unknown): string =>
+	typeof (err as { code?: unknown }).code === "string" ? (err as { code: string }).code : "unknown";
+
+// ── File sink ──
+
+/**
+ * Probe the directory holding a file sink. The probe object is created next to
+ * the store file (same directory, hence same permissions) and removed again.
+ */
+export function doctorFileSink(sinkPath: string): DoctorReport {
+	const sink = `file:${sinkPath}`;
+	const dir = dirname(sinkPath);
+	// PID-scoped so concurrent doctors never probe each other's object; opened
+	// with "w" so a stale probe from a crashed run is reused, not fatal.
+	const probe = join(dir, `.doctor-probe-${process.pid}`);
+
+	const created = writeProbe(probe);
+	if (created !== null) {
+		return report(sink, [
+			info(
+				"probe",
+				`cannot probe: this identity could not create a probe object in ${dir} (${created}) — ` +
+					"the store's delete and overwrite permissions were not exercised",
+			),
+		]);
+	}
+
+	const checks: DoctorCheck[] = [];
+	let deleted = false;
+	try {
+		unlinkSync(probe);
+		deleted = true;
+		checks.push(
+			fail("delete-denied", `this identity could delete a probe object at ${probe} right now`),
+		);
+	} catch (err) {
+		checks.push(
+			pass(
+				"delete-denied",
+				`this identity could not delete a probe object at ${probe} right now (${errnoOf(err)})`,
+			),
+		);
+	}
+
+	// The delete probe consumed the object when it succeeded; the overwrite
+	// probe needs one to truncate.
+	const recreated = deleted ? writeProbe(probe) : null;
+	if (recreated !== null) {
+		checks.push(info("overwrite-denied", `cannot probe overwrite: ${recreated}`));
+		return report(sink, checks);
+	}
+
+	checks.push(overwriteProbe(probe));
+	try {
+		unlinkSync(probe);
+	} catch {
+		// Best effort: a store that refuses the delete is the passing case, and
+		// the probe object is named in the check detail either way.
+	}
+	return report(sink, checks);
+}
+
+/** Creates or truncates the probe object; returns an errno on failure, else null. */
+function writeProbe(probe: string): string | null {
+	try {
+		const fd = openSync(probe, "w", 0o600);
+		try {
+			writeSync(fd, PROBE_BODY);
+		} finally {
+			closeSync(fd);
+		}
+		return null;
+	} catch (err) {
+		return errnoOf(err);
+	}
+}
+
+function overwriteProbe(probe: string): DoctorCheck {
+	const errno = writeProbe(probe);
+	return errno === null
+		? fail("overwrite-denied", `this identity could overwrite a probe object at ${probe} right now`)
+		: pass(
+				"overwrite-denied",
+				`this identity could not overwrite a probe object at ${probe} right now (${errno})`,
+			);
+}
+
+// ── S3 sink ──
+
+/**
+ * Probe an S3-compatible store: write a probe object, then attempt the two
+ * operations an append-only store must refuse against that same key.
+ */
+export async function doctorS3Sink(
+	cfg: S3ProbeConfig,
+	transport: HttpTransport = httpsTransport,
+): Promise<DoctorReport> {
+	const prefix = (cfg.prefix ?? "anchors").replace(/^\/+|\/+$/g, "");
+	const sink = `s3:${cfg.bucket}/${prefix}`;
+
+	const creds = credentialsFromEnv();
+	if (creds === null) {
+		return report(sink, [
+			info(
+				"probe",
+				"cannot probe: AWS credentials not found in the environment " +
+					"(AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)",
+			),
+		]);
+	}
+
+	const target = probeTarget(cfg, prefix);
+	const loc = `s3://${cfg.bucket}/${target.key}`;
+	const send = (method: string, payload: Buffer) =>
+		s3Request(transport, target, cfg.region, method, payload, creds);
+
+	const put = await attempt(() => send("PUT", PROBE_BODY));
+	if (put.error !== null) {
+		return report(sink, [info("probe", `cannot probe: writing ${loc} failed — ${put.error}`)]);
+	}
+	if (!is2xx(put.status)) {
+		return report(sink, [
+			info(
+				"probe",
+				`cannot probe: writing ${loc} returned HTTP ${put.status}${snippet(put.body)} — ` +
+					"the store's delete and overwrite permissions were not exercised",
+			),
+		]);
+	}
+
+	return report(sink, [
+		verdict("delete-denied", "delete", loc, await attempt(() => send("DELETE", Buffer.alloc(0)))),
+		verdict("overwrite-denied", "overwrite", loc, await attempt(() => send("PUT", PROBE_BODY))),
+	]);
+}
+
+interface Attempt {
+	status: number;
+	body: string;
+	versionId: string | null;
+	error: string | null;
+}
+
+async function attempt(
+	run: () => Promise<{ status: number; body: string; headers?: Record<string, string> }>,
+): Promise<Attempt> {
+	try {
+		const res = await run();
+		const headers = res.headers ?? {};
+		const versionId =
+			Object.entries(headers).find(([k]) => k.toLowerCase() === "x-amz-version-id")?.[1] ?? null;
+		return { status: res.status, body: res.body, versionId, error: null };
+	} catch (err) {
+		return { status: 0, body: "", versionId: null, error: messageOf(err) };
+	}
+}
+
+/**
+ * Turn one store response into a verdict. 403 is the shape a store takes when
+ * its policy refuses; a 2xx that carries `x-amz-version-id` is neither a
+ * refusal nor a true overwrite, so it reports as info rather than a verdict.
+ */
+function verdict(name: string, op: "delete" | "overwrite", loc: string, res: Attempt): DoctorCheck {
+	if (res.error !== null) {
+		return info(name, `cannot probe ${op}: ${loc} — ${res.error}`);
+	}
+	if (res.status === 403) {
+		return pass(
+			name,
+			`this identity could not ${op} a probe object at ${loc} right now (HTTP 403)`,
+		);
+	}
+	if (!is2xx(res.status)) {
+		return info(
+			name,
+			`inconclusive: ${op} of ${loc} returned HTTP ${res.status}${snippet(res.body)}`,
+		);
+	}
+	if (op === "overwrite" && res.versionId !== null) {
+		return info(
+			name,
+			`this identity could write a new version of a probe object at ${loc} right now ` +
+				`(HTTP ${res.status}, x-amz-version-id) — a new version does not remove the previous ` +
+				"one; confirm Object Lock retention denies deletion of individual versions",
+		);
+	}
+	return fail(
+		name,
+		`this identity could ${op} a probe object at ${loc} right now (HTTP ${res.status})`,
+	);
+}
+
+const is2xx = (status: number): boolean => status >= 200 && status < 300;
+
+const snippet = (body: string): string => (body === "" ? "" : `: ${redact(body)}`);
+
+function credentialsFromEnv(): SigV4Credentials | null {
+	const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+	const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+	if (!accessKeyId || !secretAccessKey) return null;
+	const sessionToken = process.env.AWS_SESSION_TOKEN;
+	return { accessKeyId, secretAccessKey, ...(sessionToken ? { sessionToken } : {}) };
+}
+
+interface ProbeTarget {
+	host: string;
+	path: string;
+	url: string;
+	key: string;
+}
+
+/** Virtual-host addressing by default; path-style when an endpoint is configured. */
+function probeTarget(cfg: S3ProbeConfig, prefix: string): ProbeTarget {
+	const key = `${prefix === "" ? "" : `${prefix}/`}doctor-probe/${process.pid}-${amzDate()}.json`;
+	const encoded = key.split("/").map(encodeURIComponent).join("/");
+
+	if (cfg.endpoint !== undefined) {
+		const base = parseEndpoint(cfg.endpoint);
+		const path = `/${encodeURIComponent(cfg.bucket)}/${encoded}`;
+		return { host: base.host, path, url: `${base.protocol}//${base.host}${path}`, key };
+	}
+	const host = `${cfg.bucket}.s3.${cfg.region}.amazonaws.com`;
+	return { host, path: `/${encoded}`, url: `https://${host}/${encoded}`, key };
+}
+
+function parseEndpoint(endpoint: string): URL {
+	let url: URL;
+	try {
+		url = new URL(endpoint);
+	} catch {
+		throw new Error(`s3 doctor: endpoint must include a scheme, got "${endpoint.slice(0, 60)}"`);
+	}
+	if (url.protocol !== "https:" && url.protocol !== "http:") {
+		throw new Error(`s3 doctor: endpoint scheme must be http(s), got "${url.protocol}"`);
+	}
+	return url;
+}
+
+/** `YYYYMMDDTHHMMSSZ` — also the probe key's uniqueness across runs. */
+function amzDate(): string {
+	return `${new Date().toISOString().replace(/[-:]/g, "").slice(0, 15)}Z`;
+}
+
+function s3Request(
+	transport: HttpTransport,
+	target: ProbeTarget,
+	region: string,
+	method: string,
+	payload: Buffer,
+	creds: SigV4Credentials,
+): Promise<{ status: number; body: string; headers?: Record<string, string> }> {
+	const extra = payload.length > 0 ? { "content-type": "application/json" } : {};
+	const signed = sigV4Headers(
+		{
+			method,
+			host: target.host,
+			path: target.path,
+			headers: extra,
+			payload,
+			region,
+			service: "s3",
+			amzDate: amzDate(),
+		},
+		creds,
+	);
+	// sigV4Headers signs caller headers but returns only its own — the caller
+	// must send both, or the signature covers headers that never arrive.
+	return transport({ method, url: target.url, headers: { ...extra, ...signed }, body: payload });
+}
+
+/** Default transport. `http://` endpoints (dev MinIO) require an injected one. */
+async function httpsTransport(opts: {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	body: Buffer;
+}): Promise<{ status: number; body: string; headers: Record<string, string> }> {
+	const { request } = await import("node:https");
+	return new Promise((resolve, reject) => {
+		const req = request(
+			opts.url,
+			{
+				method: opts.method,
+				headers: { ...opts.headers, "content-length": String(opts.body.length) },
+				timeout: 15_000,
+			},
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on("data", (c: Buffer) => chunks.push(c));
+				res.on("end", () => {
+					const headers: Record<string, string> = {};
+					for (const [name, value] of Object.entries(res.headers)) {
+						if (typeof value === "string") headers[name] = value;
+					}
+					resolve({
+						status: res.statusCode ?? 0,
+						body: Buffer.concat(chunks).toString("utf8").slice(0, 4096),
+						headers,
+					});
+				});
+			},
+		);
+		req.on("timeout", () => req.destroy(new Error("s3 doctor: request timeout")));
+		req.on("error", reject);
+		req.end(opts.body);
+	});
+}

--- a/packages/core/src/audit/anchor-verify.ts
+++ b/packages/core/src/audit/anchor-verify.ts
@@ -172,6 +172,22 @@ function isSafePositiveInt(n: unknown): n is number {
 	return typeof n === "number" && Number.isSafeInteger(n) && n >= 1;
 }
 
+// Matching control characters is the entire point here — they are what gets
+// removed from anything echoed back to a terminal.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the intent
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+
+/**
+ * An untrusted field NAME on its way into an error string. Control characters
+ * are stripped before truncation: these strings are printed to a terminal, and
+ * an escape sequence inside a key would let the party under audit repaint the
+ * line its own verdict is printed on.
+ */
+function clipKey(key: string): string {
+	const scrubbed = key.replace(CONTROL_CHARS, "");
+	return scrubbed.length <= 80 ? scrubbed : `${scrubbed.slice(0, 80)}...`;
+}
+
 /**
  * Strict parse of a single anchor record. Unknown fields, missing fields, and
  * range violations are all rejected (fail-closed — spec §3 strict-parse rules;
@@ -195,7 +211,7 @@ export function parseAnchorRecord(raw: string): {
 	const obj = parsed as Record<string, unknown>;
 	for (const key of Object.keys(obj)) {
 		if (!RECORD_KEYS.has(key)) {
-			return { record: null, error: `malformed-anchor: unknown field "${key}"` };
+			return { record: null, error: `malformed-anchor: unknown field "${clipKey(key)}"` };
 		}
 	}
 	if (obj.v !== 1) {
@@ -243,7 +259,10 @@ export function parseAnchorRecord(raw: string): {
 		const rotObj = rot as Record<string, unknown>;
 		for (const key of Object.keys(rotObj)) {
 			if (!ROTATION_KEYS.has(key)) {
-				return { record: null, error: `malformed-anchor: unknown rotation field "${key}"` };
+				return {
+					record: null,
+					error: `malformed-anchor: unknown rotation field "${clipKey(key)}"`,
+				};
 			}
 		}
 		if (typeof rotObj.nextKeyId !== "string" || !KEY_ID.test(rotObj.nextKeyId)) {

--- a/packages/core/src/audit/anchor-verify.ts
+++ b/packages/core/src/audit/anchor-verify.ts
@@ -91,6 +91,13 @@ export interface AnchorEvaluationOptions {
 	readonly expectedVaultId?: string;
 	/** Injectable clock for tests. Defaults to Date.now(). */
 	readonly nowMs?: number;
+	/**
+	 * Witness-attested integration time (ms) for the NEWEST anchor, from a
+	 * transparency-log receipt the caller already verified. When present it
+	 * replaces the operator-claimed timestamp as the input to --max-anchor-age:
+	 * it is the one time in the record the vault operator cannot choose.
+	 */
+	readonly attestedTimeMs?: number;
 }
 
 export interface AnchorEvaluationInput {
@@ -134,7 +141,12 @@ function nullIfNaN(n: number): number | null {
 
 // ── Reason-code classes (see spec §7.2) ──
 
-const INVALID_REASONS = new Set(["malformed-anchor", "range-invalid", "sig-invalid"]);
+const INVALID_REASONS = new Set([
+	"malformed-anchor",
+	"range-invalid",
+	"sig-invalid",
+	"rekor-receipt-invalid",
+]);
 const NON_FAIL_REASONS = new Set(["no-trust-material", "witness-unreachable"]);
 
 // ── Strict parsing ──
@@ -743,7 +755,12 @@ const STATE_SEVERITY: Record<AnchorState, number> = {
 	ANCHOR_MISMATCH: 5,
 };
 
-function worseState(a: AnchorState, b: AnchorState): AnchorState {
+/**
+ * The more severe of two states. Exported so callers layering evidence ON TOP
+ * of the state machine (the glue's Rekor receipts) escalate by the SAME
+ * severity ordering the machine itself uses, rather than hardcoding one.
+ */
+export function worseAnchorState(a: AnchorState, b: AnchorState): AnchorState {
 	return (STATE_SEVERITY[a] ?? 0) >= (STATE_SEVERITY[b] ?? 0) ? a : b;
 }
 
@@ -791,7 +808,7 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 		let finalState = state;
 		if (witnessFailed) {
 			reasons.push("witness-unreachable");
-			finalState = worseState(finalState, "ANCHOR_UNVERIFIABLE");
+			finalState = worseAnchorState(finalState, "ANCHOR_UNVERIFIABLE");
 			errors.push(`witness-unreachable: ${input.witness.error ?? "anchor URL fetch failed"}`);
 		}
 		let witness: { requested: boolean; status: WitnessStatus; error?: string };
@@ -954,10 +971,19 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 	const latest = [...records].sort((a, b) => b.treeSize - a.treeSize)[0];
 	if (latest !== undefined) {
 		const ts = Date.parse(latest.timestamp);
-		if (Number.isFinite(ts) && ts > nowMs) {
+		// A witness-attested integration time supersedes the operator's claim:
+		// the caller verified a transparency-log receipt binding this anchor to a
+		// time the vault operator did not choose, which is exactly the input the
+		// operator-claimed path lacks.
+		const attestedMs =
+			opts.attestedTimeMs !== undefined && Number.isSafeInteger(opts.attestedTimeMs)
+				? opts.attestedTimeMs
+				: null;
+		if (attestedMs === null && Number.isFinite(ts) && ts > nowMs) {
 			// Operator-claimed time is in the auditor's future — clock gaming
 			// (buyer-rejection §5.13). --max-unanchored-events is the
-			// clock-independent control.
+			// clock-independent control. Not raised on the attested path: there
+			// the operator's claim drives no policy, so it is not evidence.
 			warnings.push("future-timestamp");
 		}
 		const tail = Math.max(0, observed - latest.treeSize);
@@ -967,14 +993,17 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 			);
 			return finish("ANCHOR_STALE", records);
 		}
+		const ageBasisMs = attestedMs ?? ts;
 		if (
 			opts.maxAnchorAgeMs !== undefined &&
-			Number.isFinite(ts) &&
-			nowMs - ts > opts.maxAnchorAgeMs &&
+			Number.isFinite(ageBasisMs) &&
+			nowMs - ageBasisMs > opts.maxAnchorAgeMs &&
 			observed > latest.treeSize
 		) {
 			errors.push(
-				"stale: newest anchor is older than the supplied --max-anchor-age (operator-claimed time)",
+				attestedMs === null
+					? "stale: newest anchor is older than the supplied --max-anchor-age (operator-claimed time)"
+					: "stale: newest anchor is older than the supplied --max-anchor-age (witness-attested time)",
 			);
 			return finish("ANCHOR_STALE", records);
 		}

--- a/packages/core/src/audit/anchor-verify.ts
+++ b/packages/core/src/audit/anchor-verify.ts
@@ -998,11 +998,13 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 			opts.attestedTimeMs !== undefined && Number.isSafeInteger(opts.attestedTimeMs)
 				? opts.attestedTimeMs
 				: null;
-		if (attestedMs === null && Number.isFinite(ts) && ts > nowMs) {
+		if (Number.isFinite(ts) && ts > nowMs) {
 			// Operator-claimed time is in the auditor's future — clock gaming
-			// (buyer-rejection §5.13). --max-unanchored-events is the
-			// clock-independent control. Not raised on the attested path: there
-			// the operator's claim drives no policy, so it is not evidence.
+			// (buyer-rejection §5.13). Raised even when an attested time supersedes
+			// it below: a forward-dated claim is evidence about the operator whether
+			// or not a witness also spoke, and suppressing it on the attested path
+			// would let a receipt LAUNDER the very signal it was supplied to
+			// corroborate. --max-unanchored-events stays the clock-independent control.
 			warnings.push("future-timestamp");
 		}
 		const tail = Math.max(0, observed - latest.treeSize);

--- a/packages/core/src/audit/anchor.ts
+++ b/packages/core/src/audit/anchor.ts
@@ -154,6 +154,14 @@ export interface AnchorIdentity {
 	 * (spec §5.1). Absent on a fresh identity (first anchor allowed).
 	 */
 	lastAnchorSeq?: number;
+	/**
+	 * Every key this vault has ever anchored under, oldest first, INCLUDING the
+	 * genesis key. `keyId`/`publicKeySpki` above are the current epoch; this is
+	 * what lets a witness sink propose the key that actually signed a record
+	 * when an old record is redelivered after a rotation. Absent on identities
+	 * minted before key history existed — callers fall back to the current key.
+	 */
+	keyHistory?: { keyId: string; publicKeySpki: string }[];
 }
 
 /**
@@ -273,6 +281,7 @@ export function initAnchorIdentity(
 		keyId,
 		publicKeySpki,
 		createdAt: new Date().toISOString(),
+		keyHistory: [{ keyId, publicKeySpki }],
 	};
 	writeIdentityFile(rootDir, identity);
 	// Touch the mirror so "mirror file missing" (accidental loss / partial
@@ -1073,7 +1082,12 @@ export function mintSuccessorKey(vaultId: string): {
 	};
 }
 
-/** Update identity.json after a successful rotation emission. */
+/**
+ * Update identity.json after a successful rotation emission. The superseded key
+ * is APPENDED to the history rather than replaced: records signed under it may
+ * still be sitting in the outbox, and a witness sink must be able to name the
+ * key that actually signed each one long after the epoch moved on.
+ */
 export function recordRotatedIdentity(
 	rootDir: string,
 	next: { keyId: string; publicKeySpki: string },
@@ -1082,10 +1096,16 @@ export function recordRotatedIdentity(
 	if (identity === null) {
 		throw new Error("No anchor identity to rotate");
 	}
+	// An identity minted before key history seeds one from its current epoch, so
+	// the pre-rotation key is not lost by upgrading mid-life.
+	const history = identity.keyHistory ?? [
+		{ keyId: identity.keyId, publicKeySpki: identity.publicKeySpki },
+	];
 	const updated: AnchorIdentity = {
 		...identity,
 		keyId: next.keyId,
 		publicKeySpki: next.publicKeySpki,
+		keyHistory: [...history.filter((entry) => entry.keyId !== next.keyId), next],
 	};
 	writeIdentityFile(rootDir, updated);
 }

--- a/packages/core/src/audit/anchor.ts
+++ b/packages/core/src/audit/anchor.ts
@@ -60,6 +60,7 @@ import {
 } from "./anchor-verify.js";
 import { canonicalize } from "./canonical.js";
 import { buildMerkleTree } from "./merkle.js";
+import { DEFAULT_REKOR_URL, rekorSink, s3Sink } from "./rekor.js";
 
 // ── Config types (spec §5.4) ──
 
@@ -79,7 +80,11 @@ export type AnchorSignerConfig =
 export type SinkConfig =
 	| { type: "file"; path: string }
 	| { type: "https"; url: string; headers?: Record<string, string> }
-	| { type: "command"; argv: string[] };
+	| { type: "command"; argv: string[] }
+	/** S3-compatible object store, one object per record, SigV4-signed. */
+	| { type: "s3"; bucket: string; region: string; prefix?: string; endpoint?: string }
+	/** Rekor transparency log (EXPERIMENTAL). Defaults to rekor.sigstore.dev. */
+	| { type: "rekor"; url?: string };
 
 export interface AnchorSink {
 	readonly name: string;
@@ -420,7 +425,12 @@ function commandSink(argv: string[]): AnchorSink {
 	};
 }
 
-export function createSink(config: SinkConfig | AnchorSink): AnchorSink {
+/**
+ * `rootDir` is optional so existing callers keep working: only the Rekor sink
+ * needs it, because inclusion receipts are persisted into the vault alongside
+ * the mirror.
+ */
+export function createSink(config: SinkConfig | AnchorSink, rootDir?: string): AnchorSink {
 	// Already an AnchorSink instance (custom/test sink) — pass through.
 	if ("publish" in config && typeof config.publish === "function") {
 		return config;
@@ -433,6 +443,18 @@ export function createSink(config: SinkConfig | AnchorSink): AnchorSink {
 			return httpsSink(cfg.url, cfg.headers);
 		case "command":
 			return commandSink(cfg.argv);
+		case "s3":
+			return s3Sink({
+				bucket: cfg.bucket,
+				region: cfg.region,
+				...(cfg.prefix !== undefined ? { prefix: cfg.prefix } : {}),
+				...(cfg.endpoint !== undefined ? { endpoint: cfg.endpoint } : {}),
+			});
+		case "rekor":
+			if (rootDir === undefined) {
+				throw new Error("rekor sink requires rootDir");
+			}
+			return rekorSink(rootDir, cfg.url ?? DEFAULT_REKOR_URL);
 	}
 }
 
@@ -613,7 +635,7 @@ export function createAnchorEmitter(rootDir: string, config: AnchoringConfig): A
 	const identity: AnchorIdentity = maybeIdentity;
 	const vaultId = identity.vaultId;
 	const signer = resolveSigner(config.signer, vaultId);
-	const sinks = (config.sinks ?? []).map(createSink);
+	const sinks = (config.sinks ?? []).map((sink) => createSink(sink, rootDir));
 	const retries = config.publishRetries ?? 5;
 
 	let anchorSkips = 0;

--- a/packages/core/src/audit/rekor-verify.ts
+++ b/packages/core/src/audit/rekor-verify.ts
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Rekor Transparency-Log Receipt Verification — Zero-dependency standalone
+ *
+ * INTENTIONAL DUPLICATION: this file exists byte-for-byte in BOTH
+ * packages/verify/src/rekor-verify.ts and
+ * packages/core/src/audit/rekor-verify.ts — here even the import paths match,
+ * since the module's only sibling import is anchor-verify.js. The parity test
+ * pins the two together; any change must land in both packages.
+ *
+ * A receipt is EVIDENCE SUPPLIED BY THE PARTY UNDER AUDIT: it proves nothing on
+ * its own, and every field in it is attacker-shaped. What verification
+ * establishes, end to end, is a single chain of bindings:
+ *
+ *   our signed anchor record -> the bytes the log stored -> that entry's
+ *   position in a tree -> a checkpoint over that tree -> a log key the AUDITOR
+ *   pinned (never one the receipt names).
+ *
+ * Break any link and the receipt is worthless, so each is checked in order and
+ * the first failure is fatal (fail-closed). Rekor data deliberately lives in
+ * SEPARATE receipt files: the anchor record schema is frozen, and a
+ * transparency log must never become a field inside the thing it witnesses.
+ *
+ * Offline scope: a verified receipt proves the entry was included in the log at
+ * `integratedTime` under a pinned key. It does NOT prove the log's current head
+ * is consistent with that checkpoint — that needs a witness/consistency query,
+ * which stays out of the zero-dependency verifier by design.
+ */
+
+import { createHash } from "node:crypto";
+import {
+	type AnchorRecord,
+	anchorPayloadHash,
+	publicKeyFromPem,
+	verifySignatureRaw,
+} from "./anchor-verify.js";
+
+// ── Types ──
+
+export interface RekorReceipt {
+	v: 1;
+	vaultId: string;
+	anchorSeq: number;
+	/** 64-hex — MUST equal anchorPayloadHash(record). */
+	artifactHash: string;
+	/** base64 of the entry bytes AS STORED BY THE LOG, never a reserialization. */
+	entryBody: string;
+	log: {
+		url: string;
+		logIndex: number;
+		treeSize: number;
+		/** 64-hex root the inclusion path must reconstruct. */
+		rootHash: string;
+		/** 64-hex inclusion path, leaf -> root order. */
+		hashes: string[];
+		/** Signed note (checkpoint) over treeSize + rootHash. */
+		checkpoint: string;
+		/** Unix seconds the log attests it integrated the entry. */
+		integratedTime: number;
+	};
+}
+
+export interface SignedNote {
+	origin: string;
+	treeSize: number;
+	rootHashHex: string;
+	/** EXACTLY the bytes the log signs: 3 body lines including the trailing LF. */
+	body: string;
+	/** Note signature with the 4-byte key hint stripped off the front. */
+	sig: Buffer;
+}
+
+export interface RekorVerification {
+	ok: boolean;
+	/** Witness-attested time in ms — the input to staleness policy when present. */
+	attestedTimeMs: number | null;
+	errors: string[];
+}
+
+// ── Constants ──
+
+/**
+ * The rekor.sigstore.dev v1 log key, as served by
+ * https://rekor.sigstore.dev/api/v1/log/publicKey — ECDSA P-256, SPKI sha256
+ * c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d (the log's
+ * published logID). This is DATA, not a dependency, and it is not a blanket
+ * trust root: it is consulted ONLY for receipts whose log URL host IS
+ * rekor.sigstore.dev. Any other log must be pinned by the operator with
+ * --rekor-pubkey.
+ */
+export const REKOR_PROD_PUBKEY_PEM = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwr
+kBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==
+-----END PUBLIC KEY-----
+`;
+
+/** The one host the embedded key above is allowed to speak for. */
+const REKOR_PROD_HOST = "rekor.sigstore.dev";
+
+const ERR = "rekor-receipt-invalid";
+
+// Caps on untrusted input. A receipt is a small artifact; anything near these
+// bounds is an attempt to make the verifier do work, not to prove inclusion.
+const MAX_RECEIPT_BYTES = 256 * 1024;
+const MAX_ENTRY_BODY_BYTES = 64 * 1024;
+const MAX_CHECKPOINT_BYTES = 8 * 1024;
+const MAX_INCLUSION_PATH = 64;
+const MAX_PEM_BYTES = 16 * 1024;
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
+const UINT = /^(0|[1-9][0-9]*)$/;
+
+const LEAF_PREFIX = Buffer.from([0x00]);
+const NODE_PREFIX = Buffer.from([0x01]);
+
+const RECEIPT_KEYS = new Set(["v", "vaultId", "anchorSeq", "artifactHash", "entryBody", "log"]);
+const LOG_KEYS = new Set([
+	"url",
+	"logIndex",
+	"treeSize",
+	"rootHash",
+	"hashes",
+	"checkpoint",
+	"integratedTime",
+]);
+
+// ── Small helpers ──
+
+/** Untrusted values are never echoed whole into an error string. */
+function clip(value: string): string {
+	return value.length <= 80 ? value : `${value.slice(0, 80)}...`;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function isSafeIntAtLeast(value: unknown, min: number): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= min;
+}
+
+/** Lowercased host (INCLUDING port) of an http(s) URL, or null. */
+function logHost(url: string): string | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+	return parsed.host.toLowerCase();
+}
+
+function nodeHash(left: Buffer, right: Buffer): Buffer {
+	return createHash("sha256").update(NODE_PREFIX).update(left).update(right).digest();
+}
+
+// ── Signed notes (checkpoints) ──
+
+/**
+ * Parse a signed note:
+ *   <origin>\n<treeSize>\n<base64 rootHash>\n\n— <keyname> <base64 sig>\n
+ * Strictly LF-only and strictly this shape — a note is a signed artifact, so
+ * accepting variants would mean verifying a signature over bytes we did not
+ * actually parse. The signature payload is `4-byte keyhint || DER signature`;
+ * the hint identifies which key the log used and is ADVISORY only, because the
+ * auditor pins the key out-of-band. Only its 4 bytes are skipped.
+ */
+export function parseSignedNote(note: string): SignedNote | null {
+	if (note.length === 0 || Buffer.byteLength(note, "utf8") > MAX_CHECKPOINT_BYTES) return null;
+	if (note.includes("\r")) return null;
+	const lines = note.split("\n");
+	if (lines.length === 6 && lines[5] === "") lines.pop();
+	if (lines.length !== 5) return null;
+	const origin = lines[0] as string;
+	const sizeLine = lines[1] as string;
+	const rootB64 = lines[2] as string;
+	if (origin.length === 0 || lines[3] !== "") return null;
+	if (!UINT.test(sizeLine)) return null;
+	const treeSize = Number(sizeLine);
+	if (!Number.isSafeInteger(treeSize)) return null;
+	if (!BASE64.test(rootB64)) return null;
+	const root = Buffer.from(rootB64, "base64");
+	if (root.length !== 32) return null;
+	const parts = (lines[4] as string).split(" ");
+	if (parts.length !== 3 || parts[0] !== "—" || (parts[1] as string).length === 0) return null;
+	const sigField = parts[2] as string;
+	if (!BASE64.test(sigField)) return null;
+	const raw = Buffer.from(sigField, "base64");
+	if (raw.length <= 4) return null;
+	return {
+		origin,
+		treeSize,
+		rootHashHex: root.toString("hex"),
+		body: `${origin}\n${sizeLine}\n${rootB64}\n`,
+		sig: raw.subarray(4),
+	};
+}
+
+// ── RFC 9162 inclusion ──
+
+/**
+ * RFC 9162 §2.1.3.2 inclusion verification: walk the audit path from the leaf
+ * to the root, deciding sibling order from the leaf index rather than from any
+ * hint the proof supplies. `fn`/`sn` track the leaf's and the last leaf's
+ * positions within the current subtree; the right-shift after a left-sibling
+ * merge is what makes right-edge (incomplete) subtrees come out correct.
+ *
+ * Never throws: malformed hex, out-of-range indices, and over-long paths are
+ * rejections, because this runs on attacker-supplied input.
+ */
+export function verifyIndexInclusion(
+	leafHex: string,
+	index: number,
+	treeSize: number,
+	pathHex: readonly string[],
+	rootHex: string,
+): boolean {
+	if (!Number.isSafeInteger(index) || !Number.isSafeInteger(treeSize)) return false;
+	if (index < 0 || treeSize < 1 || index >= treeSize) return false;
+	if (!HEX64.test(leafHex) || !HEX64.test(rootHex)) return false;
+	if (pathHex.length > MAX_INCLUSION_PATH) return false;
+
+	let fn = index;
+	let sn = treeSize - 1;
+	let r: Buffer = Buffer.from(leafHex, "hex");
+	for (const pHex of pathHex) {
+		if (!HEX64.test(pHex)) return false;
+		if (sn === 0) return false;
+		const p = Buffer.from(pHex, "hex");
+		if (fn % 2 === 1 || fn === sn) {
+			r = nodeHash(p, r);
+			// LSB(fn) not set (the fn === sn right-edge case): shift both equally
+			// until LSB(fn) is set or fn is 0.
+			while (fn % 2 === 0 && fn !== 0) {
+				fn = Math.floor(fn / 2);
+				sn = Math.floor(sn / 2);
+			}
+		} else {
+			r = nodeHash(r, p);
+		}
+		fn = Math.floor(fn / 2);
+		sn = Math.floor(sn / 2);
+	}
+	return sn === 0 && r.toString("hex") === rootHex;
+}
+
+// ── Strict receipt parsing ──
+
+/**
+ * Strict parse of one receipt. Unknown fields, wrong types, and range
+ * violations are all rejected before any crypto runs — the same fail-closed
+ * posture as parseAnchorRecord, for the same reason: a field the verifier
+ * silently ignores is a field an attacker can use.
+ */
+export function parseRekorReceipt(raw: string): {
+	receipt: RekorReceipt | null;
+	error: string | null;
+} {
+	const bad = (message: string): { receipt: null; error: string } => ({
+		receipt: null,
+		error: `${ERR}: ${message}`,
+	});
+
+	if (Buffer.byteLength(raw, "utf8") > MAX_RECEIPT_BYTES) return bad("receipt exceeds 256 KiB");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return bad("not valid JSON");
+	}
+	const obj = asObject(parsed);
+	if (obj === null) return bad("not an object");
+	for (const key of Object.keys(obj)) {
+		if (!RECEIPT_KEYS.has(key)) return bad(`unknown field "${clip(key)}"`);
+	}
+	if (obj.v !== 1) return bad("unsupported version");
+	if (typeof obj.vaultId !== "string" || obj.vaultId.length === 0) return bad("missing vaultId");
+	if (!isSafeIntAtLeast(obj.anchorSeq, 1)) {
+		return bad("anchorSeq must be a safe integer >= 1");
+	}
+	if (typeof obj.artifactHash !== "string" || !HEX64.test(obj.artifactHash)) {
+		return bad("artifactHash must be 64 lowercase hex characters");
+	}
+	if (typeof obj.entryBody !== "string" || obj.entryBody.length === 0) {
+		return bad("missing entryBody");
+	}
+	if (!BASE64.test(obj.entryBody)) return bad("entryBody must be base64");
+	if (Buffer.from(obj.entryBody, "base64").length > MAX_ENTRY_BODY_BYTES) {
+		return bad("entryBody exceeds 64 KiB decoded");
+	}
+
+	const log = asObject(obj.log);
+	if (log === null) return bad("log must be an object");
+	for (const key of Object.keys(log)) {
+		if (!LOG_KEYS.has(key)) return bad(`unknown log field "${clip(key)}"`);
+	}
+	if (typeof log.url !== "string" || logHost(log.url) === null) {
+		return bad("log.url must be an http(s) URL");
+	}
+	if (!isSafeIntAtLeast(log.logIndex, 0)) return bad("log.logIndex must be a safe integer >= 0");
+	if (!isSafeIntAtLeast(log.treeSize, 1)) return bad("log.treeSize must be a safe integer >= 1");
+	if (log.logIndex >= log.treeSize) return bad("log.logIndex must be < log.treeSize");
+	if (typeof log.rootHash !== "string" || !HEX64.test(log.rootHash)) {
+		return bad("log.rootHash must be 64 lowercase hex characters");
+	}
+	if (!Array.isArray(log.hashes) || log.hashes.length > MAX_INCLUSION_PATH) {
+		return bad(`log.hashes must be an array of at most ${MAX_INCLUSION_PATH} hashes`);
+	}
+	for (const h of log.hashes) {
+		if (typeof h !== "string" || !HEX64.test(h)) {
+			return bad("log.hashes entries must be 64 lowercase hex characters");
+		}
+	}
+	if (
+		typeof log.checkpoint !== "string" ||
+		log.checkpoint.length === 0 ||
+		Buffer.byteLength(log.checkpoint, "utf8") > MAX_CHECKPOINT_BYTES
+	) {
+		return bad("log.checkpoint must be a non-empty string of at most 8 KiB");
+	}
+	if (!isSafeIntAtLeast(log.integratedTime, 1)) {
+		return bad("log.integratedTime must be a safe integer > 0");
+	}
+	return { receipt: obj as unknown as RekorReceipt, error: null };
+}
+
+// ── Entry binding ──
+
+/**
+ * The logged entry must commit to OUR artifact AND OUR signature. Without the
+ * signature binding, anyone could log the (public) payload hash of someone
+ * else's anchor and present the resulting receipt as their own.
+ */
+function checkHashedRekordEntry(
+	entryBytes: Buffer,
+	artifactHash: string,
+	recordSigBase64: string,
+): string | null {
+	if (entryBytes.length === 0) return "entryBody decodes to no bytes";
+	if (entryBytes.length > MAX_ENTRY_BODY_BYTES) return "entryBody exceeds 64 KiB decoded";
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(entryBytes.toString("utf8"));
+	} catch {
+		return "entryBody is not valid JSON";
+	}
+	const entry = asObject(parsed);
+	if (entry === null) return "entryBody is not a JSON object";
+	if (entry.kind !== "hashedrekord") return "entryBody kind is not hashedrekord";
+	const spec = asObject(entry.spec);
+	if (spec === null) return "entryBody spec is missing";
+	const hash = asObject(asObject(spec.data)?.hash);
+	if (hash === null) return "entryBody spec.data.hash is missing";
+	if (hash.algorithm !== "sha256") return "entryBody spec.data.hash.algorithm is not sha256";
+	if (hash.value !== artifactHash) {
+		return "entryBody spec.data.hash.value does not match the receipt artifactHash";
+	}
+	const signature = asObject(spec.signature);
+	if (signature === null || typeof signature.content !== "string") {
+		return "entryBody spec.signature.content is missing";
+	}
+	// Compare DECODED bytes: base64 spelling is not canonical, so string
+	// equality would reject honest receipts and is not what "same signature"
+	// means.
+	const logged = Buffer.from(signature.content, "base64");
+	const ours = Buffer.from(recordSigBase64, "base64");
+	if (ours.length === 0 || !logged.equals(ours)) {
+		return "entryBody spec.signature.content is not the anchor record signature";
+	}
+	return null;
+}
+
+/**
+ * Which key(s) may speak for this log. Supplying no key is only meaningful for
+ * the one log whose key ships with the verifier; for anything else, an unpinned
+ * receipt would be self-certifying, so it is refused rather than trusted.
+ */
+function resolveLogKeyring(
+	host: string,
+	logPubkeysPem: readonly string[],
+): { keys: readonly string[]; error: string | null } {
+	const supplied = logPubkeysPem.filter(
+		(pem) => pem.length > 0 && Buffer.byteLength(pem, "utf8") <= MAX_PEM_BYTES,
+	);
+	if (supplied.length > 0) return { keys: supplied, error: null };
+	if (host === REKOR_PROD_HOST) return { keys: [REKOR_PROD_PUBKEY_PEM], error: null };
+	return {
+		keys: [],
+		error: `custom log requires --rekor-pubkey (no pinned key for log host ${clip(host)})`,
+	};
+}
+
+// ── Receipt verification ──
+
+/**
+ * Verify one receipt against the anchor record it claims to witness, under a
+ * caller-pinned keyring (any key in the ring may verify the checkpoint).
+ *
+ * The order below is the binding chain, and it is deliberate: cheap identity
+ * and hash checks first, then the entry decode, then the inclusion walk, and
+ * only then the signature — so a receipt for the wrong record can never cost an
+ * ECDSA verification, and a failure always names the earliest broken link.
+ */
+export function verifyRekorReceipt(
+	receipt: RekorReceipt,
+	record: AnchorRecord,
+	logPubkeysPem: readonly string[],
+): RekorVerification {
+	const errors: string[] = [];
+	const fail = (message: string): RekorVerification => {
+		errors.push(`${ERR}: ${message}`);
+		return { ok: false, attestedTimeMs: null, errors };
+	};
+
+	// 1 — the receipt must name THIS record.
+	if (receipt.vaultId !== record.vaultId || receipt.anchorSeq !== record.anchorSeq) {
+		return fail(
+			`record mismatch: receipt claims vault ${clip(receipt.vaultId)} anchorSeq ${receipt.anchorSeq}`,
+		);
+	}
+
+	// 2 — and must carry that record's signing-payload hash.
+	const payloadHash = anchorPayloadHash(record);
+	if (receipt.artifactHash !== payloadHash) {
+		return fail("artifactHash is not the anchor payload hash of this record");
+	}
+
+	// 3 — the bytes the log stored must commit to the artifact and our signature.
+	const entryBytes = Buffer.from(receipt.entryBody, "base64");
+	const entryError = checkHashedRekordEntry(entryBytes, payloadHash, record.sig);
+	if (entryError !== null) return fail(entryError);
+
+	// 4/5 — sha256(0x00 || stored bytes) must sit at logIndex under log.rootHash.
+	const leafHex = createHash("sha256").update(LEAF_PREFIX).update(entryBytes).digest("hex");
+	if (
+		!verifyIndexInclusion(
+			leafHex,
+			receipt.log.logIndex,
+			receipt.log.treeSize,
+			receipt.log.hashes,
+			receipt.log.rootHash,
+		)
+	) {
+		return fail(
+			`inclusion proof does not reconstruct log.rootHash from logIndex ${receipt.log.logIndex} of ${receipt.log.treeSize}`,
+		);
+	}
+
+	// 6 — the checkpoint must be this log's, at this size, over this root.
+	const host = logHost(receipt.log.url);
+	if (host === null) return fail("log.url is not an http(s) URL");
+	const note = parseSignedNote(receipt.log.checkpoint);
+	if (note === null) return fail("log.checkpoint is not a parseable signed note");
+	if (note.origin.toLowerCase() !== host) {
+		return fail(`log.checkpoint origin ${clip(note.origin)} is not the log.url host ${clip(host)}`);
+	}
+	if (note.treeSize !== receipt.log.treeSize) {
+		return fail(
+			`log.checkpoint treeSize ${note.treeSize} does not match log.treeSize ${receipt.log.treeSize}`,
+		);
+	}
+	if (note.rootHashHex !== receipt.log.rootHash) {
+		return fail("log.checkpoint root hash does not match log.rootHash");
+	}
+
+	// 7 — and must be signed by a key the AUDITOR pinned.
+	const keyring = resolveLogKeyring(host, logPubkeysPem);
+	if (keyring.error !== null) return fail(keyring.error);
+	const sigBase64 = note.sig.toString("base64");
+	const signed = keyring.keys.some((pem) => {
+		const key = publicKeyFromPem(pem);
+		return key !== null && verifySignatureRaw("ecdsa-p256", note.body, key, sigBase64);
+	});
+	if (!signed) {
+		return fail("log.checkpoint signature does not verify under any pinned log public key");
+	}
+
+	// 8 — every link held, so the log's integration time is witness-attested.
+	return { ok: true, attestedTimeMs: receipt.log.integratedTime * 1000, errors };
+}

--- a/packages/core/src/audit/rekor-verify.ts
+++ b/packages/core/src/audit/rekor-verify.ts
@@ -68,8 +68,11 @@ export interface SignedNote {
 	rootHashHex: string;
 	/** EXACTLY the bytes the log signs: 3 body lines including the trailing LF. */
 	body: string;
-	/** Note signature with the 4-byte key hint stripped off the front. */
-	sig: Buffer;
+	/**
+	 * Note signatures, each with its 4-byte key hint stripped off the front. A
+	 * checkpoint carries the log's own signature plus one per co-signing witness.
+	 */
+	sigs: Buffer[];
 }
 
 export interface RekorVerification {
@@ -112,6 +115,10 @@ const MAX_PEM_BYTES = 16 * 1024;
 const HEX64 = /^[0-9a-f]{64}$/;
 const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
 const UINT = /^(0|[1-9][0-9]*)$/;
+// Matching control characters is the entire point here — they are what gets
+// removed from anything echoed back to a terminal.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the intent
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
 
 const LEAF_PREFIX = Buffer.from([0x00]);
 const NODE_PREFIX = Buffer.from([0x01]);
@@ -129,9 +136,16 @@ const LOG_KEYS = new Set([
 
 // ── Small helpers ──
 
-/** Untrusted values are never echoed whole into an error string. */
+/**
+ * Untrusted values are never echoed whole into an error string. Control
+ * characters are stripped BEFORE truncation, because these strings are printed
+ * to a terminal: an escape sequence or a bare CR inside a field name would let
+ * the party under audit repaint the line its own verdict is printed on, and
+ * truncating first would leave a half-consumed escape behind.
+ */
 function clip(value: string): string {
-	return value.length <= 80 ? value : `${value.slice(0, 80)}...`;
+	const scrubbed = value.replace(CONTROL_CHARS, "");
+	return scrubbed.length <= 80 ? scrubbed : `${scrubbed.slice(0, 80)}...`;
 }
 
 function asObject(value: unknown): Record<string, unknown> | null {
@@ -164,19 +178,24 @@ function nodeHash(left: Buffer, right: Buffer): Buffer {
 
 /**
  * Parse a signed note:
- *   <origin>\n<treeSize>\n<base64 rootHash>\n\n— <keyname> <base64 sig>\n
+ *   <origin>\n<treeSize>\n<base64 rootHash>\n\n— <keyname> <base64 sig>\n...
  * Strictly LF-only and strictly this shape — a note is a signed artifact, so
  * accepting variants would mean verifying a signature over bytes we did not
  * actually parse. The signature payload is `4-byte keyhint || DER signature`;
  * the hint identifies which key the log used and is ADVISORY only, because the
  * auditor pins the key out-of-band. Only its 4 bytes are skipped.
+ *
+ * ONE OR MORE signature lines are accepted: a production checkpoint is signed by
+ * the log and co-signed by its witnesses, and every line must still be
+ * well-formed. Which of them (if any) speaks for the auditor is decided later,
+ * against the pinned keyring — never here.
  */
 export function parseSignedNote(note: string): SignedNote | null {
 	if (note.length === 0 || Buffer.byteLength(note, "utf8") > MAX_CHECKPOINT_BYTES) return null;
 	if (note.includes("\r")) return null;
 	const lines = note.split("\n");
-	if (lines.length === 6 && lines[5] === "") lines.pop();
-	if (lines.length !== 5) return null;
+	if (lines.length > 5 && lines[lines.length - 1] === "") lines.pop();
+	if (lines.length < 5) return null;
 	const origin = lines[0] as string;
 	const sizeLine = lines[1] as string;
 	const rootB64 = lines[2] as string;
@@ -187,19 +206,36 @@ export function parseSignedNote(note: string): SignedNote | null {
 	if (!BASE64.test(rootB64)) return null;
 	const root = Buffer.from(rootB64, "base64");
 	if (root.length !== 32) return null;
-	const parts = (lines[4] as string).split(" ");
-	if (parts.length !== 3 || parts[0] !== "—" || (parts[1] as string).length === 0) return null;
-	const sigField = parts[2] as string;
-	if (!BASE64.test(sigField)) return null;
-	const raw = Buffer.from(sigField, "base64");
-	if (raw.length <= 4) return null;
+	const sigs: Buffer[] = [];
+	for (const line of lines.slice(4)) {
+		const parts = line.split(" ");
+		if (parts.length !== 3 || parts[0] !== "—" || (parts[1] as string).length === 0) return null;
+		const sigField = parts[2] as string;
+		if (!BASE64.test(sigField)) return null;
+		const raw = Buffer.from(sigField, "base64");
+		if (raw.length <= 4) return null;
+		sigs.push(raw.subarray(4));
+	}
 	return {
 		origin,
 		treeSize,
 		rootHashHex: root.toString("hex"),
 		body: `${origin}\n${sizeLine}\n${rootB64}\n`,
-		sig: raw.subarray(4),
+		sigs,
 	};
+}
+
+/**
+ * Does a checkpoint's signed origin name the host the receipt says it came from?
+ * A production Rekor checkpoint's origin is `"<host> - <treeID>"`, while the
+ * signed-note format also permits the bare host; both identify the same log, so
+ * only the part before the first " - " is compared. The comparison stays exact
+ * on that part — a suffix rule would let evil.example.org.attacker.net pass.
+ */
+function originNamesHost(origin: string, host: string): boolean {
+	const separator = origin.indexOf(" - ");
+	const named = separator === -1 ? origin : origin.slice(0, separator);
+	return named.toLowerCase() === host;
 }
 
 // ── RFC 9162 inclusion ──
@@ -380,6 +416,12 @@ function checkHashedRekordEntry(
  * Which key(s) may speak for this log. Supplying no key is only meaningful for
  * the one log whose key ships with the verifier; for anything else, an unpinned
  * receipt would be self-certifying, so it is refused rather than trusted.
+ *
+ * A caller who supplied material that ALL got discarded (empty file, oversized
+ * blob) is not a caller who supplied nothing: silently falling back to the
+ * embedded key there would verify a rekor.sigstore.dev receipt under a key the
+ * auditor never chose, and pass a merge gate the auditor thought they had
+ * pinned. Discarded-everything is refused instead.
  */
 function resolveLogKeyring(
 	host: string,
@@ -389,6 +431,13 @@ function resolveLogKeyring(
 		(pem) => pem.length > 0 && Buffer.byteLength(pem, "utf8") <= MAX_PEM_BYTES,
 	);
 	if (supplied.length > 0) return { keys: supplied, error: null };
+	if (logPubkeysPem.length > 0) {
+		return {
+			keys: [],
+			error:
+				"supplied --rekor-pubkey material is empty or invalid — refusing to fall back to the embedded key",
+		};
+	}
 	if (host === REKOR_PROD_HOST) return { keys: [REKOR_PROD_PUBKEY_PEM], error: null };
 	return {
 		keys: [],
@@ -457,7 +506,7 @@ export function verifyRekorReceipt(
 	if (host === null) return fail("log.url is not an http(s) URL");
 	const note = parseSignedNote(receipt.log.checkpoint);
 	if (note === null) return fail("log.checkpoint is not a parseable signed note");
-	if (note.origin.toLowerCase() !== host) {
+	if (!originNamesHost(note.origin, host)) {
 		return fail(`log.checkpoint origin ${clip(note.origin)} is not the log.url host ${clip(host)}`);
 	}
 	if (note.treeSize !== receipt.log.treeSize) {
@@ -469,13 +518,16 @@ export function verifyRekorReceipt(
 		return fail("log.checkpoint root hash does not match log.rootHash");
 	}
 
-	// 7 — and must be signed by a key the AUDITOR pinned.
+	// 7 — and must be signed by a key the AUDITOR pinned. A co-signed checkpoint
+	// carries one signature per witness, and the auditor pins only the parties
+	// they trust: ONE line verifying under ONE pinned key is the whole claim.
 	const keyring = resolveLogKeyring(host, logPubkeysPem);
 	if (keyring.error !== null) return fail(keyring.error);
-	const sigBase64 = note.sig.toString("base64");
+	const sigsBase64 = note.sigs.map((sig) => sig.toString("base64"));
 	const signed = keyring.keys.some((pem) => {
 		const key = publicKeyFromPem(pem);
-		return key !== null && verifySignatureRaw("ecdsa-p256", note.body, key, sigBase64);
+		if (key === null) return false;
+		return sigsBase64.some((sig) => verifySignatureRaw("ecdsa-p256", note.body, key, sig));
 	});
 	if (!signed) {
 		return fail("log.checkpoint signature does not verify under any pinned log public key");

--- a/packages/core/src/audit/rekor-verify.ts
+++ b/packages/core/src/audit/rekor-verify.ts
@@ -23,9 +23,13 @@
  * SEPARATE receipt files: the anchor record schema is frozen, and a
  * transparency log must never become a field inside the thing it witnesses.
  *
- * Offline scope: a verified receipt proves the entry was included in the log at
- * `integratedTime` under a pinned key. It does NOT prove the log's current head
- * is consistent with that checkpoint — that needs a witness/consistency query,
+ * Offline scope: a verified receipt proves the entry was included in the log
+ * under a pinned key. WHEN it was included is a separate, weaker claim:
+ * `integratedTime` is covered by no signature of its own, so it counts as
+ * attested only when the log's signed entry timestamp (SET) over it verifies
+ * under the same pinned keyring — otherwise the receipt proves inclusion and
+ * says nothing about time. Neither claim proves the log's current head is
+ * consistent with that checkpoint; that needs a witness/consistency query,
  * which stays out of the zero-dependency verifier by design.
  */
 
@@ -57,8 +61,20 @@ export interface RekorReceipt {
 		hashes: string[];
 		/** Signed note (checkpoint) over treeSize + rootHash. */
 		checkpoint: string;
-		/** Unix seconds the log attests it integrated the entry. */
+		/**
+		 * Unix seconds the log CLAIMS it integrated the entry. Signed by nothing
+		 * on its own — only the SET below turns it into an attested time.
+		 */
 		integratedTime: number;
+		/**
+		 * base64 ECDSA signature over the sorted-key JSON of
+		 * `{body, integratedTime, logID, logIndex}` — the log's only signature
+		 * covering integratedTime. Optional: a log that does not emit one still
+		 * yields a valid INCLUSION proof, just no attested time.
+		 */
+		signedEntryTimestamp?: string;
+		/** 64-hex log identity, part of the SET payload. Required with a SET. */
+		logID?: string;
 	};
 }
 
@@ -77,7 +93,11 @@ export interface SignedNote {
 
 export interface RekorVerification {
 	ok: boolean;
-	/** Witness-attested time in ms — the input to staleness policy when present. */
+	/**
+	 * Witness-attested time in ms — the input to staleness policy when present.
+	 * Non-null ONLY when a signed entry timestamp verified: an unsigned
+	 * integratedTime is a number the party under audit could have chosen.
+	 */
 	attestedTimeMs: number | null;
 	errors: string[];
 }
@@ -111,6 +131,13 @@ const MAX_ENTRY_BODY_BYTES = 64 * 1024;
 const MAX_CHECKPOINT_BYTES = 8 * 1024;
 const MAX_INCLUSION_PATH = 64;
 const MAX_PEM_BYTES = 16 * 1024;
+const MAX_SET_BYTES = 1024;
+/**
+ * Exclusive upper bound on integratedTime, in SECONDS: `* 1000` must stay
+ * inside the ±8.64e15 ms ECMAScript Date range, or every downstream
+ * `new Date(ms).toISOString()` throws RangeError on attacker-chosen input.
+ */
+const MAX_INTEGRATED_TIME = 8_640_000_000_000;
 
 const HEX64 = /^[0-9a-f]{64}$/;
 const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
@@ -132,6 +159,8 @@ const LOG_KEYS = new Set([
 	"hashes",
 	"checkpoint",
 	"integratedTime",
+	"signedEntryTimestamp",
+	"logID",
 ]);
 
 // ── Small helpers ──
@@ -172,6 +201,19 @@ function logHost(url: string): string | null {
 
 function nodeHash(left: Buffer, right: Buffer): Buffer {
 	return createHash("sha256").update(NODE_PREFIX).update(left).update(right).digest();
+}
+
+/**
+ * Sorted-key JSON of a FLAT object of strings and safe integers — the exact
+ * bytes a Rekor SET is computed over. Over this charset (base64, lowercase hex,
+ * integers) it is byte-identical to RFC 8785 JCS; a general JCS implementation
+ * would buy nothing here and cost the verifier its zero-dependency property.
+ */
+function sortedKeyStringify(value: Record<string, string | number>): string {
+	const fields = Object.keys(value)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${JSON.stringify(value[key])}`);
+	return `{${fields.join(",")}}`;
 }
 
 // ── Signed notes (checkpoints) ──
@@ -360,8 +402,29 @@ export function parseRekorReceipt(raw: string): {
 	) {
 		return bad("log.checkpoint must be a non-empty string of at most 8 KiB");
 	}
-	if (!isSafeIntAtLeast(log.integratedTime, 1)) {
-		return bad("log.integratedTime must be a safe integer > 0");
+	// Bounded in SECONDS so `integratedTime * 1000` cannot leave the Date range
+	// and turn a printed verdict into a RangeError on attacker-chosen input.
+	if (!isSafeIntAtLeast(log.integratedTime, 1) || log.integratedTime >= MAX_INTEGRATED_TIME) {
+		return bad(`log.integratedTime must be a safe integer > 0 and < ${MAX_INTEGRATED_TIME}`);
+	}
+	if (log.logID !== undefined && (typeof log.logID !== "string" || !HEX64.test(log.logID))) {
+		return bad("log.logID must be 64 lowercase hex characters");
+	}
+	if (log.signedEntryTimestamp !== undefined) {
+		if (
+			typeof log.signedEntryTimestamp !== "string" ||
+			log.signedEntryTimestamp.length === 0 ||
+			!BASE64.test(log.signedEntryTimestamp) ||
+			Buffer.byteLength(log.signedEntryTimestamp, "utf8") > MAX_SET_BYTES
+		) {
+			return bad("log.signedEntryTimestamp must be base64 of at most 1 KiB");
+		}
+		// The logID is part of the payload the SET signs, so a SET without one
+		// is unverifiable by construction — and unverifiable supplied evidence
+		// is a rejection, never a receipt that quietly proves less than it looks.
+		if (log.logID === undefined) {
+			return bad("log.signedEntryTimestamp requires log.logID");
+		}
 	}
 	return { receipt: obj as unknown as RekorReceipt, error: null };
 }
@@ -453,8 +516,10 @@ function resolveLogKeyring(
  *
  * The order below is the binding chain, and it is deliberate: cheap identity
  * and hash checks first, then the entry decode, then the inclusion walk, and
- * only then the signature — so a receipt for the wrong record can never cost an
- * ECDSA verification, and a failure always names the earliest broken link.
+ * only then the signatures — so a receipt for the wrong record can never cost
+ * an ECDSA verification, and a failure always names the earliest broken link.
+ * `ok` is the INCLUSION verdict; `attestedTimeMs` is the strictly weaker time
+ * claim, and only a verifying signed entry timestamp produces it.
  */
 export function verifyRekorReceipt(
 	receipt: RekorReceipt,
@@ -533,6 +598,32 @@ export function verifyRekorReceipt(
 		return fail("log.checkpoint signature does not verify under any pinned log public key");
 	}
 
-	// 8 — every link held, so the log's integration time is witness-attested.
+	// 8 — inclusion holds. TIME is a separate claim: the checkpoint signs the
+	// tree, not when this entry entered it, so integratedTime is worth exactly
+	// as much as the signed entry timestamp over it. No SET (or no logID to
+	// build its payload from) means an honest "included, time unknown" — the
+	// caller then falls back to the operator-claimed timestamp knowing it is
+	// operator-claimed. A SET that is PRESENT and does not verify is different
+	// in kind: supplied evidence that fails is a forgery attempt, not an
+	// absence, so it fails the whole receipt closed.
+	const set = receipt.log.signedEntryTimestamp;
+	const logID = receipt.log.logID;
+	if (set === undefined || logID === undefined) {
+		return { ok: true, attestedTimeMs: null, errors };
+	}
+	const setPayload = sortedKeyStringify({
+		body: receipt.entryBody,
+		integratedTime: receipt.log.integratedTime,
+		logID,
+		logIndex: receipt.log.logIndex,
+	});
+	const setSigned = keyring.keys.some((pem) => {
+		const key = publicKeyFromPem(pem);
+		if (key === null) return false;
+		return verifySignatureRaw("ecdsa-p256", setPayload, key, set);
+	});
+	if (!setSigned) return fail("signedEntryTimestamp does not verify");
+
+	// 9 — every link held AND the log signed the time, so it is witness-attested.
 	return { ok: true, attestedTimeMs: receipt.log.integratedTime * 1000, errors };
 }

--- a/packages/core/src/audit/rekor.ts
+++ b/packages/core/src/audit/rekor.ts
@@ -1,0 +1,482 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Witness sinks: S3 (native SigV4) and Rekor (hashedrekord transparency log).
+ *
+ * Both are AnchorSinks, so both inherit the emitter's contract: a publish that
+ * resolves means the record was DURABLY accepted, and a publish that rejects
+ * keeps the record in the outbox for redelivery. Everything here therefore
+ * fails closed — a sink that resolved on a response it did not fully understand
+ * would silently drop a record out of the append-only store, which is precisely
+ * the evidence loss anchoring exists to prevent.
+ *
+ * What Rekor witnesses is deliberately thin (spec §3, delta D14): the entry
+ * carries sha256 of the anchor payload, the record's signature, and the vault's
+ * public key — never event data, never the payload itself. The receipt lives in
+ * its own file because the anchor record schema is FROZEN; a transparency log
+ * must not become a field inside the thing it witnesses.
+ *
+ * EXPERIMENTAL: the Rekor path is exercised against synthetic responses only —
+ * the live API is untested in CI, and the entry `apiVersion` is pinned to
+ * 0.0.1.
+ *
+ * Network access is confined to `httpTransport` at the bottom of this file;
+ * every other function is pure or writes to the vault, so tests inject a
+ * transport and assert on bytes.
+ */
+
+import { closeSync, fsyncSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { join } from "node:path";
+// Cyclic by design: anchor.ts builds these sinks from SinkConfig, and the Rekor
+// sink needs the vault's identity + anchors directory. Both bindings are
+// function declarations used only at publish time, so the cycle never observes
+// a partially initialized module.
+import { type AnchorSink, anchorsDir, readAnchorIdentity } from "./anchor.js";
+import { type AnchorRecord, anchorPayloadHash } from "./anchor-verify.js";
+import { canonicalize } from "./canonical.js";
+import { parseRekorReceipt, type RekorReceipt } from "./rekor-verify.js";
+import { type SigV4Credentials, sigV4Headers } from "./sigv4.js";
+
+export const DEFAULT_REKOR_URL = "https://rekor.sigstore.dev";
+const REKOR_ENTRIES_PATH = "/api/v1/log/entries";
+
+/** Rekor's hashedrekord schema version. Pinned: 0.0.2+ changes the spec shape. */
+const HASHEDREKORD_API_VERSION = "0.0.1";
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
+const MAX_ENTRY_BODY_BYTES = 64 * 1024;
+const MAX_CHECKPOINT_BYTES = 8 * 1024;
+const MAX_INCLUSION_PATH = 64;
+
+/**
+ * Injectable HTTP transport — the sinks' only impure edge. Structurally
+ * identical to anchor-doctor's, so a caller may share one transport across
+ * both without either module importing the other.
+ */
+export type HttpTransport = (opts: {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	body: Buffer;
+}) => Promise<{ status: number; body: string; headers?: Record<string, string> }>;
+
+export interface S3SinkConfig {
+	bucket: string;
+	region: string;
+	prefix?: string;
+	endpoint?: string;
+}
+
+// ── Shared helpers ──
+
+const is2xx = (status: number): boolean => status >= 200 && status < 300;
+
+/**
+ * A store's response body on its way into an error message. Anything that looks
+ * like a signed header is dropped: a hostile or misconfigured endpoint can echo
+ * our request back, and an error string ends up in logs and issue trackers
+ * (delta D6). Truncated to 120 characters — the status code carries the meaning.
+ */
+function snippet(body: string): string {
+	if (body === "") return "";
+	const scrubbed = body
+		.replace(/authorization[^\n]*/gi, "[redacted]")
+		.replace(/x-amz-security-token[^\n]*/gi, "[redacted]")
+		.replace(/AWS4-HMAC-SHA256[^\n]*/g, "[redacted]")
+		.replace(/\s+/g, " ")
+		.trim();
+	return scrubbed === "" ? "" : `: ${scrubbed.slice(0, 120)}`;
+}
+
+const seq12 = (anchorSeq: number): string => String(anchorSeq).padStart(12, "0");
+
+/** `YYYYMMDDTHHMMSSZ` for SigV4. */
+function amzDate(): string {
+	return `${new Date().toISOString().replace(/[-:]/g, "").slice(0, 15)}Z`;
+}
+
+function credentialsFromEnv(): SigV4Credentials | null {
+	const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+	const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+	if (!accessKeyId || !secretAccessKey) return null;
+	const sessionToken = process.env.AWS_SESSION_TOKEN;
+	return { accessKeyId, secretAccessKey, ...(sessionToken ? { sessionToken } : {}) };
+}
+
+// ── S3 sink ──
+
+/**
+ * Endpoint for an S3-compatible store. Plaintext is refused off-loopback:
+ * SigV4 authenticates the request but does not encrypt it, so an http endpoint
+ * on the network would put the credential-bearing headers on the wire. Loopback
+ * is allowed for dev MinIO/LocalStack.
+ */
+function parseEndpoint(endpoint: string): URL {
+	let url: URL;
+	try {
+		url = new URL(endpoint);
+	} catch {
+		throw new Error(`s3 sink: endpoint must include a scheme, got "${endpoint.slice(0, 60)}"`);
+	}
+	const loopback = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+	if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+		throw new Error(
+			`s3 sink: endpoint must be https (http is allowed only for localhost/127.0.0.1), got "${url.protocol}//${url.host}"`,
+		);
+	}
+	return url;
+}
+
+/**
+ * Object key + addressing. Virtual-host style against AWS; path-style against a
+ * configured endpoint, since S3-compatible stores rarely serve bucket
+ * subdomains. Anchor records are a few hundred bytes — one PUT, no multipart.
+ */
+function s3Target(
+	cfg: S3SinkConfig,
+	vaultId: string,
+	anchorSeq: number,
+): { host: string; path: string; url: string } {
+	const prefix = (cfg.prefix ?? "anchors").replace(/^\/+|\/+$/g, "");
+	const key = `${prefix === "" ? "" : `${prefix}/`}${vaultId}/${seq12(anchorSeq)}.json`;
+	const encoded = key.split("/").map(encodeURIComponent).join("/");
+
+	if (cfg.endpoint !== undefined) {
+		const base = parseEndpoint(cfg.endpoint);
+		const path = `/${encodeURIComponent(cfg.bucket)}/${encoded}`;
+		return { host: base.host, path, url: `${base.protocol}//${base.host}${path}` };
+	}
+	const host = `${cfg.bucket}.s3.${cfg.region}.amazonaws.com`;
+	return { host, path: `/${encoded}`, url: `https://${host}/${encoded}` };
+}
+
+/**
+ * PUT one canonical record per object, keyed by vault and anchorSeq. Immutability
+ * is the STORE's job (Object Lock retention / a deny-delete bucket policy);
+ * `usertrust anchor doctor` reports whether this identity's permissions match
+ * that intent.
+ */
+export function s3Sink(cfg: S3SinkConfig, transport: HttpTransport = httpTransport): AnchorSink {
+	const prefix = (cfg.prefix ?? "anchors").replace(/^\/+|\/+$/g, "");
+	return {
+		name: `s3:${cfg.bucket}/${prefix}`,
+		publish: async (record) => {
+			const creds = credentialsFromEnv();
+			if (creds === null) {
+				throw new Error(
+					"s3 sink: AWS credentials not found in environment " +
+						"(AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)",
+				);
+			}
+			const payload = Buffer.from(canonicalize(record), "utf8");
+			const target = s3Target(cfg, record.vaultId, record.anchorSeq);
+			const extra = { "content-type": "application/json" };
+			const signed = sigV4Headers(
+				{
+					method: "PUT",
+					host: target.host,
+					path: target.path,
+					headers: extra,
+					payload,
+					region: cfg.region,
+					service: "s3",
+					amzDate: amzDate(),
+				},
+				creds,
+			);
+			// sigV4Headers signs the caller's headers but returns only its own —
+			// both must go on the wire or the signature covers headers that never
+			// arrive.
+			const res = await transport({
+				method: "PUT",
+				url: target.url,
+				headers: { ...extra, ...signed },
+				body: payload,
+			});
+			if (!is2xx(res.status)) {
+				throw new Error(`s3 sink: HTTP ${res.status}${snippet(res.body)}`);
+			}
+		},
+	};
+}
+
+// ── Rekor entry proposal ──
+
+/**
+ * SPKI base64 as PEM text. The exact bytes matter: this text is base64'd into
+ * the entry, and the entry's bytes are what the inclusion proof commits to
+ * (delta D13). 64-character lines, LF-only, trailing newline.
+ */
+function pemFromSpkiBase64(spkiBase64: string): string {
+	const compact = spkiBase64.replace(/\s+/g, "");
+	if (compact === "" || !BASE64.test(compact)) {
+		throw new Error("rekor sink: vault identity publicKeySpki is not base64");
+	}
+	const wrapped = (compact.match(/.{1,64}/g) ?? []).join("\n");
+	return `-----BEGIN PUBLIC KEY-----\n${wrapped}\n-----END PUBLIC KEY-----\n`;
+}
+
+/**
+ * The hashedrekord entry we PROPOSE for a record: the anchor payload hash as the
+ * artifact, the record's Ed25519 signature, and the vault's public key. The log
+ * stores its own serialization of this; the receipt carries the log's bytes, so
+ * these are the bytes we sign nothing over and merely offer.
+ */
+export function buildHashedRekordEntry(record: AnchorRecord, publicKeySpkiBase64: string): string {
+	return canonicalize({
+		apiVersion: HASHEDREKORD_API_VERSION,
+		kind: "hashedrekord",
+		spec: {
+			data: { hash: { algorithm: "sha256", value: anchorPayloadHash(record) } },
+			signature: {
+				content: record.sig,
+				publicKey: {
+					content: Buffer.from(pemFromSpkiBase64(publicKeySpkiBase64), "utf8").toString("base64"),
+				},
+			},
+		},
+	});
+}
+
+// ── Rekor 201 validation ──
+
+interface AcceptedEntry {
+	/** base64 of the bytes the LOG stored, verbatim. */
+	body: string;
+	integratedTime: number;
+	logIndex: number;
+	treeSize: number;
+	rootHash: string;
+	hashes: string[];
+	checkpoint: string;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function isSafeIntAtLeast(value: unknown, min: number): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= min;
+}
+
+/**
+ * Validate a 201 down to every field the receipt will quote. A receipt built
+ * from a half-understood response is worse than no receipt: it would be filed as
+ * evidence and only fail at audit time, long after the anchor left the outbox.
+ * Nothing from the response is echoed into these errors — field names only.
+ */
+function parseAcceptedEntry(raw: string): { entry: AcceptedEntry | null; error: string | null } {
+	const bad = (message: string): { entry: null; error: string } => ({
+		entry: null,
+		error: message,
+	});
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return bad("body is not valid JSON");
+	}
+	const response = asObject(parsed);
+	if (response === null) return bad("body is not a JSON object");
+	const uuids = Object.keys(response);
+	// Rekor keys the response by entry UUID. Two keys means the log is answering
+	// about an entry we did not propose; zero means it answered about none.
+	if (uuids.length !== 1) return bad(`expected exactly one entry, got ${uuids.length}`);
+	const entry = asObject(response[uuids[0] as string]);
+	if (entry === null) return bad("entry is not a JSON object");
+
+	if (typeof entry.body !== "string" || entry.body === "" || !BASE64.test(entry.body)) {
+		return bad("entry.body must be base64");
+	}
+	const decoded = Buffer.from(entry.body, "base64");
+	if (decoded.length === 0) return bad("entry.body decodes to no bytes");
+	if (decoded.length > MAX_ENTRY_BODY_BYTES) return bad("entry.body exceeds 64 KiB decoded");
+	if (!isSafeIntAtLeast(entry.logIndex, 0))
+		return bad("entry.logIndex must be a safe integer >= 0");
+	if (!isSafeIntAtLeast(entry.integratedTime, 1)) {
+		return bad("entry.integratedTime must be a safe integer > 0");
+	}
+
+	const proof = asObject(asObject(entry.verification)?.inclusionProof);
+	if (proof === null) return bad("entry.verification.inclusionProof is missing");
+	// The proof's own index — NOT the entry's global logIndex, which counts
+	// across the whole log rather than the tree this proof is against.
+	if (!isSafeIntAtLeast(proof.logIndex, 0)) return bad("inclusionProof.logIndex must be >= 0");
+	if (!isSafeIntAtLeast(proof.treeSize, 1)) return bad("inclusionProof.treeSize must be >= 1");
+	if (proof.logIndex >= proof.treeSize) {
+		return bad("inclusionProof.logIndex must be < inclusionProof.treeSize");
+	}
+	if (typeof proof.rootHash !== "string" || !HEX64.test(proof.rootHash)) {
+		return bad("inclusionProof.rootHash must be 64 lowercase hex characters");
+	}
+	if (!Array.isArray(proof.hashes) || proof.hashes.length > MAX_INCLUSION_PATH) {
+		return bad(`inclusionProof.hashes must be an array of at most ${MAX_INCLUSION_PATH} hashes`);
+	}
+	for (const h of proof.hashes) {
+		if (typeof h !== "string" || !HEX64.test(h)) {
+			return bad("inclusionProof.hashes entries must be 64 lowercase hex characters");
+		}
+	}
+	if (
+		typeof proof.checkpoint !== "string" ||
+		proof.checkpoint === "" ||
+		Buffer.byteLength(proof.checkpoint, "utf8") > MAX_CHECKPOINT_BYTES ||
+		proof.checkpoint.includes("\r")
+	) {
+		return bad("inclusionProof.checkpoint must be a non-empty LF-only string of at most 8 KiB");
+	}
+
+	return {
+		entry: {
+			body: entry.body,
+			integratedTime: entry.integratedTime,
+			logIndex: proof.logIndex,
+			treeSize: proof.treeSize,
+			rootHash: proof.rootHash,
+			hashes: proof.hashes as string[],
+			checkpoint: proof.checkpoint,
+		},
+		error: null,
+	};
+}
+
+// ── Receipt persistence ──
+
+export function rekorReceiptPath(rootDir: string, anchorSeq: number): string {
+	return join(anchorsDir(rootDir), "rekor", `${seq12(anchorSeq)}.json`);
+}
+
+/** Fsync'd receipt write — the same durability the outbox and mirror get. */
+function writeReceipt(rootDir: string, receipt: RekorReceipt): void {
+	const serialized = `${canonicalize(receipt)}\n`;
+	// A receipt our own parser rejects is a bug in this module, and it would be
+	// discovered at audit time by whoever is relying on it. Fail here instead.
+	const check = parseRekorReceipt(serialized);
+	if (check.receipt === null) {
+		throw new Error(`rekor sink: assembled an unparseable receipt (${check.error})`);
+	}
+	const dir = join(anchorsDir(rootDir), "rekor");
+	mkdirSync(dir, { recursive: true });
+	const fd = openSync(rekorReceiptPath(rootDir, receipt.anchorSeq), "w", 0o600);
+	try {
+		writeSync(fd, serialized);
+		fsyncSync(fd);
+	} finally {
+		closeSync(fd);
+	}
+}
+
+// ── Rekor sink ──
+
+/**
+ * Publish a record's payload hash to a Rekor transparency log and persist the
+ * inclusion receipt next to the mirror.
+ *
+ * Any non-201 rejects, 409 included: a duplicate means an entry we cannot see
+ * already exists, and fabricating a receipt from a Location header would mean
+ * filing evidence about bytes we never verified (delta D1). The emitter's
+ * retry/outbox path is the recovery mechanism, and re-proposing the same entry
+ * is idempotent at the log.
+ */
+export function rekorSink(
+	rootDir: string,
+	url: string = DEFAULT_REKOR_URL,
+	transport: HttpTransport = httpTransport,
+): AnchorSink {
+	const base = url.replace(/\/+$/, "");
+	return {
+		name: `rekor:${base}`,
+		publish: async (record) => {
+			const identity = readAnchorIdentity(rootDir);
+			if (identity === null) {
+				throw new Error("rekor sink: no anchor identity — run `usertrust anchor init` first");
+			}
+			const proposal = Buffer.from(buildHashedRekordEntry(record, identity.publicKeySpki), "utf8");
+			const res = await transport({
+				method: "POST",
+				url: `${base}${REKOR_ENTRIES_PATH}`,
+				headers: {
+					accept: "application/json",
+					"content-type": "application/json",
+				},
+				body: proposal,
+			});
+			if (res.status !== 201) {
+				throw new Error(`rekor sink: HTTP ${res.status}${snippet(res.body)}`);
+			}
+			const { entry, error } = parseAcceptedEntry(res.body);
+			if (entry === null) {
+				throw new Error(`rekor sink: invalid 201 response: ${error}`);
+			}
+			writeReceipt(rootDir, {
+				v: 1,
+				vaultId: record.vaultId,
+				anchorSeq: record.anchorSeq,
+				artifactHash: anchorPayloadHash(record),
+				// VERBATIM (delta D13): the leaf hash is over the bytes the LOG
+				// stored, so any reserialization here would break inclusion.
+				entryBody: entry.body,
+				log: {
+					url: base,
+					logIndex: entry.logIndex,
+					treeSize: entry.treeSize,
+					rootHash: entry.rootHash,
+					hashes: entry.hashes,
+					checkpoint: entry.checkpoint,
+					integratedTime: entry.integratedTime,
+				},
+			});
+		},
+	};
+}
+
+// ── Default transport ──
+
+/** The module's only network access. `http://` is reachable for dev endpoints. */
+async function httpTransport(opts: {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	body: Buffer;
+}): Promise<{ status: number; body: string; headers: Record<string, string> }> {
+	const { request } = await (opts.url.startsWith("http://")
+		? import("node:http")
+		: import("node:https"));
+	return new Promise((resolve, reject) => {
+		const req = request(
+			opts.url,
+			{
+				method: opts.method,
+				headers: { ...opts.headers, "content-length": String(opts.body.length) },
+				timeout: 15_000,
+			},
+			(res) => {
+				const chunks: Buffer[] = [];
+				res.on("data", (c: Buffer) => chunks.push(c));
+				res.on("end", () => {
+					const headers: Record<string, string> = {};
+					for (const [name, value] of Object.entries(res.headers)) {
+						if (typeof value === "string") headers[name] = value;
+					}
+					resolve({
+						status: res.statusCode ?? 0,
+						// Bounded: a receipt is small, and an error body is only ever
+						// a snippet.
+						body: Buffer.concat(chunks)
+							.toString("utf8")
+							.slice(0, 256 * 1024),
+						headers,
+					});
+				});
+			},
+		);
+		req.on("timeout", () => req.destroy(new Error("anchor sink: request timeout")));
+		req.on("error", reject);
+		req.end(opts.body);
+	});
+}

--- a/packages/core/src/audit/rekor.ts
+++ b/packages/core/src/audit/rekor.ts
@@ -26,13 +26,22 @@
  * transport and assert on bytes.
  */
 
-import { closeSync, fsyncSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+	closeSync,
+	fsyncSync,
+	mkdirSync,
+	openSync,
+	readdirSync,
+	readFileSync,
+	writeSync,
+} from "node:fs";
 import { join } from "node:path";
 // Cyclic by design: anchor.ts builds these sinks from SinkConfig, and the Rekor
 // sink needs the vault's identity + anchors directory. Both bindings are
 // function declarations used only at publish time, so the cycle never observes
 // a partially initialized module.
-import { type AnchorSink, anchorsDir, readAnchorIdentity } from "./anchor.js";
+import { type AnchorIdentity, type AnchorSink, anchorsDir, readAnchorIdentity } from "./anchor.js";
 import { type AnchorRecord, anchorPayloadHash } from "./anchor-verify.js";
 import { canonicalize } from "./canonical.js";
 import { parseRekorReceipt, type RekorReceipt } from "./rekor-verify.js";
@@ -49,6 +58,9 @@ const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
 const MAX_ENTRY_BODY_BYTES = 64 * 1024;
 const MAX_CHECKPOINT_BYTES = 8 * 1024;
 const MAX_INCLUSION_PATH = 64;
+const MAX_SET_BYTES = 1024;
+/** Matches the receipt parser's bound: `* 1000` must stay a valid Date. */
+const MAX_INTEGRATED_TIME = 8_640_000_000_000;
 
 /**
  * Injectable HTTP transport — the sinks' only impure edge. Structurally
@@ -108,22 +120,24 @@ function credentialsFromEnv(): SigV4Credentials | null {
 // ── S3 sink ──
 
 /**
- * Endpoint for an S3-compatible store. Plaintext is refused off-loopback:
+ * Endpoint rule for BOTH sinks. Plaintext is refused off-loopback: for S3,
  * SigV4 authenticates the request but does not encrypt it, so an http endpoint
- * on the network would put the credential-bearing headers on the wire. Loopback
- * is allowed for dev MinIO/LocalStack.
+ * on the network would put the credential-bearing headers on the wire; for
+ * Rekor, an http log URL lets anyone on the path answer for the witness — and
+ * a sink that accepts a forged 201 files forged evidence. Loopback is allowed
+ * for dev MinIO/LocalStack and local log instances.
  */
-function parseEndpoint(endpoint: string): URL {
+export function parseEndpoint(endpoint: string, sinkName = "s3 sink"): URL {
 	let url: URL;
 	try {
 		url = new URL(endpoint);
 	} catch {
-		throw new Error(`s3 sink: endpoint must include a scheme, got "${endpoint.slice(0, 60)}"`);
+		throw new Error(`${sinkName}: endpoint must include a scheme, got "${endpoint.slice(0, 60)}"`);
 	}
 	const loopback = url.hostname === "localhost" || url.hostname === "127.0.0.1";
 	if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
 		throw new Error(
-			`s3 sink: endpoint must be https (http is allowed only for localhost/127.0.0.1), got "${url.protocol}//${url.host}"`,
+			`${sinkName}: endpoint must be https (http is allowed only for localhost/127.0.0.1), got "${url.protocol}//${url.host}"`,
 		);
 	}
 	return url;
@@ -251,6 +265,9 @@ interface AcceptedEntry {
 	rootHash: string;
 	hashes: string[];
 	checkpoint: string;
+	/** The log's signature over integratedTime — absent on logs that omit it. */
+	signedEntryTimestamp?: string;
+	logID?: string;
 }
 
 function asObject(value: unknown): Record<string, unknown> | null {
@@ -298,11 +315,17 @@ function parseAcceptedEntry(raw: string): { entry: AcceptedEntry | null; error: 
 	if (decoded.length > MAX_ENTRY_BODY_BYTES) return bad("entry.body exceeds 64 KiB decoded");
 	if (!isSafeIntAtLeast(entry.logIndex, 0))
 		return bad("entry.logIndex must be a safe integer >= 0");
-	if (!isSafeIntAtLeast(entry.integratedTime, 1)) {
-		return bad("entry.integratedTime must be a safe integer > 0");
+	// Same bound the receipt parser enforces: a receipt we write must be one we
+	// can read back, and `integratedTime * 1000` has to stay a printable Date.
+	if (!isSafeIntAtLeast(entry.integratedTime, 1) || entry.integratedTime >= MAX_INTEGRATED_TIME) {
+		return bad(`entry.integratedTime must be a safe integer > 0 and < ${MAX_INTEGRATED_TIME}`);
+	}
+	if (entry.logID !== undefined && (typeof entry.logID !== "string" || !HEX64.test(entry.logID))) {
+		return bad("entry.logID must be 64 lowercase hex characters");
 	}
 
-	const proof = asObject(asObject(entry.verification)?.inclusionProof);
+	const verification = asObject(entry.verification);
+	const proof = asObject(verification?.inclusionProof);
 	if (proof === null) return bad("entry.verification.inclusionProof is missing");
 	// The proof's own index — NOT the entry's global logIndex, which counts
 	// across the whole log rather than the tree this proof is against.
@@ -331,6 +354,26 @@ function parseAcceptedEntry(raw: string): { entry: AcceptedEntry | null; error: 
 		return bad("inclusionProof.checkpoint must be a non-empty LF-only string of at most 8 KiB");
 	}
 
+	// The signed entry timestamp is what makes integratedTime worth anything to
+	// an auditor, so it is captured whenever the log offers one — but a SET with
+	// no logID cannot be verified by anybody (the logID is inside the payload it
+	// signs), and filing evidence nobody can check is the failure this module
+	// exists to avoid.
+	const set = verification?.signedEntryTimestamp;
+	if (set !== undefined) {
+		if (
+			typeof set !== "string" ||
+			set === "" ||
+			!BASE64.test(set) ||
+			Buffer.byteLength(set, "utf8") > MAX_SET_BYTES
+		) {
+			return bad("verification.signedEntryTimestamp must be base64 of at most 1 KiB");
+		}
+		if (entry.logID === undefined) {
+			return bad("verification.signedEntryTimestamp present without entry.logID");
+		}
+	}
+
 	return {
 		entry: {
 			body: entry.body,
@@ -340,6 +383,8 @@ function parseAcceptedEntry(raw: string): { entry: AcceptedEntry | null; error: 
 			rootHash: proof.rootHash,
 			hashes: proof.hashes as string[],
 			checkpoint: proof.checkpoint,
+			...(typeof set === "string" ? { signedEntryTimestamp: set } : {}),
+			...(typeof entry.logID === "string" ? { logID: entry.logID } : {}),
 		},
 		error: null,
 	};
@@ -347,8 +392,17 @@ function parseAcceptedEntry(raw: string): { entry: AcceptedEntry | null; error: 
 
 // ── Receipt persistence ──
 
-export function rekorReceiptPath(rootDir: string, anchorSeq: number): string {
-	return join(anchorsDir(rootDir), "rekor", `${seq12(anchorSeq)}.json`);
+/**
+ * `<seq12>.<8 hex of sha256(log url)>.json` — one receipt per (anchor, LOG).
+ * Keying by anchorSeq alone made two rekor sinks silently overwrite each
+ * other's evidence: the second witness's receipt replaced the first's, and the
+ * operator ended up with fewer independent attestations than they configured.
+ * Readers glob `*.json` in this directory, so pre-existing `<seq12>.json`
+ * receipts keep being found.
+ */
+export function rekorReceiptPath(rootDir: string, anchorSeq: number, logUrl: string): string {
+	const tag = createHash("sha256").update(logUrl, "utf8").digest("hex").slice(0, 8);
+	return join(anchorsDir(rootDir), "rekor", `${seq12(anchorSeq)}.${tag}.json`);
 }
 
 /** Fsync'd receipt write — the same durability the outbox and mirror get. */
@@ -362,7 +416,7 @@ function writeReceipt(rootDir: string, receipt: RekorReceipt): void {
 	}
 	const dir = join(anchorsDir(rootDir), "rekor");
 	mkdirSync(dir, { recursive: true });
-	const fd = openSync(rekorReceiptPath(rootDir, receipt.anchorSeq), "w", 0o600);
+	const fd = openSync(rekorReceiptPath(rootDir, receipt.anchorSeq, receipt.log.url), "w", 0o600);
 	try {
 		writeSync(fd, serialized);
 		fsyncSync(fd);
@@ -371,23 +425,115 @@ function writeReceipt(rootDir: string, receipt: RekorReceipt): void {
 	}
 }
 
+/**
+ * Do the bytes a log stored commit to THIS record — our payload hash AND our
+ * signature? Reused for the 201 response and for receipts already on disk; in
+ * both cases the alternative is filing evidence about someone else's entry.
+ * Decoded bytes are compared, never base64 spellings, since base64 is not
+ * canonical and equivalent encodings are the same signature.
+ */
+function entryBindsRecord(entryBodyBase64: string, record: AnchorRecord): boolean {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(Buffer.from(entryBodyBase64, "base64").toString("utf8"));
+	} catch {
+		return false;
+	}
+	const spec = asObject(asObject(parsed)?.spec);
+	if (spec === null) return false;
+	const hash = asObject(asObject(spec.data)?.hash);
+	const signature = asObject(spec.signature);
+	if (hash === null || signature === null || typeof signature.content !== "string") return false;
+	if (hash.value !== anchorPayloadHash(record)) return false;
+	const logged = Buffer.from(signature.content, "base64");
+	const ours = Buffer.from(record.sig, "base64");
+	return ours.length > 0 && logged.equals(ours);
+}
+
+/**
+ * A receipt already on disk from THIS log that witnesses THIS record. Every
+ * `*.json` in the directory is considered, because the filename is a
+ * convenience and the receipt's own contents are the evidence — a receipt is
+ * only accepted when it names the record, carries its payload hash, and its
+ * stored entry binds the record's signature.
+ */
+function findBindingReceipt(rootDir: string, record: AnchorRecord, logUrl: string): boolean {
+	const dir = join(anchorsDir(rootDir), "rekor");
+	let names: string[];
+	try {
+		names = readdirSync(dir).filter((f) => f.endsWith(".json"));
+	} catch {
+		return false;
+	}
+	for (const name of names.sort()) {
+		let raw: string;
+		try {
+			raw = readFileSync(join(dir, name), "utf-8");
+		} catch {
+			continue;
+		}
+		const { receipt } = parseRekorReceipt(raw);
+		if (receipt === null) continue;
+		if (
+			receipt.vaultId === record.vaultId &&
+			receipt.anchorSeq === record.anchorSeq &&
+			receipt.log.url === logUrl &&
+			receipt.artifactHash === anchorPayloadHash(record) &&
+			entryBindsRecord(receipt.entryBody, record)
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * The public key to PROPOSE for a record, resolved from the record's OWN key
+ * epoch rather than from whatever key the vault holds today. A record minted
+ * before a rotation and redelivered after it is still signed by the old key, so
+ * proposing the live key would log a public key that does not verify the
+ * signature sitting beside it — a permanently wrong entry in an append-only
+ * log. Identities predating key history keep the old behavior; once a history
+ * exists, a keyId absent from it is refused rather than guessed at.
+ */
+function spkiForRecord(identity: AnchorIdentity, record: AnchorRecord): string {
+	if (identity.keyHistory === undefined) return identity.publicKeySpki;
+	const known = [
+		...identity.keyHistory,
+		{ keyId: identity.keyId, publicKeySpki: identity.publicKeySpki },
+	];
+	const match = known.find((entry) => entry.keyId === record.keyId);
+	if (match === undefined) {
+		throw new Error(
+			`rekor sink: no public key for keyId ${record.keyId} in this vault's key history`,
+		);
+	}
+	return match.publicKeySpki;
+}
+
 // ── Rekor sink ──
 
 /**
  * Publish a record's payload hash to a Rekor transparency log and persist the
  * inclusion receipt next to the mirror.
  *
- * Any non-201 rejects, 409 included: a duplicate means an entry we cannot see
- * already exists, and fabricating a receipt from a Location header would mean
- * filing evidence about bytes we never verified (delta D1). The emitter's
- * retry/outbox path is the recovery mechanism, and re-proposing the same entry
- * is idempotent at the log.
+ * A 409 means the log already holds an entry for this proposal, which happens
+ * on exactly one honest path: a crash between writing the receipt and clearing
+ * the outbox, so the emitter redelivers a record that IS already witnessed.
+ * That case is resolved from the receipt we already hold — never from the 409
+ * itself, which carries no evidence. A 409 with no such receipt is a duplicate
+ * we cannot account for, and fabricating one from a Location header would mean
+ * filing evidence about bytes we never saw (delta D1), so it rejects and the
+ * outbox keeps the record for a human.
  */
 export function rekorSink(
 	rootDir: string,
 	url: string = DEFAULT_REKOR_URL,
 	transport: HttpTransport = httpTransport,
 ): AnchorSink {
+	// Same rule as the S3 sink, applied at CONSTRUCTION so a plaintext log URL
+	// fails before a record is ever offered to it.
+	parseEndpoint(url, "rekor sink");
 	const base = url.replace(/\/+$/, "");
 	return {
 		name: `rekor:${base}`,
@@ -396,7 +542,10 @@ export function rekorSink(
 			if (identity === null) {
 				throw new Error("rekor sink: no anchor identity — run `usertrust anchor init` first");
 			}
-			const proposal = Buffer.from(buildHashedRekordEntry(record, identity.publicKeySpki), "utf8");
+			const proposal = Buffer.from(
+				buildHashedRekordEntry(record, spkiForRecord(identity, record)),
+				"utf8",
+			);
 			const res = await transport({
 				method: "POST",
 				url: `${base}${REKOR_ENTRIES_PATH}`,
@@ -406,12 +555,28 @@ export function rekorSink(
 				},
 				body: proposal,
 			});
+			if (res.status === 409) {
+				if (findBindingReceipt(rootDir, record, base)) return;
+				throw new Error(
+					"rekor sink: HTTP 409 (duplicate without local receipt — fetch the entry manually)",
+				);
+			}
 			if (res.status !== 201) {
 				throw new Error(`rekor sink: HTTP ${res.status}${snippet(res.body)}`);
 			}
 			const { entry, error } = parseAcceptedEntry(res.body);
 			if (entry === null) {
 				throw new Error(`rekor sink: invalid 201 response: ${error}`);
+			}
+			// A well-formed 201 is not yet OUR 201: the receipt is built from the
+			// log's bytes, so a response describing somebody else's entry would be
+			// persisted as evidence for this record and only fall apart at audit
+			// time. Bind it to the record before trusting a single field of it.
+			if (!entryBindsRecord(entry.body, record)) {
+				throw new Error(
+					"rekor sink: 201 response describes an entry that is not this record's " +
+						"(payload hash or signature mismatch)",
+				);
 			}
 			writeReceipt(rootDir, {
 				v: 1,
@@ -429,6 +594,10 @@ export function rekorSink(
 					hashes: entry.hashes,
 					checkpoint: entry.checkpoint,
 					integratedTime: entry.integratedTime,
+					...(entry.signedEntryTimestamp !== undefined
+						? { signedEntryTimestamp: entry.signedEntryTimestamp }
+						: {}),
+					...(entry.logID !== undefined ? { logID: entry.logID } : {}),
 				},
 			});
 		},

--- a/packages/core/src/audit/sigv4.ts
+++ b/packages/core/src/audit/sigv4.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * AWS Signature Version 4 — pure signer for the S3 anchor sink.
+ *
+ * Node built-ins only: pulling an AWS SDK in for four HMACs would put a
+ * multi-megabyte transitive dependency tree behind the audit trail, which is
+ * exactly what the anchoring design refuses to do.
+ *
+ * Every function here is pure — `amzDate` is supplied by the caller rather than
+ * read from the clock, so signatures are reproducible in tests and validated
+ * against AWS's published test vector (see tests/audit/sigv4.test.ts).
+ *
+ * Scope: SigV4 for requests whose payload is fully in memory (anchor records
+ * are a few hundred bytes). No streaming/chunked signing, no multipart.
+ *
+ * Credentials are never logged, echoed into errors, or returned — only the
+ * derived `authorization` header leaves this module.
+ */
+
+import { createHash, createHmac } from "node:crypto";
+
+const ALGORITHM = "AWS4-HMAC-SHA256";
+const TERMINATOR = "aws4_request";
+const AMZ_DATE = /^\d{8}T\d{6}Z$/;
+
+// ── Types ──
+
+export interface SigV4Credentials {
+	accessKeyId: string;
+	secretAccessKey: string;
+	sessionToken?: string;
+}
+
+export interface SigV4Request {
+	method: string;
+	/** Virtual-host or path-style host, no scheme. Signed as the `host` header. */
+	host: string;
+	/** Already URI-encoded absolute path, e.g. `/bucket/key`. */
+	path: string;
+	/** Canonical (sorted, encoded) query string; empty when absent. */
+	query?: string;
+	/** Lowercase-normalized on the way in; `host` is supplied by `host` above. */
+	headers: Record<string, string>;
+	payload: Buffer;
+	region: string;
+	service: string;
+	/** `YYYYMMDDTHHMMSSZ` — injected rather than read from the clock. */
+	amzDate: string;
+}
+
+// ── Primitives ──
+
+function hmac(key: Buffer | string, data: string): Buffer {
+	return createHmac("sha256", key).update(data, "utf8").digest();
+}
+
+/**
+ * The `YYYYMMDD` half of an amz date. A malformed date would otherwise be
+ * signed into a credential scope AWS cannot resolve, surfacing as an opaque
+ * 403 at publish time; fail here instead, where the cause is visible.
+ */
+function date8Of(amzDate: string): string {
+	if (!AMZ_DATE.test(amzDate)) {
+		throw new Error(`sigv4: amzDate must be YYYYMMDDTHHMMSSZ, got "${amzDate.slice(0, 32)}"`);
+	}
+	return amzDate.slice(0, 8);
+}
+
+function credentialScope(date8: string, region: string, service: string): string {
+	return `${date8}/${region}/${service}/${TERMINATOR}`;
+}
+
+/** sha256 hex of the request payload — S3 requires it as `x-amz-content-sha256`. */
+export function hashPayload(payload: Buffer): string {
+	return createHash("sha256").update(payload).digest("hex");
+}
+
+/**
+ * Canonical request plus the `;`-joined list of header names it signs.
+ *
+ * Header values are normalized the way AWS re-normalizes them server-side
+ * (trimmed, inner runs of spaces collapsed) so a value carrying incidental
+ * whitespace still verifies.
+ */
+function canonicalParts(
+	req: SigV4Request,
+	payloadHash: string,
+): { canonical: string; signedHeaders: string } {
+	const merged = new Map<string, string>();
+	for (const [name, value] of Object.entries(req.headers)) {
+		merged.set(name.trim().toLowerCase(), value.trim().replace(/ {2,}/g, " "));
+	}
+	// These three are ours: a caller-supplied `host` header must never decide
+	// what the signature covers, and the digest must match the bytes we send.
+	merged.set("host", req.host);
+	merged.set("x-amz-date", req.amzDate);
+	merged.set("x-amz-content-sha256", payloadHash);
+
+	// Map keys are unique, so a comparator that never returns 0 is still total.
+	const entries = [...merged].sort((a, b) => (a[0] < b[0] ? -1 : 1));
+	const signedHeaders = entries.map(([name]) => name).join(";");
+	const canonical = [
+		req.method.toUpperCase(),
+		req.path,
+		req.query ?? "",
+		entries.map(([name, value]) => `${name}:${value}\n`).join(""),
+		signedHeaders,
+		payloadHash,
+	].join("\n");
+	return { canonical, signedHeaders };
+}
+
+/**
+ * `METHOD\n<path>\n<query>\n<canonicalHeaders>\n<signedHeaders>\n<payloadHash>`
+ * — canonicalHeaders is a sorted `name:value\n` block, hence the blank line
+ * before the signed-header list.
+ */
+export function canonicalRequest(req: SigV4Request, payloadHash: string): string {
+	return canonicalParts(req, payloadHash).canonical;
+}
+
+/** `AWS4-HMAC-SHA256\n<amzDate>\n<scope>\n<sha256hex(canonicalRequest)>`. */
+export function stringToSign(req: SigV4Request, canonicalReqSha256: string): string {
+	const date8 = date8Of(req.amzDate);
+	return [
+		ALGORITHM,
+		req.amzDate,
+		credentialScope(date8, req.region, req.service),
+		canonicalReqSha256,
+	].join("\n");
+}
+
+/**
+ * The date/region/service-scoped derived key. Scoping is what keeps a leaked
+ * signature from being replayable outside its day, region and service.
+ */
+export function signingKey(secret: string, date8: string, region: string, service: string): Buffer {
+	const kDate = hmac(`AWS4${secret}`, date8);
+	const kRegion = hmac(kDate, region);
+	const kService = hmac(kRegion, service);
+	return hmac(kService, TERMINATOR);
+}
+
+/**
+ * Headers to add to the outbound request: `host`, `x-amz-date`,
+ * `x-amz-content-sha256`, `authorization`, and `x-amz-security-token` when the
+ * credentials are temporary. Caller-supplied headers are signed but not
+ * returned — the caller already has them and must send them verbatim.
+ */
+export function sigV4Headers(req: SigV4Request, creds: SigV4Credentials): Record<string, string> {
+	const date8 = date8Of(req.amzDate);
+	const payloadHash = hashPayload(req.payload);
+	// The session token is part of the signature, not just a header alongside it.
+	const signReq: SigV4Request = creds.sessionToken
+		? { ...req, headers: { ...req.headers, "x-amz-security-token": creds.sessionToken } }
+		: req;
+
+	const { canonical, signedHeaders } = canonicalParts(signReq, payloadHash);
+	const canonicalHash = createHash("sha256").update(canonical, "utf8").digest("hex");
+	const key = signingKey(creds.secretAccessKey, date8, req.region, req.service);
+	const signature = hmac(key, stringToSign(signReq, canonicalHash)).toString("hex");
+
+	const scope = credentialScope(date8, req.region, req.service);
+	const out: Record<string, string> = {
+		host: req.host,
+		"x-amz-date": req.amzDate,
+		"x-amz-content-sha256": payloadHash,
+		authorization:
+			`${ALGORITHM} Credential=${creds.accessKeyId}/${scope}, ` +
+			`SignedHeaders=${signedHeaders}, Signature=${signature}`,
+	};
+	if (creds.sessionToken) {
+		out["x-amz-security-token"] = creds.sessionToken;
+	}
+	return out;
+}

--- a/packages/core/src/audit/verify.ts
+++ b/packages/core/src/audit/verify.ts
@@ -490,7 +490,16 @@ function verifySuppliedRekorReceipts(
 	let receiptsFailed = 0;
 	let latestAttestedTimeMs: number | null = null;
 	for (const raw of receiptsRaw) {
-		for (const document of splitReceiptDocuments(raw)) {
+		const documents = splitReceiptDocuments(raw);
+		if (documents.length === 0) {
+			// A receipts artifact that holds no receipts is a supply failure, not an
+			// absence of evidence: the caller passed --rekor-receipts, so an empty
+			// file means the receipt they meant to present never made it here.
+			receiptsFailed++;
+			errors.push("rekor-receipt-invalid: receipts artifact contained no receipts");
+			continue;
+		}
+		for (const document of documents) {
 			const parsed = parseRekorReceipt(document);
 			if (parsed.receipt === null) {
 				receiptsFailed++;

--- a/packages/core/src/audit/verify.ts
+++ b/packages/core/src/audit/verify.ts
@@ -35,9 +35,11 @@ import {
 	readAnchorMirror,
 	type WitnessInput,
 	type WitnessStatus,
+	worseAnchorState,
 } from "./anchor-verify.js";
 import { canonicalize } from "./canonical.js";
 import { buildMerkleTree } from "./merkle.js";
+import { parseRekorReceipt, type RekorVerification, verifyRekorReceipt } from "./rekor-verify.js";
 
 export type { AnchorRecord, AnchorSource, AnchorState, AnchorTrust, WitnessInput };
 
@@ -376,6 +378,14 @@ export function verifyVault(vaultPath: string): VaultVerificationResult {
 export interface AnchorVerifyParams {
 	/** Raw contents of caller-fetched anchor artifacts (single JSON or JSONL). */
 	readonly externalAnchorsRaw?: readonly string[] | undefined;
+	/** Raw transparency-log receipts: one receipt JSON, or JSONL of receipts. */
+	readonly rekorReceiptsRaw?: readonly string[] | undefined;
+	/**
+	 * Caller-pinned transparency-log keys. Supplying none is only meaningful for
+	 * the one log whose key ships with the verifier (rekor.sigstore.dev); any
+	 * other log without a pin is refused rather than trusted.
+	 */
+	readonly rekorLogPubkeysPem?: readonly string[] | undefined;
 	/** Caller-pinned trust material — NEVER read from the vault under audit. */
 	readonly trust?: AnchorTrust | undefined;
 	readonly witness?: WitnessInput | undefined;
@@ -383,6 +393,14 @@ export interface AnchorVerifyParams {
 	readonly maxUnanchoredEvents?: number | undefined;
 	readonly expectedVaultId?: string | undefined;
 	readonly nowMs?: number | undefined;
+}
+
+export interface RekorReport {
+	receiptsVerified: number;
+	receiptsFailed: number;
+	/** Max attested time among verified receipts of the NEWEST anchor (ms). */
+	latestAttestedTimeMs: number | null;
+	errors: string[];
 }
 
 export interface AnchoringReport {
@@ -399,11 +417,118 @@ export interface AnchoringReport {
 	witness: { requested: boolean; status: WitnessStatus; error?: string };
 	reasons: string[];
 	warnings: string[];
+	/** Present only when transparency-log receipts were supplied. */
+	rekor?: RekorReport;
 }
 
 export interface AnchoredVaultVerificationResult extends VaultVerificationResult {
 	anchorState: AnchorState;
 	anchoring: AnchoringReport;
+}
+
+/**
+ * Split one raw receipt artifact into receipt documents. A file may hold a
+ * single (possibly pretty-printed) receipt or JSONL of many, so the whole-file
+ * parse is tried first and line-splitting is the fallback — the reverse would
+ * shred a pretty-printed receipt into unparseable fragments.
+ *
+ * IDENTICAL in packages/core/src/audit/verify.ts.
+ */
+function splitReceiptDocuments(raw: string): string[] {
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) return [];
+	try {
+		JSON.parse(trimmed);
+		return [trimmed];
+	} catch {
+		return trimmed
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+	}
+}
+
+/**
+ * Verify every supplied transparency-log receipt against the anchor record it
+ * names. Receipts are OPTIONAL evidence, but supplied evidence is not
+ * advisory: a receipt is only ever presented to strengthen a claim, so one
+ * that does not verify fails the vault closed rather than being dropped.
+ *
+ * Records are matched by anchorSeq with the external copy governing (the same
+ * precedence the evaluator's merge uses). A receipt may bind to ANY record at
+ * its anchorSeq: committed-equal twins differ in exactly the timestamp and
+ * signature a receipt commits to, so the emitter's published twin must not
+ * depend on which copy the auditor happened to fetch first.
+ *
+ * IDENTICAL in packages/core/src/audit/verify.ts.
+ */
+function verifySuppliedRekorReceipts(
+	receiptsRaw: readonly string[],
+	externalRecords: readonly AnchorRecord[],
+	mirrorRecords: readonly AnchorRecord[],
+	logPubkeysPem: readonly string[],
+): RekorReport | null {
+	if (receiptsRaw.length === 0) return null;
+	const bySeq = new Map<number, AnchorRecord[]>();
+	for (const record of [...externalRecords, ...mirrorRecords]) {
+		const twins = bySeq.get(record.anchorSeq);
+		if (twins === undefined) {
+			bySeq.set(record.anchorSeq, [record]);
+		} else {
+			twins.push(record);
+		}
+	}
+	// The NEWEST anchor by the evaluator's own rule (largest treeSize, earliest
+	// anchorSeq on a tie) — only its receipts may speak for freshness.
+	const merged = [...bySeq.keys()]
+		.sort((a, b) => a - b)
+		.map((seq) => (bySeq.get(seq) as AnchorRecord[])[0] as AnchorRecord);
+	const latestSeq = [...merged].sort((a, b) => b.treeSize - a.treeSize)[0]?.anchorSeq ?? null;
+
+	const errors: string[] = [];
+	let receiptsVerified = 0;
+	let receiptsFailed = 0;
+	let latestAttestedTimeMs: number | null = null;
+	for (const raw of receiptsRaw) {
+		for (const document of splitReceiptDocuments(raw)) {
+			const parsed = parseRekorReceipt(document);
+			if (parsed.receipt === null) {
+				receiptsFailed++;
+				errors.push(parsed.error as string);
+				continue;
+			}
+			const receipt = parsed.receipt;
+			const candidates = bySeq.get(receipt.anchorSeq) ?? [];
+			if (candidates.length === 0) {
+				receiptsFailed++;
+				errors.push(`rekor-receipt-invalid: receipt for unknown anchorSeq ${receipt.anchorSeq}`);
+				continue;
+			}
+			let verified: RekorVerification | null = null;
+			let firstErrors: string[] = [];
+			for (const candidate of candidates) {
+				const result = verifyRekorReceipt(receipt, candidate, logPubkeysPem);
+				if (result.ok) {
+					verified = result;
+					break;
+				}
+				if (firstErrors.length === 0) firstErrors = result.errors;
+			}
+			if (verified === null) {
+				receiptsFailed++;
+				errors.push(...firstErrors);
+				continue;
+			}
+			receiptsVerified++;
+			if (receipt.anchorSeq === latestSeq && verified.attestedTimeMs !== null) {
+				latestAttestedTimeMs =
+					latestAttestedTimeMs === null
+						? verified.attestedTimeMs
+						: Math.max(latestAttestedTimeMs, verified.attestedTimeMs);
+			}
+		}
+	}
+	return { receiptsVerified, receiptsFailed, latestAttestedTimeMs, errors };
 }
 
 /**
@@ -425,6 +550,12 @@ export function verifyVaultWithAnchors(
 		externalErrors.push(...parsed.errors);
 	}
 	const mirror = readAnchorMirror(vaultPath);
+	const rekor = verifySuppliedRekorReceipts(
+		params.rekorReceiptsRaw ?? [],
+		externalRecords,
+		mirror.records,
+		params.rekorLogPubkeysPem ?? [],
+	);
 	const evaluation = evaluateAnchoredVault({
 		orderedHashes: gatherOrderedEventHashes(vaultPath),
 		externalAnchors: externalRecords,
@@ -440,21 +571,32 @@ export function verifyVaultWithAnchors(
 				: {}),
 			...(params.expectedVaultId !== undefined ? { expectedVaultId: params.expectedVaultId } : {}),
 			...(params.nowMs !== undefined ? { nowMs: params.nowMs } : {}),
+			...(rekor !== null && rekor.latestAttestedTimeMs !== null
+				? { attestedTimeMs: rekor.latestAttestedTimeMs }
+				: {}),
 		},
 	});
+	// A broken receipt is ANCHOR_INVALID (fail-closed), escalated by the state
+	// machine's own severity ordering so MISMATCH still outranks it.
+	const rekorFailed = rekor !== null && rekor.receiptsFailed > 0;
 	return {
 		...base,
-		valid: base.valid && evaluation.anchorsValid,
-		errors: [...base.errors, ...evaluation.errors],
-		anchorState: evaluation.anchorState,
+		valid: base.valid && evaluation.anchorsValid && !rekorFailed,
+		errors: [...base.errors, ...evaluation.errors, ...(rekor?.errors ?? [])],
+		anchorState: rekorFailed
+			? worseAnchorState(evaluation.anchorState, "ANCHOR_INVALID")
+			: evaluation.anchorState,
 		anchoring: {
 			anchorSource: evaluation.anchorSource,
 			anchorCount: evaluation.anchorCount,
 			latestAnchor: evaluation.latestAnchor,
 			unanchoredTail: evaluation.unanchoredTail,
 			witness: evaluation.witness,
-			reasons: evaluation.reasons,
+			reasons: rekorFailed
+				? [...new Set([...evaluation.reasons, "rekor-receipt-invalid"])]
+				: evaluation.reasons,
 			warnings: evaluation.warnings,
+			...(rekor !== null ? { rekor } : {}),
 		},
 	};
 }

--- a/packages/core/src/cli/anchor.ts
+++ b/packages/core/src/cli/anchor.ts
@@ -4,17 +4,19 @@
 /**
  * CLI: usertrust anchor — external audit anchoring
  *
- * init    Mint the vault's anchor identity (Ed25519 key OUTSIDE the vault)
- * now     One snapshot → sign → mirror → publish cycle
- * status  Last anchor, unanchored tail, outbox depth
- * export  Print mirror records (JSONL) for pull-mode shipping
- * rotate  Cross-signed key rotation (spec §6)
- * resume  Re-seed a lost mirror from the store's newest record
+ * init           Mint the vault's anchor identity (Ed25519 key OUTSIDE the vault)
+ * now            One snapshot → sign → mirror → publish cycle
+ * status         Last anchor, unanchored tail, outbox depth
+ * export         Print mirror records (JSONL) for pull-mode shipping
+ * export-bundle  Records + transparency-log receipts as one auditor artifact
+ * doctor         Probe what this identity can delete/overwrite in the store
+ * rotate         Cross-signed key rotation (spec §6)
+ * resume         Re-seed a lost mirror from the store's newest record
  *
  * Spec: docs/superpowers/specs/2026-07-26-external-anchoring-design.md
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import pc from "picocolors";
 import {
@@ -28,22 +30,81 @@ import {
 	resumeAnchorMirror,
 	type SinkConfig,
 } from "../audit/anchor.js";
+import { type DoctorReport, doctorFileSink, doctorS3Sink } from "../audit/anchor-doctor.js";
 import { parseAnchorsContent } from "../audit/anchor-verify.js";
+import { DEFAULT_REKOR_URL } from "../audit/rekor.js";
+import { parseRekorReceipt, type RekorReceipt } from "../audit/rekor-verify.js";
 import { VAULT_DIR } from "../shared/constants.js";
 import type { CliOptions } from "./init.js";
+
+const REKOR_FLAG = "--sink-rekor";
+const S3_KEYS = new Set(["bucket", "region", "prefix", "endpoint"]);
+/** Same cap the verify CLI enforces on `--bundle` — never export what it refuses. */
+const MAX_BUNDLE_ITEMS = 10_000;
 
 function sinksFromArgs(args: string[]): SinkConfig[] {
 	const sinks: SinkConfig[] = [];
 	for (let i = 0; i < args.length; i++) {
-		if (args[i] === "--sink-file" && args[i + 1] !== undefined) {
+		const arg = args[i] as string;
+		if (arg === "--sink-file" && args[i + 1] !== undefined) {
 			sinks.push({ type: "file", path: args[i + 1] as string });
 			i++;
-		} else if (args[i] === "--sink-url" && args[i + 1] !== undefined) {
+		} else if (arg === "--sink-url" && args[i + 1] !== undefined) {
 			sinks.push({ type: "https", url: args[i + 1] as string });
 			i++;
+		} else if (arg === "--sink-s3" && args[i + 1] !== undefined) {
+			sinks.push(s3SinkFromSpec(args[i + 1] as string));
+			i++;
+		} else if (arg === REKOR_FLAG) {
+			// Delta D8: this flag never consumes the token after it, so
+			// `--sink-rekor --sink-file /mnt/worm/a.jsonl` keeps its file sink. A
+			// URL parked there was meant as the log address, and defaulting to
+			// the public log instead would publish somewhere the operator never
+			// named — refuse rather than reinterpret.
+			const stray = args[i + 1];
+			if (stray !== undefined && /^https?:\/\//.test(stray)) {
+				throw new Error(`${REKOR_FLAG} takes no separate value — use ${REKOR_FLAG}=<url>`);
+			}
+			sinks.push({ type: "rekor" });
+		} else if (arg.startsWith(`${REKOR_FLAG}=`)) {
+			const url = arg.slice(REKOR_FLAG.length + 1);
+			if (url === "") throw new Error(`${REKOR_FLAG}=<url> requires a URL`);
+			sinks.push({ type: "rekor", url });
 		}
 	}
 	return sinks;
+}
+
+/** `bucket=B,region=R[,prefix=P][,endpoint=E]` — every key is explicit, none inferred. */
+function s3SinkFromSpec(spec: string): SinkConfig {
+	const fields: Record<string, string> = {};
+	for (const part of spec.split(",")) {
+		if (part.trim() === "") continue;
+		const eq = part.indexOf("=");
+		if (eq <= 0) {
+			throw new Error(`--sink-s3: expected key=value, got "${part.slice(0, 60)}"`);
+		}
+		const key = part.slice(0, eq).trim();
+		const value = part.slice(eq + 1).trim();
+		if (!S3_KEYS.has(key)) {
+			throw new Error(
+				`--sink-s3: unknown key "${key.slice(0, 40)}" (bucket, region, prefix, endpoint)`,
+			);
+		}
+		if (value === "") throw new Error(`--sink-s3: ${key} requires a value`);
+		fields[key] = value;
+	}
+	const { bucket, region, prefix, endpoint } = fields;
+	if (bucket === undefined || region === undefined) {
+		throw new Error("--sink-s3 requires bucket=<name>,region=<region>");
+	}
+	return {
+		type: "s3",
+		bucket,
+		region,
+		...(prefix !== undefined ? { prefix } : {}),
+		...(endpoint !== undefined ? { endpoint } : {}),
+	};
 }
 
 function flagValue(args: string[], flag: string): string | undefined {
@@ -66,6 +127,172 @@ function emitterConfig(args: string[]): AnchoringConfig {
 		sinks: sinksFromArgs(args),
 		...(retries !== undefined ? { publishRetries: retries } : {}),
 	};
+}
+
+// ── doctor ──
+
+/** A sink the doctor cannot probe without writing to someone else's store. */
+function notProbed(sink: string, detail: string): DoctorReport {
+	return { sink, checks: [{ name: "probe", status: "info", detail }], failed: false };
+}
+
+async function doctorReports(args: string[]): Promise<DoctorReport[]> {
+	const sinks = sinksFromArgs(args);
+	if (sinks.length === 0) {
+		throw new Error(
+			"anchor doctor: no sink configured — pass --sink-file, --sink-s3, --sink-url or --sink-rekor",
+		);
+	}
+	const reports: DoctorReport[] = [];
+	for (const sink of sinks) {
+		switch (sink.type) {
+			case "file":
+				reports.push(doctorFileSink(sink.path));
+				break;
+			case "s3":
+				reports.push(
+					await doctorS3Sink({
+						bucket: sink.bucket,
+						region: sink.region,
+						...(sink.prefix !== undefined ? { prefix: sink.prefix } : {}),
+						...(sink.endpoint !== undefined ? { endpoint: sink.endpoint } : {}),
+					}),
+				);
+				break;
+			case "https":
+				reports.push(
+					notProbed(
+						`https:${sink.url}`,
+						"not probed: an ingest endpoint is append-only for this credential by " +
+							"construction — probe the store BEHIND it with its own credentials",
+					),
+				);
+				break;
+			case "rekor":
+				reports.push(
+					notProbed(
+						`rekor:${sink.url ?? DEFAULT_REKOR_URL}`,
+						"not probed: a transparency log is append-only by construction — its " +
+							"inclusion receipts under audit/anchors/rekor/ are the evidence",
+					),
+				);
+				break;
+			case "command":
+				reports.push(
+					notProbed(
+						`command:${sink.argv[0] ?? ""}`,
+						"not probed: the store behind a command " +
+							"sink is opaque from here — probe it with its own tooling",
+					),
+				);
+				break;
+		}
+	}
+	return reports;
+}
+
+function printDoctor(reports: DoctorReport[]): void {
+	const paint = { pass: pc.green, fail: pc.red, info: pc.yellow } as const;
+	console.log(pc.bold("anchor doctor — permission probe (NOT proof of immutability)"));
+	for (const report of reports) {
+		console.log("");
+		console.log(report.sink);
+		for (const check of report.checks) {
+			console.log(
+				`  ${paint[check.status](check.status.toUpperCase())} ${check.name}: ${check.detail}`,
+			);
+		}
+	}
+	console.log("");
+	console.log("Each verdict describes what these credentials could do at this location right now.");
+	console.log("Durable immutability comes from the store's own configuration (S3 Object Lock");
+	console.log("retention, POSIX directory permissions, an appliance's WORM mode).");
+}
+
+// ── export-bundle ──
+
+interface BundleResult {
+	/** The one line stdout gets, or null when nothing may be emitted (delta D9). */
+	bundle: string | null;
+	errors: string[];
+}
+
+/**
+ * Build the auditor bundle `{v:1, records, rekorReceipts}` consumed by
+ * `usertrust verify --bundle`.
+ *
+ * Fail-closed by construction (delta D9): a bundle is what an auditor receives
+ * INSTEAD of the vault, so a partial one — records present, a receipt quietly
+ * dropped because its file did not parse — is worse than no bundle at all. Every
+ * failure path returns `bundle: null`, and callers print diagnostics to stderr
+ * so stdout is either one complete bundle or empty.
+ */
+function buildBundle(root: string, args: string[]): BundleResult {
+	const errors: string[] = [];
+	try {
+		const sinceRaw = flagValue(args, "--since") ?? "0";
+		if (!/^(0|[1-9][0-9]*)$/.test(sinceRaw)) {
+			return { bundle: null, errors: [`export-bundle: --since must be an integer >= 0`] };
+		}
+		const since = Number.parseInt(sinceRaw, 10);
+
+		const mirrorPath = join(anchorsDir(root), "anchors.jsonl");
+		if (!existsSync(mirrorPath)) {
+			return { bundle: null, errors: ["export-bundle: no anchor mirror found"] };
+		}
+		const mirror = parseAnchorsContent(readFileSync(mirrorPath, "utf-8"));
+		for (const err of mirror.errors) errors.push(`export-bundle: mirror: ${err}`);
+
+		const records = mirror.records
+			.filter((r) => r.anchorSeq > since)
+			.sort((a, b) => a.anchorSeq - b.anchorSeq);
+		const receipts = readReceipts(root, errors)
+			.filter((r) => r.anchorSeq > since)
+			.sort((a, b) => a.anchorSeq - b.anchorSeq);
+		for (const [what, count] of [
+			["records", records.length],
+			["rekorReceipts", receipts.length],
+		] as const) {
+			if (count > MAX_BUNDLE_ITEMS) {
+				errors.push(
+					`export-bundle: ${count} ${what} exceeds the ${MAX_BUNDLE_ITEMS} cap the verifier ` +
+						"accepts — export in slices with --since",
+				);
+			}
+		}
+		if (errors.length > 0) return { bundle: null, errors };
+		return { bundle: JSON.stringify({ v: 1, records, rekorReceipts: receipts }), errors };
+	} catch (err) {
+		errors.push(`export-bundle: ${err instanceof Error ? err.message : String(err)}`);
+		return { bundle: null, errors };
+	}
+}
+
+/** Every receipt the Rekor sink persisted; unparseable ones become errors, never gaps. */
+function readReceipts(root: string, errors: string[]): RekorReceipt[] {
+	const dir = join(anchorsDir(root), "rekor");
+	if (!existsSync(dir)) return [];
+	const receipts: RekorReceipt[] = [];
+	for (const name of readdirSync(dir)
+		.filter((f) => f.endsWith(".json"))
+		.sort()) {
+		let raw: string;
+		try {
+			raw = readFileSync(join(dir, name), "utf-8");
+		} catch (err) {
+			errors.push(
+				`export-bundle: ${name}: unreadable (${err instanceof Error ? err.message : String(err)})`,
+			);
+			continue;
+		}
+		const { receipt, error } = parseRekorReceipt(raw);
+		if (receipt === null) {
+			errors.push(`export-bundle: ${name}: ${error}`);
+			continue;
+		}
+		receipts.push(receipt);
+	}
+	return receipts;
 }
 
 export async function run(args: string[] = [], opts?: CliOptions): Promise<void> {
@@ -248,6 +475,39 @@ export async function run(args: string[] = [], opts?: CliOptions): Promise<void>
 				if (errors.length > 0) process.exitCode = 1;
 				return;
 			}
+			case "export-bundle": {
+				const { bundle, errors } = buildBundle(root, args);
+				if (bundle === null) {
+					for (const err of errors) {
+						console.error(err);
+					}
+					console.error("export-bundle: refusing to emit a partial bundle");
+					process.exitCode = 1;
+					return;
+				}
+				// Deliberately NOT wrapped in the {command, success, data} envelope
+				// under --json: a bundle is an interchange artifact fed straight to
+				// `usertrust verify --bundle -`, not a status report.
+				console.log(bundle);
+				return;
+			}
+			case "doctor": {
+				const reports = await doctorReports(args);
+				const failed = reports.some((r) => r.failed);
+				if (json) {
+					console.log(
+						JSON.stringify({
+							command: "anchor doctor",
+							success: !failed,
+							data: { failed, reports },
+						}),
+					);
+				} else {
+					printDoctor(reports);
+				}
+				if (failed) process.exitCode = 1;
+				return;
+			}
 			case "rotate": {
 				const identity = readAnchorIdentity(root);
 				if (identity === null) {
@@ -356,14 +616,22 @@ export async function run(args: string[] = [], opts?: CliOptions): Promise<void>
 				return;
 			}
 			default: {
-				console.log(`Usage: usertrust anchor <init|now|status|export|rotate|resume>
+				console.log(`Usage: usertrust anchor <init|now|status|export|export-bundle|doctor|rotate|resume>
 
-  init   [--key-file <path>]                 Mint identity + Ed25519 key (outside the vault)
-  now    [--sink-file <p>] [--sink-url <u>]  Snapshot, sign, mirror, publish
-  status                                     Last anchor, unanchored tail, outbox
-  export [--since <anchorSeq>]               Print mirror records (pull-mode shipping)
-  rotate [--key-file <path>]                 Cross-signed key rotation
-  resume --latest <record.json|->            Re-seed a lost mirror from the store`);
+  init          [--key-file <path>]     Mint identity + Ed25519 key (outside the vault)
+  now           [sink flags]            Snapshot, sign, mirror, publish
+  status                                Last anchor, unanchored tail, outbox
+  export        [--since <anchorSeq>]   Print mirror records (pull-mode shipping)
+  export-bundle [--since <anchorSeq>]   Records + Rekor receipts for \`verify --bundle\`
+  doctor        [sink flags]            What can this identity delete/overwrite in the store?
+  rotate        [--key-file <path>]     Cross-signed key rotation
+  resume        --latest <record|->     Re-seed a lost mirror from the store
+
+Sink flags:
+  --sink-file <path>                    Append-only file store
+  --sink-url <url>                      Ingest endpoint (POST per record)
+  --sink-s3 bucket=B,region=R[,prefix=P][,endpoint=E]
+  --sink-rekor[=<url>]                  Rekor transparency log (default ${DEFAULT_REKOR_URL})`);
 				if (action !== undefined) process.exitCode = 1;
 				return;
 			}

--- a/packages/core/src/cli/anchor.ts
+++ b/packages/core/src/cli/anchor.ts
@@ -39,6 +39,8 @@ import type { CliOptions } from "./init.js";
 
 const REKOR_FLAG = "--sink-rekor";
 const S3_KEYS = new Set(["bucket", "region", "prefix", "endpoint"]);
+/** Sink flags that take the following argv token as their operand. */
+const VALUE_SINK_FLAGS = new Set(["--sink-file", "--sink-url", "--sink-s3"]);
 /** Same cap the verify CLI enforces on `--bundle` — never export what it refuses. */
 const MAX_BUNDLE_ITEMS = 10_000;
 
@@ -46,15 +48,21 @@ function sinksFromArgs(args: string[]): SinkConfig[] {
 	const sinks: SinkConfig[] = [];
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i] as string;
-		if (arg === "--sink-file" && args[i + 1] !== undefined) {
-			sinks.push({ type: "file", path: args[i + 1] as string });
+		if (VALUE_SINK_FLAGS.has(arg)) {
+			// A missing operand used to drop the flag on the floor, so
+			// `anchor now --sink-s3` ran with ZERO sinks, published nowhere and
+			// still exited 0 — a skipped publication an operator would only
+			// discover at audit time. Refuse the run instead.
+			const value = args[i + 1];
+			if (value === undefined) throw new Error(`${arg} requires a value`);
 			i++;
-		} else if (arg === "--sink-url" && args[i + 1] !== undefined) {
-			sinks.push({ type: "https", url: args[i + 1] as string });
-			i++;
-		} else if (arg === "--sink-s3" && args[i + 1] !== undefined) {
-			sinks.push(s3SinkFromSpec(args[i + 1] as string));
-			i++;
+			if (arg === "--sink-file") {
+				sinks.push({ type: "file", path: value });
+			} else if (arg === "--sink-url") {
+				sinks.push({ type: "https", url: value });
+			} else {
+				sinks.push(s3SinkFromSpec(value));
+			}
 		} else if (arg === REKOR_FLAG) {
 			// Delta D8: this flag never consumes the token after it, so
 			// `--sink-rekor --sink-file /mnt/worm/a.jsonl` keeps its file sink. A
@@ -111,6 +119,18 @@ function flagValue(args: string[], flag: string): string | undefined {
 	const idx = args.indexOf(flag);
 	if (idx === -1 || args[idx + 1] === undefined) return undefined;
 	return args[idx + 1];
+}
+
+/**
+ * `--since <anchorSeq>`, or null when the operand is not a non-negative
+ * integer. Both `export` and `export-bundle` validate here: a bare parseInt
+ * turns `--since abc` into NaN, every `anchorSeq > NaN` comparison is false,
+ * and the command prints nothing while exiting 0 — indistinguishable from a
+ * vault with nothing left to ship.
+ */
+function sinceFromArgs(args: string[]): number | null {
+	const raw = flagValue(args, "--since") ?? "0";
+	return /^(0|[1-9][0-9]*)$/.test(raw) ? Number.parseInt(raw, 10) : null;
 }
 
 function emitterConfig(args: string[]): AnchoringConfig {
@@ -215,6 +235,8 @@ interface BundleResult {
 	/** The one line stdout gets, or null when nothing may be emitted (delta D9). */
 	bundle: string | null;
 	errors: string[];
+	/** Non-fatal notices for stderr — the bundle is still complete without them. */
+	warnings: string[];
 }
 
 /**
@@ -226,19 +248,30 @@ interface BundleResult {
  * dropped because its file did not parse — is worse than no bundle at all. Every
  * failure path returns `bundle: null`, and callers print diagnostics to stderr
  * so stdout is either one complete bundle or empty.
+ *
+ * A receipt whose record is absent from the mirror is the one exception, and it
+ * is not a parse failure: `anchor resume` re-seeds the mirror from the store's
+ * newest record alone, leaving the receipts for every earlier anchor on disk
+ * with nothing to pair against. Shipping them would hard-fail the verifier
+ * ("receipt for unknown anchorSeq"), so they are excluded with a warning and
+ * the bundle stays valid.
  */
 function buildBundle(root: string, args: string[]): BundleResult {
 	const errors: string[] = [];
+	const warnings: string[] = [];
 	try {
-		const sinceRaw = flagValue(args, "--since") ?? "0";
-		if (!/^(0|[1-9][0-9]*)$/.test(sinceRaw)) {
-			return { bundle: null, errors: [`export-bundle: --since must be an integer >= 0`] };
+		const since = sinceFromArgs(args);
+		if (since === null) {
+			return {
+				bundle: null,
+				errors: ["export-bundle: --since must be an integer >= 0"],
+				warnings,
+			};
 		}
-		const since = Number.parseInt(sinceRaw, 10);
 
 		const mirrorPath = join(anchorsDir(root), "anchors.jsonl");
 		if (!existsSync(mirrorPath)) {
-			return { bundle: null, errors: ["export-bundle: no anchor mirror found"] };
+			return { bundle: null, errors: ["export-bundle: no anchor mirror found"], warnings };
 		}
 		const mirror = parseAnchorsContent(readFileSync(mirrorPath, "utf-8"));
 		for (const err of mirror.errors) errors.push(`export-bundle: mirror: ${err}`);
@@ -246,9 +279,20 @@ function buildBundle(root: string, args: string[]): BundleResult {
 		const records = mirror.records
 			.filter((r) => r.anchorSeq > since)
 			.sort((a, b) => a.anchorSeq - b.anchorSeq);
-		const receipts = readReceipts(root, errors)
+		const found = readReceipts(root, errors)
 			.filter((r) => r.anchorSeq > since)
 			.sort((a, b) => a.anchorSeq - b.anchorSeq);
+		if (errors.length > 0) return { bundle: null, errors, warnings };
+
+		const bundledSeqs = new Set(records.map((r) => r.anchorSeq));
+		const receipts = found.filter((r) => {
+			if (bundledSeqs.has(r.anchorSeq)) return true;
+			warnings.push(
+				`export-bundle: excluding receipt for anchorSeq ${r.anchorSeq} (no matching record ` +
+					"in mirror — re-fetch the full history to include it)",
+			);
+			return false;
+		});
 		for (const [what, count] of [
 			["records", records.length],
 			["rekorReceipts", receipts.length],
@@ -260,15 +304,24 @@ function buildBundle(root: string, args: string[]): BundleResult {
 				);
 			}
 		}
-		if (errors.length > 0) return { bundle: null, errors };
-		return { bundle: JSON.stringify({ v: 1, records, rekorReceipts: receipts }), errors };
+		if (errors.length > 0) return { bundle: null, errors, warnings };
+		return {
+			bundle: JSON.stringify({ v: 1, records, rekorReceipts: receipts }),
+			errors,
+			warnings,
+		};
 	} catch (err) {
 		errors.push(`export-bundle: ${err instanceof Error ? err.message : String(err)}`);
-		return { bundle: null, errors };
+		return { bundle: null, errors, warnings };
 	}
 }
 
-/** Every receipt the Rekor sink persisted; unparseable ones become errors, never gaps. */
+/**
+ * Every receipt the Rekor sink persisted; unparseable ones become errors, never
+ * gaps. Any `*.json` under the receipts directory is a candidate and each one is
+ * keyed by the `anchorSeq` INSIDE it — the filename is an index for humans, not
+ * a fact about the receipt.
+ */
 function readReceipts(root: string, errors: string[]): RekorReceipt[] {
 	const dir = join(anchorsDir(root), "rekor");
 	if (!existsSync(dir)) return [];
@@ -456,7 +509,12 @@ export async function run(args: string[] = [], opts?: CliOptions): Promise<void>
 				return;
 			}
 			case "export": {
-				const since = Number.parseInt(flagValue(args, "--since") ?? "0", 10);
+				const since = sinceFromArgs(args);
+				if (since === null) {
+					console.error("export: --since must be an integer >= 0");
+					process.exitCode = 1;
+					return;
+				}
 				const mirrorPath = join(anchorsDir(root), "anchors.jsonl");
 				if (!existsSync(mirrorPath)) {
 					console.error("No anchor mirror found.");
@@ -476,7 +534,10 @@ export async function run(args: string[] = [], opts?: CliOptions): Promise<void>
 				return;
 			}
 			case "export-bundle": {
-				const { bundle, errors } = buildBundle(root, args);
+				const { bundle, errors, warnings } = buildBundle(root, args);
+				for (const warning of warnings) {
+					console.error(warning);
+				}
 				if (bundle === null) {
 					for (const err of errors) {
 						console.error(err);

--- a/packages/core/src/cli/verify.ts
+++ b/packages/core/src/cli/verify.ts
@@ -276,6 +276,16 @@ async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 	};
 }
 
+/**
+ * A witness-attested time on its way to a terminal. The receipt parser bounds
+ * integratedTime, but this value also arrives from library callers, and
+ * `toISOString()` throws RangeError outside ±8.64e15 ms — printing raw
+ * milliseconds beats crashing the verifier over a number it already distrusts.
+ */
+function formatAttestedMs(ms: number): string {
+	return Number.isFinite(ms) && Math.abs(ms) <= 8.64e15 ? new Date(ms).toISOString() : `${ms} ms`;
+}
+
 export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 	const root = rootDir ?? process.cwd();
 	const vaultPath = join(root, VAULT_DIR);
@@ -358,7 +368,7 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 			const attested =
 				rekor.latestAttestedTimeMs === null
 					? ""
-					: `, attested ${new Date(rekor.latestAttestedTimeMs).toISOString()}`;
+					: `, attested ${formatAttestedMs(rekor.latestAttestedTimeMs)}`;
 			const failed = rekor.receiptsFailed > 0 ? `, ${rekor.receiptsFailed} FAILED` : "";
 			console.log(`Rekor: ${rekor.receiptsVerified} receipt(s) verified${failed}${attested}`);
 		}

--- a/packages/core/src/cli/verify.ts
+++ b/packages/core/src/cli/verify.ts
@@ -56,6 +56,9 @@ const KNOWN_VERIFY_FLAGS = new Set([
 	"--anchor",
 	"--anchors",
 	"--anchor-url",
+	"--bundle",
+	"--rekor-receipts",
+	"--rekor-pubkey",
 	"--pubkey",
 	"--successor-pin",
 	"--require-anchor",
@@ -64,6 +67,60 @@ const KNOWN_VERIFY_FLAGS = new Set([
 	"--max-unanchored-events",
 	"--vault-id",
 ]);
+
+const MAX_PEM_BYTES = 16 * 1024;
+const MAX_BUNDLE_ITEMS = 10_000;
+const BUNDLE_KEYS = new Set(["v", "records", "rekorReceipts"]);
+
+function readArtifact(pathOrDash: string): string {
+	return pathOrDash === "-" ? readFileSync(0, "utf-8") : readFileSync(pathOrDash, "utf-8");
+}
+
+function readPinnedPem(path: string): string {
+	const pem = readFileSync(path, "utf-8");
+	if (Buffer.byteLength(pem, "utf8") > MAX_PEM_BYTES) {
+		throw new Error(`--rekor-pubkey ${path}: PEM exceeds 16 KiB`);
+	}
+	return pem;
+}
+
+/**
+ * Strict parse of an auditor bundle: `{v:1, records, rekorReceipts?}`. A bundle
+ * is untrusted transport, so unknown top-level fields are rejected rather than
+ * ignored — a field the CLI silently drops is one an exporter can use to carry
+ * evidence the verifier never looks at. Element shapes are NOT validated here:
+ * records and receipts are re-serialized and go through the same strict parsers
+ * every other input does.
+ */
+function parseBundle(raw: string): { anchorsRaw: string; receiptsRaw: string[] } {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new Error("--bundle: not valid JSON");
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("--bundle: not an object");
+	}
+	const obj = parsed as Record<string, unknown>;
+	for (const key of Object.keys(obj)) {
+		if (!BUNDLE_KEYS.has(key)) throw new Error(`--bundle: unknown field "${key.slice(0, 80)}"`);
+	}
+	if (obj.v !== 1) throw new Error("--bundle: unsupported version (expected 1)");
+	if (!Array.isArray(obj.records)) throw new Error("--bundle: records must be an array");
+	if (obj.records.length > MAX_BUNDLE_ITEMS) {
+		throw new Error(`--bundle: records exceeds the ${MAX_BUNDLE_ITEMS} cap`);
+	}
+	const receipts = obj.rekorReceipts ?? [];
+	if (!Array.isArray(receipts)) throw new Error("--bundle: rekorReceipts must be an array");
+	if (receipts.length > MAX_BUNDLE_ITEMS) {
+		throw new Error(`--bundle: rekorReceipts exceeds the ${MAX_BUNDLE_ITEMS} cap`);
+	}
+	return {
+		anchorsRaw: obj.records.map((record) => JSON.stringify(record)).join("\n"),
+		receiptsRaw: receipts.map((receipt) => JSON.stringify(receipt)),
+	};
+}
 
 function fetchAnchorUrl(url: string): Promise<{ ok: boolean; body?: string; error?: string }> {
 	return new Promise((resolve) => {
@@ -89,6 +146,9 @@ function fetchAnchorUrl(url: string): Promise<{ ok: boolean; body?: string; erro
 
 async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 	const anchorFiles: string[] = [];
+	const rekorReceiptFiles: string[] = [];
+	const rekorPubkeyFiles: string[] = [];
+	let bundleFile: string | undefined;
 	let anchorUrl: string | undefined;
 	let pubkeyFile: string | undefined;
 	const successorPinFiles: string[] = [];
@@ -103,7 +163,14 @@ async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 		if (arg === "--anchor" || arg === "--anchors") {
 			const v = next();
 			if (v !== undefined) anchorFiles.push(v);
-		} else if (arg === "--anchor-url") anchorUrl = next();
+		} else if (arg === "--rekor-receipts") {
+			const v = next();
+			if (v !== undefined) rekorReceiptFiles.push(v);
+		} else if (arg === "--rekor-pubkey") {
+			const v = next();
+			if (v !== undefined) rekorPubkeyFiles.push(v);
+		} else if (arg === "--bundle") bundleFile = next();
+		else if (arg === "--anchor-url") anchorUrl = next();
 		else if (arg === "--pubkey") pubkeyFile = next();
 		else if (arg === "--successor-pin") {
 			const v = next();
@@ -134,9 +201,14 @@ async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 			throw new Error(`Unknown flag: ${arg}`);
 		}
 	}
-	const externalAnchorsRaw = anchorFiles.map((f) =>
-		f === "-" ? readFileSync(0, "utf-8") : readFileSync(f, "utf-8"),
-	);
+	const externalAnchorsRaw = anchorFiles.map(readArtifact);
+	const rekorReceiptsRaw = rekorReceiptFiles.map(readArtifact);
+	const rekorLogPubkeysPem = rekorPubkeyFiles.map(readPinnedPem);
+	if (bundleFile !== undefined) {
+		const bundle = parseBundle(readArtifact(bundleFile));
+		externalAnchorsRaw.push(bundle.anchorsRaw);
+		rekorReceiptsRaw.push(...bundle.receiptsRaw);
+	}
 	let witness: WitnessInput = { requested: false };
 	if (anchorUrl !== undefined) {
 		const fetched = await fetchAnchorUrl(anchorUrl);
@@ -163,6 +235,8 @@ async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 		anchorFiles.length > 0 ||
 		anchorUrl !== undefined ||
 		pubkeyFile !== undefined ||
+		bundleFile !== undefined ||
+		rekorReceiptFiles.length > 0 ||
 		requireAnchor ||
 		requireExternalAnchor;
 	const trust =
@@ -180,6 +254,8 @@ async function parseAnchorFlags(argv: string[]): Promise<AnchorFlags> {
 		requireExternalAnchor,
 		params: {
 			externalAnchorsRaw,
+			rekorReceiptsRaw,
+			rekorLogPubkeysPem,
 			...(trust !== undefined ? { trust } : {}),
 			witness,
 			...(maxAnchorAgeMs !== undefined ? { maxAnchorAgeMs } : {}),
@@ -266,6 +342,15 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 			console.log(`Latest anchor: #${la.anchorSeq} treeSize ${la.treeSize} (${la.timestamp})`);
 		}
 		console.log(`Unanchored tail: ${result.anchoring.unanchoredTail.events} event(s)`);
+		const rekor = result.anchoring.rekor;
+		if (rekor !== undefined) {
+			const attested =
+				rekor.latestAttestedTimeMs === null
+					? ""
+					: `, attested ${new Date(rekor.latestAttestedTimeMs).toISOString()}`;
+			const failed = rekor.receiptsFailed > 0 ? `, ${rekor.receiptsFailed} FAILED` : "";
+			console.log(`Rekor: ${rekor.receiptsVerified} receipt(s) verified${failed}${attested}`);
+		}
 		if (result.anchoring.anchorSource === "vault-mirror") {
 			console.log(
 				pc.yellow(

--- a/packages/core/src/cli/verify.ts
+++ b/packages/core/src/cli/verify.ts
@@ -76,10 +76,21 @@ function readArtifact(pathOrDash: string): string {
 	return pathOrDash === "-" ? readFileSync(0, "utf-8") : readFileSync(pathOrDash, "utf-8");
 }
 
+/**
+ * Read one pinned log key. A file that carries no usable PEM is a usage error,
+ * not an empty pin: the verifier discards unusable entries, so accepting one
+ * here would leave the caller believing they pinned a key while the receipt was
+ * checked against something else entirely.
+ */
 function readPinnedPem(path: string): string {
 	const pem = readFileSync(path, "utf-8");
 	if (Buffer.byteLength(pem, "utf8") > MAX_PEM_BYTES) {
 		throw new Error(`--rekor-pubkey ${path}: PEM exceeds 16 KiB`);
+	}
+	if (pem.trim().length === 0 || !pem.includes("-----BEGIN PUBLIC KEY-----")) {
+		throw new Error(
+			`--rekor-pubkey ${path}: not a PEM public key (-----BEGIN PUBLIC KEY----- missing)`,
+		);
 	}
 	return pem;
 }

--- a/packages/core/tests/audit/sigv4.test.ts
+++ b/packages/core/tests/audit/sigv4.test.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * SigV4 signer tests.
+ *
+ * The trust anchor here is AWS's own published example ("Signature Version 4
+ * signing process", GET ListUsers against iam.amazonaws.com): the derived
+ * signing key, the string-to-sign layout and the final signature are all
+ * asserted against the documented hex. Our pipeline always signs
+ * x-amz-content-sha256 (S3 requires it) while the documented example does not,
+ * so the canonical request itself is checked structurally and the documented
+ * canonical-request hash is fed into stringToSign directly — that keeps the
+ * external vector covering every step from string-to-sign onward.
+ */
+
+import { createHash, createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+	canonicalRequest,
+	hashPayload,
+	signingKey,
+	sigV4Headers,
+	stringToSign,
+} from "../../src/audit/sigv4.js";
+
+const VECTOR = {
+	method: "GET",
+	host: "iam.amazonaws.com",
+	path: "/",
+	query: "Action=ListUsers&Version=2010-05-08",
+	headers: { "content-type": "application/x-www-form-urlencoded; charset=utf-8" },
+	payload: Buffer.alloc(0),
+	region: "us-east-1",
+	service: "iam",
+	amzDate: "20150830T123600Z",
+};
+const CREDS = {
+	accessKeyId: "AKIDEXAMPLE",
+	secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+};
+
+/** sha256 hex of AWS's documented canonical request for the ListUsers example. */
+const DOC_CANONICAL_REQUEST_HASH =
+	"f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59";
+/** The signature AWS documents for that request. */
+const DOC_SIGNATURE = "5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7";
+const EMPTY_SHA256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+describe("SigV4 (AWS published test vector)", () => {
+	it("reproduces the documented signature", () => {
+		const out = sigV4Headers(VECTOR, CREDS);
+		expect(out.authorization).toBe(
+			"AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, " +
+				"SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, " +
+				"Signature=" +
+				out.authorization.split("Signature=")[1],
+		);
+		// The documented example signs content-type;host;x-amz-date (no
+		// x-amz-content-sha256); assert OUR pipeline is self-consistent instead:
+		// canonical → stringToSign → signature reproduce deterministically.
+		const ph = hashPayload(VECTOR.payload);
+		expect(ph).toBe(EMPTY_SHA256);
+		const cr = canonicalRequest(VECTOR, ph);
+		expect(cr.split("\n")[0]).toBe("GET");
+		expect(cr.split("\n").at(-1)).toBe(ph);
+		const sts = stringToSign(VECTOR, "0".repeat(64));
+		expect(sts.split("\n")).toEqual([
+			"AWS4-HMAC-SHA256",
+			"20150830T123600Z",
+			"20150830/us-east-1/iam/aws4_request",
+			"0".repeat(64),
+		]);
+		const key = signingKey(CREDS.secretAccessKey, "20150830", "us-east-1", "iam");
+		expect(key.toString("hex")).toBe(
+			"c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9",
+		);
+	});
+
+	it("derives AWS's documented signature from the documented canonical-request hash", () => {
+		const sts = stringToSign(VECTOR, DOC_CANONICAL_REQUEST_HASH);
+		const key = signingKey(CREDS.secretAccessKey, "20150830", "us-east-1", "iam");
+		expect(createHmac("sha256", key).update(sts).digest("hex")).toBe(DOC_SIGNATURE);
+	});
+
+	it("builds the canonical request in the documented layout", () => {
+		const lines = canonicalRequest(VECTOR, EMPTY_SHA256).split("\n");
+		expect(lines).toEqual([
+			"GET",
+			"/",
+			"Action=ListUsers&Version=2010-05-08",
+			"content-type:application/x-www-form-urlencoded; charset=utf-8",
+			"host:iam.amazonaws.com",
+			`x-amz-content-sha256:${EMPTY_SHA256}`,
+			"x-amz-date:20150830T123600Z",
+			"",
+			"content-type;host;x-amz-content-sha256;x-amz-date",
+			EMPTY_SHA256,
+		]);
+	});
+});
+
+describe("SigV4 — S3 PUT shape", () => {
+	const body = Buffer.from('{"v":1,"anchorSeq":1}', "utf8");
+	const PUT = {
+		method: "PUT",
+		host: "vault-anchors.s3.us-east-1.amazonaws.com",
+		path: "/anchors/vault-a/000000000001.json",
+		headers: {},
+		payload: body,
+		region: "us-east-1",
+		service: "s3",
+		amzDate: "20260727T101500Z",
+	};
+
+	it("signs host, x-amz-content-sha256 and x-amz-date with the payload digest", () => {
+		const out = sigV4Headers(PUT, CREDS);
+		expect(out.host).toBe(PUT.host);
+		expect(out["x-amz-date"]).toBe("20260727T101500Z");
+		expect(out["x-amz-content-sha256"]).toBe(createHash("sha256").update(body).digest("hex"));
+		expect(out.authorization).toContain(
+			"Credential=AKIDEXAMPLE/20260727/us-east-1/s3/aws4_request",
+		);
+		expect(out.authorization).toContain("SignedHeaders=host;x-amz-content-sha256;x-amz-date");
+		expect(out.authorization).toMatch(/Signature=[0-9a-f]{64}$/);
+		expect(out["x-amz-security-token"]).toBeUndefined();
+	});
+
+	it("is deterministic for identical inputs and payload-bound", () => {
+		const a = sigV4Headers(PUT, CREDS);
+		const b = sigV4Headers(PUT, CREDS);
+		expect(a.authorization).toBe(b.authorization);
+		const other = sigV4Headers({ ...PUT, payload: Buffer.from("different", "utf8") }, CREDS);
+		expect(other.authorization).not.toBe(a.authorization);
+		expect(other["x-amz-content-sha256"]).not.toBe(a["x-amz-content-sha256"]);
+	});
+
+	it("includes an empty canonical query string when none is supplied", () => {
+		expect(canonicalRequest(PUT, hashPayload(body)).split("\n")[2]).toBe("");
+	});
+
+	it("signs the session token when one is present", () => {
+		const out = sigV4Headers(PUT, { ...CREDS, sessionToken: "FwoGZXIvYXdzEB" });
+		expect(out["x-amz-security-token"]).toBe("FwoGZXIvYXdzEB");
+		expect(out.authorization).toContain(
+			"SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token",
+		);
+		// A signature that ignored the token would match the token-free one.
+		expect(out.authorization).not.toBe(sigV4Headers(PUT, CREDS).authorization);
+	});
+});
+
+describe("SigV4 — header canonicalization", () => {
+	const base = {
+		method: "PUT",
+		host: "example.s3.us-east-1.amazonaws.com",
+		path: "/k",
+		headers: {},
+		payload: Buffer.alloc(0),
+		region: "us-east-1",
+		service: "s3",
+		amzDate: "20260727T101500Z",
+	};
+
+	it("lowercases header names, trims values and collapses inner runs of spaces", () => {
+		const lines = canonicalRequest(
+			{ ...base, headers: { "Content-Type": "  application/json   charset=utf-8  " } },
+			EMPTY_SHA256,
+		).split("\n");
+		expect(lines[3]).toBe("content-type:application/json charset=utf-8");
+	});
+
+	it("takes host from the request, not from a caller-supplied host header", () => {
+		const lines = canonicalRequest({ ...base, headers: { host: "spoofed.example" } }, EMPTY_SHA256)
+			.split("\n")
+			.filter((l) => l.startsWith("host:"));
+		expect(lines).toEqual(["host:example.s3.us-east-1.amazonaws.com"]);
+	});
+
+	it("rejects a malformed amzDate rather than signing an unusable scope", () => {
+		expect(() => sigV4Headers({ ...base, amzDate: "2026-07-27T10:15:00Z" }, CREDS)).toThrow(
+			/amzDate/,
+		);
+		expect(() => stringToSign({ ...base, amzDate: "" }, EMPTY_SHA256)).toThrow(/amzDate/);
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-additive.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-additive.test.ts
@@ -99,12 +99,14 @@ describe("HARDEN: anchoring additive proofs", () => {
 		// The import lint above is structurally blind to vendored source (a
 		// vendored crypto file IS a sibling file). This budget is a tripwire:
 		// growing past it requires consciously editing this number — at which
-		// point the reviewer asks what was added. Current size ~2.6k lines.
+		// point the reviewer asks what was added. Raised from 3200 for the
+		// Phase-2 anchoring work (rekor-verify.ts, ~490 lines of node:crypto-only
+		// receipt verification — no vendored source). Current size ~3.3k lines.
 		let total = 0;
 		for (const file of readdirSync(VERIFY_SRC).filter((f) => f.endsWith(".ts"))) {
 			total += readFileSync(join(VERIFY_SRC, file), "utf-8").split("\n").length;
 		}
-		expect(total).toBeLessThan(3200);
+		expect(total).toBeLessThan(4200);
 	});
 
 	it("7. mirror parity: anchor-verify.ts is byte-identical across packages modulo import paths", () => {

--- a/packages/core/tests/harden/anchoring/anchor-differential.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-differential.test.ts
@@ -28,6 +28,7 @@ import {
 	mutateAndRechain,
 	storeRaw,
 } from "./fixtures.js";
+import { makeRekorReceipt } from "./rekor-fixtures.js";
 
 afterEach(() => {
 	cleanupAll();
@@ -42,6 +43,14 @@ function verdict(result: {
 		anchorCount: number;
 		anchorSource: string;
 		unanchoredTail: { events: number };
+		rekor?:
+			| {
+					receiptsVerified: number;
+					receiptsFailed: number;
+					latestAttestedTimeMs: number | null;
+					errors: string[];
+			  }
+			| undefined;
 	};
 	chainLength: number;
 }): string {
@@ -54,6 +63,7 @@ function verdict(result: {
 		anchorSource: result.anchoring.anchorSource,
 		tail: result.anchoring.unanchoredTail.events,
 		chainLength: result.chainLength,
+		rekor: result.anchoring.rekor ?? null,
 	});
 }
 
@@ -69,12 +79,38 @@ describe("HARDEN: core vs verify pkg produce identical ANCHOR verdicts", () => {
 		const s = await makeAnchoredVault(3);
 		await anchorOnce(s);
 		await appendEvents(s.root, 3, 4);
-		await anchorOnce(s);
+		const latest = await anchorOnce(s);
 
 		const base = { externalAnchorsRaw: [storeRaw(s)], trust: s.trust };
 
 		// 1. Happy path.
 		expect(assertAgree(s.vaultPath, base)).toBe("ANCHORED_VERIFIED");
+
+		// 1b. Rekor receipts: both glues must agree on the rekor block too — a
+		// receipt that fails in one package and passes in the other would be a
+		// silent trust split between the shipped verifier and the CLI.
+		const f = makeRekorReceipt(latest, { integratedTime: 1_760_000_000 });
+		const rekorPins = { rekorLogPubkeysPem: [f.logPubkeyPem] };
+		expect(
+			assertAgree(s.vaultPath, {
+				...base,
+				...rekorPins,
+				rekorReceiptsRaw: [JSON.stringify(f.receipt)],
+			}),
+		).toBe("ANCHORED_VERIFIED");
+		expect(
+			assertAgree(s.vaultPath, {
+				...base,
+				...rekorPins,
+				rekorReceiptsRaw: [
+					JSON.stringify(
+						f.tamper((r) => {
+							r.artifactHash = "c".repeat(64);
+						}),
+					),
+				],
+			}),
+		).toBe("ANCHOR_INVALID");
 
 		// 2. Stale under a caller-supplied freshness policy.
 		await appendEvents(s.root, 4, 7);

--- a/packages/core/tests/harden/anchoring/anchor-doctor.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-doctor.test.ts
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — `anchor doctor` store probes (spec §12, plan T4 + delta D10).
+ *
+ * The doctor is a PERMISSION PROBE, never a proof of immutability: it writes a
+ * throwaway probe object and reports whether THIS identity could delete or
+ * overwrite it RIGHT NOW. These tests pin that semantic — the verdicts, the
+ * copy that carries them, and the D6 rule that a probe error never echoes the
+ * `authorization` or `x-amz-security-token` headers.
+ */
+
+import { chmodSync, existsSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	type DoctorReport,
+	doctorFileSink,
+	doctorS3Sink,
+	type HttpTransport,
+} from "../../../src/audit/anchor-doctor.js";
+import { hashPayload } from "../../../src/audit/sigv4.js";
+import { cleanupAll, tmp } from "./fixtures.js";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	cleanupAll();
+});
+
+const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+
+function check(report: DoctorReport, name: string): { status: string; detail: string } {
+	const found = report.checks.find((c) => c.name === name);
+	if (found === undefined) {
+		throw new Error(`no "${name}" check in: ${report.checks.map((c) => c.name).join(", ")}`);
+	}
+	return found;
+}
+
+const copy = (report: DoctorReport): string => report.checks.map((c) => c.detail).join("\n");
+
+interface Call {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	body: Buffer;
+}
+
+interface Scripted {
+	status?: number;
+	body?: string;
+	headers?: Record<string, string>;
+	throws?: Error;
+}
+
+/** Transport that replays `responses` in order and records what it was asked to send. */
+function scriptedTransport(responses: Scripted[]): { transport: HttpTransport; calls: Call[] } {
+	const calls: Call[] = [];
+	let next = 0;
+	const transport: HttpTransport = async (opts) => {
+		calls.push({ method: opts.method, url: opts.url, headers: opts.headers, body: opts.body });
+		const scripted = responses[next++];
+		if (scripted === undefined) {
+			throw new Error(`unscripted request #${next}: ${opts.method} ${opts.url}`);
+		}
+		if (scripted.throws !== undefined) throw scripted.throws;
+		return {
+			status: scripted.status ?? 200,
+			body: scripted.body ?? "",
+			...(scripted.headers === undefined ? {} : { headers: scripted.headers }),
+		};
+	};
+	return { transport, calls };
+}
+
+const S3_CFG = { bucket: "b", region: "us-east-1" };
+
+function stubCreds(sessionToken?: string): void {
+	vi.stubEnv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE");
+	vi.stubEnv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
+	vi.stubEnv("AWS_SESSION_TOKEN", sessionToken);
+}
+
+// ── File sink ──
+
+describe("doctorFileSink", () => {
+	it("fails both probes in an ordinary writable store directory", () => {
+		const dir = tmp("doctor-file-");
+		const sinkPath = join(dir, "anchors.jsonl");
+		writeFileSync(sinkPath, "");
+
+		const report = doctorFileSink(sinkPath);
+
+		expect(check(report, "delete-denied").status).toBe("fail");
+		expect(check(report, "overwrite-denied").status).toBe("fail");
+		expect(report.failed).toBe(true);
+	});
+
+	it("removes the probe object it created", () => {
+		const dir = tmp("doctor-file-clean-");
+		const sinkPath = join(dir, "anchors.jsonl");
+		writeFileSync(sinkPath, "");
+
+		doctorFileSink(sinkPath);
+
+		expect(readdirSync(dir).filter((f) => f.startsWith(".doctor-probe"))).toEqual([]);
+		expect(existsSync(sinkPath)).toBe(true);
+	});
+
+	it("worded as a permission probe — never as proof that the store is append-only", () => {
+		const dir = tmp("doctor-file-copy-");
+		const sinkPath = join(dir, "anchors.jsonl");
+		writeFileSync(sinkPath, "");
+
+		const text = copy(doctorFileSink(sinkPath));
+
+		expect(text).toMatch(/this identity could delete a probe object at .+ right now/);
+		expect(text).toMatch(/this identity could overwrite a probe object at .+ right now/);
+		expect(text).not.toMatch(/append-only|immutab|write-once|WORM/i);
+		expect(text).not.toMatch(/proven|guarantee/i);
+	});
+
+	it.skipIf(isRoot)("reports info, not pass, when it cannot create a probe object", () => {
+		const dir = tmp("doctor-file-ro-");
+		const sinkPath = join(dir, "anchors.jsonl");
+		writeFileSync(sinkPath, "");
+		chmodSync(dir, 0o555);
+		try {
+			const report = doctorFileSink(sinkPath);
+
+			expect(report.checks).toHaveLength(1);
+			expect(check(report, "probe").status).toBe("info");
+			expect(check(report, "probe").detail).toMatch(/cannot probe/);
+			// The absence of a delete verdict must not read as a passing one.
+			expect(report.checks.some((c) => c.status === "pass")).toBe(false);
+			expect(report.failed).toBe(false);
+		} finally {
+			chmodSync(dir, 0o700);
+		}
+	});
+
+	it("names the sink it probed", () => {
+		const dir = tmp("doctor-file-name-");
+		const sinkPath = join(dir, "anchors.jsonl");
+		writeFileSync(sinkPath, "");
+
+		expect(doctorFileSink(sinkPath).sink).toBe(`file:${sinkPath}`);
+	});
+});
+
+// ── S3 sink ──
+
+describe("doctorS3Sink", () => {
+	it("passes both probes when the store denies delete and overwrite", async () => {
+		stubCreds();
+		const { transport } = scriptedTransport([
+			{ status: 200 },
+			{ status: 403, body: "<Error><Code>AccessDenied</Code></Error>" },
+			{ status: 403, body: "<Error><Code>AccessDenied</Code></Error>" },
+		]);
+
+		const report = await doctorS3Sink(S3_CFG, transport);
+
+		expect(check(report, "delete-denied").status).toBe("pass");
+		expect(check(report, "overwrite-denied").status).toBe("pass");
+		expect(report.failed).toBe(false);
+		expect(copy(report)).toMatch(/could not delete a probe object at .+ right now/);
+		expect(copy(report)).toMatch(/could not overwrite a probe object at .+ right now/);
+	});
+
+	it("signs a PUT / DELETE / PUT cycle against one probe key", async () => {
+		stubCreds();
+		const { transport, calls } = scriptedTransport([
+			{ status: 200 },
+			{ status: 403 },
+			{ status: 403 },
+		]);
+
+		await doctorS3Sink(S3_CFG, transport);
+
+		expect(calls.map((c) => c.method)).toEqual(["PUT", "DELETE", "PUT"]);
+		const urls = new Set(calls.map((c) => c.url));
+		expect(urls.size).toBe(1);
+		expect(calls[0]?.url).toMatch(
+			/^https:\/\/b\.s3\.us-east-1\.amazonaws\.com\/anchors\/doctor-probe\/\d+-\d{8}T\d{6}Z\.json$/,
+		);
+		for (const call of calls) {
+			expect(call.headers.authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
+			expect(call.headers["x-amz-content-sha256"]).toBe(hashPayload(call.body));
+			expect(call.headers["x-amz-security-token"]).toBeUndefined();
+		}
+		// A probe writes a throwaway object, never store data.
+		expect(calls[0]?.body.length).toBeGreaterThan(0);
+		expect(calls[1]?.body.length).toBe(0);
+	});
+
+	it("carries a session token into the signed request when one is in the environment", async () => {
+		stubCreds("SESSIONTOKENSECRET");
+		const { transport, calls } = scriptedTransport([
+			{ status: 200 },
+			{ status: 403 },
+			{ status: 403 },
+		]);
+
+		await doctorS3Sink(S3_CFG, transport);
+
+		expect(calls[0]?.headers["x-amz-security-token"]).toBe("SESSIONTOKENSECRET");
+	});
+
+	it("fails when the store lets this identity delete and overwrite the probe", async () => {
+		stubCreds();
+		const { transport } = scriptedTransport([{ status: 200 }, { status: 204 }, { status: 200 }]);
+
+		const report = await doctorS3Sink(S3_CFG, transport);
+
+		expect(check(report, "delete-denied").status).toBe("fail");
+		expect(check(report, "overwrite-denied").status).toBe("fail");
+		expect(report.failed).toBe(true);
+		expect(copy(report)).toMatch(/could delete a probe object at .+ right now/);
+	});
+
+	it("reports info, not fail, when an overwrite lands as a new version", async () => {
+		stubCreds();
+		const versioned = { "x-amz-version-id": "3sL4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY" };
+		const { transport } = scriptedTransport([
+			{ status: 200, headers: versioned },
+			{ status: 403 },
+			{ status: 200, headers: versioned },
+		]);
+
+		const report = await doctorS3Sink(S3_CFG, transport);
+
+		expect(check(report, "delete-denied").status).toBe("pass");
+		expect(check(report, "overwrite-denied").status).toBe("info");
+		expect(check(report, "overwrite-denied").detail).toMatch(/version/i);
+		expect(check(report, "overwrite-denied").detail).toMatch(/Object Lock/);
+		expect(report.failed).toBe(false);
+	});
+
+	it("uses a path-style URL against a configured endpoint", async () => {
+		stubCreds();
+		const { transport, calls } = scriptedTransport([
+			{ status: 200 },
+			{ status: 403 },
+			{ status: 403 },
+		]);
+
+		await doctorS3Sink(
+			{ ...S3_CFG, prefix: "vault-anchors", endpoint: "https://s3.example" },
+			transport,
+		);
+
+		expect(calls[0]?.url).toMatch(
+			/^https:\/\/s3\.example\/b\/vault-anchors\/doctor-probe\/\d+-\d{8}T\d{6}Z\.json$/,
+		);
+	});
+
+	it("reports info and stops when the probe object cannot be written at all", async () => {
+		stubCreds();
+		const { transport, calls } = scriptedTransport([
+			{ status: 403, body: "<Error><Code>AccessDenied</Code></Error>" },
+		]);
+
+		const report = await doctorS3Sink(S3_CFG, transport);
+
+		expect(calls).toHaveLength(1);
+		expect(report.checks).toHaveLength(1);
+		expect(check(report, "probe").status).toBe("info");
+		expect(check(report, "probe").detail).toMatch(/cannot probe/);
+		expect(report.failed).toBe(false);
+	});
+
+	it("reports info without touching the network when credentials are absent", async () => {
+		vi.stubEnv("AWS_ACCESS_KEY_ID", undefined);
+		vi.stubEnv("AWS_SECRET_ACCESS_KEY", undefined);
+		const { transport, calls } = scriptedTransport([]);
+
+		const report = await doctorS3Sink(S3_CFG, transport);
+
+		expect(calls).toHaveLength(0);
+		expect(check(report, "probe").status).toBe("info");
+		expect(check(report, "probe").detail).toMatch(/AWS_ACCESS_KEY_ID/);
+		expect(report.failed).toBe(false);
+	});
+
+	it("never echoes the authorization or session-token headers into a probe error", async () => {
+		stubCreds("SESSIONTOKENSECRET");
+		const leak = new Error(
+			"socket hang up while sending headers: authorization=AWS4-HMAC-SHA256 " +
+				"Credential=AKIDEXAMPLE/20260727/us-east-1/s3/aws4_request, Signature=deadbeef; " +
+				"x-amz-security-token=SESSIONTOKENSECRET",
+		);
+		const { transport } = scriptedTransport([{ throws: leak }]);
+
+		const report = await doctorS3Sink(S3_CFG, transport);
+
+		const text = copy(report);
+		expect(text).not.toMatch(/AKIDEXAMPLE/);
+		expect(text).not.toMatch(/SESSIONTOKENSECRET/);
+		expect(text).not.toMatch(/AWS4-HMAC-SHA256/);
+		expect(text).not.toMatch(/Signature=/);
+		expect(check(report, "probe").status).toBe("info");
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-doctor.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-doctor.test.ts
@@ -256,6 +256,33 @@ describe("doctorS3Sink", () => {
 		);
 	});
 
+	it("refuses a plaintext endpoint before a single credential-bearing request leaves (P2-2)", async () => {
+		stubCreds("SESSIONTOKENSECRET");
+		const { transport, calls } = scriptedTransport([]);
+
+		// The doctor signs its probes exactly like the sink does, so an http
+		// endpoint off loopback would put the authorization header on the wire —
+		// and a diagnostic command is where an attacker-suggested URL gets pasted.
+		await expect(
+			doctorS3Sink({ ...S3_CFG, endpoint: "http://attacker.example" }, transport),
+		).rejects.toThrow(/endpoint must be https/);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("still allows a loopback endpoint, matching the sink's rule for dev MinIO", async () => {
+		stubCreds();
+		const { transport, calls } = scriptedTransport([
+			{ status: 200 },
+			{ status: 403 },
+			{ status: 403 },
+		]);
+
+		const report = await doctorS3Sink({ ...S3_CFG, endpoint: "http://localhost:9000" }, transport);
+
+		expect(calls[0]?.url).toMatch(/^http:\/\/localhost:9000\/b\/anchors\/doctor-probe\//);
+		expect(check(report, "delete-denied").status).toBe("pass");
+	});
+
 	it("reports info and stops when the probe object cannot be written at all", async () => {
 		stubCreds();
 		const { transport, calls } = scriptedTransport([

--- a/packages/core/tests/harden/anchoring/anchor-p2-cli.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-p2-cli.test.ts
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — `anchor doctor`, the S3/Rekor sink flags, and `anchor export-bundle`
+ * (plan T6 + deltas D8/D9/D10).
+ *
+ * Two properties are worth more than the surface area they sit on:
+ *
+ *   1. `--sink-rekor` NEVER consumes the token after it. A flag that swallows
+ *      the next argv entry turns `--sink-rekor --sink-file /mnt/worm/a.jsonl`
+ *      into a run with NO file sink, and the operator would only find out at
+ *      audit time (D8).
+ *   2. `export-bundle` is all-or-nothing on stdout. A bundle is what an auditor
+ *      receives INSTEAD of the vault, so a partial one — records present,
+ *      receipts silently dropped because a file failed to parse — is worse than
+ *      no bundle at all. Any parse error means diagnostics on stderr, exit 1,
+ *      and not one byte on stdout (D9).
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { anchorsDir } from "../../../src/audit/anchor.js";
+import type { AnchorRecord } from "../../../src/audit/anchor-verify.js";
+import { verifyVaultWithAnchors } from "../../../src/audit/verify.js";
+import { run as anchorRun } from "../../../src/cli/anchor.js";
+import {
+	type AnchoredSetup,
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	tmp,
+} from "./fixtures.js";
+import { makeRekorReceipt } from "./rekor-fixtures.js";
+
+const origCwd = process.cwd();
+
+afterEach(() => {
+	process.chdir(origCwd);
+	process.exitCode = 0;
+	vi.restoreAllMocks();
+	cleanupAll();
+});
+
+interface CliOutput {
+	out: string[];
+	err: string[];
+}
+
+/** Run the CLI in-process with stdout and stderr captured separately. */
+async function cli(args: string[], json = false): Promise<CliOutput> {
+	const out: string[] = [];
+	const err: string[] = [];
+	const logSpy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+		out.push(a.map(String).join(" "));
+	});
+	const errSpy = vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+		err.push(a.map(String).join(" "));
+	});
+	try {
+		await anchorRun(args, { json });
+	} finally {
+		logSpy.mockRestore();
+		errSpy.mockRestore();
+	}
+	return { out, err };
+}
+
+interface DoctorJson {
+	success: boolean;
+	data: {
+		failed: boolean;
+		reports: { sink: string; failed: boolean; checks: { name: string; status: string }[] }[];
+	};
+}
+
+const doctorJson = (o: CliOutput): DoctorJson => JSON.parse(o.out.at(-1) as string) as DoctorJson;
+
+interface Bundle {
+	v: number;
+	records: AnchorRecord[];
+	rekorReceipts: unknown[];
+}
+
+/** A vault with two anchors in its local mirror. */
+async function twoAnchorVault(): Promise<{ s: AnchoredSetup; records: AnchorRecord[] }> {
+	const s = await makeAnchoredVault(3);
+	const first = await anchorOnce(s);
+	await appendEvents(s.root, 2, 4);
+	const second = await anchorOnce(s);
+	return { s, records: [first, second] };
+}
+
+/** Place a receipt where the Rekor sink writes them: audit/anchors/rekor/<seq12>.json */
+function placeReceipt(root: string, anchorSeq: number, body: string): void {
+	const dir = join(anchorsDir(root), "rekor");
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(join(dir, `${String(anchorSeq).padStart(12, "0")}.json`), body);
+}
+
+describe("HARDEN: `anchor doctor` reports what this identity can do to the store", () => {
+	it("1. a deletable file-sink directory fails the probe (exit 1, failed:true)", async () => {
+		const dir = tmp("doctor-cli-");
+		const sink = join(dir, "anchors.jsonl");
+		writeFileSync(sink, "");
+
+		const o = await cli(["doctor", "--sink-file", sink], true);
+
+		const parsed = doctorJson(o);
+		expect(parsed.success).toBe(false);
+		expect(parsed.data.failed).toBe(true);
+		expect(parsed.data.reports).toHaveLength(1);
+		expect(parsed.data.reports[0]?.sink).toBe(`file:${sink}`);
+		expect(parsed.data.reports[0]?.failed).toBe(true);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("2. human output carries the permission-probe wording, never a proof claim", async () => {
+		const dir = tmp("doctor-copy-");
+		const sink = join(dir, "anchors.jsonl");
+		writeFileSync(sink, "");
+
+		const o = await cli(["doctor", "--sink-file", sink]);
+
+		const text = o.out.join("\n");
+		expect(text).toMatch(/could delete a probe object at .* right now/);
+		expect(text).not.toMatch(/append-only.{0,40}(proven|verified|guaranteed)/i);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("3. url and transparency-log sinks report info rows instead of a probe", async () => {
+		const o = await cli(["doctor", "--sink-url", "https://ingest.example/anchors"], true);
+
+		const parsed = doctorJson(o);
+		expect(parsed.success).toBe(true);
+		expect(parsed.data.failed).toBe(false);
+		expect(parsed.data.reports[0]?.sink).toBe("https:https://ingest.example/anchors");
+		expect(parsed.data.reports[0]?.checks[0]?.status).toBe("info");
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("4. probing nothing is an error, not a silent pass", async () => {
+		const o = await cli(["doctor"], true);
+
+		expect(JSON.parse(o.out.at(-1) as string).success).toBe(false);
+		expect(o.out.join("\n")).toMatch(/no sink configured/);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("HARDEN: sink flag parsing (--sink-s3, --sink-rekor)", () => {
+	it("5. --sink-s3 without a region fails loudly instead of guessing one", async () => {
+		const o = await cli(["doctor", "--sink-s3", "bucket=b"], true);
+
+		const parsed = JSON.parse(o.out.at(-1) as string);
+		expect(parsed.success).toBe(false);
+		expect(parsed.data.message).toMatch(/--sink-s3/);
+		expect(parsed.data.message).toMatch(/region/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("6. --sink-s3 rejects unknown keys", async () => {
+		const o = await cli(["doctor", "--sink-s3", "bucket=b,region=us-east-1,bukcet=typo"], true);
+
+		expect(JSON.parse(o.out.at(-1) as string).data.message).toMatch(/bukcet/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("7. bare --sink-rekor takes the default log and does NOT eat the next token", async () => {
+		const dir = tmp("rekor-flag-");
+		const sink = join(dir, "anchors.jsonl");
+		writeFileSync(sink, "");
+
+		const o = await cli(["doctor", "--sink-rekor", "--sink-file", sink], true);
+
+		const reports = doctorJson(o).data.reports;
+		expect(reports.map((r) => r.sink)).toEqual([
+			"rekor:https://rekor.sigstore.dev",
+			`file:${sink}`,
+		]);
+	});
+
+	it("8. --sink-rekor=<url> pins a custom log", async () => {
+		const o = await cli(["doctor", "--sink-rekor=https://log.internal:8443"], true);
+
+		expect(doctorJson(o).data.reports[0]?.sink).toBe("rekor:https://log.internal:8443");
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("9. the space-separated form is refused rather than silently routed to the default", async () => {
+		const o = await cli(["doctor", "--sink-rekor", "https://log.internal"], true);
+
+		expect(JSON.parse(o.out.at(-1) as string).data.message).toMatch(/--sink-rekor=<url>/);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("HARDEN: `anchor export-bundle`", () => {
+	it("10. bundles the mirror records together with the receipts on disk", async () => {
+		const { s, records } = await twoAnchorVault();
+		const f = makeRekorReceipt(records[1] as AnchorRecord);
+		placeReceipt(s.root, 2, JSON.stringify(f.receipt));
+		process.chdir(s.root);
+
+		const o = await cli(["export-bundle"]);
+
+		expect(o.out).toHaveLength(1);
+		const bundle = JSON.parse(o.out[0] as string) as Bundle;
+		expect(bundle.v).toBe(1);
+		expect(bundle.records).toHaveLength(2);
+		expect(bundle.records.map((r) => r.anchorSeq)).toEqual([1, 2]);
+		expect(bundle.rekorReceipts).toHaveLength(1);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("11. the exported bundle verifies the vault it came from (round trip)", async () => {
+		const { s, records } = await twoAnchorVault();
+		const f = makeRekorReceipt(records[1] as AnchorRecord);
+		placeReceipt(s.root, 2, JSON.stringify(f.receipt));
+		process.chdir(s.root);
+
+		const bundle = JSON.parse((await cli(["export-bundle"])).out[0] as string) as Bundle;
+		process.chdir(origCwd);
+
+		const result = verifyVaultWithAnchors(s.vaultPath, {
+			externalAnchorsRaw: [bundle.records.map((r) => JSON.stringify(r)).join("\n")],
+			rekorReceiptsRaw: bundle.rekorReceipts.map((r) => JSON.stringify(r)),
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+			trust: s.trust,
+			witness: { requested: false },
+		});
+
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.rekor?.receiptsVerified).toBe(1);
+		expect(result.anchoring.rekor?.receiptsFailed).toBe(0);
+	});
+
+	it("12. --since drops everything already shipped, and an empty bundle is still valid", async () => {
+		const { s, records } = await twoAnchorVault();
+		placeReceipt(s.root, 2, JSON.stringify(makeRekorReceipt(records[1] as AnchorRecord).receipt));
+		process.chdir(s.root);
+
+		const since1 = JSON.parse(
+			(await cli(["export-bundle", "--since", "1"])).out[0] as string,
+		) as Bundle;
+		expect(since1.records.map((r) => r.anchorSeq)).toEqual([2]);
+		expect(since1.rekorReceipts).toHaveLength(1);
+
+		const since2 = JSON.parse(
+			(await cli(["export-bundle", "--since", "2"])).out[0] as string,
+		) as Bundle;
+		expect(since2.records).toEqual([]);
+		expect(since2.rekorReceipts).toEqual([]);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("13. a corrupt receipt file fails the export closed — stderr, exit 1, NO stdout", async () => {
+		const { s, records } = await twoAnchorVault();
+		placeReceipt(s.root, 1, JSON.stringify(makeRekorReceipt(records[0] as AnchorRecord).receipt));
+		placeReceipt(s.root, 2, "{ this is not a receipt");
+		process.chdir(s.root);
+
+		const o = await cli(["export-bundle"]);
+
+		expect(o.out).toEqual([]);
+		expect(o.err.join("\n")).toMatch(/000000000002\.json/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("14. a receipt that parses but is structurally invalid also fails closed", async () => {
+		const { s } = await twoAnchorVault();
+		placeReceipt(s.root, 2, JSON.stringify({ v: 1, vaultId: "x", anchorSeq: 2 }));
+		process.chdir(s.root);
+
+		const o = await cli(["export-bundle"], true);
+
+		expect(o.out).toEqual([]);
+		expect(o.err.join("\n")).toMatch(/rekor-receipt-invalid/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("15. --since must be a non-negative integer", async () => {
+		const { s } = await twoAnchorVault();
+		process.chdir(s.root);
+
+		const o = await cli(["export-bundle", "--since", "1O"]);
+
+		expect(o.out).toEqual([]);
+		expect(o.err.join("\n")).toMatch(/--since/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("16. a vault with no mirror exports nothing at all", async () => {
+		const root = tmp("bundle-empty-");
+		await appendEvents(root, 2);
+		process.chdir(root);
+
+		const o = await cli(["export-bundle"]);
+
+		expect(o.out).toEqual([]);
+		expect(o.err.join("\n")).toMatch(/mirror/);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("HARDEN: usage text", () => {
+	it("17. lists the new actions and sink flags", async () => {
+		const o = await cli([]);
+
+		const usage = o.out.join("\n");
+		expect(usage).toMatch(/export-bundle/);
+		expect(usage).toMatch(/doctor/);
+		expect(usage).toMatch(/--sink-s3/);
+		expect(usage).toMatch(/--sink-rekor/);
+	});
+});

--- a/packages/core/tests/harden/anchoring/anchor-p2-cli.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-p2-cli.test.ts
@@ -5,17 +5,23 @@
  * HARDEN — `anchor doctor`, the S3/Rekor sink flags, and `anchor export-bundle`
  * (plan T6 + deltas D8/D9/D10).
  *
- * Two properties are worth more than the surface area they sit on:
+ * These properties are worth more than the surface area they sit on:
  *
  *   1. `--sink-rekor` NEVER consumes the token after it. A flag that swallows
  *      the next argv entry turns `--sink-rekor --sink-file /mnt/worm/a.jsonl`
  *      into a run with NO file sink, and the operator would only find out at
  *      audit time (D8).
- *   2. `export-bundle` is all-or-nothing on stdout. A bundle is what an auditor
+ *   2. A sink flag whose value is missing is fatal. The mirror-image failure of
+ *      (1): `anchor now --sink-s3` parsing to zero sinks means the anchor is
+ *      signed, mirrored locally, published NOWHERE, and reported as success.
+ *   3. `export-bundle` is all-or-nothing on stdout. A bundle is what an auditor
  *      receives INSTEAD of the vault, so a partial one — records present,
  *      receipts silently dropped because a file failed to parse — is worse than
  *      no bundle at all. Any parse error means diagnostics on stderr, exit 1,
  *      and not one byte on stdout (D9).
+ *   4. …with exactly one exception, which is not a parse failure: receipts
+ *      orphaned by `anchor resume` are excluded with a warning, because
+ *      including them would make the verifier reject the whole bundle.
  */
 
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -23,6 +29,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { anchorsDir } from "../../../src/audit/anchor.js";
 import type { AnchorRecord } from "../../../src/audit/anchor-verify.js";
+import type { RekorReceipt } from "../../../src/audit/rekor-verify.js";
 import { verifyVaultWithAnchors } from "../../../src/audit/verify.js";
 import { run as anchorRun } from "../../../src/cli/anchor.js";
 import {
@@ -81,7 +88,7 @@ const doctorJson = (o: CliOutput): DoctorJson => JSON.parse(o.out.at(-1) as stri
 interface Bundle {
 	v: number;
 	records: AnchorRecord[];
-	rekorReceipts: unknown[];
+	rekorReceipts: RekorReceipt[];
 }
 
 /** A vault with two anchors in its local mirror. */
@@ -314,5 +321,95 @@ describe("HARDEN: usage text", () => {
 		expect(usage).toMatch(/doctor/);
 		expect(usage).toMatch(/--sink-s3/);
 		expect(usage).toMatch(/--sink-rekor/);
+	});
+});
+
+describe("HARDEN: a sink flag with no value never degrades into publishing nowhere", () => {
+	// `anchor now --sink-s3` used to parse to ZERO sinks: the record was signed
+	// and mirrored locally, nothing was published, and the exit code said 0. The
+	// operator finds out at audit time, which is the worst possible moment.
+	const flags = ["--sink-file", "--sink-url", "--sink-s3"] as const;
+	flags.forEach((flag, i) => {
+		it(`${18 + i}. \`anchor now ${flag}\` with a missing value exits 1`, async () => {
+			const o = await cli(["now", flag], true);
+
+			const parsed = JSON.parse(o.out.at(-1) as string);
+			expect(parsed.success).toBe(false);
+			expect(parsed.data.message).toBe(`${flag} requires a value`);
+			expect(process.exitCode).toBe(1);
+		});
+	});
+});
+
+describe("HARDEN: `anchor export` --since", () => {
+	it("21. a non-numeric --since is refused, not silently read as NaN", async () => {
+		const { s } = await twoAnchorVault();
+		process.chdir(s.root);
+
+		const o = await cli(["export", "--since", "abc"]);
+
+		// NaN made every `anchorSeq > since` false, so the command printed no
+		// records and exited 0 — indistinguishable from "nothing left to ship".
+		expect(o.out).toEqual([]);
+		expect(o.err.join("\n")).toMatch(/--since/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("22. a valid --since still filters normally", async () => {
+		const { s } = await twoAnchorVault();
+		process.chdir(s.root);
+
+		const o = await cli(["export", "--since", "1"]);
+
+		expect(o.out.map((line) => (JSON.parse(line) as AnchorRecord).anchorSeq)).toEqual([2]);
+		expect(process.exitCode).toBe(0);
+	});
+});
+
+describe("HARDEN: export-bundle never ships a receipt the verifier would reject", () => {
+	it("23. a receipt with no record in the mirror is excluded with a stderr warning", async () => {
+		const { s, records } = await twoAnchorVault();
+		placeReceipt(s.root, 1, JSON.stringify(makeRekorReceipt(records[0] as AnchorRecord).receipt));
+		placeReceipt(s.root, 2, JSON.stringify(makeRekorReceipt(records[1] as AnchorRecord).receipt));
+		// The shape `anchor resume` leaves behind: receipts on disk for anchors
+		// whose records are no longer in the re-seeded mirror. Bundling one makes
+		// the verifier hard-fail with "receipt for unknown anchorSeq".
+		const orphan: RekorReceipt = {
+			...makeRekorReceipt(records[1] as AnchorRecord).receipt,
+			anchorSeq: 3,
+		};
+		placeReceipt(s.root, 3, JSON.stringify(orphan));
+		process.chdir(s.root);
+
+		const o = await cli(["export-bundle"]);
+
+		const bundle = JSON.parse(o.out[0] as string) as Bundle;
+		expect(bundle.records.map((r) => r.anchorSeq)).toEqual([1, 2]);
+		expect(bundle.rekorReceipts.map((r) => r.anchorSeq)).toEqual([1, 2]);
+		expect(o.err.join("\n")).toContain(
+			"export-bundle: excluding receipt for anchorSeq 3 (no matching record in mirror — " +
+				"re-fetch the full history to include it)",
+		);
+		// Expected after a resume, so it is a warning and not a failure (D9's
+		// fail-closed rule covers PARSE errors, which this is not).
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("24. receipts are keyed by the anchorSeq inside them, not by their filename", async () => {
+		const { s, records } = await twoAnchorVault();
+		const dir = join(anchorsDir(s.root), "rekor");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			join(dir, "000000000002.a1b2c3d4.json"),
+			JSON.stringify(makeRekorReceipt(records[1] as AnchorRecord).receipt),
+		);
+		process.chdir(s.root);
+
+		const o = await cli(["export-bundle"]);
+
+		const bundle = JSON.parse(o.out[0] as string) as Bundle;
+		expect(bundle.rekorReceipts.map((r) => r.anchorSeq)).toEqual([2]);
+		expect(o.err).toEqual([]);
+		expect(process.exitCode).toBe(0);
 	});
 });

--- a/packages/core/tests/harden/anchoring/anchor-p2-transport.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-p2-transport.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Coverage for the default network transport in rekor.ts (the module's only
+ * impure escape hatch — exercised against a local node:http server via the
+ * documented localhost-http dev allowance) and the inconclusive/unprobeable
+ * verdict branches of the s3 doctor.
+ */
+
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { doctorS3Sink } from "../../../src/audit/anchor-doctor.js";
+import { rekorSink, s3Sink } from "../../../src/audit/rekor.js";
+import { anchorOnce, cleanupAll, makeAnchoredVault } from "./fixtures.js";
+
+let server: Server | null = null;
+
+afterEach(async () => {
+	vi.unstubAllEnvs();
+	if (server !== null) {
+		await new Promise<void>((resolve) => server?.close(() => resolve()));
+		server = null;
+	}
+	cleanupAll();
+});
+
+function startServer(handler: Parameters<typeof createServer>[1]): Promise<number> {
+	server = createServer(handler);
+	return new Promise((resolve) => {
+		server?.listen(0, "127.0.0.1", () => {
+			const addr = server?.address();
+			resolve(typeof addr === "object" && addr !== null ? addr.port : 0);
+		});
+	});
+}
+
+describe("default transport (localhost http dev allowance)", () => {
+	it("s3 sink publishes through the real transport to a local endpoint", async () => {
+		const s = await makeAnchoredVault(2);
+		const record = await anchorOnce(s);
+		const seen: { method?: string; url?: string; auth?: string } = {};
+		const port = await startServer((req, res) => {
+			seen.method = req.method ?? "";
+			seen.url = req.url ?? "";
+			seen.auth = String(req.headers.authorization ?? "");
+			req.resume();
+			req.on("end", () => {
+				res.writeHead(200);
+				res.end();
+			});
+		});
+		vi.stubEnv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE");
+		vi.stubEnv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
+		const sink = s3Sink({
+			bucket: "probe-bucket",
+			region: "us-east-1",
+			endpoint: `http://127.0.0.1:${port}`,
+		});
+		await sink.publish(record);
+		expect(seen.method).toBe("PUT");
+		expect(seen.url).toContain("/probe-bucket/");
+		expect(seen.auth).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
+	});
+
+	it("rekor sink surfaces a non-201 through the real transport without leaking headers", async () => {
+		const s = await makeAnchoredVault(2);
+		const record = await anchorOnce(s);
+		const port = await startServer((req, res) => {
+			req.resume();
+			req.on("end", () => {
+				res.writeHead(500);
+				res.end("upstream exploded");
+			});
+		});
+		const sink = rekorSink(s.root, `http://127.0.0.1:${port}`);
+		await expect(sink.publish(record)).rejects.toThrow(/rekor sink: HTTP 500/);
+		try {
+			await sink.publish(record);
+		} catch (err) {
+			expect(String(err)).not.toMatch(/authorization|x-amz-security-token/i);
+		}
+	});
+});
+
+describe("s3 doctor verdict branches", () => {
+	it("non-403 non-2xx mutation responses report inconclusive, transport errors report unprobeable", async () => {
+		vi.stubEnv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE");
+		vi.stubEnv("AWS_SECRET_ACCESS_KEY", "secret");
+		const scripted = (answers: (number | Error)[]): Parameters<typeof doctorS3Sink>[1] => {
+			let i = 0;
+			return async () => {
+				const a = answers[i++];
+				if (a instanceof Error) throw a;
+				return { status: a as number, body: "", headers: {} };
+			};
+		};
+		// PUT ok, DELETE 500 (inconclusive), overwrite PUT 403 (denied).
+		const inconclusive = await doctorS3Sink(
+			{ bucket: "b", region: "us-east-1" },
+			scripted([200, 500, 403]),
+		);
+		expect(inconclusive.failed).toBe(false);
+		expect(
+			inconclusive.checks.some((c) => c.status === "info" && /inconclusive/.test(c.detail)),
+		).toBe(true);
+		// Probe PUT itself fails at the transport → cannot probe at all.
+		const unprobeable = await doctorS3Sink(
+			{ bucket: "b", region: "us-east-1" },
+			scripted([new Error("ECONNREFUSED")]),
+		);
+		expect(unprobeable.failed).toBe(false);
+		expect(unprobeable.checks.every((c) => c.status !== "fail")).toBe(true);
+	});
+});

--- a/packages/core/tests/harden/anchoring/rekor-fixtures.ts
+++ b/packages/core/tests/harden/anchoring/rekor-fixtures.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Synthetic transparency-log fixtures for the Rekor receipt corpus.
+ *
+ * The Merkle primitives here are an INDEPENDENT reference implementation of
+ * RFC 6962 §2.1 (MTH) and §2.1.1 (PATH) — deliberately recursive and
+ * deliberately NOT sharing code with src/audit/merkle.ts or the RFC 9162
+ * index-walk verifier under test. A verifier checked against its own algorithm
+ * proves nothing; the property test drives this reference against
+ * verifyIndexInclusion for every (treeSize <= 20, index) pair.
+ */
+
+import {
+	createHash,
+	sign as cryptoSign,
+	generateKeyPairSync,
+	type KeyObject,
+	randomBytes,
+} from "node:crypto";
+import { type AnchorRecord, anchorPayloadHash } from "../../../src/audit/anchor-verify.js";
+import { canonicalize } from "../../../src/audit/canonical.js";
+import type { RekorReceipt } from "../../../src/audit/rekor-verify.js";
+
+const LEAF_PREFIX = Buffer.from([0x00]);
+const NODE_PREFIX = Buffer.from([0x01]);
+
+/** RFC 6962 leaf hash: sha256(0x00 || entry). */
+export function leafHash(entry: Buffer): Buffer {
+	return createHash("sha256").update(LEAF_PREFIX).update(entry).digest();
+}
+
+function nodeHash(left: Buffer, right: Buffer): Buffer {
+	return createHash("sha256").update(NODE_PREFIX).update(left).update(right).digest();
+}
+
+/** Largest power of two strictly less than n (n > 1). */
+function splitPoint(n: number): number {
+	let k = 1;
+	while (k * 2 < n) k *= 2;
+	return k;
+}
+
+/** RFC 6962 §2.1 MTH(D[n]) over raw entries. */
+export function mth(leaves: readonly Buffer[]): Buffer {
+	if (leaves.length === 0) return createHash("sha256").digest();
+	if (leaves.length === 1) return leafHash(leaves[0] as Buffer);
+	const k = splitPoint(leaves.length);
+	return nodeHash(mth(leaves.slice(0, k)), mth(leaves.slice(k)));
+}
+
+/**
+ * RFC 6962 §2.1.1 PATH(m, D[n]) — the audit path for leaf m, leaf->root order.
+ * PATH(m, D[1]) = {}; with k = largest power of two < n,
+ * m < k  => PATH(m, D[0:k]) : MTH(D[k:n]),
+ * m >= k => PATH(m - k, D[k:n]) : MTH(D[0:k]).
+ */
+export function inclusionPath(m: number, leaves: readonly Buffer[]): Buffer[] {
+	const n = leaves.length;
+	if (n === 1) return [];
+	const k = splitPoint(n);
+	if (m < k) return [...inclusionPath(m, leaves.slice(0, k)), mth(leaves.slice(k))];
+	return [...inclusionPath(m - k, leaves.slice(k)), mth(leaves.slice(0, k))];
+}
+
+/**
+ * Build a signed note (checkpoint) exactly as the verifier parses it:
+ * `<origin>\n<treeSize>\n<base64 root>\n\n— <origin> <base64(keyhint || DER sig)>\n`
+ * The signature covers the 3 body lines INCLUDING their trailing LF.
+ */
+export function signedNote(
+	origin: string,
+	treeSize: number,
+	root: Buffer,
+	signKey: KeyObject,
+	keyhint: Buffer = Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+): string {
+	const body = `${origin}\n${treeSize}\n${root.toString("base64")}\n`;
+	const der = cryptoSign("sha256", Buffer.from(body, "utf8"), {
+		key: signKey,
+		dsaEncoding: "der",
+	});
+	const noteSig = Buffer.concat([keyhint, der]).toString("base64");
+	return `${body}\n— ${origin} ${noteSig}\n`;
+}
+
+export interface SyntheticLog {
+	treeSize: number;
+	rootHex: string;
+	checkpoint: string;
+	pathFor(index: number): string[];
+}
+
+/** A whole synthetic log: root, a signed checkpoint over it, and audit paths. */
+export function makeSyntheticLog(
+	entries: readonly Buffer[],
+	signKey: KeyObject,
+	origin: string,
+): SyntheticLog {
+	const root = mth(entries);
+	return {
+		treeSize: entries.length,
+		rootHex: root.toString("hex"),
+		checkpoint: signedNote(origin, entries.length, root, signKey),
+		pathFor: (index: number): string[] =>
+			inclusionPath(index, entries).map((h) => h.toString("hex")),
+	};
+}
+
+/** Stand-in for the record signer's public key inside the logged entry body. */
+const FIXTURE_RECORD_PUBKEY_PEM = generateKeyPairSync("ed25519").publicKey.export({
+	type: "spki",
+	format: "pem",
+}) as string;
+
+/** The hashedrekord entry body the Rekor sink (T3) proposes for a record. */
+export function hashedRekordEntry(record: AnchorRecord, publicKeyPem: string): Buffer {
+	return Buffer.from(
+		canonicalize({
+			apiVersion: "0.0.1",
+			kind: "hashedrekord",
+			spec: {
+				data: { hash: { algorithm: "sha256", value: anchorPayloadHash(record) } },
+				signature: {
+					content: record.sig,
+					publicKey: { content: Buffer.from(publicKeyPem, "utf8").toString("base64") },
+				},
+			},
+		}),
+		"utf8",
+	);
+}
+
+export interface RekorFixtureOptions {
+	logSize?: number;
+	logIndex?: number;
+	origin?: string;
+	url?: string;
+	integratedTime?: number;
+	publicKeyPem?: string;
+}
+
+export interface RekorFixture {
+	receipt: RekorReceipt;
+	logPubkeyPem: string;
+	logPrivateKey: KeyObject;
+	entryBody: Buffer;
+	/** Deep copy with `mutate` applied — the adversarial-mutation driver. */
+	tamper(mutate: (receipt: RekorReceipt) => void): RekorReceipt;
+}
+
+/**
+ * A complete, verifying receipt for a REAL anchor record: the record's entry is
+ * planted at `logIndex` in a synthetic log of `logSize` entries, and the
+ * checkpoint is signed by a freshly generated P-256 log key.
+ */
+export function makeRekorReceipt(
+	record: AnchorRecord,
+	opts: RekorFixtureOptions = {},
+): RekorFixture {
+	const url = opts.url ?? "https://rekor.sigstore.dev";
+	const origin = opts.origin ?? new URL(url).host;
+	const logSize = opts.logSize ?? 8;
+	const logIndex = opts.logIndex ?? logSize - 1;
+	const entry = hashedRekordEntry(record, opts.publicKeyPem ?? FIXTURE_RECORD_PUBKEY_PEM);
+	const entries: Buffer[] = [];
+	for (let i = 0; i < logSize; i++) {
+		entries.push(i === logIndex ? entry : randomBytes(48));
+	}
+	const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+	const log = makeSyntheticLog(entries, privateKey, origin);
+	const receipt: RekorReceipt = {
+		v: 1,
+		vaultId: record.vaultId,
+		anchorSeq: record.anchorSeq,
+		artifactHash: anchorPayloadHash(record),
+		entryBody: entry.toString("base64"),
+		log: {
+			url,
+			logIndex,
+			treeSize: logSize,
+			rootHash: log.rootHex,
+			hashes: log.pathFor(logIndex),
+			checkpoint: log.checkpoint,
+			integratedTime: opts.integratedTime ?? 1_760_000_000,
+		},
+	};
+	return {
+		receipt,
+		logPubkeyPem: publicKey.export({ type: "spki", format: "pem" }) as string,
+		logPrivateKey: privateKey,
+		entryBody: entry,
+		tamper: (mutate: (receipt: RekorReceipt) => void): RekorReceipt => {
+			const copy = JSON.parse(JSON.stringify(receipt)) as RekorReceipt;
+			mutate(copy);
+			return copy;
+		},
+	};
+}

--- a/packages/core/tests/harden/anchoring/rekor-fixtures.ts
+++ b/packages/core/tests/harden/anchoring/rekor-fixtures.ts
@@ -68,6 +68,11 @@ export function inclusionPath(m: number, leaves: readonly Buffer[]): Buffer[] {
  * Build a signed note (checkpoint) exactly as the verifier parses it:
  * `<origin>\n<treeSize>\n<base64 root>\n\n— <origin> <base64(keyhint || DER sig)>\n`
  * The signature covers the 3 body lines INCLUDING their trailing LF.
+ *
+ * `extraSignatureLines` are emitted BEFORE the log's own signature, which is
+ * where a witness co-signature sits on a real checkpoint — and which position
+ * matters: a verifier that only ever looked at the first line would miss the
+ * one signature that counts.
  */
 export function signedNote(
 	origin: string,
@@ -75,6 +80,7 @@ export function signedNote(
 	root: Buffer,
 	signKey: KeyObject,
 	keyhint: Buffer = Buffer.from([0xde, 0xad, 0xbe, 0xef]),
+	extraSignatureLines: readonly string[] = [],
 ): string {
 	const body = `${origin}\n${treeSize}\n${root.toString("base64")}\n`;
 	const der = cryptoSign("sha256", Buffer.from(body, "utf8"), {
@@ -82,13 +88,36 @@ export function signedNote(
 		dsaEncoding: "der",
 	});
 	const noteSig = Buffer.concat([keyhint, der]).toString("base64");
-	return `${body}\n— ${origin} ${noteSig}\n`;
+	// The signature line names a KEY, not the origin: a production origin is
+	// `"<host> - <treeID>"` and a note's key name may not contain spaces, so the
+	// log signs `— <host> <sig>` under either origin form.
+	const separator = origin.indexOf(" - ");
+	const keyName = separator === -1 ? origin : origin.slice(0, separator);
+	const signatures = [...extraSignatureLines, `— ${keyName} ${noteSig}`];
+	return `${body}\n${signatures.join("\n")}\n`;
+}
+
+/** A well-formed signature line that no pinned key will ever verify. */
+export function bogusSignatureLine(name = "witness.example.org"): string {
+	return `— ${name} ${randomBytes(76).toString("base64")}`;
+}
+
+export interface SyntheticLogOptions {
+	/**
+	 * Emit the origin form a PRODUCTION Rekor checkpoint uses,
+	 * `"<host> - <treeID>"`, instead of the bare host.
+	 */
+	treeId?: string;
+	/** Witness co-signatures to carry alongside the log's own. */
+	extraSignatureLines?: readonly string[];
 }
 
 export interface SyntheticLog {
 	treeSize: number;
 	rootHex: string;
 	checkpoint: string;
+	/** The origin actually signed into the checkpoint. */
+	origin: string;
 	pathFor(index: number): string[];
 }
 
@@ -97,12 +126,22 @@ export function makeSyntheticLog(
 	entries: readonly Buffer[],
 	signKey: KeyObject,
 	origin: string,
+	opts: SyntheticLogOptions = {},
 ): SyntheticLog {
 	const root = mth(entries);
+	const signedOrigin = opts.treeId === undefined ? origin : `${origin} - ${opts.treeId}`;
 	return {
 		treeSize: entries.length,
 		rootHex: root.toString("hex"),
-		checkpoint: signedNote(origin, entries.length, root, signKey),
+		origin: signedOrigin,
+		checkpoint: signedNote(
+			signedOrigin,
+			entries.length,
+			root,
+			signKey,
+			undefined,
+			opts.extraSignatureLines ?? [],
+		),
 		pathFor: (index: number): string[] =>
 			inclusionPath(index, entries).map((h) => h.toString("hex")),
 	};
@@ -139,6 +178,10 @@ export interface RekorFixtureOptions {
 	url?: string;
 	integratedTime?: number;
 	publicKeyPem?: string;
+	/** Emit the production origin form `"<host> - <treeID>"`. */
+	treeId?: string;
+	/** Witness co-signature lines carried ahead of the log's own signature. */
+	extraSignatureLines?: readonly string[];
 }
 
 export interface RekorFixture {
@@ -169,7 +212,12 @@ export function makeRekorReceipt(
 		entries.push(i === logIndex ? entry : randomBytes(48));
 	}
 	const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
-	const log = makeSyntheticLog(entries, privateKey, origin);
+	const log = makeSyntheticLog(entries, privateKey, origin, {
+		...(opts.treeId === undefined ? {} : { treeId: opts.treeId }),
+		...(opts.extraSignatureLines === undefined
+			? {}
+			: { extraSignatureLines: opts.extraSignatureLines }),
+	});
 	const receipt: RekorReceipt = {
 		v: 1,
 		vaultId: record.vaultId,

--- a/packages/core/tests/harden/anchoring/rekor-fixtures.ts
+++ b/packages/core/tests/harden/anchoring/rekor-fixtures.ts
@@ -14,6 +14,7 @@
 
 import {
 	createHash,
+	createPublicKey,
 	sign as cryptoSign,
 	generateKeyPairSync,
 	type KeyObject,
@@ -102,6 +103,41 @@ export function bogusSignatureLine(name = "witness.example.org"): string {
 	return `— ${name} ${randomBytes(76).toString("base64")}`;
 }
 
+/** The log's ID the way Rekor derives it: sha256 of the log key's SPKI DER. */
+export function logIdFor(signKey: KeyObject): string {
+	// @types/node 26 dropped KeyObject from createPublicKey's input union; Node
+	// derives the public key from a private KeyObject at runtime (documented).
+	const pub = createPublicKey(signKey as unknown as Parameters<typeof createPublicKey>[0]);
+	return createHash("sha256")
+		.update(pub.export({ type: "spki", format: "der" }) as Buffer)
+		.digest("hex");
+}
+
+/** Sorted-key JSON — the SET payload form the verifier reconstructs. */
+function sortedKeyStringify(value: Record<string, string | number>): string {
+	const fields = Object.keys(value)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${JSON.stringify(value[key])}`);
+	return `{${fields.join(",")}}`;
+}
+
+/**
+ * The log's signed entry timestamp: an ECDSA signature over the sorted-key JSON
+ * of `{body, integratedTime, logID, logIndex}`. This is the ONLY signature that
+ * covers integratedTime, which is what makes it the thing an attacker who can
+ * edit a receipt cannot reproduce — the checkpoint says nothing about time.
+ */
+export function signedEntryTimestamp(
+	fields: { body: string; integratedTime: number; logID: string; logIndex: number },
+	signKey: KeyObject,
+): string {
+	const payload = sortedKeyStringify({ ...fields });
+	return cryptoSign("sha256", Buffer.from(payload, "utf8"), {
+		key: signKey,
+		dsaEncoding: "der",
+	}).toString("base64");
+}
+
 export interface SyntheticLogOptions {
 	/**
 	 * Emit the origin form a PRODUCTION Rekor checkpoint uses,
@@ -118,7 +154,11 @@ export interface SyntheticLog {
 	checkpoint: string;
 	/** The origin actually signed into the checkpoint. */
 	origin: string;
+	/** 64-hex log identity, part of every SET payload this log signs. */
+	logId: string;
 	pathFor(index: number): string[];
+	/** A signed entry timestamp from THIS log's key, over these exact fields. */
+	setFor(fields: { body: string; integratedTime: number; logIndex: number }): string;
 }
 
 /** A whole synthetic log: root, a signed checkpoint over it, and audit paths. */
@@ -130,10 +170,12 @@ export function makeSyntheticLog(
 ): SyntheticLog {
 	const root = mth(entries);
 	const signedOrigin = opts.treeId === undefined ? origin : `${origin} - ${opts.treeId}`;
+	const logId = logIdFor(signKey);
 	return {
 		treeSize: entries.length,
 		rootHex: root.toString("hex"),
 		origin: signedOrigin,
+		logId,
 		checkpoint: signedNote(
 			signedOrigin,
 			entries.length,
@@ -144,6 +186,7 @@ export function makeSyntheticLog(
 		),
 		pathFor: (index: number): string[] =>
 			inclusionPath(index, entries).map((h) => h.toString("hex")),
+		setFor: (fields): string => signedEntryTimestamp({ ...fields, logID: logId }, signKey),
 	};
 }
 
@@ -182,12 +225,19 @@ export interface RekorFixtureOptions {
 	treeId?: string;
 	/** Witness co-signature lines carried ahead of the log's own signature. */
 	extraSignatureLines?: readonly string[];
+	/**
+	 * Emit the signed entry timestamp (default true). A log that omits it still
+	 * proves INCLUSION — it just cannot attest when, which is what a receipt
+	 * built with `withSet: false` exists to exercise.
+	 */
+	withSet?: boolean;
 }
 
 export interface RekorFixture {
 	receipt: RekorReceipt;
 	logPubkeyPem: string;
 	logPrivateKey: KeyObject;
+	logId: string;
 	entryBody: Buffer;
 	/** Deep copy with `mutate` applied — the adversarial-mutation driver. */
 	tamper(mutate: (receipt: RekorReceipt) => void): RekorReceipt;
@@ -195,8 +245,10 @@ export interface RekorFixture {
 
 /**
  * A complete, verifying receipt for a REAL anchor record: the record's entry is
- * planted at `logIndex` in a synthetic log of `logSize` entries, and the
- * checkpoint is signed by a freshly generated P-256 log key.
+ * planted at `logIndex` in a synthetic log of `logSize` entries, and both the
+ * checkpoint and the signed entry timestamp are signed by a freshly generated
+ * P-256 log key. The SET is emitted by default so the happy path exercises
+ * attested time; `withSet: false` models a log that does not offer one.
  */
 export function makeRekorReceipt(
 	record: AnchorRecord,
@@ -218,12 +270,14 @@ export function makeRekorReceipt(
 			? {}
 			: { extraSignatureLines: opts.extraSignatureLines }),
 	});
+	const entryBody = entry.toString("base64");
+	const integratedTime = opts.integratedTime ?? 1_760_000_000;
 	const receipt: RekorReceipt = {
 		v: 1,
 		vaultId: record.vaultId,
 		anchorSeq: record.anchorSeq,
 		artifactHash: anchorPayloadHash(record),
-		entryBody: entry.toString("base64"),
+		entryBody,
 		log: {
 			url,
 			logIndex,
@@ -231,13 +285,20 @@ export function makeRekorReceipt(
 			rootHash: log.rootHex,
 			hashes: log.pathFor(logIndex),
 			checkpoint: log.checkpoint,
-			integratedTime: opts.integratedTime ?? 1_760_000_000,
+			integratedTime,
+			...(opts.withSet === false
+				? {}
+				: {
+						logID: log.logId,
+						signedEntryTimestamp: log.setFor({ body: entryBody, integratedTime, logIndex }),
+					}),
 		},
 	};
 	return {
 		receipt,
 		logPubkeyPem: publicKey.export({ type: "spki", format: "pem" }) as string,
 		logPrivateKey: privateKey,
+		logId: log.logId,
 		entryBody: entry,
 		tamper: (mutate: (receipt: RekorReceipt) => void): RekorReceipt => {
 			const copy = JSON.parse(JSON.stringify(receipt)) as RekorReceipt;

--- a/packages/core/tests/harden/anchoring/rekor-glue.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-glue.test.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — REKOR RECEIPTS IN THE ANCHORED-VAULT FLOW (plan T5)
+ *
+ * The receipt verifier itself is covered by rekor-verify.test.ts. What is at
+ * stake here is the GLUE: whether a receipt supplied alongside a vault changes
+ * the verdict the way it must — evidence that verifies strengthens the vault's
+ * freshness claim with a time the operator could not choose, and evidence that
+ * does not verify fails the vault closed instead of being quietly dropped.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	exitCodeForAnchored as pkgExitCodeForAnchored,
+	verifyVaultWithAnchors as pkgVerifyVaultWithAnchors,
+} from "../../../../verify/src/index.js";
+import { exitCodeForAnchored, verifyVaultWithAnchors } from "../../../src/audit/verify.js";
+import {
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	storeRaw,
+	verify,
+} from "./fixtures.js";
+import { makeRekorReceipt } from "./rekor-fixtures.js";
+
+afterEach(() => {
+	cleanupAll();
+});
+
+const ATTESTED_SECONDS = 1_760_000_000;
+
+describe("HARDEN: Rekor receipts in verifyVaultWithAnchors", () => {
+	it("1. a verifying receipt keeps the vault ANCHORED_VERIFIED and reports the attested time", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		const f = makeRekorReceipt(record, { integratedTime: ATTESTED_SECONDS });
+
+		const result = verify(s, {
+			rekorReceiptsRaw: [JSON.stringify(f.receipt)],
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+		});
+
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.valid).toBe(true);
+		expect(result.anchoring.rekor).toEqual({
+			receiptsVerified: 1,
+			receiptsFailed: 0,
+			latestAttestedTimeMs: ATTESTED_SECONDS * 1000,
+			errors: [],
+		});
+		expect(exitCodeForAnchored(result)).toBe(0);
+	});
+
+	it("2. no receipts supplied ⇒ no rekor block at all (additive)", async () => {
+		const s = await makeAnchoredVault(2);
+		await anchorOnce(s);
+		const result = verify(s);
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.rekor).toBeUndefined();
+	});
+
+	it("3. a tampered receipt is ANCHOR_INVALID with reason rekor-receipt-invalid and exit 1", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		const f = makeRekorReceipt(record, { integratedTime: ATTESTED_SECONDS });
+		const tampered = f.tamper((r) => {
+			r.log.hashes[0] = "a".repeat(64);
+		});
+
+		const result = verify(s, {
+			rekorReceiptsRaw: [JSON.stringify(tampered)],
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+		});
+
+		expect(result.anchorState).toBe("ANCHOR_INVALID");
+		expect(result.valid).toBe(false);
+		expect(result.anchoring.reasons).toContain("rekor-receipt-invalid");
+		expect(result.anchoring.rekor?.receiptsVerified).toBe(0);
+		expect(result.anchoring.rekor?.receiptsFailed).toBe(1);
+		expect(result.errors.some((e) => e.includes("inclusion proof"))).toBe(true);
+		expect(exitCodeForAnchored(result)).toBe(1);
+	});
+
+	it("4. an unparseable receipt fails closed rather than being ignored", async () => {
+		const s = await makeAnchoredVault(2);
+		await anchorOnce(s);
+		const result = verify(s, { rekorReceiptsRaw: ['{"v":1,"nope":true}'] });
+		expect(result.anchorState).toBe("ANCHOR_INVALID");
+		expect(result.anchoring.rekor?.receiptsFailed).toBe(1);
+	});
+
+	it("5. a receipt for an anchorSeq the record set does not contain is INVALID", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		const f = makeRekorReceipt(record);
+		const orphan = f.tamper((r) => {
+			r.anchorSeq = 99;
+		});
+
+		const result = verify(s, {
+			rekorReceiptsRaw: [JSON.stringify(orphan)],
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+		});
+
+		expect(result.anchorState).toBe("ANCHOR_INVALID");
+		expect(result.errors.some((e) => e.includes("receipt for unknown anchorSeq 99"))).toBe(true);
+	});
+
+	it("6. a custom log with no pinned key is refused, never trusted (D4)", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		const f = makeRekorReceipt(record, { url: "https://log.example.org" });
+
+		// The receipt is internally perfect — only the TRUST is missing.
+		expect(
+			verify(s, {
+				rekorReceiptsRaw: [JSON.stringify(f.receipt)],
+				rekorLogPubkeysPem: [f.logPubkeyPem],
+			}).anchorState,
+		).toBe("ANCHORED_VERIFIED");
+
+		const unpinned = verify(s, { rekorReceiptsRaw: [JSON.stringify(f.receipt)] });
+		expect(unpinned.anchorState).toBe("ANCHOR_INVALID");
+		expect(unpinned.errors.some((e) => e.includes("custom log requires --rekor-pubkey"))).toBe(
+			true,
+		);
+	});
+
+	it("7. JSONL input: several receipts for one anchor verify, newest attested time wins (D11)", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		const older = makeRekorReceipt(record, { integratedTime: ATTESTED_SECONDS });
+		const newer = makeRekorReceipt(record, { integratedTime: ATTESTED_SECONDS + 4242 });
+
+		const result = verify(s, {
+			rekorReceiptsRaw: [`${JSON.stringify(older.receipt)}\n${JSON.stringify(newer.receipt)}\n`],
+			rekorLogPubkeysPem: [older.logPubkeyPem, newer.logPubkeyPem],
+		});
+
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.rekor?.receiptsVerified).toBe(2);
+		expect(result.anchoring.rekor?.latestAttestedTimeMs).toBe((ATTESTED_SECONDS + 4242) * 1000);
+	});
+});
+
+describe("HARDEN: attested-time staleness (clock gaming defeated)", () => {
+	it("8. a stale ATTESTED time makes a fresh operator timestamp ANCHOR_STALE", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		// Unanchored tail: --max-anchor-age only bites once the vault has moved on.
+		await appendEvents(s.root, 2, 4);
+		const nowMs = Date.parse(record.timestamp) + 1000;
+		const f = makeRekorReceipt(record, {
+			integratedTime: Math.floor(nowMs / 1000) - 30 * 86_400,
+		});
+		const policy = { maxAnchorAgeMs: 60_000, nowMs };
+
+		// Operator-claimed time alone says fresh...
+		expect(verify(s, policy).anchorState).toBe("ANCHORED_VERIFIED");
+
+		// ...the witness says otherwise, and the witness is the one the operator
+		// cannot choose.
+		const attested = verify(s, {
+			...policy,
+			rekorReceiptsRaw: [JSON.stringify(f.receipt)],
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+		});
+		expect(attested.anchorState).toBe("ANCHOR_STALE");
+		expect(
+			attested.errors.some((e) => e.includes("--max-anchor-age (witness-attested time)")),
+		).toBe(true);
+	});
+
+	it("9. a fresh ATTESTED time rescues an anchor whose operator timestamp looks stale", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		await appendEvents(s.root, 2, 4);
+		// The auditor's clock is 30 days ahead of the operator's claim.
+		const nowMs = Date.parse(record.timestamp) + 30 * 86_400_000;
+		const f = makeRekorReceipt(record, { integratedTime: Math.floor(nowMs / 1000) - 30 });
+		const policy = { maxAnchorAgeMs: 60_000, nowMs };
+
+		expect(verify(s, policy).anchorState).toBe("ANCHOR_STALE");
+
+		const attested = verify(s, {
+			...policy,
+			rekorReceiptsRaw: [JSON.stringify(f.receipt)],
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+		});
+		expect(attested.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(attested.anchoring.rekor?.receiptsVerified).toBe(1);
+	});
+
+	it("10. only the NEWEST anchor's receipt drives freshness", async () => {
+		const s = await makeAnchoredVault(3);
+		const first = await anchorOnce(s);
+		await appendEvents(s.root, 3, 4);
+		const second = await anchorOnce(s);
+		await appendEvents(s.root, 2, 7);
+		const nowMs = Date.parse(second.timestamp) + 1000;
+
+		// A stale receipt for the SUPERSEDED anchor must not age out the vault.
+		const stale = makeRekorReceipt(first, {
+			integratedTime: Math.floor(nowMs / 1000) - 30 * 86_400,
+		});
+		const result = verify(s, {
+			maxAnchorAgeMs: 60_000,
+			nowMs,
+			rekorReceiptsRaw: [JSON.stringify(stale.receipt)],
+			rekorLogPubkeysPem: [stale.logPubkeyPem],
+		});
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.rekor?.latestAttestedTimeMs).toBeNull();
+	});
+});
+
+describe("HARDEN: core ↔ verify pkg behavior parity on the receipt path (D12)", () => {
+	it("11. identical inputs produce deep-equal results and exit codes in both glues", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		await appendEvents(s.root, 2, 4);
+		const f = makeRekorReceipt(record, { integratedTime: ATTESTED_SECONDS });
+		const tampered = f.tamper((r) => {
+			r.log.rootHash = "b".repeat(64);
+		});
+
+		for (const receipt of [f.receipt, tampered]) {
+			const params = {
+				externalAnchorsRaw: [storeRaw(s)],
+				trust: s.trust,
+				rekorReceiptsRaw: [JSON.stringify(receipt)],
+				rekorLogPubkeysPem: [f.logPubkeyPem],
+				nowMs: Date.parse(record.timestamp) + 1000,
+			};
+			const core = verifyVaultWithAnchors(s.vaultPath, params);
+			const pkg = pkgVerifyVaultWithAnchors(s.vaultPath, params);
+			expect(pkg).toEqual(core);
+			expect(pkgExitCodeForAnchored(pkg)).toBe(exitCodeForAnchored(core));
+		}
+	});
+});

--- a/packages/core/tests/harden/anchoring/rekor-glue.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-glue.test.ts
@@ -238,6 +238,62 @@ describe("HARDEN: attested-time staleness (clock gaming defeated)", () => {
 	});
 });
 
+describe("HARDEN: an UNSIGNED integratedTime is not attested time (P2 review, FIX A)", () => {
+	it("13. a receipt with no SET verifies, but freshness falls back to the operator's clock", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		await appendEvents(s.root, 2, 4);
+		const nowMs = Date.parse(record.timestamp) + 1000;
+		// Exactly test 9's stale receipt, minus the log's signature over its time.
+		const f = makeRekorReceipt(record, {
+			integratedTime: Math.floor(nowMs / 1000) - 30 * 86_400,
+			withSet: false,
+		});
+
+		const result = verify(s, {
+			maxAnchorAgeMs: 60_000,
+			nowMs,
+			rekorReceiptsRaw: [JSON.stringify(f.receipt)],
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+		});
+
+		// The inclusion evidence is good, so the vault is not failed; but a number
+		// no one signed cannot age it out either — that would let anyone holding a
+		// receipt editor decide the verdict.
+		expect(result.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(result.anchoring.rekor?.receiptsVerified).toBe(1);
+		expect(result.anchoring.rekor?.receiptsFailed).toBe(0);
+		expect(result.anchoring.rekor?.latestAttestedTimeMs).toBeNull();
+	});
+
+	it("14. a forward-dated operator timestamp still warns when a witness attests the time", async () => {
+		const s = await makeAnchoredVault(3);
+		const record = await anchorOnce(s);
+		// The auditor's clock sits BEHIND the operator's claim — the clock-gaming
+		// signal (buyer-rejection §5.13).
+		const nowMs = Date.parse(record.timestamp) - 60_000;
+		const f = makeRekorReceipt(record, { integratedTime: Math.floor(nowMs / 1000) - 10 });
+
+		const withoutReceipt = verify(s, { nowMs });
+		expect(withoutReceipt.anchoring.warnings).toContain("future-timestamp");
+
+		const attested = verify(s, {
+			nowMs,
+			rekorReceiptsRaw: [JSON.stringify(f.receipt)],
+			rekorLogPubkeysPem: [f.logPubkeyPem],
+		});
+
+		// A receipt corroborates the anchor; it does not erase what the operator
+		// claimed. Suppressing the warning here would let a receipt LAUNDER the
+		// forward-dated timestamp it was supplied to corroborate.
+		expect(attested.anchorState).toBe("ANCHORED_VERIFIED");
+		expect(attested.anchoring.warnings).toContain("future-timestamp");
+		expect(attested.anchoring.rekor?.latestAttestedTimeMs).toBe(
+			f.receipt.log.integratedTime * 1000,
+		);
+	});
+});
+
 describe("HARDEN: core ↔ verify pkg behavior parity on the receipt path (D12)", () => {
 	it("12. identical inputs produce deep-equal results and exit codes in both glues", async () => {
 		const s = await makeAnchoredVault(3);

--- a/packages/core/tests/harden/anchoring/rekor-glue.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-glue.test.ts
@@ -130,7 +130,27 @@ describe("HARDEN: Rekor receipts in verifyVaultWithAnchors", () => {
 		);
 	});
 
-	it("7. JSONL input: several receipts for one anchor verify, newest attested time wins (D11)", async () => {
+	it("7. a receipts artifact holding no receipts fails closed (P2-5)", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+
+		// The caller asked for receipt evidence and handed over a blank file. That
+		// is a missing receipt, not an absence of a claim — treating it as "no
+		// receipts supplied" would silently drop the evidence they meant to show.
+		const result = verify(s, { rekorReceiptsRaw: ["  \n"] });
+
+		expect(result.anchorState).toBe("ANCHOR_INVALID");
+		expect(result.valid).toBe(false);
+		expect(result.anchoring.reasons).toContain("rekor-receipt-invalid");
+		expect(result.anchoring.rekor?.receiptsVerified).toBe(0);
+		expect(result.anchoring.rekor?.receiptsFailed).toBe(1);
+		expect(result.errors.some((e) => e.includes("receipts artifact contained no receipts"))).toBe(
+			true,
+		);
+		expect(exitCodeForAnchored(result)).toBe(1);
+	});
+
+	it("8. JSONL input: several receipts for one anchor verify, newest attested time wins (D11)", async () => {
 		const s = await makeAnchoredVault(3);
 		const record = await anchorOnce(s);
 		const older = makeRekorReceipt(record, { integratedTime: ATTESTED_SECONDS });
@@ -148,7 +168,7 @@ describe("HARDEN: Rekor receipts in verifyVaultWithAnchors", () => {
 });
 
 describe("HARDEN: attested-time staleness (clock gaming defeated)", () => {
-	it("8. a stale ATTESTED time makes a fresh operator timestamp ANCHOR_STALE", async () => {
+	it("9. a stale ATTESTED time makes a fresh operator timestamp ANCHOR_STALE", async () => {
 		const s = await makeAnchoredVault(3);
 		const record = await anchorOnce(s);
 		// Unanchored tail: --max-anchor-age only bites once the vault has moved on.
@@ -175,7 +195,7 @@ describe("HARDEN: attested-time staleness (clock gaming defeated)", () => {
 		).toBe(true);
 	});
 
-	it("9. a fresh ATTESTED time rescues an anchor whose operator timestamp looks stale", async () => {
+	it("10. a fresh ATTESTED time rescues an anchor whose operator timestamp looks stale", async () => {
 		const s = await makeAnchoredVault(3);
 		const record = await anchorOnce(s);
 		await appendEvents(s.root, 2, 4);
@@ -195,7 +215,7 @@ describe("HARDEN: attested-time staleness (clock gaming defeated)", () => {
 		expect(attested.anchoring.rekor?.receiptsVerified).toBe(1);
 	});
 
-	it("10. only the NEWEST anchor's receipt drives freshness", async () => {
+	it("11. only the NEWEST anchor's receipt drives freshness", async () => {
 		const s = await makeAnchoredVault(3);
 		const first = await anchorOnce(s);
 		await appendEvents(s.root, 3, 4);
@@ -219,7 +239,7 @@ describe("HARDEN: attested-time staleness (clock gaming defeated)", () => {
 });
 
 describe("HARDEN: core ↔ verify pkg behavior parity on the receipt path (D12)", () => {
-	it("11. identical inputs produce deep-equal results and exit codes in both glues", async () => {
+	it("12. identical inputs produce deep-equal results and exit codes in both glues", async () => {
 		const s = await makeAnchoredVault(3);
 		const record = await anchorOnce(s);
 		await appendEvents(s.root, 2, 4);

--- a/packages/core/tests/harden/anchoring/rekor-sink.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-sink.test.ts
@@ -1,0 +1,392 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — emitter sinks: S3 (native SigV4) and Rekor (hashedrekord witness).
+ * Plan T3 with deltas D1 (no 409 recovery, strict 201 validation), D6 (S3
+ * addressing + error hygiene), D7 (`createSink(config, rootDir?)`) and D13
+ * (proposal canonicalized locally, receipt entryBody stored VERBATIM).
+ *
+ * Both sinks talk to the network through an injected transport, so every
+ * assertion here is about bytes we send and bytes we persist — never about a
+ * live log. The load-bearing test is the round trip: a receipt this sink writes
+ * from a synthetic 201 must satisfy the independent verifier
+ * (`verifyRekorReceipt`) under the fixture log key. A sink that writes receipts
+ * its own verifier rejects would ship silent, undetectable evidence loss.
+ */
+
+import { generateKeyPairSync, randomBytes } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAnchorEmitter, createSink, readAnchorIdentity } from "../../../src/audit/anchor.js";
+import { type AnchorRecord, anchorPayloadHash } from "../../../src/audit/anchor-verify.js";
+import { canonicalize } from "../../../src/audit/canonical.js";
+import { type HttpTransport, rekorSink, s3Sink } from "../../../src/audit/rekor.js";
+import { parseRekorReceipt, verifyRekorReceipt } from "../../../src/audit/rekor-verify.js";
+import { hashPayload } from "../../../src/audit/sigv4.js";
+import { VAULT_DIR } from "../../../src/shared/constants.js";
+import { type AnchoredSetup, anchorOnce, cleanupAll, makeAnchoredVault } from "./fixtures.js";
+import { makeSyntheticLog } from "./rekor-fixtures.js";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+	cleanupAll();
+});
+
+const REKOR_URL = "https://rekor.example.test";
+const ENTRIES_PATH = "/api/v1/log/entries";
+
+interface Call {
+	method: string;
+	url: string;
+	headers: Record<string, string>;
+	body: Buffer;
+}
+
+/** Transport that records what it was asked to send and replies from `respond`. */
+function fakeTransport(respond: (call: Call) => { status: number; body: string }): {
+	transport: HttpTransport;
+	calls: Call[];
+} {
+	const calls: Call[] = [];
+	return {
+		calls,
+		transport: async (opts) => {
+			const call: Call = { ...opts, body: Buffer.from(opts.body) };
+			calls.push(call);
+			return respond(call);
+		},
+	};
+}
+
+async function anchored(): Promise<{ setup: AnchoredSetup; record: AnchorRecord }> {
+	const setup = await makeAnchoredVault(3);
+	return { setup, record: await anchorOnce(setup) };
+}
+
+function stubCreds(): void {
+	vi.stubEnv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE");
+	vi.stubEnv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY");
+	vi.stubEnv("AWS_SESSION_TOKEN", "");
+}
+
+const receiptPath = (root: string, anchorSeq: number): string =>
+	join(root, VAULT_DIR, "audit", "anchors", "rekor", `${String(anchorSeq).padStart(12, "0")}.json`);
+
+/**
+ * A synthetic Rekor 201. The log is modelled honestly: it stores its OWN
+ * serialization of the proposal (pretty-printed here, so the stored bytes
+ * differ from the bytes we posted), the entry's global `logIndex` differs from
+ * its index within the proven tree, and the response carries fields we do not
+ * consume. Only bytes the log returned may end up in the receipt.
+ */
+function rekorAccepted(
+	proposal: Buffer,
+	opts: { logSize?: number; logIndex?: number; integratedTime?: number; origin?: string } = {},
+): { body: string; storedB64: string; logPubkeyPem: string } {
+	const stored = Buffer.from(
+		`${JSON.stringify(JSON.parse(proposal.toString("utf8")) as unknown, null, 2)}\n`,
+		"utf8",
+	);
+	const logSize = opts.logSize ?? 5;
+	const logIndex = opts.logIndex ?? 3;
+	const entries = Array.from({ length: logSize }, (_, i) =>
+		i === logIndex ? stored : randomBytes(32),
+	);
+	const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+	const log = makeSyntheticLog(entries, privateKey, opts.origin ?? new URL(REKOR_URL).host);
+	return {
+		body: JSON.stringify({
+			"24296fb24b8ad77a51a1f0e4e0f0c0f2c8a1f0d0e2b3a4c5d6e7f8091a2b3c4d5": {
+				apiVersion: "0.0.1",
+				body: stored.toString("base64"),
+				integratedTime: opts.integratedTime ?? 1_760_000_111,
+				logID: "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+				logIndex: 90_000_000,
+				verification: {
+					inclusionProof: {
+						checkpoint: log.checkpoint,
+						hashes: log.pathFor(logIndex),
+						logIndex,
+						rootHash: log.rootHex,
+						treeSize: logSize,
+					},
+					signedEntryTimestamp: "MEUCIQD0000000000000000000000000000000000000000000000000000",
+				},
+			},
+		}),
+		storedB64: stored.toString("base64"),
+		logPubkeyPem: publicKey.export({ type: "spki", format: "pem" }) as string,
+	};
+}
+
+describe("s3 anchor sink (native SigV4)", () => {
+	it("PUTs the canonical record bytes to the virtual-host URL, SigV4-signed", async () => {
+		stubCreds();
+		const { record } = await anchored();
+		const { transport, calls } = fakeTransport(() => ({ status: 200, body: "" }));
+
+		await s3Sink({ bucket: "b", region: "us-east-1" }, transport).publish(record);
+
+		expect(calls).toHaveLength(1);
+		const call = calls[0] as Call;
+		expect(call.method).toBe("PUT");
+		expect(call.url).toBe(
+			`https://b.s3.us-east-1.amazonaws.com/anchors/${record.vaultId}/000000000001.json`,
+		);
+		// Exactly the canonical record — no trailing newline, no envelope.
+		expect(call.body.toString("utf8")).toBe(canonicalize(record));
+		expect(call.headers.authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
+		expect(call.headers["x-amz-content-sha256"]).toBe(hashPayload(call.body));
+		expect(call.headers["x-amz-date"]).toMatch(/^\d{8}T\d{6}Z$/);
+	});
+
+	it("accepts any 2xx, not just 200", async () => {
+		stubCreds();
+		const { record } = await anchored();
+		const { transport } = fakeTransport(() => ({ status: 204, body: "" }));
+		await expect(
+			s3Sink({ bucket: "b", region: "eu-west-1" }, transport).publish(record),
+		).resolves.toBeUndefined();
+	});
+
+	it("addresses a configured endpoint path-style", async () => {
+		stubCreds();
+		const { record } = await anchored();
+		const { transport, calls } = fakeTransport(() => ({ status: 200, body: "" }));
+
+		await s3Sink(
+			{
+				bucket: "vault-anchors",
+				region: "us-east-1",
+				prefix: "prod/anchors",
+				endpoint: "http://127.0.0.1:9000",
+			},
+			transport,
+		).publish(record);
+
+		expect(calls[0]?.url).toBe(
+			`http://127.0.0.1:9000/vault-anchors/prod/anchors/${record.vaultId}/000000000001.json`,
+		);
+	});
+
+	it("refuses an endpoint without a scheme or with plaintext http off-localhost", async () => {
+		stubCreds();
+		const { record } = await anchored();
+		const { transport } = fakeTransport(() => ({ status: 200, body: "" }));
+
+		await expect(
+			s3Sink({ bucket: "b", region: "us-east-1", endpoint: "s3.example.com" }, transport).publish(
+				record,
+			),
+		).rejects.toThrow(/endpoint must include a scheme/);
+		await expect(
+			s3Sink(
+				{ bucket: "b", region: "us-east-1", endpoint: "http://s3.example.com" },
+				transport,
+			).publish(record),
+		).rejects.toThrow(/https/);
+	});
+
+	it("rejects a non-2xx store response without echoing request headers", async () => {
+		stubCreds();
+		const { record } = await anchored();
+		const { transport } = fakeTransport(() => ({
+			status: 403,
+			body: `<Error><Code>AccessDenied</Code><Message>Access Denied</Message></Error>${"x".repeat(400)}`,
+		}));
+
+		const err = await s3Sink({ bucket: "b", region: "us-east-1" }, transport)
+			.publish(record)
+			.then(
+				() => null,
+				(e: unknown) => e as Error,
+			);
+		expect(err?.message).toMatch(/^s3 sink: HTTP 403/);
+		expect(err?.message).toContain("AccessDenied");
+		expect(err?.message.length).toBeLessThanOrEqual(160);
+		expect(err?.message).not.toMatch(/AWS4-HMAC-SHA256|authorization|x-amz-security-token/i);
+	});
+
+	it("rejects when AWS credentials are absent from the environment", async () => {
+		vi.stubEnv("AWS_ACCESS_KEY_ID", "");
+		vi.stubEnv("AWS_SECRET_ACCESS_KEY", "");
+		const { record } = await anchored();
+		const { transport, calls } = fakeTransport(() => ({ status: 200, body: "" }));
+
+		await expect(
+			s3Sink({ bucket: "b", region: "us-east-1" }, transport).publish(record),
+		).rejects.toThrow("s3 sink: AWS credentials not found in environment");
+		expect(calls).toHaveLength(0);
+	});
+});
+
+describe("rekor anchor sink (hashedrekord witness)", () => {
+	it("proposes an entry bound to the record's payload hash, signature and vault key", async () => {
+		const { setup, record } = await anchored();
+		const { transport, calls } = fakeTransport((call) => ({
+			status: 201,
+			body: rekorAccepted(call.body).body,
+		}));
+
+		await rekorSink(setup.root, REKOR_URL, transport).publish(record);
+
+		expect(calls).toHaveLength(1);
+		const call = calls[0] as Call;
+		expect(call.method).toBe("POST");
+		expect(call.url).toBe(`${REKOR_URL}${ENTRIES_PATH}`);
+		const entry = JSON.parse(call.body.toString("utf8")) as {
+			apiVersion: string;
+			kind: string;
+			spec: {
+				data: { hash: { algorithm: string; value: string } };
+				signature: { content: string; publicKey: { content: string } };
+			};
+		};
+		expect(entry.kind).toBe("hashedrekord");
+		expect(entry.apiVersion).toBe("0.0.1");
+		expect(entry.spec.data.hash).toEqual({
+			algorithm: "sha256",
+			value: anchorPayloadHash(record),
+		});
+		expect(entry.spec.signature.content).toBe(record.sig);
+		// D13: the public key travels as base64 of exact PEM text bytes, LF-only.
+		const pem = Buffer.from(entry.spec.signature.publicKey.content, "base64").toString("utf8");
+		const spki = readAnchorIdentity(setup.root)?.publicKeySpki as string;
+		expect(pem).toBe(`-----BEGIN PUBLIC KEY-----\n${spki}\n-----END PUBLIC KEY-----\n`);
+		expect(pem).not.toContain("\r");
+	});
+
+	it("writes a receipt the independent verifier accepts under the log's key", async () => {
+		const { setup, record } = await anchored();
+		let accepted: ReturnType<typeof rekorAccepted> | null = null;
+		const { transport } = fakeTransport((call) => {
+			accepted = rekorAccepted(call.body, { integratedTime: 1_760_000_222 });
+			return { status: 201, body: accepted.body };
+		});
+
+		await rekorSink(setup.root, REKOR_URL, transport).publish(record);
+
+		const path = receiptPath(setup.root, record.anchorSeq);
+		expect(existsSync(path)).toBe(true);
+		const { receipt, error } = parseRekorReceipt(readFileSync(path, "utf-8"));
+		expect(error).toBeNull();
+		if (receipt === null) throw new Error("receipt did not parse");
+
+		const fixture = accepted as unknown as ReturnType<typeof rekorAccepted>;
+		// D13: the receipt carries the LOG's bytes, not a reserialization of ours.
+		expect(receipt.entryBody).toBe(fixture.storedB64);
+		// The proof's index is the one that proves inclusion — not the global one.
+		expect(receipt.log).toMatchObject({ url: REKOR_URL, logIndex: 3, treeSize: 5 });
+		expect(receipt.log.integratedTime).toBe(1_760_000_222);
+
+		const verification = verifyRekorReceipt(receipt, record, [fixture.logPubkeyPem]);
+		expect(verification.errors).toEqual([]);
+		expect(verification.ok).toBe(true);
+		expect(verification.attestedTimeMs).toBe(1_760_000_222_000);
+	});
+
+	it("rejects a failed publish and writes no receipt", async () => {
+		const { setup, record } = await anchored();
+		const { transport } = fakeTransport(() => ({ status: 500, body: "upstream unavailable" }));
+
+		await expect(rekorSink(setup.root, REKOR_URL, transport).publish(record)).rejects.toThrow(
+			/^rekor sink: HTTP 500/,
+		);
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq))).toBe(false);
+	});
+
+	it("treats 409 as a failure rather than recovering the duplicate entry (D1)", async () => {
+		const { setup, record } = await anchored();
+		const { transport, calls } = fakeTransport(() => ({
+			status: 409,
+			body: "entry already exists",
+		}));
+
+		await expect(rekorSink(setup.root, REKOR_URL, transport).publish(record)).rejects.toThrow(
+			/^rekor sink: HTTP 409/,
+		);
+		expect(calls).toHaveLength(1);
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq))).toBe(false);
+	});
+
+	it("rejects a 201 whose inclusion proof is malformed or ambiguous", async () => {
+		const { setup, record } = await anchored();
+		type Entry = Record<string, unknown>;
+		/** `mutate` rewrites the whole `{uuid: entry}` response the log returned. */
+		const publishWith = (mutate: (response: Record<string, Entry>) => unknown): Promise<void> => {
+			const { transport } = fakeTransport((call) => {
+				const response = JSON.parse(rekorAccepted(call.body).body) as Record<string, Entry>;
+				return { status: 201, body: JSON.stringify(mutate(response)) };
+			});
+			return rekorSink(setup.root, REKOR_URL, transport).publish(record);
+		};
+		const entryOf = (response: Record<string, Entry>): Entry => Object.values(response)[0] as Entry;
+		const proofOf = (response: Record<string, Entry>): Entry =>
+			(entryOf(response).verification as Entry).inclusionProof as Entry;
+
+		await expect(
+			publishWith((response) => {
+				proofOf(response).rootHash = "NOTHEX";
+				return response;
+			}),
+		).rejects.toThrow(/rekor sink: invalid 201 response/);
+
+		await expect(
+			publishWith((response) => {
+				entryOf(response).verification = {};
+				return response;
+			}),
+		).rejects.toThrow(/rekor sink: invalid 201 response/);
+
+		await expect(
+			publishWith((response) => {
+				proofOf(response).treeSize = 2;
+				return response;
+			}),
+		).rejects.toThrow(/rekor sink: invalid 201 response/);
+
+		// Two top-level keys: which entry the log means is undecidable.
+		await expect(
+			publishWith((response) => ({ a: entryOf(response), b: entryOf(response) })),
+		).rejects.toThrow(/rekor sink: invalid 201 response/);
+
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq))).toBe(false);
+	});
+
+	it("publishes through the emitter's outbox path", async () => {
+		const setup = await makeAnchoredVault(3);
+		const { transport, calls } = fakeTransport((call) => ({
+			status: 201,
+			body: rekorAccepted(call.body).body,
+		}));
+		const emitter = createAnchorEmitter(setup.root, {
+			signer: { type: "pem", file: setup.keyFile },
+			sinks: [rekorSink(setup.root, REKOR_URL, transport)],
+		});
+
+		const result = await emitter.anchorNow();
+		await emitter.stop();
+
+		expect(result.emitted).toBe(true);
+		expect(calls).toHaveLength(1);
+		expect(existsSync(receiptPath(setup.root, 1))).toBe(true);
+		expect(emitter.status().outboxDepth).toBe(0);
+	});
+});
+
+describe("createSink (D7 — rootDir is optional and only rekor needs it)", () => {
+	it("builds the declarative s3 and rekor sinks", async () => {
+		const setup = await makeAnchoredVault(1);
+		expect(createSink({ type: "s3", bucket: "b", region: "us-east-1" }).name).toBe("s3:b/anchors");
+		expect(createSink({ type: "rekor" }, setup.root).name).toBe("rekor:https://rekor.sigstore.dev");
+		expect(createSink({ type: "rekor", url: REKOR_URL }, setup.root).name).toBe(
+			`rekor:${REKOR_URL}`,
+		);
+	});
+
+	it("refuses a rekor sink with no vault to persist receipts into", () => {
+		expect(() => createSink({ type: "rekor" })).toThrow("rekor sink requires rootDir");
+	});
+});

--- a/packages/core/tests/harden/anchoring/rekor-sink.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-sink.test.ts
@@ -15,18 +15,29 @@
  * its own verifier rejects would ship silent, undetectable evidence loss.
  */
 
-import { generateKeyPairSync, randomBytes } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { createHash, generateKeyPairSync, randomBytes } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAnchorEmitter, createSink, readAnchorIdentity } from "../../../src/audit/anchor.js";
 import { type AnchorRecord, anchorPayloadHash } from "../../../src/audit/anchor-verify.js";
 import { canonicalize } from "../../../src/audit/canonical.js";
 import { type HttpTransport, rekorSink, s3Sink } from "../../../src/audit/rekor.js";
-import { parseRekorReceipt, verifyRekorReceipt } from "../../../src/audit/rekor-verify.js";
+import {
+	parseRekorReceipt,
+	type RekorReceipt,
+	verifyRekorReceipt,
+} from "../../../src/audit/rekor-verify.js";
 import { hashPayload } from "../../../src/audit/sigv4.js";
 import { VAULT_DIR } from "../../../src/shared/constants.js";
-import { type AnchoredSetup, anchorOnce, cleanupAll, makeAnchoredVault } from "./fixtures.js";
+import {
+	type AnchoredSetup,
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+	rotateOnce,
+} from "./fixtures.js";
 import { makeSyntheticLog } from "./rekor-fixtures.js";
 
 afterEach(() => {
@@ -71,8 +82,19 @@ function stubCreds(): void {
 	vi.stubEnv("AWS_SESSION_TOKEN", "");
 }
 
-const receiptPath = (root: string, anchorSeq: number): string =>
-	join(root, VAULT_DIR, "audit", "anchors", "rekor", `${String(anchorSeq).padStart(12, "0")}.json`);
+/** The sink's per-log receipt name: `<seq12>.<8 hex of sha256(log url)>.json`. */
+const receiptPath = (root: string, anchorSeq: number, logUrl = REKOR_URL): string =>
+	join(
+		root,
+		VAULT_DIR,
+		"audit",
+		"anchors",
+		"rekor",
+		`${String(anchorSeq).padStart(12, "0")}.${createHash("sha256")
+			.update(logUrl, "utf8")
+			.digest("hex")
+			.slice(0, 8)}.json`,
+	);
 
 /**
  * A synthetic Rekor 201. The log is modelled honestly: it stores its OWN
@@ -96,13 +118,15 @@ function rekorAccepted(
 	);
 	const { privateKey, publicKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
 	const log = makeSyntheticLog(entries, privateKey, opts.origin ?? new URL(REKOR_URL).host);
+	const storedB64 = stored.toString("base64");
+	const integratedTime = opts.integratedTime ?? 1_760_000_111;
 	return {
 		body: JSON.stringify({
 			"24296fb24b8ad77a51a1f0e4e0f0c0f2c8a1f0d0e2b3a4c5d6e7f8091a2b3c4d5": {
 				apiVersion: "0.0.1",
-				body: stored.toString("base64"),
-				integratedTime: opts.integratedTime ?? 1_760_000_111,
-				logID: "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+				body: storedB64,
+				integratedTime,
+				logID: log.logId,
 				logIndex: 90_000_000,
 				verification: {
 					inclusionProof: {
@@ -112,11 +136,13 @@ function rekorAccepted(
 						rootHash: log.rootHex,
 						treeSize: logSize,
 					},
-					signedEntryTimestamp: "MEUCIQD0000000000000000000000000000000000000000000000000000",
+					// The log's real signature over integratedTime — the only reason
+					// the receipt this produces can attest a time at all.
+					signedEntryTimestamp: log.setFor({ body: storedB64, integratedTime, logIndex }),
 				},
 			},
 		}),
-		storedB64: stored.toString("base64"),
+		storedB64,
 		logPubkeyPem: publicKey.export({ type: "spki", format: "pem" }) as string,
 	};
 }
@@ -373,6 +399,176 @@ describe("rekor anchor sink (hashedrekord witness)", () => {
 		expect(calls).toHaveLength(1);
 		expect(existsSync(receiptPath(setup.root, 1))).toBe(true);
 		expect(emitter.status().outboxDepth).toBe(0);
+	});
+});
+
+describe("rekor sink: P2 review remediation (409 / response binding / URL / keys / per-log)", () => {
+	it("FIX C: a 409 redelivery resolves when the local receipt already witnesses the record", async () => {
+		const { setup, record } = await anchored();
+		let attempt = 0;
+		const { transport, calls } = fakeTransport((call) => {
+			attempt++;
+			return attempt === 1
+				? { status: 201, body: rekorAccepted(call.body).body }
+				: { status: 409, body: "entry already exists" };
+		});
+		const sink = rekorSink(setup.root, REKOR_URL, transport);
+
+		await sink.publish(record);
+		// The honest 409: a crash between writing the receipt and clearing the
+		// outbox, so the emitter redelivers a record the log already holds. The
+		// evidence is on disk; refusing forever would wedge the outbox over an
+		// entry we can already prove.
+		await expect(sink.publish(record)).resolves.toBeUndefined();
+		expect(calls).toHaveLength(2);
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq))).toBe(true);
+	});
+
+	it("FIX C: a 409 with no local receipt still rejects — a duplicate is not evidence", async () => {
+		const { setup, record } = await anchored();
+		const { transport } = fakeTransport(() => ({ status: 409, body: "entry already exists" }));
+
+		await expect(rekorSink(setup.root, REKOR_URL, transport).publish(record)).rejects.toThrow(
+			/duplicate without local receipt/,
+		);
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq))).toBe(false);
+	});
+
+	it("FIX C: a receipt for a DIFFERENT record does not satisfy this record's 409", async () => {
+		const { setup, record } = await anchored();
+		const { transport } = fakeTransport((call) => ({
+			status: 201,
+			body: rekorAccepted(call.body).body,
+		}));
+		await rekorSink(setup.root, REKOR_URL, transport).publish(record);
+
+		// Anchor #2 is a different record; the receipt on disk is #1's.
+		await appendEvents(setup.root, 2, 4);
+		const second = await anchorOnce(setup);
+		const { transport: conflicting } = fakeTransport(() => ({ status: 409, body: "" }));
+		await expect(rekorSink(setup.root, REKOR_URL, conflicting).publish(second)).rejects.toThrow(
+			/duplicate without local receipt/,
+		);
+	});
+
+	it("FIX D: a 201 describing somebody else's entry is refused and writes no receipt", async () => {
+		const { setup, record } = await anchored();
+		/** A well-formed 201 built from a proposal we did NOT send. */
+		const publishWithForgedProposal = (
+			mutate: (proposal: Record<string, unknown>) => void,
+		): Promise<void> => {
+			const { transport } = fakeTransport((call) => {
+				const proposal = JSON.parse(call.body.toString("utf8")) as Record<string, unknown>;
+				mutate(proposal);
+				return {
+					status: 201,
+					body: rekorAccepted(Buffer.from(JSON.stringify(proposal), "utf8")).body,
+				};
+			});
+			return rekorSink(setup.root, REKOR_URL, transport).publish(record);
+		};
+		type Spec = {
+			data: { hash: { value: string } };
+			signature: { content: string };
+		};
+
+		// The log answers with an entry that is internally perfect — valid
+		// inclusion proof, signed checkpoint — for a different artifact.
+		await expect(
+			publishWithForgedProposal((proposal) => {
+				(proposal.spec as Spec).data.hash.value = randomBytes(32).toString("hex");
+			}),
+		).rejects.toThrow(/not this record's/);
+
+		// Same shape, right artifact, somebody else's signature: without the
+		// signature binding, anyone could log the (public) payload hash of our
+		// anchor and hand us back the receipt.
+		await expect(
+			publishWithForgedProposal((proposal) => {
+				(proposal.spec as Spec).signature.content = randomBytes(64).toString("base64");
+			}),
+		).rejects.toThrow(/not this record's/);
+
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq))).toBe(false);
+	});
+
+	it("FIX E: a plaintext log URL is refused at construction, before any record is offered", async () => {
+		const setup = await makeAnchoredVault(1);
+		const { transport, calls } = fakeTransport(() => ({ status: 201, body: "" }));
+
+		expect(() => rekorSink(setup.root, "http://attacker.example", transport)).toThrow(
+			/rekor sink: endpoint must be https/,
+		);
+		expect(() => rekorSink(setup.root, "rekor.example.test", transport)).toThrow(
+			/rekor sink: endpoint must include a scheme/,
+		);
+		// Loopback stays reachable for a dev log instance, as for the s3 sink.
+		expect(() => rekorSink(setup.root, "http://127.0.0.1:3000", transport)).not.toThrow();
+		expect(calls).toHaveLength(0);
+	});
+
+	it("FIX F: a record redelivered after a rotation proposes the key that SIGNED it", async () => {
+		const setup = await makeAnchoredVault(3);
+		const record = await anchorOnce(setup);
+		const genesisSpki = readAnchorIdentity(setup.root)?.publicKeySpki as string;
+
+		await rotateOnce(setup);
+		const identity = readAnchorIdentity(setup.root);
+		expect(identity?.publicKeySpki).not.toBe(genesisSpki);
+		expect(identity?.keyHistory?.map((k) => k.keyId)).toContain(record.keyId);
+
+		const { transport, calls } = fakeTransport((call) => ({
+			status: 201,
+			body: rekorAccepted(call.body).body,
+		}));
+		await rekorSink(setup.root, REKOR_URL, transport).publish(record);
+
+		const entry = JSON.parse((calls[0] as Call).body.toString("utf8")) as {
+			spec: { signature: { publicKey: { content: string } } };
+		};
+		const pem = Buffer.from(entry.spec.signature.publicKey.content, "base64").toString("utf8");
+		// The pre-rotation record is still signed by the pre-rotation key. Logging
+		// the live key beside that signature would put a permanently unverifiable
+		// entry in an append-only log.
+		expect(pem).toBe(`-----BEGIN PUBLIC KEY-----\n${genesisSpki}\n-----END PUBLIC KEY-----\n`);
+	});
+
+	it("FIX F: a keyId absent from the history is refused rather than guessed at", async () => {
+		const { setup, record } = await anchored();
+		const { transport, calls } = fakeTransport(() => ({ status: 201, body: "" }));
+		const foreign = { ...record, keyId: `sha256:${"9".repeat(64)}` };
+
+		await expect(rekorSink(setup.root, REKOR_URL, transport).publish(foreign)).rejects.toThrow(
+			/no public key for keyId/,
+		);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("FIX G: two logs produce two receipt files for one record, not one overwrite", async () => {
+		const { setup, record } = await anchored();
+		const SECOND_URL = "https://rekor2.example.test";
+		for (const url of [REKOR_URL, SECOND_URL]) {
+			const { transport } = fakeTransport((call) => ({
+				status: 201,
+				body: rekorAccepted(call.body, { origin: new URL(url).host }).body,
+			}));
+			await rekorSink(setup.root, url, transport).publish(record);
+		}
+
+		const dir = join(setup.root, VAULT_DIR, "audit", "anchors", "rekor");
+		const names = readdirSync(dir)
+			.filter((f) => f.endsWith(".json"))
+			.sort();
+		// Two witnesses configured, two independent attestations kept. Keying by
+		// anchorSeq alone silently left the operator with one.
+		expect(names).toHaveLength(2);
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq, REKOR_URL))).toBe(true);
+		expect(existsSync(receiptPath(setup.root, record.anchorSeq, SECOND_URL))).toBe(true);
+		const urls = names.map(
+			(name) =>
+				(parseRekorReceipt(readFileSync(join(dir, name), "utf-8")).receipt as RekorReceipt).log.url,
+		);
+		expect([...urls].sort()).toEqual([REKOR_URL, SECOND_URL].sort());
 	});
 });
 

--- a/packages/core/tests/harden/anchoring/rekor-verify.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-verify.test.ts
@@ -23,7 +23,11 @@ import {
 	verifyIndexInclusion as pkgVerifyIndexInclusion,
 	verifyRekorReceipt as pkgVerifyRekorReceipt,
 } from "../../../../verify/src/index.js";
-import { type AnchorRecord, anchorPayloadHash } from "../../../src/audit/anchor-verify.js";
+import {
+	type AnchorRecord,
+	anchorPayloadHash,
+	parseAnchorRecord,
+} from "../../../src/audit/anchor-verify.js";
 import {
 	parseRekorReceipt,
 	parseSignedNote,
@@ -39,6 +43,7 @@ import {
 	makeAnchoredVault,
 } from "./fixtures.js";
 import {
+	bogusSignatureLine,
 	hashedRekordEntry,
 	inclusionPath,
 	leafHash,
@@ -134,7 +139,8 @@ describe("HARDEN: signed-note checkpoint parsing", () => {
 		expect(parsed?.rootHashHex).toBe(root.toString("hex"));
 		expect(parsed?.body).toBe(`rekor.sigstore.dev\n42\n${root.toString("base64")}\n`);
 		// The 4-byte key hint is advisory and stripped; the rest is the DER sig.
-		expect((parsed?.sig.length ?? 0) > 8).toBe(true);
+		expect(parsed?.sigs).toHaveLength(1);
+		expect((parsed?.sigs[0]?.length ?? 0) > 8).toBe(true);
 	});
 
 	it("5. rejects CRLF, wrong line counts, short roots, and malformed signature lines", () => {
@@ -148,8 +154,10 @@ describe("HARDEN: signed-note checkpoint parsing", () => {
 		expect(parseSignedNote("origin\n9\n")).toBeNull();
 		// No blank separator line.
 		expect(parseSignedNote(good.replace("\n\n—", "\n—"))).toBeNull();
-		// A second signature line is not the accepted shape.
-		expect(parseSignedNote(`${good}${good.split("\n")[4] as string}\n`)).toBeNull();
+		// Witness co-signatures are the accepted shape; a malformed one is not.
+		expect(parseSignedNote(`${good}${bogusSignatureLine()}\n`)?.sigs).toHaveLength(2);
+		expect(parseSignedNote(`${good}not-a-signature-line\n`)).toBeNull();
+		expect(parseSignedNote(`${good}\n`)).toBeNull();
 		// Non-numeric / oversized tree size.
 		expect(parseSignedNote(good.replace("\n9\n", "\nnine\n"))).toBeNull();
 		// Root that does not decode to 32 bytes.
@@ -394,6 +402,135 @@ describe("HARDEN: trust pinning for custom logs (plan-review D4)", () => {
 		// It got as far as the signature check — the embedded key WAS consulted.
 		expect(result.errors.join(" | ")).toContain("signature does not verify");
 		expect(result.errors.join(" | ")).not.toContain("custom log requires");
+	});
+});
+
+describe("HARDEN: a supplied keyring that all got discarded is never the embedded key (P1-1)", () => {
+	const REFUSAL = "refusing to fall back to the embedded key";
+	const EMBEDDED_PATH = "does not verify under any pinned log public key";
+
+	it("31. an empty --rekor-pubkey entry refuses instead of silently reverting to the embedded key", () => {
+		// The dangerous case: the log host IS the one the embedded key speaks for,
+		// so a fallback here would verify under a key the auditor never chose and
+		// pass a merge gate they believed they had pinned.
+		const f = makeRekorReceipt(record, { url: "https://rekor.sigstore.dev" });
+		const result = verifyRekorReceipt(f.receipt, record, [""]);
+
+		expect(result.ok).toBe(false);
+		expect(result.errors.join(" | ")).toContain(REFUSAL);
+		expect(result.errors.join(" | ")).not.toContain(EMBEDDED_PATH);
+		// Both packages refuse identically — this is a merge gate, not a nicety.
+		expect(pkgVerifyRekorReceipt(f.receipt, record, [""])).toEqual(result);
+	});
+
+	it("32. a PEM over the 16 KiB cap is discarded material, not an absent pin", () => {
+		const f = makeRekorReceipt(record, { url: "https://rekor.sigstore.dev" });
+		const oversized = `${"x".repeat(17 * 1024)}\n`;
+		const result = verifyRekorReceipt(f.receipt, record, [oversized]);
+
+		expect(result.ok).toBe(false);
+		expect(result.errors.join(" | ")).toContain(REFUSAL);
+		expect(result.errors.join(" | ")).not.toContain(EMBEDDED_PATH);
+		// The blob itself is never echoed back.
+		expect(result.errors.join(" | ")).not.toContain("xxxx");
+	});
+
+	it("33. supplying NOTHING still reaches the embedded key, and a real pin still verifies", () => {
+		const f = makeRekorReceipt(record, { url: "https://rekor.sigstore.dev" });
+		// Unchanged behavior: no material supplied ⇒ the embedded key is consulted.
+		expect(verifyRekorReceipt(f.receipt, record, []).errors.join(" | ")).toContain(EMBEDDED_PATH);
+		expect(verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]).ok).toBe(true);
+		// A custom log with discarded material names the supply failure, which is
+		// the more useful truth than "no pin for this host".
+		const custom = makeRekorReceipt(record, { url: "https://log.example.org" });
+		expect(verifyRekorReceipt(custom.receipt, record, [""]).errors.join(" | ")).toContain(REFUSAL);
+	});
+});
+
+describe("HARDEN: live-Rekor checkpoint shapes (P2-1)", () => {
+	it("34. the production origin form `<host> - <treeID>` verifies", () => {
+		const f = makeRekorReceipt(record, { treeId: "2605736670972794746" });
+		expect(f.receipt.log.checkpoint.split("\n")[0]).toBe(
+			"rekor.sigstore.dev - 2605736670972794746",
+		);
+		expect(verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]).errors).toEqual([]);
+		expect(verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]).ok).toBe(true);
+	});
+
+	it("35. a witness co-signed checkpoint verifies on the signature the auditor pinned", () => {
+		// The log's own signature is emitted LAST, behind a witness line no pinned
+		// key verifies — a verifier that stopped at the first line would fail here.
+		const f = makeRekorReceipt(record, {
+			treeId: "2605736670972794746",
+			extraSignatureLines: [bogusSignatureLine()],
+		});
+		expect(parseSignedNote(f.receipt.log.checkpoint)?.sigs).toHaveLength(2);
+		expect(verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]).ok).toBe(true);
+	});
+
+	it("36. zero signatures verifying under the keyring still fails closed", () => {
+		const f = makeRekorReceipt(record);
+		const foreign = generateKeyPairSync("ec", { namedCurve: "P-256" });
+		const cosignedByStrangers = f.tamper((r) => {
+			r.log.checkpoint = signedNote(
+				"rekor.sigstore.dev",
+				r.log.treeSize,
+				Buffer.from(r.log.rootHash, "hex"),
+				foreign.privateKey,
+				undefined,
+				[bogusSignatureLine()],
+			);
+		});
+		const result = verifyRekorReceipt(cosignedByStrangers, record, [f.logPubkeyPem]);
+		expect(result.ok).toBe(false);
+		expect(result.errors.join(" | ")).toContain("signature does not verify");
+	});
+
+	it("37. the origin still has to NAME the log.url host — prefix, never suffix", () => {
+		for (const origin of ["rekor.sigstore.dev.evil.net", "evil.example.org"]) {
+			const f = makeRekorReceipt(record, { origin, treeId: "2605736670972794746" });
+			const result = verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]);
+			expect(result.ok).toBe(false);
+			expect(result.errors.join(" | ")).toContain("origin");
+		}
+		// And the treeID half is not a place to hide the host either.
+		const smuggled = makeRekorReceipt(record, {
+			origin: "evil.example.org",
+			treeId: "rekor.sigstore.dev",
+		});
+		expect(verifyRekorReceipt(smuggled.receipt, record, [smuggled.logPubkeyPem]).ok).toBe(false);
+	});
+});
+
+describe("HARDEN: error strings are terminal-safe (P2-3)", () => {
+	const ESCAPE = "\u001b[2K\rANCHOR STATE: VERIFIED";
+
+	it("38. a receipt field name carrying terminal escapes is stripped, not echoed", () => {
+		const obj = JSON.parse(JSON.stringify(makeRekorReceipt(record).receipt)) as Record<
+			string,
+			unknown
+		>;
+		obj[ESCAPE] = 1;
+		const { receipt, error } = parseRekorReceipt(JSON.stringify(obj));
+
+		expect(receipt).toBeNull();
+		expect(error).toContain("unknown field");
+		expect(error).not.toContain("\u001b");
+		expect(error).not.toContain("\r");
+		// The readable remainder still names what was wrong.
+		expect(error).toContain("ANCHOR STATE: VERIFIED");
+	});
+
+	it("39. the same holds for an anchor record's unknown-field echo", () => {
+		const { record: parsed, error } = parseAnchorRecord(JSON.stringify({ [ESCAPE]: 1 }));
+
+		expect(parsed).toBeNull();
+		expect(error).toContain("unknown field");
+		expect(error).not.toContain("\u001b");
+		expect(error).not.toContain("\r");
+		// A very long key is truncated as well, so the echo cannot fill a screen.
+		const long = parseAnchorRecord(JSON.stringify({ [`${"k".repeat(400)}`]: 1 })).error as string;
+		expect(long.length).toBeLessThan(160);
 	});
 });
 

--- a/packages/core/tests/harden/anchoring/rekor-verify.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-verify.test.ts
@@ -49,6 +49,7 @@ import {
 	leafHash,
 	makeRekorReceipt,
 	mth,
+	signedEntryTimestamp,
 	signedNote,
 } from "./rekor-fixtures.js";
 
@@ -382,6 +383,74 @@ describe("HARDEN: adversarial receipt mutations (every one must fail closed)", (
 	});
 });
 
+describe("HARDEN: attested time is only ever a SIGNED time (P2 review, FIX A)", () => {
+	it("40. editing integratedTime alone now fails — the SET is the only signature over it", () => {
+		const f = makeRekorReceipt(record, { integratedTime: 1_700_000_042 });
+		expect(verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]).attestedTimeMs).toBe(
+			1_700_000_042_000,
+		);
+
+		// Everything else in the receipt is untouched: the inclusion proof still
+		// reconstructs the root and the checkpoint still verifies. The ONLY thing
+		// standing between an operator and a freely chosen "witness-attested" time
+		// is a signature they do not hold the key for.
+		const backdated = f.tamper((r) => {
+			r.log.integratedTime = 1_600_000_000;
+		});
+		const result = verifyRekorReceipt(backdated, record, [f.logPubkeyPem]);
+		expect(result.ok).toBe(false);
+		expect(result.attestedTimeMs).toBeNull();
+		expect(result.errors.join(" | ")).toContain("signedEntryTimestamp does not verify");
+	});
+
+	it("41. re-signing the backdated time with the attacker's own key does not help either", () => {
+		const f = makeRekorReceipt(record, { integratedTime: 1_700_000_042 });
+		const foreign = generateKeyPairSync("ec", { namedCurve: "P-256" });
+		const forged = f.tamper((r) => {
+			r.log.integratedTime = 1_600_000_000;
+			r.log.signedEntryTimestamp = signedEntryTimestamp(
+				{
+					body: r.entryBody,
+					integratedTime: r.log.integratedTime,
+					logID: r.log.logID as string,
+					logIndex: r.log.logIndex,
+				},
+				foreign.privateKey,
+			);
+		});
+		const result = verifyRekorReceipt(forged, record, [f.logPubkeyPem]);
+		expect(result.ok).toBe(false);
+		expect(result.errors.join(" | ")).toContain("signedEntryTimestamp does not verify");
+	});
+
+	it("42. the SET covers the logID, not just the time", () => {
+		const f = makeRekorReceipt(record);
+		const swapped = f.tamper((r) => {
+			r.log.logID = randomBytes(32).toString("hex");
+		});
+		expect(verifyRekorReceipt(swapped, record, [f.logPubkeyPem]).ok).toBe(false);
+	});
+
+	it("43. a receipt with NO SET proves inclusion and attests no time", () => {
+		const f = makeRekorReceipt(record, { integratedTime: 1_700_000_042, withSet: false });
+		const result = verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]);
+
+		// Inclusion is a separate claim and it still holds — a log that emits no
+		// signed entry timestamp is not a broken receipt, just a quieter one.
+		expect(result.errors).toEqual([]);
+		expect(result.ok).toBe(true);
+		expect(result.attestedTimeMs).toBeNull();
+		// And it is not a loophole: with no SET, integratedTime buys nothing at all.
+		const rewritten = f.tamper((r) => {
+			r.log.integratedTime = 1;
+		});
+		const after = verifyRekorReceipt(rewritten, record, [f.logPubkeyPem]);
+		expect(after.ok).toBe(true);
+		expect(after.attestedTimeMs).toBeNull();
+		expect(pkgVerifyRekorReceipt(f.receipt, record, [f.logPubkeyPem])).toEqual(result);
+	});
+});
+
 describe("HARDEN: trust pinning for custom logs (plan-review D4)", () => {
 	it("21. the embedded production key is data, not a dependency: P-256 and only for rekor.sigstore.dev", () => {
 		expect(REKOR_PROD_PUBKEY_PEM).toContain("-----BEGIN PUBLIC KEY-----");
@@ -608,6 +677,39 @@ describe("HARDEN: strict receipt parsing", () => {
 		rejects((r) => {
 			(r.log as Record<string, unknown>).integratedTime = 0;
 		}, "log.integratedTime");
+	});
+
+	it("44. rejects an integratedTime whose milliseconds leave the ECMAScript Date range", () => {
+		// `integratedTime * 1000` is printed as an ISO timestamp downstream, and
+		// toISOString throws past ±8.64e15 ms — an attacker-chosen number must not
+		// be able to crash the verdict it appears in.
+		rejects((r) => {
+			(r.log as Record<string, unknown>).integratedTime = 8_640_000_000_000;
+		}, "log.integratedTime");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).integratedTime = Number.MAX_SAFE_INTEGER;
+		}, "log.integratedTime");
+		// The boundary value itself still parses.
+		const ok = base();
+		(ok.log as Record<string, unknown>).integratedTime = 8_639_999_999_999;
+		expect(parseRekorReceipt(JSON.stringify(ok)).error).toBeNull();
+	});
+
+	it("45. rejects malformed SET material, and a SET with no logID to verify it against", () => {
+		rejects((r) => {
+			(r.log as Record<string, unknown>).logID = "not-hex";
+		}, "log.logID");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).signedEntryTimestamp = "x".repeat(1100);
+		}, "log.signedEntryTimestamp");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).signedEntryTimestamp = "not base64!!";
+		}, "log.signedEntryTimestamp");
+		// The logID is inside the payload the SET signs, so a SET without one can
+		// never be checked by anyone — it is refused, not silently ignored.
+		rejects((r) => {
+			delete (r.log as Record<string, unknown>).logID;
+		}, "requires log.logID");
 	});
 
 	it("26. error strings never echo untrusted blobs (plan-review D5)", () => {

--- a/packages/core/tests/harden/anchoring/rekor-verify.test.ts
+++ b/packages/core/tests/harden/anchoring/rekor-verify.test.ts
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — REKOR RECEIPT VERIFICATION (plan T2)
+ *
+ * A Rekor receipt is caller-supplied, attacker-shaped input whose only job is
+ * to convince an auditor that a specific anchor record was published to a
+ * transparency log at a specific time. Every check that stands between those
+ * two claims is exercised here adversarially: inclusion math against an
+ * independent RFC 6962 reference, the entry->record binding, checkpoint
+ * origin/size/root/signature, and the trust-pinning rule for custom logs.
+ */
+
+import { createHash, generateKeyPairSync, randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	anchorPayloadHash as pkgAnchorPayloadHash,
+	parseRekorReceipt as pkgParseRekorReceipt,
+	REKOR_PROD_PUBKEY_PEM as pkgRekorProdPubkeyPem,
+	verifyIndexInclusion as pkgVerifyIndexInclusion,
+	verifyRekorReceipt as pkgVerifyRekorReceipt,
+} from "../../../../verify/src/index.js";
+import { type AnchorRecord, anchorPayloadHash } from "../../../src/audit/anchor-verify.js";
+import {
+	parseRekorReceipt,
+	parseSignedNote,
+	REKOR_PROD_PUBKEY_PEM,
+	verifyIndexInclusion,
+	verifyRekorReceipt,
+} from "../../../src/audit/rekor-verify.js";
+import {
+	type AnchoredSetup,
+	anchorOnce,
+	appendEvents,
+	cleanupAll,
+	makeAnchoredVault,
+} from "./fixtures.js";
+import {
+	hashedRekordEntry,
+	inclusionPath,
+	leafHash,
+	makeRekorReceipt,
+	mth,
+	signedNote,
+} from "./rekor-fixtures.js";
+
+const REPO_ROOT = join(import.meta.dirname, "..", "..", "..", "..", "..");
+
+let setup: AnchoredSetup;
+let record: AnchorRecord;
+
+beforeAll(async () => {
+	setup = await makeAnchoredVault(4);
+	record = await anchorOnce(setup);
+});
+
+afterAll(() => {
+	cleanupAll();
+});
+
+describe("HARDEN: RFC 9162 index inclusion vs the RFC 6962 PATH reference", () => {
+	it("1. accepts the reference path for every (treeSize <= 20, index) pair", () => {
+		let checked = 0;
+		for (let n = 1; n <= 20; n++) {
+			const entries = Array.from({ length: n }, () => randomBytes(32));
+			const rootHex = mth(entries).toString("hex");
+			for (let i = 0; i < n; i++) {
+				const path = inclusionPath(i, entries).map((h) => h.toString("hex"));
+				const leaf = leafHash(entries[i] as Buffer).toString("hex");
+				expect(verifyIndexInclusion(leaf, i, n, path, rootHex)).toBe(true);
+				checked++;
+			}
+		}
+		expect(checked).toBe(210);
+	});
+
+	it("2. rejects a path with ANY single element replaced by an unrelated hash", () => {
+		for (let n = 2; n <= 20; n++) {
+			const entries = Array.from({ length: n }, () => randomBytes(32));
+			const rootHex = mth(entries).toString("hex");
+			for (let i = 0; i < n; i++) {
+				const path = inclusionPath(i, entries).map((h) => h.toString("hex"));
+				const leaf = leafHash(entries[i] as Buffer).toString("hex");
+				for (let j = 0; j < path.length; j++) {
+					const mutated = [...path];
+					mutated[j] = randomBytes(32).toString("hex");
+					expect(verifyIndexInclusion(leaf, i, n, mutated, rootHex)).toBe(false);
+				}
+			}
+		}
+	});
+
+	it("3. rejects wrong leaf, wrong index, out-of-range index, wrong root, and truncated paths", () => {
+		const entries = Array.from({ length: 11 }, () => randomBytes(32));
+		const rootHex = mth(entries).toString("hex");
+		const index = 6;
+		const path = inclusionPath(index, entries).map((h) => h.toString("hex"));
+		const leaf = leafHash(entries[index] as Buffer).toString("hex");
+
+		expect(verifyIndexInclusion(leaf, index, 11, path, rootHex)).toBe(true);
+		expect(verifyIndexInclusion(randomBytes(32).toString("hex"), index, 11, path, rootHex)).toBe(
+			false,
+		);
+		expect(verifyIndexInclusion(leaf, 5, 11, path, rootHex)).toBe(false);
+		expect(verifyIndexInclusion(leaf, 11, 11, path, rootHex)).toBe(false);
+		expect(verifyIndexInclusion(leaf, -1, 11, path, rootHex)).toBe(false);
+		expect(verifyIndexInclusion(leaf, 1.5, 11, path, rootHex)).toBe(false);
+		expect(verifyIndexInclusion(leaf, index, 11, path.slice(1), rootHex)).toBe(false);
+		expect(verifyIndexInclusion(leaf, index, 11, [...path, path[0] as string], rootHex)).toBe(
+			false,
+		);
+		expect(verifyIndexInclusion(leaf, index, 11, path, randomBytes(32).toString("hex"))).toBe(
+			false,
+		);
+		// Malformed hex anywhere is a rejection, never a throw.
+		expect(verifyIndexInclusion("zz", index, 11, path, rootHex)).toBe(false);
+		expect(verifyIndexInclusion(leaf, index, 11, ["nothex"], rootHex)).toBe(false);
+		expect(verifyIndexInclusion(leaf, 0, 1, [], leaf)).toBe(true);
+	});
+});
+
+describe("HARDEN: signed-note checkpoint parsing", () => {
+	it("4. parses the canonical 5-line note and exposes the signed body verbatim", () => {
+		const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+		const root = randomBytes(32);
+		const note = signedNote("rekor.sigstore.dev", 42, root, privateKey);
+		const parsed = parseSignedNote(note);
+		expect(parsed).not.toBeNull();
+		expect(parsed?.origin).toBe("rekor.sigstore.dev");
+		expect(parsed?.treeSize).toBe(42);
+		expect(parsed?.rootHashHex).toBe(root.toString("hex"));
+		expect(parsed?.body).toBe(`rekor.sigstore.dev\n42\n${root.toString("base64")}\n`);
+		// The 4-byte key hint is advisory and stripped; the rest is the DER sig.
+		expect((parsed?.sig.length ?? 0) > 8).toBe(true);
+	});
+
+	it("5. rejects CRLF, wrong line counts, short roots, and malformed signature lines", () => {
+		const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+		const root = randomBytes(32);
+		const good = signedNote("log.example.org", 9, root, privateKey);
+		expect(parseSignedNote(good)).not.toBeNull();
+
+		expect(parseSignedNote(good.replace(/\n/g, "\r\n"))).toBeNull();
+		expect(parseSignedNote("")).toBeNull();
+		expect(parseSignedNote("origin\n9\n")).toBeNull();
+		// No blank separator line.
+		expect(parseSignedNote(good.replace("\n\n—", "\n—"))).toBeNull();
+		// A second signature line is not the accepted shape.
+		expect(parseSignedNote(`${good}${good.split("\n")[4] as string}\n`)).toBeNull();
+		// Non-numeric / oversized tree size.
+		expect(parseSignedNote(good.replace("\n9\n", "\nnine\n"))).toBeNull();
+		// Root that does not decode to 32 bytes.
+		expect(
+			parseSignedNote(signedNote("log.example.org", 9, randomBytes(16), privateKey)),
+		).toBeNull();
+		// Signature line without the em-dash marker.
+		expect(parseSignedNote(good.replace("—", "-"))).toBeNull();
+		// Signature payload shorter than the 4-byte key hint.
+		expect(parseSignedNote(good.replace(/— (\S+) (\S+)/, "— $1 AAAA"))).toBeNull();
+		// An 8 KiB+ checkpoint is refused outright.
+		expect(parseSignedNote(good + "x".repeat(9000))).toBeNull();
+	});
+});
+
+describe("HARDEN: receipt verification against a real anchor record", () => {
+	it("6. a well-formed receipt for the record verifies and attests its time", () => {
+		const f = makeRekorReceipt(record, { integratedTime: 1_700_000_042 });
+		const result = verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]);
+		expect(result.errors).toEqual([]);
+		expect(result.ok).toBe(true);
+		expect(result.attestedTimeMs).toBe(1_700_000_042_000);
+	});
+
+	it("7. verifies at every position of the log, not just the tail", () => {
+		for (const logIndex of [0, 1, 4, 6]) {
+			const f = makeRekorReceipt(record, { logSize: 7, logIndex });
+			expect(verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]).ok).toBe(true);
+		}
+	});
+
+	it("8. round-trips through parseRekorReceipt (the CLI ingestion path)", () => {
+		const f = makeRekorReceipt(record);
+		const { receipt, error } = parseRekorReceipt(JSON.stringify(f.receipt));
+		expect(error).toBeNull();
+		expect(receipt).not.toBeNull();
+		expect(verifyRekorReceipt(receipt as never, record, [f.logPubkeyPem]).ok).toBe(true);
+	});
+});
+
+describe("HARDEN: adversarial receipt mutations (every one must fail closed)", () => {
+	const expectFailure = (mutated: unknown, keys: string[], needle: string): void => {
+		const result = verifyRekorReceipt(mutated as never, record, keys);
+		expect(result.ok).toBe(false);
+		expect(result.attestedTimeMs).toBeNull();
+		expect(result.errors.length).toBeGreaterThan(0);
+		expect(result.errors.every((e) => e.startsWith("rekor-receipt-invalid: "))).toBe(true);
+		expect(result.errors.join(" | ")).toContain(needle);
+	};
+
+	it("9. wrong vaultId / wrong anchorSeq — the receipt is for a different record", () => {
+		const f = makeRekorReceipt(record);
+		expectFailure(
+			f.tamper((r) => {
+				r.vaultId = "vault_other";
+			}),
+			[f.logPubkeyPem],
+			"record mismatch",
+		);
+		expectFailure(
+			f.tamper((r) => {
+				r.anchorSeq = record.anchorSeq + 1;
+			}),
+			[f.logPubkeyPem],
+			"record mismatch",
+		);
+	});
+
+	it("10. artifactHash that is not the record's anchor payload hash", () => {
+		const f = makeRekorReceipt(record);
+		expectFailure(
+			f.tamper((r) => {
+				r.artifactHash = randomBytes(32).toString("hex");
+			}),
+			[f.logPubkeyPem],
+			"artifactHash",
+		);
+	});
+
+	it("11. entryBody hash value diverges from artifactHash", () => {
+		const f = makeRekorReceipt(record);
+		const forged = { ...JSON.parse(f.entryBody.toString("utf8")) } as {
+			spec: { data: { hash: { value: string } } };
+		};
+		forged.spec.data.hash.value = randomBytes(32).toString("hex");
+		expectFailure(
+			f.tamper((r) => {
+				r.entryBody = Buffer.from(JSON.stringify(forged), "utf8").toString("base64");
+			}),
+			[f.logPubkeyPem],
+			"spec.data.hash.value",
+		);
+	});
+
+	it("12. entryBody signature is not the anchor record's signature", () => {
+		const f = makeRekorReceipt(record);
+		const forged = JSON.parse(f.entryBody.toString("utf8")) as {
+			spec: { signature: { content: string } };
+		};
+		forged.spec.signature.content = randomBytes(64).toString("base64");
+		expectFailure(
+			f.tamper((r) => {
+				r.entryBody = Buffer.from(JSON.stringify(forged), "utf8").toString("base64");
+			}),
+			[f.logPubkeyPem],
+			"signature",
+		);
+	});
+
+	it("13. entryBody of the wrong kind, or not JSON at all", () => {
+		const f = makeRekorReceipt(record);
+		const forged = JSON.parse(f.entryBody.toString("utf8")) as { kind: string };
+		forged.kind = "intoto";
+		expectFailure(
+			f.tamper((r) => {
+				r.entryBody = Buffer.from(JSON.stringify(forged), "utf8").toString("base64");
+			}),
+			[f.logPubkeyPem],
+			"hashedrekord",
+		);
+		expectFailure(
+			f.tamper((r) => {
+				r.entryBody = Buffer.from("not json", "utf8").toString("base64");
+			}),
+			[f.logPubkeyPem],
+			"entryBody",
+		);
+	});
+
+	it("14. wrong logIndex — the entry is not where the receipt claims", () => {
+		const f = makeRekorReceipt(record, { logSize: 8, logIndex: 5 });
+		expectFailure(
+			f.tamper((r) => {
+				r.log.logIndex = 4;
+			}),
+			[f.logPubkeyPem],
+			"inclusion proof",
+		);
+	});
+
+	it("15. a tampered inclusion-path element", () => {
+		const f = makeRekorReceipt(record);
+		expectFailure(
+			f.tamper((r) => {
+				r.log.hashes[0] = randomBytes(32).toString("hex");
+			}),
+			[f.logPubkeyPem],
+			"inclusion proof",
+		);
+	});
+
+	it("16. checkpoint attests a different tree size than the proof was built for", () => {
+		const f = makeRekorReceipt(record, { logSize: 8 });
+		expectFailure(
+			f.tamper((r) => {
+				r.log.checkpoint = signedNote(
+					"rekor.sigstore.dev",
+					9,
+					Buffer.from(r.log.rootHash, "hex"),
+					f.logPrivateKey,
+				);
+			}),
+			[f.logPubkeyPem],
+			"treeSize",
+		);
+	});
+
+	it("17. checkpoint attests a different root than the proof reconstructs", () => {
+		const f = makeRekorReceipt(record, { logSize: 8 });
+		expectFailure(
+			f.tamper((r) => {
+				r.log.checkpoint = signedNote(
+					"rekor.sigstore.dev",
+					r.log.treeSize,
+					randomBytes(32),
+					f.logPrivateKey,
+				);
+			}),
+			[f.logPubkeyPem],
+			"root hash",
+		);
+	});
+
+	it("18. checkpoint origin is not the host of log.url", () => {
+		const f = makeRekorReceipt(record, { logSize: 8 });
+		expectFailure(
+			f.tamper((r) => {
+				r.log.checkpoint = signedNote(
+					"evil.example.org",
+					r.log.treeSize,
+					Buffer.from(r.log.rootHash, "hex"),
+					f.logPrivateKey,
+				);
+			}),
+			[f.logPubkeyPem],
+			"origin",
+		);
+	});
+
+	it("19. checkpoint signed by a key the auditor did not pin", () => {
+		const f = makeRekorReceipt(record);
+		const foreign = generateKeyPairSync("ec", { namedCurve: "P-256" });
+		expectFailure(
+			f.receipt,
+			[foreign.publicKey.export({ type: "spki", format: "pem" }) as string],
+			"signature does not verify",
+		);
+		// A keyring is a keyring: the right key ANYWHERE in it passes.
+		const ring = [
+			foreign.publicKey.export({ type: "spki", format: "pem" }) as string,
+			f.logPubkeyPem,
+		];
+		expect(verifyRekorReceipt(f.receipt, record, ring).ok).toBe(true);
+	});
+
+	it("20. a receipt bound to a DIFFERENT record of the same vault does not transfer", async () => {
+		await appendEvents(setup.root, 2);
+		const second = await anchorOnce(setup);
+		const f = makeRekorReceipt(second);
+		expect(verifyRekorReceipt(f.receipt, second, [f.logPubkeyPem]).ok).toBe(true);
+		expectFailure(f.receipt, [f.logPubkeyPem], "record mismatch");
+	});
+});
+
+describe("HARDEN: trust pinning for custom logs (plan-review D4)", () => {
+	it("21. the embedded production key is data, not a dependency: P-256 and only for rekor.sigstore.dev", () => {
+		expect(REKOR_PROD_PUBKEY_PEM).toContain("-----BEGIN PUBLIC KEY-----");
+		expect(REKOR_PROD_PUBKEY_PEM).toBe(pkgRekorProdPubkeyPem);
+		// An unpinned custom log must never supply its own trust root.
+		const custom = makeRekorReceipt(record, { url: "https://log.example.org" });
+		const unpinned = verifyRekorReceipt(custom.receipt, record, []);
+		expect(unpinned.ok).toBe(false);
+		expect(unpinned.errors.join(" | ")).toContain("custom log requires");
+		// With the key supplied, the very same receipt verifies.
+		expect(verifyRekorReceipt(custom.receipt, record, [custom.logPubkeyPem]).ok).toBe(true);
+	});
+
+	it("22. an unpinned rekor.sigstore.dev receipt is checked against the embedded key (and fails when forged)", () => {
+		const f = makeRekorReceipt(record, { url: "https://rekor.sigstore.dev" });
+		const result = verifyRekorReceipt(f.receipt, record, []);
+		expect(result.ok).toBe(false);
+		// It got as far as the signature check — the embedded key WAS consulted.
+		expect(result.errors.join(" | ")).toContain("signature does not verify");
+		expect(result.errors.join(" | ")).not.toContain("custom log requires");
+	});
+});
+
+describe("HARDEN: strict receipt parsing", () => {
+	const base = (): Record<string, unknown> =>
+		JSON.parse(JSON.stringify(makeRekorReceipt(record).receipt)) as Record<string, unknown>;
+
+	const rejects = (mutate: (r: Record<string, unknown>) => void, needle: string): void => {
+		const obj = base();
+		mutate(obj);
+		const { receipt, error } = parseRekorReceipt(JSON.stringify(obj));
+		expect(receipt).toBeNull();
+		expect(error).toContain("rekor-receipt-invalid: ");
+		expect(error).toContain(needle);
+	};
+
+	it("23. rejects non-JSON, non-objects, and oversized input", () => {
+		expect(parseRekorReceipt("{").error).toContain("not valid JSON");
+		expect(parseRekorReceipt("[]").error).toContain("not an object");
+		expect(parseRekorReceipt("null").error).toContain("not an object");
+		expect(parseRekorReceipt(`"${"x".repeat(300 * 1024)}"`).error).toContain("256 KiB");
+	});
+
+	it("24. rejects unknown fields at both levels (the schema is frozen)", () => {
+		rejects((r) => {
+			r.extra = 1;
+		}, 'unknown field "extra"');
+		rejects((r) => {
+			(r.log as Record<string, unknown>).extra = 1;
+		}, 'unknown log field "extra"');
+	});
+
+	it("25. rejects malformed scalars and range violations", () => {
+		rejects((r) => {
+			r.v = 2;
+		}, "unsupported version");
+		rejects((r) => {
+			r.vaultId = "";
+		}, "vaultId");
+		rejects((r) => {
+			r.anchorSeq = 0;
+		}, "anchorSeq");
+		rejects((r) => {
+			r.artifactHash = "ABC";
+		}, "artifactHash");
+		rejects((r) => {
+			r.artifactHash = (r.artifactHash as string).toUpperCase();
+		}, "artifactHash");
+		rejects((r) => {
+			r.entryBody = "";
+		}, "entryBody");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).url = "ftp://example.org";
+		}, "log.url");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).logIndex = 1.5;
+		}, "log.logIndex");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).logIndex = 99;
+		}, "logIndex must be < log.treeSize");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).rootHash = "not-hex";
+		}, "log.rootHash");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).hashes = ["nope"];
+		}, "log.hashes");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).hashes = Array.from({ length: 65 }, () =>
+				randomBytes(32).toString("hex"),
+			);
+		}, "log.hashes");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).checkpoint = "x".repeat(9000);
+		}, "log.checkpoint");
+		rejects((r) => {
+			(r.log as Record<string, unknown>).integratedTime = 0;
+		}, "log.integratedTime");
+	});
+
+	it("26. error strings never echo untrusted blobs (plan-review D5)", () => {
+		const f = makeRekorReceipt(record);
+		const long = "q".repeat(400);
+		const mutated = f.tamper((r) => {
+			r.vaultId = long;
+		});
+		const result = verifyRekorReceipt(mutated, record, [f.logPubkeyPem]);
+		const joined = result.errors.join(" | ");
+		expect(joined).not.toContain(long);
+		expect(joined).not.toContain(f.receipt.entryBody);
+		expect(joined).not.toContain(f.receipt.log.checkpoint);
+		expect(joined).not.toContain(f.logPubkeyPem);
+		for (const e of result.errors) {
+			expect(e.length).toBeLessThan(240);
+		}
+	});
+});
+
+describe("HARDEN: core <-> verify parity", () => {
+	it("27. rekor-verify.ts is byte-identical across packages modulo import paths", () => {
+		const strip = (s: string): string =>
+			s
+				.split("\n")
+				.filter((l) => !l.includes('from "'))
+				.join("\n");
+		const pkgCopy = readFileSync(
+			join(REPO_ROOT, "packages", "verify", "src", "rekor-verify.ts"),
+			"utf-8",
+		);
+		const coreCopy = readFileSync(
+			join(REPO_ROOT, "packages", "core", "src", "audit", "rekor-verify.ts"),
+			"utf-8",
+		);
+		expect(strip(coreCopy)).toBe(strip(pkgCopy));
+	});
+
+	it("28. behavior parity: identical inputs produce identical results in both packages (D12)", () => {
+		const f = makeRekorReceipt(record, { integratedTime: 1_699_999_999 });
+		const raw = JSON.stringify(f.receipt);
+
+		expect(pkgAnchorPayloadHash(record)).toBe(anchorPayloadHash(record));
+		expect(pkgParseRekorReceipt(raw)).toEqual(parseRekorReceipt(raw));
+		expect(pkgVerifyRekorReceipt(f.receipt, record, [f.logPubkeyPem])).toEqual(
+			verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]),
+		);
+
+		// Failure paths must agree too — identical error strings, not just verdicts.
+		const tampered = f.tamper((r) => {
+			r.log.hashes[0] = randomBytes(32).toString("hex");
+		});
+		expect(pkgVerifyRekorReceipt(tampered, record, [f.logPubkeyPem])).toEqual(
+			verifyRekorReceipt(tampered, record, [f.logPubkeyPem]),
+		);
+		expect(pkgVerifyRekorReceipt(f.receipt, record, [])).toEqual(
+			verifyRekorReceipt(f.receipt, record, []),
+		);
+
+		const entries = Array.from({ length: 13 }, () => randomBytes(32));
+		const rootHex = mth(entries).toString("hex");
+		const path = inclusionPath(9, entries).map((h) => h.toString("hex"));
+		const leaf = leafHash(entries[9] as Buffer).toString("hex");
+		expect(pkgVerifyIndexInclusion(leaf, 9, 13, path, rootHex)).toBe(
+			verifyIndexInclusion(leaf, 9, 13, path, rootHex),
+		);
+	});
+
+	it("29. the leaf hash is sha256(0x00 || the log's stored bytes), never a reserialization", () => {
+		const f = makeRekorReceipt(record, { logSize: 1, logIndex: 0 });
+		const expected = createHash("sha256")
+			.update(Buffer.from([0x00]))
+			.update(f.entryBody)
+			.digest("hex");
+		expect(f.receipt.log.rootHash).toBe(expected);
+		// Re-serializing the entry (even to equivalent JSON) breaks inclusion.
+		const reserialized = Buffer.from(`${f.entryBody.toString("utf8")} `, "utf8").toString("base64");
+		const result = verifyRekorReceipt(
+			f.tamper((r) => {
+				r.entryBody = reserialized;
+			}),
+			record,
+			[f.logPubkeyPem],
+		);
+		expect(result.ok).toBe(false);
+		expect(result.errors.join(" | ")).toContain("inclusion proof");
+	});
+
+	it("30. the entry body the sink will build (T3) is exactly what this verifier accepts", () => {
+		const pem = "-----BEGIN PUBLIC KEY-----\nZmFrZQ==\n-----END PUBLIC KEY-----\n";
+		const entry = hashedRekordEntry(record, pem);
+		const parsed = JSON.parse(entry.toString("utf8")) as Record<string, unknown>;
+		expect(parsed.apiVersion).toBe("0.0.1");
+		expect(parsed.kind).toBe("hashedrekord");
+		const f = makeRekorReceipt(record, { publicKeyPem: pem });
+		expect(f.entryBody.equals(entry)).toBe(true);
+		expect(verifyRekorReceipt(f.receipt, record, [f.logPubkeyPem]).ok).toBe(true);
+	});
+});

--- a/packages/verify/README.md
+++ b/packages/verify/README.md
@@ -38,7 +38,20 @@ aws s3 cp s3://…/000000000042.json - | usertrust-verify .usertrust --anchor - 
 # CI gate: externally anchored, fresh, verified — or exit 1
 usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
   --require-anchor --require-external-anchor --max-unanchored-events 5000
+
+# Transparency-log receipts (repeatable; JSON or JSONL; - = stdin)
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
+  --rekor-receipts .usertrust/audit/anchors/rekor/000000000042.json
+
+# A self-hosted log needs its key pinned too (repeatable — any pinned key may verify)
+usertrust-verify .usertrust --anchors anchors.jsonl --pubkey root.pem \
+  --rekor-receipts receipts.jsonl --rekor-pubkey rekor-internal.pem
+
+# One operator-supplied handoff file: usertrust anchor export-bundle
+usertrust-verify .usertrust --bundle audit-bundle.json --pubkey root.pem
 ```
+
+`--rekor-receipts` verification is offline and fail-closed: the signed-note checkpoint and its ECDSA P-256 signature, an RFC 9162 inclusion proof, and the binding of the log entry to your record all have to check out, or you get `ANCHOR_INVALID` (reason `rekor-receipt-invalid`) and exit 1. A verified receipt also makes `--max-anchor-age` measure against the log's attested `integratedTime` instead of the operator's own timestamp. Without `--rekor-pubkey`, the embedded rekor.sigstore.dev key is used **only** for receipts whose log host is `rekor.sigstore.dev`; any other log must be pinned explicitly. `--bundle` takes `{v:1, records, rekorReceipts}` and is parsed strictly — unknown fields, a version other than 1, or oversized lists are errors.
 
 Result states: `ANCHORED_VERIFIED`, `UNANCHORED` (legacy vaults — valid, weaker, labeled), `ANCHOR_UNVERIFIABLE`, `ANCHOR_STALE`, and the hard failures `ANCHOR_INVALID` / `ANCHOR_MISMATCH` (rewrite, rollback, deletion, or fork against the signed checkpoints — always exit 1). After a key rotation, keep pinning the original root key and pass the announced successor fingerprints with `--successor-pin`. See the [anchoring guide](https://github.com/usertools-ai/usertrust/blob/master/docs/anchoring.md) for the operator side.
 

--- a/packages/verify/src/anchor-verify.ts
+++ b/packages/verify/src/anchor-verify.ts
@@ -172,6 +172,22 @@ function isSafePositiveInt(n: unknown): n is number {
 	return typeof n === "number" && Number.isSafeInteger(n) && n >= 1;
 }
 
+// Matching control characters is the entire point here — they are what gets
+// removed from anything echoed back to a terminal.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the intent
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+
+/**
+ * An untrusted field NAME on its way into an error string. Control characters
+ * are stripped before truncation: these strings are printed to a terminal, and
+ * an escape sequence inside a key would let the party under audit repaint the
+ * line its own verdict is printed on.
+ */
+function clipKey(key: string): string {
+	const scrubbed = key.replace(CONTROL_CHARS, "");
+	return scrubbed.length <= 80 ? scrubbed : `${scrubbed.slice(0, 80)}...`;
+}
+
 /**
  * Strict parse of a single anchor record. Unknown fields, missing fields, and
  * range violations are all rejected (fail-closed — spec §3 strict-parse rules;
@@ -195,7 +211,7 @@ export function parseAnchorRecord(raw: string): {
 	const obj = parsed as Record<string, unknown>;
 	for (const key of Object.keys(obj)) {
 		if (!RECORD_KEYS.has(key)) {
-			return { record: null, error: `malformed-anchor: unknown field "${key}"` };
+			return { record: null, error: `malformed-anchor: unknown field "${clipKey(key)}"` };
 		}
 	}
 	if (obj.v !== 1) {
@@ -243,7 +259,10 @@ export function parseAnchorRecord(raw: string): {
 		const rotObj = rot as Record<string, unknown>;
 		for (const key of Object.keys(rotObj)) {
 			if (!ROTATION_KEYS.has(key)) {
-				return { record: null, error: `malformed-anchor: unknown rotation field "${key}"` };
+				return {
+					record: null,
+					error: `malformed-anchor: unknown rotation field "${clipKey(key)}"`,
+				};
 			}
 		}
 		if (typeof rotObj.nextKeyId !== "string" || !KEY_ID.test(rotObj.nextKeyId)) {

--- a/packages/verify/src/anchor-verify.ts
+++ b/packages/verify/src/anchor-verify.ts
@@ -91,6 +91,13 @@ export interface AnchorEvaluationOptions {
 	readonly expectedVaultId?: string;
 	/** Injectable clock for tests. Defaults to Date.now(). */
 	readonly nowMs?: number;
+	/**
+	 * Witness-attested integration time (ms) for the NEWEST anchor, from a
+	 * transparency-log receipt the caller already verified. When present it
+	 * replaces the operator-claimed timestamp as the input to --max-anchor-age:
+	 * it is the one time in the record the vault operator cannot choose.
+	 */
+	readonly attestedTimeMs?: number;
 }
 
 export interface AnchorEvaluationInput {
@@ -134,7 +141,12 @@ function nullIfNaN(n: number): number | null {
 
 // ── Reason-code classes (see spec §7.2) ──
 
-const INVALID_REASONS = new Set(["malformed-anchor", "range-invalid", "sig-invalid"]);
+const INVALID_REASONS = new Set([
+	"malformed-anchor",
+	"range-invalid",
+	"sig-invalid",
+	"rekor-receipt-invalid",
+]);
 const NON_FAIL_REASONS = new Set(["no-trust-material", "witness-unreachable"]);
 
 // ── Strict parsing ──
@@ -743,7 +755,12 @@ const STATE_SEVERITY: Record<AnchorState, number> = {
 	ANCHOR_MISMATCH: 5,
 };
 
-function worseState(a: AnchorState, b: AnchorState): AnchorState {
+/**
+ * The more severe of two states. Exported so callers layering evidence ON TOP
+ * of the state machine (the glue's Rekor receipts) escalate by the SAME
+ * severity ordering the machine itself uses, rather than hardcoding one.
+ */
+export function worseAnchorState(a: AnchorState, b: AnchorState): AnchorState {
 	return (STATE_SEVERITY[a] ?? 0) >= (STATE_SEVERITY[b] ?? 0) ? a : b;
 }
 
@@ -791,7 +808,7 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 		let finalState = state;
 		if (witnessFailed) {
 			reasons.push("witness-unreachable");
-			finalState = worseState(finalState, "ANCHOR_UNVERIFIABLE");
+			finalState = worseAnchorState(finalState, "ANCHOR_UNVERIFIABLE");
 			errors.push(`witness-unreachable: ${input.witness.error ?? "anchor URL fetch failed"}`);
 		}
 		let witness: { requested: boolean; status: WitnessStatus; error?: string };
@@ -954,10 +971,19 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 	const latest = [...records].sort((a, b) => b.treeSize - a.treeSize)[0];
 	if (latest !== undefined) {
 		const ts = Date.parse(latest.timestamp);
-		if (Number.isFinite(ts) && ts > nowMs) {
+		// A witness-attested integration time supersedes the operator's claim:
+		// the caller verified a transparency-log receipt binding this anchor to a
+		// time the vault operator did not choose, which is exactly the input the
+		// operator-claimed path lacks.
+		const attestedMs =
+			opts.attestedTimeMs !== undefined && Number.isSafeInteger(opts.attestedTimeMs)
+				? opts.attestedTimeMs
+				: null;
+		if (attestedMs === null && Number.isFinite(ts) && ts > nowMs) {
 			// Operator-claimed time is in the auditor's future — clock gaming
 			// (buyer-rejection §5.13). --max-unanchored-events is the
-			// clock-independent control.
+			// clock-independent control. Not raised on the attested path: there
+			// the operator's claim drives no policy, so it is not evidence.
 			warnings.push("future-timestamp");
 		}
 		const tail = Math.max(0, observed - latest.treeSize);
@@ -967,14 +993,17 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 			);
 			return finish("ANCHOR_STALE", records);
 		}
+		const ageBasisMs = attestedMs ?? ts;
 		if (
 			opts.maxAnchorAgeMs !== undefined &&
-			Number.isFinite(ts) &&
-			nowMs - ts > opts.maxAnchorAgeMs &&
+			Number.isFinite(ageBasisMs) &&
+			nowMs - ageBasisMs > opts.maxAnchorAgeMs &&
 			observed > latest.treeSize
 		) {
 			errors.push(
-				"stale: newest anchor is older than the supplied --max-anchor-age (operator-claimed time)",
+				attestedMs === null
+					? "stale: newest anchor is older than the supplied --max-anchor-age (operator-claimed time)"
+					: "stale: newest anchor is older than the supplied --max-anchor-age (witness-attested time)",
 			);
 			return finish("ANCHOR_STALE", records);
 		}

--- a/packages/verify/src/anchor-verify.ts
+++ b/packages/verify/src/anchor-verify.ts
@@ -998,11 +998,13 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 			opts.attestedTimeMs !== undefined && Number.isSafeInteger(opts.attestedTimeMs)
 				? opts.attestedTimeMs
 				: null;
-		if (attestedMs === null && Number.isFinite(ts) && ts > nowMs) {
+		if (Number.isFinite(ts) && ts > nowMs) {
 			// Operator-claimed time is in the auditor's future — clock gaming
-			// (buyer-rejection §5.13). --max-unanchored-events is the
-			// clock-independent control. Not raised on the attested path: there
-			// the operator's claim drives no policy, so it is not evidence.
+			// (buyer-rejection §5.13). Raised even when an attested time supersedes
+			// it below: a forward-dated claim is evidence about the operator whether
+			// or not a witness also spoke, and suppressing it on the attested path
+			// would let a receipt LAUNDER the very signal it was supplied to
+			// corroborate. --max-unanchored-events stays the clock-independent control.
 			warnings.push("future-timestamp");
 		}
 		const tail = Math.max(0, observed - latest.treeSize);

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -35,6 +35,9 @@ Options:
   --anchor <file|->              Caller-fetched anchor artifact (repeatable; - = stdin)
   --anchors <file>               Anchor history file (JSONL; repeatable)
   --anchor-url <url>             Opt-in: fetch one anchor artifact over HTTPS
+  --bundle <file|->              Auditor bundle {v,records,rekorReceipts} (usertrust anchor export-bundle)
+  --rekor-receipts <file|->      Transparency-log receipt(s), JSON or JSONL (repeatable)
+  --rekor-pubkey <pem-file>      PINNED transparency-log public key (repeatable)
   --pubkey <pem-file>            PINNED genesis root public key (out-of-band)
   --successor-pin <pem-file>     Pinned rotation-successor key (repeatable)
   --vault-id <uuid>              Expected vaultId
@@ -59,6 +62,57 @@ function parseDurationMs(raw: string): number {
 function readArtifact(pathOrDash: string): string {
 	if (pathOrDash === "-") return readFileSync(0, "utf-8");
 	return readFileSync(pathOrDash, "utf-8");
+}
+
+const MAX_PEM_BYTES = 16 * 1024;
+const MAX_BUNDLE_ITEMS = 10_000;
+const BUNDLE_KEYS = new Set(["v", "records", "rekorReceipts"]);
+
+function readPinnedPem(path: string): string {
+	const pem = readFileSync(path, "utf-8");
+	if (Buffer.byteLength(pem, "utf8") > MAX_PEM_BYTES) {
+		console.error(`--rekor-pubkey ${path}: PEM exceeds 16 KiB`);
+		process.exit(1);
+	}
+	return pem;
+}
+
+/**
+ * Strict parse of an auditor bundle: `{v:1, records, rekorReceipts?}`. A bundle
+ * is untrusted transport, so unknown top-level fields are rejected rather than
+ * ignored — a field the CLI silently drops is one an exporter can use to carry
+ * evidence the verifier never looks at. Element shapes are NOT validated here:
+ * records and receipts are re-serialized and go through the same strict parsers
+ * every other input does.
+ */
+function parseBundle(raw: string): { anchorsRaw: string; receiptsRaw: string[] } {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new Error("--bundle: not valid JSON");
+	}
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		throw new Error("--bundle: not an object");
+	}
+	const obj = parsed as Record<string, unknown>;
+	for (const key of Object.keys(obj)) {
+		if (!BUNDLE_KEYS.has(key)) throw new Error(`--bundle: unknown field "${key.slice(0, 80)}"`);
+	}
+	if (obj.v !== 1) throw new Error("--bundle: unsupported version (expected 1)");
+	if (!Array.isArray(obj.records)) throw new Error("--bundle: records must be an array");
+	if (obj.records.length > MAX_BUNDLE_ITEMS) {
+		throw new Error(`--bundle: records exceeds the ${MAX_BUNDLE_ITEMS} cap`);
+	}
+	const receipts = obj.rekorReceipts ?? [];
+	if (!Array.isArray(receipts)) throw new Error("--bundle: rekorReceipts must be an array");
+	if (receipts.length > MAX_BUNDLE_ITEMS) {
+		throw new Error(`--bundle: rekorReceipts exceeds the ${MAX_BUNDLE_ITEMS} cap`);
+	}
+	return {
+		anchorsRaw: obj.records.map((record) => JSON.stringify(record)).join("\n"),
+		receiptsRaw: receipts.map((receipt) => JSON.stringify(receipt)),
+	};
 }
 
 function fetchAnchorUrl(url: string): Promise<{ ok: boolean; body?: string; error?: string }> {
@@ -88,6 +142,9 @@ function fetchAnchorUrl(url: string): Promise<{ ok: boolean; body?: string; erro
 let vaultPath: string | undefined;
 let txId: string | undefined;
 const anchorFiles: string[] = [];
+const rekorReceiptFiles: string[] = [];
+const rekorPubkeyFiles: string[] = [];
+let bundleFile: string | undefined;
 let anchorUrl: string | undefined;
 let pubkeyFile: string | undefined;
 const successorPinFiles: string[] = [];
@@ -108,6 +165,9 @@ for (let i = 0; i < args.length; i++) {
 	if (arg === "--tx") txId = next();
 	else if (arg === "--anchor" || arg === "--anchors") anchorFiles.push(next());
 	else if (arg === "--anchor-url") anchorUrl = next();
+	else if (arg === "--rekor-receipts") rekorReceiptFiles.push(next());
+	else if (arg === "--rekor-pubkey") rekorPubkeyFiles.push(next());
+	else if (arg === "--bundle") bundleFile = next();
 	else if (arg === "--pubkey") pubkeyFile = next();
 	else if (arg === "--successor-pin") successorPinFiles.push(next());
 	else if (arg === "--vault-id") vaultId = next();
@@ -138,11 +198,24 @@ const anchorMode =
 	anchorFiles.length > 0 ||
 	anchorUrl !== undefined ||
 	pubkeyFile !== undefined ||
+	bundleFile !== undefined ||
+	rekorReceiptFiles.length > 0 ||
 	requireAnchor ||
 	requireExternalAnchor;
 
 async function buildAnchorParams(): Promise<AnchorVerifyParams> {
 	const externalAnchorsRaw: string[] = anchorFiles.map(readArtifact);
+	const rekorReceiptsRaw: string[] = rekorReceiptFiles.map(readArtifact);
+	if (bundleFile !== undefined) {
+		try {
+			const bundle = parseBundle(readArtifact(bundleFile));
+			externalAnchorsRaw.push(bundle.anchorsRaw);
+			rekorReceiptsRaw.push(...bundle.receiptsRaw);
+		} catch (err) {
+			console.error(err instanceof Error ? err.message : String(err));
+			process.exit(1);
+		}
+	}
 	let witness: WitnessInput = { requested: false };
 	if (anchorUrl !== undefined) {
 		const fetched = await fetchAnchorUrl(anchorUrl);
@@ -179,6 +252,8 @@ async function buildAnchorParams(): Promise<AnchorVerifyParams> {
 			: undefined;
 	return {
 		externalAnchorsRaw,
+		rekorReceiptsRaw,
+		rekorLogPubkeysPem: rekorPubkeyFiles.map(readPinnedPem),
 		...(trust !== undefined ? { trust } : {}),
 		witness,
 		...(maxAnchorAgeMs !== undefined ? { maxAnchorAgeMs } : {}),
@@ -202,6 +277,14 @@ function printAnchorSection(result: AnchoredVaultVerificationResult): void {
 		);
 	}
 	console.log(`Unanchored tail: ${a.unanchoredTail.events} event(s)`);
+	if (a.rekor !== undefined) {
+		const attested =
+			a.rekor.latestAttestedTimeMs === null
+				? ""
+				: `, attested ${new Date(a.rekor.latestAttestedTimeMs).toISOString()}`;
+		const failed = a.rekor.receiptsFailed > 0 ? `, ${a.rekor.receiptsFailed} FAILED` : "";
+		console.log(`Rekor: ${a.rekor.receiptsVerified} receipt(s) verified${failed}${attested}`);
+	}
 	if (a.witness.requested) {
 		console.log(`Witness: ${a.witness.status}${a.witness.error ? ` (${a.witness.error})` : ""}`);
 	}

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -68,10 +68,22 @@ const MAX_PEM_BYTES = 16 * 1024;
 const MAX_BUNDLE_ITEMS = 10_000;
 const BUNDLE_KEYS = new Set(["v", "records", "rekorReceipts"]);
 
+/**
+ * Read one pinned log key. A file that carries no usable PEM is a usage error,
+ * not an empty pin: the verifier discards unusable entries, so accepting one
+ * here would leave the caller believing they pinned a key while the receipt was
+ * checked against something else entirely.
+ */
 function readPinnedPem(path: string): string {
 	const pem = readFileSync(path, "utf-8");
 	if (Buffer.byteLength(pem, "utf8") > MAX_PEM_BYTES) {
 		console.error(`--rekor-pubkey ${path}: PEM exceeds 16 KiB`);
+		process.exit(1);
+	}
+	if (pem.trim().length === 0 || !pem.includes("-----BEGIN PUBLIC KEY-----")) {
+		console.error(
+			`--rekor-pubkey ${path}: not a PEM public key (-----BEGIN PUBLIC KEY----- missing)`,
+		);
 		process.exit(1);
 	}
 	return pem;

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -274,6 +274,16 @@ async function buildAnchorParams(): Promise<AnchorVerifyParams> {
 	};
 }
 
+/**
+ * A witness-attested time on its way to a terminal. The receipt parser bounds
+ * integratedTime, but this value also arrives from library callers, and
+ * `toISOString()` throws RangeError outside ±8.64e15 ms — printing raw
+ * milliseconds beats crashing the verifier over a number it already distrusts.
+ */
+function formatAttestedMs(ms: number): string {
+	return Number.isFinite(ms) && Math.abs(ms) <= 8.64e15 ? new Date(ms).toISOString() : `${ms} ms`;
+}
+
 function printAnchorSection(result: AnchoredVaultVerificationResult): void {
 	const a = result.anchoring;
 	if (result.anchorState === "UNANCHORED") {
@@ -293,7 +303,7 @@ function printAnchorSection(result: AnchoredVaultVerificationResult): void {
 		const attested =
 			a.rekor.latestAttestedTimeMs === null
 				? ""
-				: `, attested ${new Date(a.rekor.latestAttestedTimeMs).toISOString()}`;
+				: `, attested ${formatAttestedMs(a.rekor.latestAttestedTimeMs)}`;
 		const failed = a.rekor.receiptsFailed > 0 ? `, ${a.rekor.receiptsFailed} FAILED` : "";
 		console.log(`Rekor: ${a.rekor.receiptsVerified} receipt(s) verified${failed}${attested}`);
 	}

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -436,7 +436,16 @@ function verifySuppliedRekorReceipts(
 	let receiptsFailed = 0;
 	let latestAttestedTimeMs: number | null = null;
 	for (const raw of receiptsRaw) {
-		for (const document of splitReceiptDocuments(raw)) {
+		const documents = splitReceiptDocuments(raw);
+		if (documents.length === 0) {
+			// A receipts artifact that holds no receipts is a supply failure, not an
+			// absence of evidence: the caller passed --rekor-receipts, so an empty
+			// file means the receipt they meant to present never made it here.
+			receiptsFailed++;
+			errors.push("rekor-receipt-invalid: receipts artifact contained no receipts");
+			continue;
+		}
+		for (const document of documents) {
 			const parsed = parseRekorReceipt(document);
 			if (parsed.receipt === null) {
 				receiptsFailed++;

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -76,6 +76,16 @@ export {
 	type TransactionEvent,
 } from "./receipt.js";
 export {
+	parseRekorReceipt,
+	parseSignedNote,
+	REKOR_PROD_PUBKEY_PEM,
+	type RekorReceipt,
+	type RekorVerification,
+	type SignedNote,
+	verifyIndexInclusion,
+	verifyRekorReceipt,
+} from "./rekor-verify.js";
+export {
 	buildMerkleTree,
 	type ChainVerificationResult,
 	generateConsistencyProof,

--- a/packages/verify/src/index.ts
+++ b/packages/verify/src/index.ts
@@ -20,6 +20,7 @@ import {
 	verifyInclusionAgainstAnchor,
 	type WitnessInput,
 	type WitnessStatus,
+	worseAnchorState,
 } from "./anchor-verify.js";
 import { canonicalize } from "./canonical.js";
 import { GENESIS_HASH } from "./constants.js";
@@ -29,6 +30,7 @@ import {
 	renderReceipt,
 	type TransactionEvent,
 } from "./receipt.js";
+import { parseRekorReceipt, type RekorVerification, verifyRekorReceipt } from "./rekor-verify.js";
 import {
 	buildMerkleTree,
 	generateInclusionProof,
@@ -66,6 +68,7 @@ export {
 	verifySignatureRaw,
 	type WitnessInput,
 	type WitnessStatus,
+	worseAnchorState,
 } from "./anchor-verify.js";
 export { canonicalize } from "./canonical.js";
 export { GENESIS_HASH } from "./constants.js";
@@ -321,6 +324,14 @@ export function exitCodeFor(result: { valid: boolean }): number {
 export interface AnchorVerifyParams {
 	/** Raw contents of caller-fetched anchor artifacts (single JSON or JSONL). */
 	readonly externalAnchorsRaw?: readonly string[] | undefined;
+	/** Raw transparency-log receipts: one receipt JSON, or JSONL of receipts. */
+	readonly rekorReceiptsRaw?: readonly string[] | undefined;
+	/**
+	 * Caller-pinned transparency-log keys. Supplying none is only meaningful for
+	 * the one log whose key ships with the verifier (rekor.sigstore.dev); any
+	 * other log without a pin is refused rather than trusted.
+	 */
+	readonly rekorLogPubkeysPem?: readonly string[] | undefined;
 	/** Caller-pinned trust material — NEVER read from the vault under audit. */
 	readonly trust?: AnchorTrust | undefined;
 	readonly witness?: WitnessInput | undefined;
@@ -328,6 +339,14 @@ export interface AnchorVerifyParams {
 	readonly maxUnanchoredEvents?: number | undefined;
 	readonly expectedVaultId?: string | undefined;
 	readonly nowMs?: number | undefined;
+}
+
+export interface RekorReport {
+	receiptsVerified: number;
+	receiptsFailed: number;
+	/** Max attested time among verified receipts of the NEWEST anchor (ms). */
+	latestAttestedTimeMs: number | null;
+	errors: string[];
 }
 
 export interface AnchoringReport {
@@ -344,11 +363,118 @@ export interface AnchoringReport {
 	witness: { requested: boolean; status: WitnessStatus; error?: string };
 	reasons: string[];
 	warnings: string[];
+	/** Present only when transparency-log receipts were supplied. */
+	rekor?: RekorReport;
 }
 
 export interface AnchoredVaultVerificationResult extends VaultVerificationResult {
 	anchorState: AnchorState;
 	anchoring: AnchoringReport;
+}
+
+/**
+ * Split one raw receipt artifact into receipt documents. A file may hold a
+ * single (possibly pretty-printed) receipt or JSONL of many, so the whole-file
+ * parse is tried first and line-splitting is the fallback — the reverse would
+ * shred a pretty-printed receipt into unparseable fragments.
+ *
+ * IDENTICAL in packages/core/src/audit/verify.ts.
+ */
+function splitReceiptDocuments(raw: string): string[] {
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) return [];
+	try {
+		JSON.parse(trimmed);
+		return [trimmed];
+	} catch {
+		return trimmed
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+	}
+}
+
+/**
+ * Verify every supplied transparency-log receipt against the anchor record it
+ * names. Receipts are OPTIONAL evidence, but supplied evidence is not
+ * advisory: a receipt is only ever presented to strengthen a claim, so one
+ * that does not verify fails the vault closed rather than being dropped.
+ *
+ * Records are matched by anchorSeq with the external copy governing (the same
+ * precedence the evaluator's merge uses). A receipt may bind to ANY record at
+ * its anchorSeq: committed-equal twins differ in exactly the timestamp and
+ * signature a receipt commits to, so the emitter's published twin must not
+ * depend on which copy the auditor happened to fetch first.
+ *
+ * IDENTICAL in packages/core/src/audit/verify.ts.
+ */
+function verifySuppliedRekorReceipts(
+	receiptsRaw: readonly string[],
+	externalRecords: readonly AnchorRecord[],
+	mirrorRecords: readonly AnchorRecord[],
+	logPubkeysPem: readonly string[],
+): RekorReport | null {
+	if (receiptsRaw.length === 0) return null;
+	const bySeq = new Map<number, AnchorRecord[]>();
+	for (const record of [...externalRecords, ...mirrorRecords]) {
+		const twins = bySeq.get(record.anchorSeq);
+		if (twins === undefined) {
+			bySeq.set(record.anchorSeq, [record]);
+		} else {
+			twins.push(record);
+		}
+	}
+	// The NEWEST anchor by the evaluator's own rule (largest treeSize, earliest
+	// anchorSeq on a tie) — only its receipts may speak for freshness.
+	const merged = [...bySeq.keys()]
+		.sort((a, b) => a - b)
+		.map((seq) => (bySeq.get(seq) as AnchorRecord[])[0] as AnchorRecord);
+	const latestSeq = [...merged].sort((a, b) => b.treeSize - a.treeSize)[0]?.anchorSeq ?? null;
+
+	const errors: string[] = [];
+	let receiptsVerified = 0;
+	let receiptsFailed = 0;
+	let latestAttestedTimeMs: number | null = null;
+	for (const raw of receiptsRaw) {
+		for (const document of splitReceiptDocuments(raw)) {
+			const parsed = parseRekorReceipt(document);
+			if (parsed.receipt === null) {
+				receiptsFailed++;
+				errors.push(parsed.error as string);
+				continue;
+			}
+			const receipt = parsed.receipt;
+			const candidates = bySeq.get(receipt.anchorSeq) ?? [];
+			if (candidates.length === 0) {
+				receiptsFailed++;
+				errors.push(`rekor-receipt-invalid: receipt for unknown anchorSeq ${receipt.anchorSeq}`);
+				continue;
+			}
+			let verified: RekorVerification | null = null;
+			let firstErrors: string[] = [];
+			for (const candidate of candidates) {
+				const result = verifyRekorReceipt(receipt, candidate, logPubkeysPem);
+				if (result.ok) {
+					verified = result;
+					break;
+				}
+				if (firstErrors.length === 0) firstErrors = result.errors;
+			}
+			if (verified === null) {
+				receiptsFailed++;
+				errors.push(...firstErrors);
+				continue;
+			}
+			receiptsVerified++;
+			if (receipt.anchorSeq === latestSeq && verified.attestedTimeMs !== null) {
+				latestAttestedTimeMs =
+					latestAttestedTimeMs === null
+						? verified.attestedTimeMs
+						: Math.max(latestAttestedTimeMs, verified.attestedTimeMs);
+			}
+		}
+	}
+	return { receiptsVerified, receiptsFailed, latestAttestedTimeMs, errors };
 }
 
 /**
@@ -370,6 +496,12 @@ export function verifyVaultWithAnchors(
 		externalErrors.push(...parsed.errors);
 	}
 	const mirror = readAnchorMirror(vaultPath);
+	const rekor = verifySuppliedRekorReceipts(
+		params.rekorReceiptsRaw ?? [],
+		externalRecords,
+		mirror.records,
+		params.rekorLogPubkeysPem ?? [],
+	);
 	const evaluation = evaluateAnchoredVault({
 		orderedHashes: gatherOrderedEventHashes(vaultPath),
 		externalAnchors: externalRecords,
@@ -385,21 +517,32 @@ export function verifyVaultWithAnchors(
 				: {}),
 			...(params.expectedVaultId !== undefined ? { expectedVaultId: params.expectedVaultId } : {}),
 			...(params.nowMs !== undefined ? { nowMs: params.nowMs } : {}),
+			...(rekor !== null && rekor.latestAttestedTimeMs !== null
+				? { attestedTimeMs: rekor.latestAttestedTimeMs }
+				: {}),
 		},
 	});
+	// A broken receipt is ANCHOR_INVALID (fail-closed), escalated by the state
+	// machine's own severity ordering so MISMATCH still outranks it.
+	const rekorFailed = rekor !== null && rekor.receiptsFailed > 0;
 	return {
 		...base,
-		valid: base.valid && evaluation.anchorsValid,
-		errors: [...base.errors, ...evaluation.errors],
-		anchorState: evaluation.anchorState,
+		valid: base.valid && evaluation.anchorsValid && !rekorFailed,
+		errors: [...base.errors, ...evaluation.errors, ...(rekor?.errors ?? [])],
+		anchorState: rekorFailed
+			? worseAnchorState(evaluation.anchorState, "ANCHOR_INVALID")
+			: evaluation.anchorState,
 		anchoring: {
 			anchorSource: evaluation.anchorSource,
 			anchorCount: evaluation.anchorCount,
 			latestAnchor: evaluation.latestAnchor,
 			unanchoredTail: evaluation.unanchoredTail,
 			witness: evaluation.witness,
-			reasons: evaluation.reasons,
+			reasons: rekorFailed
+				? [...new Set([...evaluation.reasons, "rekor-receipt-invalid"])]
+				: evaluation.reasons,
 			warnings: evaluation.warnings,
+			...(rekor !== null ? { rekor } : {}),
 		},
 	};
 }

--- a/packages/verify/src/rekor-verify.ts
+++ b/packages/verify/src/rekor-verify.ts
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Rekor Transparency-Log Receipt Verification — Zero-dependency standalone
+ *
+ * INTENTIONAL DUPLICATION: this file exists byte-for-byte in BOTH
+ * packages/verify/src/rekor-verify.ts and
+ * packages/core/src/audit/rekor-verify.ts — here even the import paths match,
+ * since the module's only sibling import is anchor-verify.js. The parity test
+ * pins the two together; any change must land in both packages.
+ *
+ * A receipt is EVIDENCE SUPPLIED BY THE PARTY UNDER AUDIT: it proves nothing on
+ * its own, and every field in it is attacker-shaped. What verification
+ * establishes, end to end, is a single chain of bindings:
+ *
+ *   our signed anchor record -> the bytes the log stored -> that entry's
+ *   position in a tree -> a checkpoint over that tree -> a log key the AUDITOR
+ *   pinned (never one the receipt names).
+ *
+ * Break any link and the receipt is worthless, so each is checked in order and
+ * the first failure is fatal (fail-closed). Rekor data deliberately lives in
+ * SEPARATE receipt files: the anchor record schema is frozen, and a
+ * transparency log must never become a field inside the thing it witnesses.
+ *
+ * Offline scope: a verified receipt proves the entry was included in the log at
+ * `integratedTime` under a pinned key. It does NOT prove the log's current head
+ * is consistent with that checkpoint — that needs a witness/consistency query,
+ * which stays out of the zero-dependency verifier by design.
+ */
+
+import { createHash } from "node:crypto";
+import {
+	type AnchorRecord,
+	anchorPayloadHash,
+	publicKeyFromPem,
+	verifySignatureRaw,
+} from "./anchor-verify.js";
+
+// ── Types ──
+
+export interface RekorReceipt {
+	v: 1;
+	vaultId: string;
+	anchorSeq: number;
+	/** 64-hex — MUST equal anchorPayloadHash(record). */
+	artifactHash: string;
+	/** base64 of the entry bytes AS STORED BY THE LOG, never a reserialization. */
+	entryBody: string;
+	log: {
+		url: string;
+		logIndex: number;
+		treeSize: number;
+		/** 64-hex root the inclusion path must reconstruct. */
+		rootHash: string;
+		/** 64-hex inclusion path, leaf -> root order. */
+		hashes: string[];
+		/** Signed note (checkpoint) over treeSize + rootHash. */
+		checkpoint: string;
+		/** Unix seconds the log attests it integrated the entry. */
+		integratedTime: number;
+	};
+}
+
+export interface SignedNote {
+	origin: string;
+	treeSize: number;
+	rootHashHex: string;
+	/** EXACTLY the bytes the log signs: 3 body lines including the trailing LF. */
+	body: string;
+	/** Note signature with the 4-byte key hint stripped off the front. */
+	sig: Buffer;
+}
+
+export interface RekorVerification {
+	ok: boolean;
+	/** Witness-attested time in ms — the input to staleness policy when present. */
+	attestedTimeMs: number | null;
+	errors: string[];
+}
+
+// ── Constants ──
+
+/**
+ * The rekor.sigstore.dev v1 log key, as served by
+ * https://rekor.sigstore.dev/api/v1/log/publicKey — ECDSA P-256, SPKI sha256
+ * c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d (the log's
+ * published logID). This is DATA, not a dependency, and it is not a blanket
+ * trust root: it is consulted ONLY for receipts whose log URL host IS
+ * rekor.sigstore.dev. Any other log must be pinned by the operator with
+ * --rekor-pubkey.
+ */
+export const REKOR_PROD_PUBKEY_PEM = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2G2Y+2tabdTV5BcGiBIx0a9fAFwr
+kBbmLSGtks4L3qX6yYY0zufBnhC8Ur/iy55GhWP/9A/bY2LhC30M9+RYtw==
+-----END PUBLIC KEY-----
+`;
+
+/** The one host the embedded key above is allowed to speak for. */
+const REKOR_PROD_HOST = "rekor.sigstore.dev";
+
+const ERR = "rekor-receipt-invalid";
+
+// Caps on untrusted input. A receipt is a small artifact; anything near these
+// bounds is an attempt to make the verifier do work, not to prove inclusion.
+const MAX_RECEIPT_BYTES = 256 * 1024;
+const MAX_ENTRY_BODY_BYTES = 64 * 1024;
+const MAX_CHECKPOINT_BYTES = 8 * 1024;
+const MAX_INCLUSION_PATH = 64;
+const MAX_PEM_BYTES = 16 * 1024;
+
+const HEX64 = /^[0-9a-f]{64}$/;
+const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
+const UINT = /^(0|[1-9][0-9]*)$/;
+
+const LEAF_PREFIX = Buffer.from([0x00]);
+const NODE_PREFIX = Buffer.from([0x01]);
+
+const RECEIPT_KEYS = new Set(["v", "vaultId", "anchorSeq", "artifactHash", "entryBody", "log"]);
+const LOG_KEYS = new Set([
+	"url",
+	"logIndex",
+	"treeSize",
+	"rootHash",
+	"hashes",
+	"checkpoint",
+	"integratedTime",
+]);
+
+// ── Small helpers ──
+
+/** Untrusted values are never echoed whole into an error string. */
+function clip(value: string): string {
+	return value.length <= 80 ? value : `${value.slice(0, 80)}...`;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function isSafeIntAtLeast(value: unknown, min: number): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= min;
+}
+
+/** Lowercased host (INCLUDING port) of an http(s) URL, or null. */
+function logHost(url: string): string | null {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+	return parsed.host.toLowerCase();
+}
+
+function nodeHash(left: Buffer, right: Buffer): Buffer {
+	return createHash("sha256").update(NODE_PREFIX).update(left).update(right).digest();
+}
+
+// ── Signed notes (checkpoints) ──
+
+/**
+ * Parse a signed note:
+ *   <origin>\n<treeSize>\n<base64 rootHash>\n\n— <keyname> <base64 sig>\n
+ * Strictly LF-only and strictly this shape — a note is a signed artifact, so
+ * accepting variants would mean verifying a signature over bytes we did not
+ * actually parse. The signature payload is `4-byte keyhint || DER signature`;
+ * the hint identifies which key the log used and is ADVISORY only, because the
+ * auditor pins the key out-of-band. Only its 4 bytes are skipped.
+ */
+export function parseSignedNote(note: string): SignedNote | null {
+	if (note.length === 0 || Buffer.byteLength(note, "utf8") > MAX_CHECKPOINT_BYTES) return null;
+	if (note.includes("\r")) return null;
+	const lines = note.split("\n");
+	if (lines.length === 6 && lines[5] === "") lines.pop();
+	if (lines.length !== 5) return null;
+	const origin = lines[0] as string;
+	const sizeLine = lines[1] as string;
+	const rootB64 = lines[2] as string;
+	if (origin.length === 0 || lines[3] !== "") return null;
+	if (!UINT.test(sizeLine)) return null;
+	const treeSize = Number(sizeLine);
+	if (!Number.isSafeInteger(treeSize)) return null;
+	if (!BASE64.test(rootB64)) return null;
+	const root = Buffer.from(rootB64, "base64");
+	if (root.length !== 32) return null;
+	const parts = (lines[4] as string).split(" ");
+	if (parts.length !== 3 || parts[0] !== "—" || (parts[1] as string).length === 0) return null;
+	const sigField = parts[2] as string;
+	if (!BASE64.test(sigField)) return null;
+	const raw = Buffer.from(sigField, "base64");
+	if (raw.length <= 4) return null;
+	return {
+		origin,
+		treeSize,
+		rootHashHex: root.toString("hex"),
+		body: `${origin}\n${sizeLine}\n${rootB64}\n`,
+		sig: raw.subarray(4),
+	};
+}
+
+// ── RFC 9162 inclusion ──
+
+/**
+ * RFC 9162 §2.1.3.2 inclusion verification: walk the audit path from the leaf
+ * to the root, deciding sibling order from the leaf index rather than from any
+ * hint the proof supplies. `fn`/`sn` track the leaf's and the last leaf's
+ * positions within the current subtree; the right-shift after a left-sibling
+ * merge is what makes right-edge (incomplete) subtrees come out correct.
+ *
+ * Never throws: malformed hex, out-of-range indices, and over-long paths are
+ * rejections, because this runs on attacker-supplied input.
+ */
+export function verifyIndexInclusion(
+	leafHex: string,
+	index: number,
+	treeSize: number,
+	pathHex: readonly string[],
+	rootHex: string,
+): boolean {
+	if (!Number.isSafeInteger(index) || !Number.isSafeInteger(treeSize)) return false;
+	if (index < 0 || treeSize < 1 || index >= treeSize) return false;
+	if (!HEX64.test(leafHex) || !HEX64.test(rootHex)) return false;
+	if (pathHex.length > MAX_INCLUSION_PATH) return false;
+
+	let fn = index;
+	let sn = treeSize - 1;
+	let r: Buffer = Buffer.from(leafHex, "hex");
+	for (const pHex of pathHex) {
+		if (!HEX64.test(pHex)) return false;
+		if (sn === 0) return false;
+		const p = Buffer.from(pHex, "hex");
+		if (fn % 2 === 1 || fn === sn) {
+			r = nodeHash(p, r);
+			// LSB(fn) not set (the fn === sn right-edge case): shift both equally
+			// until LSB(fn) is set or fn is 0.
+			while (fn % 2 === 0 && fn !== 0) {
+				fn = Math.floor(fn / 2);
+				sn = Math.floor(sn / 2);
+			}
+		} else {
+			r = nodeHash(r, p);
+		}
+		fn = Math.floor(fn / 2);
+		sn = Math.floor(sn / 2);
+	}
+	return sn === 0 && r.toString("hex") === rootHex;
+}
+
+// ── Strict receipt parsing ──
+
+/**
+ * Strict parse of one receipt. Unknown fields, wrong types, and range
+ * violations are all rejected before any crypto runs — the same fail-closed
+ * posture as parseAnchorRecord, for the same reason: a field the verifier
+ * silently ignores is a field an attacker can use.
+ */
+export function parseRekorReceipt(raw: string): {
+	receipt: RekorReceipt | null;
+	error: string | null;
+} {
+	const bad = (message: string): { receipt: null; error: string } => ({
+		receipt: null,
+		error: `${ERR}: ${message}`,
+	});
+
+	if (Buffer.byteLength(raw, "utf8") > MAX_RECEIPT_BYTES) return bad("receipt exceeds 256 KiB");
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return bad("not valid JSON");
+	}
+	const obj = asObject(parsed);
+	if (obj === null) return bad("not an object");
+	for (const key of Object.keys(obj)) {
+		if (!RECEIPT_KEYS.has(key)) return bad(`unknown field "${clip(key)}"`);
+	}
+	if (obj.v !== 1) return bad("unsupported version");
+	if (typeof obj.vaultId !== "string" || obj.vaultId.length === 0) return bad("missing vaultId");
+	if (!isSafeIntAtLeast(obj.anchorSeq, 1)) {
+		return bad("anchorSeq must be a safe integer >= 1");
+	}
+	if (typeof obj.artifactHash !== "string" || !HEX64.test(obj.artifactHash)) {
+		return bad("artifactHash must be 64 lowercase hex characters");
+	}
+	if (typeof obj.entryBody !== "string" || obj.entryBody.length === 0) {
+		return bad("missing entryBody");
+	}
+	if (!BASE64.test(obj.entryBody)) return bad("entryBody must be base64");
+	if (Buffer.from(obj.entryBody, "base64").length > MAX_ENTRY_BODY_BYTES) {
+		return bad("entryBody exceeds 64 KiB decoded");
+	}
+
+	const log = asObject(obj.log);
+	if (log === null) return bad("log must be an object");
+	for (const key of Object.keys(log)) {
+		if (!LOG_KEYS.has(key)) return bad(`unknown log field "${clip(key)}"`);
+	}
+	if (typeof log.url !== "string" || logHost(log.url) === null) {
+		return bad("log.url must be an http(s) URL");
+	}
+	if (!isSafeIntAtLeast(log.logIndex, 0)) return bad("log.logIndex must be a safe integer >= 0");
+	if (!isSafeIntAtLeast(log.treeSize, 1)) return bad("log.treeSize must be a safe integer >= 1");
+	if (log.logIndex >= log.treeSize) return bad("log.logIndex must be < log.treeSize");
+	if (typeof log.rootHash !== "string" || !HEX64.test(log.rootHash)) {
+		return bad("log.rootHash must be 64 lowercase hex characters");
+	}
+	if (!Array.isArray(log.hashes) || log.hashes.length > MAX_INCLUSION_PATH) {
+		return bad(`log.hashes must be an array of at most ${MAX_INCLUSION_PATH} hashes`);
+	}
+	for (const h of log.hashes) {
+		if (typeof h !== "string" || !HEX64.test(h)) {
+			return bad("log.hashes entries must be 64 lowercase hex characters");
+		}
+	}
+	if (
+		typeof log.checkpoint !== "string" ||
+		log.checkpoint.length === 0 ||
+		Buffer.byteLength(log.checkpoint, "utf8") > MAX_CHECKPOINT_BYTES
+	) {
+		return bad("log.checkpoint must be a non-empty string of at most 8 KiB");
+	}
+	if (!isSafeIntAtLeast(log.integratedTime, 1)) {
+		return bad("log.integratedTime must be a safe integer > 0");
+	}
+	return { receipt: obj as unknown as RekorReceipt, error: null };
+}
+
+// ── Entry binding ──
+
+/**
+ * The logged entry must commit to OUR artifact AND OUR signature. Without the
+ * signature binding, anyone could log the (public) payload hash of someone
+ * else's anchor and present the resulting receipt as their own.
+ */
+function checkHashedRekordEntry(
+	entryBytes: Buffer,
+	artifactHash: string,
+	recordSigBase64: string,
+): string | null {
+	if (entryBytes.length === 0) return "entryBody decodes to no bytes";
+	if (entryBytes.length > MAX_ENTRY_BODY_BYTES) return "entryBody exceeds 64 KiB decoded";
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(entryBytes.toString("utf8"));
+	} catch {
+		return "entryBody is not valid JSON";
+	}
+	const entry = asObject(parsed);
+	if (entry === null) return "entryBody is not a JSON object";
+	if (entry.kind !== "hashedrekord") return "entryBody kind is not hashedrekord";
+	const spec = asObject(entry.spec);
+	if (spec === null) return "entryBody spec is missing";
+	const hash = asObject(asObject(spec.data)?.hash);
+	if (hash === null) return "entryBody spec.data.hash is missing";
+	if (hash.algorithm !== "sha256") return "entryBody spec.data.hash.algorithm is not sha256";
+	if (hash.value !== artifactHash) {
+		return "entryBody spec.data.hash.value does not match the receipt artifactHash";
+	}
+	const signature = asObject(spec.signature);
+	if (signature === null || typeof signature.content !== "string") {
+		return "entryBody spec.signature.content is missing";
+	}
+	// Compare DECODED bytes: base64 spelling is not canonical, so string
+	// equality would reject honest receipts and is not what "same signature"
+	// means.
+	const logged = Buffer.from(signature.content, "base64");
+	const ours = Buffer.from(recordSigBase64, "base64");
+	if (ours.length === 0 || !logged.equals(ours)) {
+		return "entryBody spec.signature.content is not the anchor record signature";
+	}
+	return null;
+}
+
+/**
+ * Which key(s) may speak for this log. Supplying no key is only meaningful for
+ * the one log whose key ships with the verifier; for anything else, an unpinned
+ * receipt would be self-certifying, so it is refused rather than trusted.
+ */
+function resolveLogKeyring(
+	host: string,
+	logPubkeysPem: readonly string[],
+): { keys: readonly string[]; error: string | null } {
+	const supplied = logPubkeysPem.filter(
+		(pem) => pem.length > 0 && Buffer.byteLength(pem, "utf8") <= MAX_PEM_BYTES,
+	);
+	if (supplied.length > 0) return { keys: supplied, error: null };
+	if (host === REKOR_PROD_HOST) return { keys: [REKOR_PROD_PUBKEY_PEM], error: null };
+	return {
+		keys: [],
+		error: `custom log requires --rekor-pubkey (no pinned key for log host ${clip(host)})`,
+	};
+}
+
+// ── Receipt verification ──
+
+/**
+ * Verify one receipt against the anchor record it claims to witness, under a
+ * caller-pinned keyring (any key in the ring may verify the checkpoint).
+ *
+ * The order below is the binding chain, and it is deliberate: cheap identity
+ * and hash checks first, then the entry decode, then the inclusion walk, and
+ * only then the signature — so a receipt for the wrong record can never cost an
+ * ECDSA verification, and a failure always names the earliest broken link.
+ */
+export function verifyRekorReceipt(
+	receipt: RekorReceipt,
+	record: AnchorRecord,
+	logPubkeysPem: readonly string[],
+): RekorVerification {
+	const errors: string[] = [];
+	const fail = (message: string): RekorVerification => {
+		errors.push(`${ERR}: ${message}`);
+		return { ok: false, attestedTimeMs: null, errors };
+	};
+
+	// 1 — the receipt must name THIS record.
+	if (receipt.vaultId !== record.vaultId || receipt.anchorSeq !== record.anchorSeq) {
+		return fail(
+			`record mismatch: receipt claims vault ${clip(receipt.vaultId)} anchorSeq ${receipt.anchorSeq}`,
+		);
+	}
+
+	// 2 — and must carry that record's signing-payload hash.
+	const payloadHash = anchorPayloadHash(record);
+	if (receipt.artifactHash !== payloadHash) {
+		return fail("artifactHash is not the anchor payload hash of this record");
+	}
+
+	// 3 — the bytes the log stored must commit to the artifact and our signature.
+	const entryBytes = Buffer.from(receipt.entryBody, "base64");
+	const entryError = checkHashedRekordEntry(entryBytes, payloadHash, record.sig);
+	if (entryError !== null) return fail(entryError);
+
+	// 4/5 — sha256(0x00 || stored bytes) must sit at logIndex under log.rootHash.
+	const leafHex = createHash("sha256").update(LEAF_PREFIX).update(entryBytes).digest("hex");
+	if (
+		!verifyIndexInclusion(
+			leafHex,
+			receipt.log.logIndex,
+			receipt.log.treeSize,
+			receipt.log.hashes,
+			receipt.log.rootHash,
+		)
+	) {
+		return fail(
+			`inclusion proof does not reconstruct log.rootHash from logIndex ${receipt.log.logIndex} of ${receipt.log.treeSize}`,
+		);
+	}
+
+	// 6 — the checkpoint must be this log's, at this size, over this root.
+	const host = logHost(receipt.log.url);
+	if (host === null) return fail("log.url is not an http(s) URL");
+	const note = parseSignedNote(receipt.log.checkpoint);
+	if (note === null) return fail("log.checkpoint is not a parseable signed note");
+	if (note.origin.toLowerCase() !== host) {
+		return fail(`log.checkpoint origin ${clip(note.origin)} is not the log.url host ${clip(host)}`);
+	}
+	if (note.treeSize !== receipt.log.treeSize) {
+		return fail(
+			`log.checkpoint treeSize ${note.treeSize} does not match log.treeSize ${receipt.log.treeSize}`,
+		);
+	}
+	if (note.rootHashHex !== receipt.log.rootHash) {
+		return fail("log.checkpoint root hash does not match log.rootHash");
+	}
+
+	// 7 — and must be signed by a key the AUDITOR pinned.
+	const keyring = resolveLogKeyring(host, logPubkeysPem);
+	if (keyring.error !== null) return fail(keyring.error);
+	const sigBase64 = note.sig.toString("base64");
+	const signed = keyring.keys.some((pem) => {
+		const key = publicKeyFromPem(pem);
+		return key !== null && verifySignatureRaw("ecdsa-p256", note.body, key, sigBase64);
+	});
+	if (!signed) {
+		return fail("log.checkpoint signature does not verify under any pinned log public key");
+	}
+
+	// 8 — every link held, so the log's integration time is witness-attested.
+	return { ok: true, attestedTimeMs: receipt.log.integratedTime * 1000, errors };
+}

--- a/packages/verify/src/rekor-verify.ts
+++ b/packages/verify/src/rekor-verify.ts
@@ -68,8 +68,11 @@ export interface SignedNote {
 	rootHashHex: string;
 	/** EXACTLY the bytes the log signs: 3 body lines including the trailing LF. */
 	body: string;
-	/** Note signature with the 4-byte key hint stripped off the front. */
-	sig: Buffer;
+	/**
+	 * Note signatures, each with its 4-byte key hint stripped off the front. A
+	 * checkpoint carries the log's own signature plus one per co-signing witness.
+	 */
+	sigs: Buffer[];
 }
 
 export interface RekorVerification {
@@ -112,6 +115,10 @@ const MAX_PEM_BYTES = 16 * 1024;
 const HEX64 = /^[0-9a-f]{64}$/;
 const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
 const UINT = /^(0|[1-9][0-9]*)$/;
+// Matching control characters is the entire point here — they are what gets
+// removed from anything echoed back to a terminal.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the intent
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
 
 const LEAF_PREFIX = Buffer.from([0x00]);
 const NODE_PREFIX = Buffer.from([0x01]);
@@ -129,9 +136,16 @@ const LOG_KEYS = new Set([
 
 // ── Small helpers ──
 
-/** Untrusted values are never echoed whole into an error string. */
+/**
+ * Untrusted values are never echoed whole into an error string. Control
+ * characters are stripped BEFORE truncation, because these strings are printed
+ * to a terminal: an escape sequence or a bare CR inside a field name would let
+ * the party under audit repaint the line its own verdict is printed on, and
+ * truncating first would leave a half-consumed escape behind.
+ */
 function clip(value: string): string {
-	return value.length <= 80 ? value : `${value.slice(0, 80)}...`;
+	const scrubbed = value.replace(CONTROL_CHARS, "");
+	return scrubbed.length <= 80 ? scrubbed : `${scrubbed.slice(0, 80)}...`;
 }
 
 function asObject(value: unknown): Record<string, unknown> | null {
@@ -164,19 +178,24 @@ function nodeHash(left: Buffer, right: Buffer): Buffer {
 
 /**
  * Parse a signed note:
- *   <origin>\n<treeSize>\n<base64 rootHash>\n\n— <keyname> <base64 sig>\n
+ *   <origin>\n<treeSize>\n<base64 rootHash>\n\n— <keyname> <base64 sig>\n...
  * Strictly LF-only and strictly this shape — a note is a signed artifact, so
  * accepting variants would mean verifying a signature over bytes we did not
  * actually parse. The signature payload is `4-byte keyhint || DER signature`;
  * the hint identifies which key the log used and is ADVISORY only, because the
  * auditor pins the key out-of-band. Only its 4 bytes are skipped.
+ *
+ * ONE OR MORE signature lines are accepted: a production checkpoint is signed by
+ * the log and co-signed by its witnesses, and every line must still be
+ * well-formed. Which of them (if any) speaks for the auditor is decided later,
+ * against the pinned keyring — never here.
  */
 export function parseSignedNote(note: string): SignedNote | null {
 	if (note.length === 0 || Buffer.byteLength(note, "utf8") > MAX_CHECKPOINT_BYTES) return null;
 	if (note.includes("\r")) return null;
 	const lines = note.split("\n");
-	if (lines.length === 6 && lines[5] === "") lines.pop();
-	if (lines.length !== 5) return null;
+	if (lines.length > 5 && lines[lines.length - 1] === "") lines.pop();
+	if (lines.length < 5) return null;
 	const origin = lines[0] as string;
 	const sizeLine = lines[1] as string;
 	const rootB64 = lines[2] as string;
@@ -187,19 +206,36 @@ export function parseSignedNote(note: string): SignedNote | null {
 	if (!BASE64.test(rootB64)) return null;
 	const root = Buffer.from(rootB64, "base64");
 	if (root.length !== 32) return null;
-	const parts = (lines[4] as string).split(" ");
-	if (parts.length !== 3 || parts[0] !== "—" || (parts[1] as string).length === 0) return null;
-	const sigField = parts[2] as string;
-	if (!BASE64.test(sigField)) return null;
-	const raw = Buffer.from(sigField, "base64");
-	if (raw.length <= 4) return null;
+	const sigs: Buffer[] = [];
+	for (const line of lines.slice(4)) {
+		const parts = line.split(" ");
+		if (parts.length !== 3 || parts[0] !== "—" || (parts[1] as string).length === 0) return null;
+		const sigField = parts[2] as string;
+		if (!BASE64.test(sigField)) return null;
+		const raw = Buffer.from(sigField, "base64");
+		if (raw.length <= 4) return null;
+		sigs.push(raw.subarray(4));
+	}
 	return {
 		origin,
 		treeSize,
 		rootHashHex: root.toString("hex"),
 		body: `${origin}\n${sizeLine}\n${rootB64}\n`,
-		sig: raw.subarray(4),
+		sigs,
 	};
+}
+
+/**
+ * Does a checkpoint's signed origin name the host the receipt says it came from?
+ * A production Rekor checkpoint's origin is `"<host> - <treeID>"`, while the
+ * signed-note format also permits the bare host; both identify the same log, so
+ * only the part before the first " - " is compared. The comparison stays exact
+ * on that part — a suffix rule would let evil.example.org.attacker.net pass.
+ */
+function originNamesHost(origin: string, host: string): boolean {
+	const separator = origin.indexOf(" - ");
+	const named = separator === -1 ? origin : origin.slice(0, separator);
+	return named.toLowerCase() === host;
 }
 
 // ── RFC 9162 inclusion ──
@@ -380,6 +416,12 @@ function checkHashedRekordEntry(
  * Which key(s) may speak for this log. Supplying no key is only meaningful for
  * the one log whose key ships with the verifier; for anything else, an unpinned
  * receipt would be self-certifying, so it is refused rather than trusted.
+ *
+ * A caller who supplied material that ALL got discarded (empty file, oversized
+ * blob) is not a caller who supplied nothing: silently falling back to the
+ * embedded key there would verify a rekor.sigstore.dev receipt under a key the
+ * auditor never chose, and pass a merge gate the auditor thought they had
+ * pinned. Discarded-everything is refused instead.
  */
 function resolveLogKeyring(
 	host: string,
@@ -389,6 +431,13 @@ function resolveLogKeyring(
 		(pem) => pem.length > 0 && Buffer.byteLength(pem, "utf8") <= MAX_PEM_BYTES,
 	);
 	if (supplied.length > 0) return { keys: supplied, error: null };
+	if (logPubkeysPem.length > 0) {
+		return {
+			keys: [],
+			error:
+				"supplied --rekor-pubkey material is empty or invalid — refusing to fall back to the embedded key",
+		};
+	}
 	if (host === REKOR_PROD_HOST) return { keys: [REKOR_PROD_PUBKEY_PEM], error: null };
 	return {
 		keys: [],
@@ -457,7 +506,7 @@ export function verifyRekorReceipt(
 	if (host === null) return fail("log.url is not an http(s) URL");
 	const note = parseSignedNote(receipt.log.checkpoint);
 	if (note === null) return fail("log.checkpoint is not a parseable signed note");
-	if (note.origin.toLowerCase() !== host) {
+	if (!originNamesHost(note.origin, host)) {
 		return fail(`log.checkpoint origin ${clip(note.origin)} is not the log.url host ${clip(host)}`);
 	}
 	if (note.treeSize !== receipt.log.treeSize) {
@@ -469,13 +518,16 @@ export function verifyRekorReceipt(
 		return fail("log.checkpoint root hash does not match log.rootHash");
 	}
 
-	// 7 — and must be signed by a key the AUDITOR pinned.
+	// 7 — and must be signed by a key the AUDITOR pinned. A co-signed checkpoint
+	// carries one signature per witness, and the auditor pins only the parties
+	// they trust: ONE line verifying under ONE pinned key is the whole claim.
 	const keyring = resolveLogKeyring(host, logPubkeysPem);
 	if (keyring.error !== null) return fail(keyring.error);
-	const sigBase64 = note.sig.toString("base64");
+	const sigsBase64 = note.sigs.map((sig) => sig.toString("base64"));
 	const signed = keyring.keys.some((pem) => {
 		const key = publicKeyFromPem(pem);
-		return key !== null && verifySignatureRaw("ecdsa-p256", note.body, key, sigBase64);
+		if (key === null) return false;
+		return sigsBase64.some((sig) => verifySignatureRaw("ecdsa-p256", note.body, key, sig));
 	});
 	if (!signed) {
 		return fail("log.checkpoint signature does not verify under any pinned log public key");

--- a/packages/verify/src/rekor-verify.ts
+++ b/packages/verify/src/rekor-verify.ts
@@ -23,9 +23,13 @@
  * SEPARATE receipt files: the anchor record schema is frozen, and a
  * transparency log must never become a field inside the thing it witnesses.
  *
- * Offline scope: a verified receipt proves the entry was included in the log at
- * `integratedTime` under a pinned key. It does NOT prove the log's current head
- * is consistent with that checkpoint — that needs a witness/consistency query,
+ * Offline scope: a verified receipt proves the entry was included in the log
+ * under a pinned key. WHEN it was included is a separate, weaker claim:
+ * `integratedTime` is covered by no signature of its own, so it counts as
+ * attested only when the log's signed entry timestamp (SET) over it verifies
+ * under the same pinned keyring — otherwise the receipt proves inclusion and
+ * says nothing about time. Neither claim proves the log's current head is
+ * consistent with that checkpoint; that needs a witness/consistency query,
  * which stays out of the zero-dependency verifier by design.
  */
 
@@ -57,8 +61,20 @@ export interface RekorReceipt {
 		hashes: string[];
 		/** Signed note (checkpoint) over treeSize + rootHash. */
 		checkpoint: string;
-		/** Unix seconds the log attests it integrated the entry. */
+		/**
+		 * Unix seconds the log CLAIMS it integrated the entry. Signed by nothing
+		 * on its own — only the SET below turns it into an attested time.
+		 */
 		integratedTime: number;
+		/**
+		 * base64 ECDSA signature over the sorted-key JSON of
+		 * `{body, integratedTime, logID, logIndex}` — the log's only signature
+		 * covering integratedTime. Optional: a log that does not emit one still
+		 * yields a valid INCLUSION proof, just no attested time.
+		 */
+		signedEntryTimestamp?: string;
+		/** 64-hex log identity, part of the SET payload. Required with a SET. */
+		logID?: string;
 	};
 }
 
@@ -77,7 +93,11 @@ export interface SignedNote {
 
 export interface RekorVerification {
 	ok: boolean;
-	/** Witness-attested time in ms — the input to staleness policy when present. */
+	/**
+	 * Witness-attested time in ms — the input to staleness policy when present.
+	 * Non-null ONLY when a signed entry timestamp verified: an unsigned
+	 * integratedTime is a number the party under audit could have chosen.
+	 */
 	attestedTimeMs: number | null;
 	errors: string[];
 }
@@ -111,6 +131,13 @@ const MAX_ENTRY_BODY_BYTES = 64 * 1024;
 const MAX_CHECKPOINT_BYTES = 8 * 1024;
 const MAX_INCLUSION_PATH = 64;
 const MAX_PEM_BYTES = 16 * 1024;
+const MAX_SET_BYTES = 1024;
+/**
+ * Exclusive upper bound on integratedTime, in SECONDS: `* 1000` must stay
+ * inside the ±8.64e15 ms ECMAScript Date range, or every downstream
+ * `new Date(ms).toISOString()` throws RangeError on attacker-chosen input.
+ */
+const MAX_INTEGRATED_TIME = 8_640_000_000_000;
 
 const HEX64 = /^[0-9a-f]{64}$/;
 const BASE64 = /^[A-Za-z0-9+/]*={0,2}$/;
@@ -132,6 +159,8 @@ const LOG_KEYS = new Set([
 	"hashes",
 	"checkpoint",
 	"integratedTime",
+	"signedEntryTimestamp",
+	"logID",
 ]);
 
 // ── Small helpers ──
@@ -172,6 +201,19 @@ function logHost(url: string): string | null {
 
 function nodeHash(left: Buffer, right: Buffer): Buffer {
 	return createHash("sha256").update(NODE_PREFIX).update(left).update(right).digest();
+}
+
+/**
+ * Sorted-key JSON of a FLAT object of strings and safe integers — the exact
+ * bytes a Rekor SET is computed over. Over this charset (base64, lowercase hex,
+ * integers) it is byte-identical to RFC 8785 JCS; a general JCS implementation
+ * would buy nothing here and cost the verifier its zero-dependency property.
+ */
+function sortedKeyStringify(value: Record<string, string | number>): string {
+	const fields = Object.keys(value)
+		.sort()
+		.map((key) => `${JSON.stringify(key)}:${JSON.stringify(value[key])}`);
+	return `{${fields.join(",")}}`;
 }
 
 // ── Signed notes (checkpoints) ──
@@ -360,8 +402,29 @@ export function parseRekorReceipt(raw: string): {
 	) {
 		return bad("log.checkpoint must be a non-empty string of at most 8 KiB");
 	}
-	if (!isSafeIntAtLeast(log.integratedTime, 1)) {
-		return bad("log.integratedTime must be a safe integer > 0");
+	// Bounded in SECONDS so `integratedTime * 1000` cannot leave the Date range
+	// and turn a printed verdict into a RangeError on attacker-chosen input.
+	if (!isSafeIntAtLeast(log.integratedTime, 1) || log.integratedTime >= MAX_INTEGRATED_TIME) {
+		return bad(`log.integratedTime must be a safe integer > 0 and < ${MAX_INTEGRATED_TIME}`);
+	}
+	if (log.logID !== undefined && (typeof log.logID !== "string" || !HEX64.test(log.logID))) {
+		return bad("log.logID must be 64 lowercase hex characters");
+	}
+	if (log.signedEntryTimestamp !== undefined) {
+		if (
+			typeof log.signedEntryTimestamp !== "string" ||
+			log.signedEntryTimestamp.length === 0 ||
+			!BASE64.test(log.signedEntryTimestamp) ||
+			Buffer.byteLength(log.signedEntryTimestamp, "utf8") > MAX_SET_BYTES
+		) {
+			return bad("log.signedEntryTimestamp must be base64 of at most 1 KiB");
+		}
+		// The logID is part of the payload the SET signs, so a SET without one
+		// is unverifiable by construction — and unverifiable supplied evidence
+		// is a rejection, never a receipt that quietly proves less than it looks.
+		if (log.logID === undefined) {
+			return bad("log.signedEntryTimestamp requires log.logID");
+		}
 	}
 	return { receipt: obj as unknown as RekorReceipt, error: null };
 }
@@ -453,8 +516,10 @@ function resolveLogKeyring(
  *
  * The order below is the binding chain, and it is deliberate: cheap identity
  * and hash checks first, then the entry decode, then the inclusion walk, and
- * only then the signature — so a receipt for the wrong record can never cost an
- * ECDSA verification, and a failure always names the earliest broken link.
+ * only then the signatures — so a receipt for the wrong record can never cost
+ * an ECDSA verification, and a failure always names the earliest broken link.
+ * `ok` is the INCLUSION verdict; `attestedTimeMs` is the strictly weaker time
+ * claim, and only a verifying signed entry timestamp produces it.
  */
 export function verifyRekorReceipt(
 	receipt: RekorReceipt,
@@ -533,6 +598,32 @@ export function verifyRekorReceipt(
 		return fail("log.checkpoint signature does not verify under any pinned log public key");
 	}
 
-	// 8 — every link held, so the log's integration time is witness-attested.
+	// 8 — inclusion holds. TIME is a separate claim: the checkpoint signs the
+	// tree, not when this entry entered it, so integratedTime is worth exactly
+	// as much as the signed entry timestamp over it. No SET (or no logID to
+	// build its payload from) means an honest "included, time unknown" — the
+	// caller then falls back to the operator-claimed timestamp knowing it is
+	// operator-claimed. A SET that is PRESENT and does not verify is different
+	// in kind: supplied evidence that fails is a forgery attempt, not an
+	// absence, so it fails the whole receipt closed.
+	const set = receipt.log.signedEntryTimestamp;
+	const logID = receipt.log.logID;
+	if (set === undefined || logID === undefined) {
+		return { ok: true, attestedTimeMs: null, errors };
+	}
+	const setPayload = sortedKeyStringify({
+		body: receipt.entryBody,
+		integratedTime: receipt.log.integratedTime,
+		logID,
+		logIndex: receipt.log.logIndex,
+	});
+	const setSigned = keyring.keys.some((pem) => {
+		const key = publicKeyFromPem(pem);
+		if (key === null) return false;
+		return verifySignatureRaw("ecdsa-p256", setPayload, key, set);
+	});
+	if (!setSigned) return fail("signedEntryTimestamp does not verify");
+
+	// 9 — every link held AND the log signed the time, so it is witness-attested.
 	return { ok: true, attestedTimeMs: receipt.log.integratedTime * 1000, errors };
 }


### PR DESCRIPTION
Continues the merged Phase-1 anchoring (#51) with spec §12's Phase 1.5 and Phase 2 items.

## What's in this PR

**Phase 1.5**
- **Native SigV4 S3 sink** (`audit/sigv4.ts` + `s3Sink`) — pure `node:crypto`, validated against AWS's published signing-key test vector. Virtual-host or path-style (custom endpoint); `http://` only for loopback (SigV4 authenticates but does not encrypt); credentials from env, never echoed in errors.
- **`usertrust anchor doctor`** — permission probes against the configured store. Deliberately framed as *"this identity could/could not delete or overwrite a probe object here right now"*, never as proof of append-only; WORM guarantees come from the store's own configuration.
- **KMS/HSM:** the Phase-1 `external` signer interface plus a documented Vault-transit recipe. Hosted AWS/GCP KMS adapters are **deferred** — neither signs Ed25519, so a real adapter needs signing-algorithm agility in the record schema.

**Phase 2**
- **Rekor witness verification** (`rekor-verify.ts`, mirrored byte-identically into both packages): strict receipt schema with hostile-input caps, signed-note checkpoint parsing (single or witness co-signed), RFC 9162 index-based inclusion, receipt↔record binding by *decoded* signature bytes, and **SET-verified attested time**.
- **Rekor sink** (`rekor.ts`) — `hashedrekord` proposals, response binding before the record leaves the outbox, 409-idempotent redelivery, per-log receipt files, key-history resolution so post-rotation redelivery proposes the right key.
- **Verification surface:** `--rekor-receipts`, `--rekor-pubkey` (repeatable), `--bundle` on both verify CLIs; `usertrust anchor export-bundle` for the auditor hand-off; witness-attested staleness for `--max-anchor-age`.

## Known limitation (disclosed in docs)

The Rekor sink **does not work against the public `rekor.sigstore.dev` yet**: anchor records are signed with pure Ed25519, but a `hashedrekord` asks the log to verify a signature against only the artifact digest, which pure Ed25519 cannot do. Fixing it requires signing-algorithm agility in the record schema — out of scope here. What ships is the complete, tested *verification* path plus a sink that works against any log accepting these entries. Marked EXPERIMENTAL throughout.

## Review audit trail

- **Plan review (GPT-5.4, pre-code):** 30+ findings triaged; 14 accepted as binding deltas (strict response validation, input size caps, decoded-bytes binding, trust pinning, fail-closed `export-bundle`, honest doctor wording), rest rejected with reasoning.
- **Security review:** 1 P1 + 5 P2, no P0. P1 was a real pinning bypass — an empty/oversized `--rekor-pubkey` was silently discarded and fell back to the embedded production key. All five actionable findings fixed with regressions.
- **Code review (xhigh workflow, 51 agents):** 15 confirmed findings. Fixed: unsigned `integratedTime` (the headline — "witness-attested" freshness was operator-forgeable; now requires a verified SET), 409 outbox wedge, unbound 201 responses, missing Rekor URL scheme rule, rotation key-history, per-log receipt collisions, silent sink-flag drops, `--since` NaN, orphaned-receipt bundles, control-character output, `toISOString` RangeError. Disclosed rather than fixed: the live-Rekor algorithm incompatibility above.

## Test plan

- `npx vitest run` → 2,232 passing (196 anchoring-specific)
- Coverage over all four CI thresholds: statements 92.18, branches 84.99, functions 93.69, lines 93.61
- `npx tsc -b` and `npx biome check .` clean; both mirrored pairs (`anchor-verify.ts`, `rekor-verify.ts`) byte-identical modulo import lines
- No live-network tests: S3/Rekor transports are injectable; the default transports are covered against a local `node:http` server

Manual:
```bash
usertrust anchor doctor --sink-file /tmp/anchors.jsonl   # expect FAIL: deletable
usertrust anchor export-bundle > bundle.json
npx usertrust-verify .usertrust --bundle bundle.json --pubkey root.pem
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)