### PR TITLE
feat(ui): CSV export of the ledger view

### DIFF
--- a/packages/ui/src/app/app.tsx
+++ b/packages/ui/src/app/app.tsx
@@ -2,7 +2,8 @@
 // Copyright 2026 Usertools, Inc.
 
 import { useMemo, useState } from "react";
-import { applyFilters, EMPTY_FILTERS, type FilterState } from "../shared/filters.js";
+import { csvFilename, toCsv } from "../shared/csv.js";
+import { applyFilters, EMPTY_FILTERS, type FilterState, isFiltering } from "../shared/filters.js";
 import type { LedgerRow } from "../shared/rows.js";
 import { AuditTable } from "./audit-table.js";
 import { FilterBar } from "./filter-bar.js";
@@ -20,25 +21,48 @@ export function App(): React.JSX.Element {
 	const [open, setOpen] = useState<LedgerRow | null>(null);
 	const filtered = useMemo(() => applyFilters(rows, filters), [rows, filters]);
 
+	// Export what the operator is looking at — the filtered set, not the vault.
+	// BOM first: Excel reads UTF-8 CSV as latin-1 without it.
+	function exportCsv(): void {
+		const blob = new Blob([`﻿${toCsv(filtered)}`], { type: "text/csv;charset=utf-8" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		a.download = csvFilename(new Date(), isFiltering(filters));
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
 	return (
 		<div className="mx-auto flex h-screen max-w-[1400px] flex-col gap-3 p-4">
 			<SummaryStrip summary={summary} live={live} />
-			<nav
-				aria-label="view"
-				className="reveal reveal-2 inline-flex gap-0.5 self-start rounded-md border border-[var(--border)] bg-[var(--panel)] p-0.5"
-			>
-				{(["audit", "trends"] as const).map((v) => (
-					<button
-						key={v}
-						type="button"
-						onClick={() => setView(v)}
-						aria-pressed={view === v}
-						className={`rounded px-3 py-1 text-xs uppercase tracking-wider transition-colors duration-100 ${view === v ? "bg-[var(--panel-2)] text-[var(--text)]" : "text-[var(--muted)] hover:text-[var(--text)]"}`}
-					>
-						{v}
-					</button>
-				))}
-			</nav>
+			<div className="reveal reveal-2 flex items-center justify-between gap-3">
+				<nav
+					aria-label="view"
+					className="inline-flex gap-0.5 self-start rounded-md border border-[var(--border)] bg-[var(--panel)] p-0.5"
+				>
+					{(["audit", "trends"] as const).map((v) => (
+						<button
+							key={v}
+							type="button"
+							onClick={() => setView(v)}
+							aria-pressed={view === v}
+							className={`rounded px-3 py-1 text-xs uppercase tracking-wider transition-colors duration-100 ${view === v ? "bg-[var(--panel-2)] text-[var(--text)]" : "text-[var(--muted)] hover:text-[var(--text)]"}`}
+						>
+							{v}
+						</button>
+					))}
+				</nav>
+				<button
+					type="button"
+					onClick={exportCsv}
+					disabled={filtered.length === 0}
+					title="Download the filtered ledger as CSV"
+					className="h-8 rounded-md border border-[var(--border)] bg-[var(--panel)] px-3 text-xs uppercase tracking-wider text-[var(--muted)] transition-colors duration-100 hover:text-[var(--text)] disabled:opacity-40"
+				>
+					Export CSV
+				</button>
+			</div>
 			{/* P6: reveal stays on chrome — the table/scroll surface never animates */}
 			<div className="reveal reveal-3">
 				<FilterBar rows={rows} filters={filters} onChange={setFilters} />

--- a/packages/ui/src/shared/csv.ts
+++ b/packages/ui/src/shared/csv.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * CSV serialization of ledger rows.
+ *
+ * Spreadsheet-facing: the finance workflow is "close the books, hand the
+ * auditor the receipts". Cost columns stay unquoted numerics so Excel/Sheets
+ * sum them without coercion; every free-text cell is formula-neutralized
+ * (CSV injection) because `actor`/`model` originate in caller-supplied event
+ * data. CRLF line endings — Excel's expectation.
+ */
+
+import { type LedgerRow, statusOf } from "./rows.js";
+
+export const CSV_HEADERS = [
+	"seq",
+	"timestamp",
+	"kind",
+	"actor",
+	"model",
+	"provider",
+	"cost_ut",
+	"cost_usd",
+	"status",
+	"integrity",
+	"transfer_id",
+	"event_id",
+	"hash",
+	"previous_hash",
+] as const;
+
+/** Leading =,+,-,@ make a cell executable in Excel/Sheets — defang with a quote. */
+function neutralize(value: string): string {
+	return /^[=+\-@]/.test(value) ? `'${value}` : value;
+}
+
+function cell(value: string | undefined): string {
+	if (value === undefined || value === "") return "";
+	const safe = neutralize(value);
+	// Quote when the payload needs it, and always when defanged: a bare leading
+	// apostrophe is handled inconsistently across parsers, quoted is not.
+	return /[",\r\n]/.test(safe) || safe !== value ? `"${safe.replace(/"/g, '""')}"` : safe;
+}
+
+/** Numerics are emitted bare so spreadsheets treat them as numbers. */
+function num(value: number | undefined): string {
+	return value === undefined ? "" : String(value);
+}
+
+export function toCsv(rows: LedgerRow[]): string {
+	const lines = [CSV_HEADERS.join(",")];
+	for (const r of rows) {
+		lines.push(
+			[
+				num(r.seq ?? undefined),
+				cell(r.ts),
+				cell(r.kind),
+				cell(r.actor),
+				cell(r.model),
+				cell(r.provider),
+				num(r.costUt),
+				num(r.costUsd),
+				cell(statusOf(r)),
+				cell(r.integrity),
+				cell(r.transferId),
+				cell(r.id),
+				cell(r.hash),
+				cell(r.previousHash),
+			].join(","),
+		);
+	}
+	return lines.join("\r\n");
+}
+
+export function csvFilename(now: Date, filtered: boolean): string {
+	const day = now.toISOString().slice(0, 10);
+	return `usertrust-ledger-${day}${filtered ? "-filtered" : ""}.csv`;
+}

--- a/packages/ui/tests/csv.test.ts
+++ b/packages/ui/tests/csv.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { CSV_HEADERS, csvFilename, toCsv } from "../src/shared/csv.js";
+import type { LedgerRow } from "../src/shared/rows.js";
+
+function row(overrides: Partial<LedgerRow> = {}): LedgerRow {
+	return {
+		seq: 1,
+		id: "evt-1",
+		ts: "2026-07-27T13:45:02.000Z",
+		kind: "llm_call",
+		actor: "code-review",
+		model: "claude-sonnet-4-6",
+		provider: "anthropic",
+		costUt: 336,
+		costUsd: 0.0336,
+		settled: true,
+		transferId: "tx_abc_123",
+		hash: "a".repeat(64),
+		previousHash: "b".repeat(64),
+		integrity: "verified",
+		...overrides,
+	};
+}
+
+describe("toCsv", () => {
+	it("emits a header row followed by one line per row", () => {
+		const csv = toCsv([row(), row({ id: "evt-2", seq: 2 })]);
+		const lines = csv.split("\r\n");
+		expect(lines[0]).toBe(CSV_HEADERS.join(","));
+		expect(lines).toHaveLength(3);
+		expect(lines[1]).toContain("code-review");
+		expect(lines[1]).toContain("claude-sonnet-4-6");
+	});
+
+	it("writes numeric cost columns unquoted so spreadsheets sum them", () => {
+		const cells = toCsv([row()]).split("\r\n")[1]?.split(",") as string[];
+		expect(cells).toContain("336");
+		expect(cells).toContain("0.0336");
+	});
+
+	it("quotes and escapes values containing commas or quotes", () => {
+		const csv = toCsv([row({ actor: 'ops,"night"' })]);
+		expect(csv).toContain('"ops,""night"""');
+	});
+
+	it("neutralizes spreadsheet formula injection", () => {
+		for (const hostile of ["=cmd()", "+1", "-1", "@SUM(A1)"]) {
+			const csv = toCsv([row({ actor: hostile })]);
+			expect(csv).toContain(`"'${hostile}"`);
+		}
+	});
+
+	it("renders missing optional fields as empty cells", () => {
+		const csv = toCsv([
+			row({ model: undefined, provider: undefined, costUt: undefined, costUsd: undefined }),
+		]);
+		const cells = csv.split("\r\n")[1]?.split(",") as string[];
+		expect(cells.filter((c) => c === "").length).toBeGreaterThan(0);
+	});
+
+	it("maps status from kind and settled flag", () => {
+		expect(toCsv([row()])).toContain("settled");
+		expect(toCsv([row({ kind: "llm_call_failed", settled: false })])).toContain("failed");
+		expect(toCsv([row({ settled: undefined })])).toContain("pending");
+	});
+
+	it("returns just the header for an empty ledger", () => {
+		expect(toCsv([])).toBe(CSV_HEADERS.join(","));
+	});
+});
+
+describe("csvFilename", () => {
+	it("stamps the date and marks filtered exports", () => {
+		expect(csvFilename(new Date("2026-07-27T10:00:00Z"), false)).toBe(
+			"usertrust-ledger-2026-07-27.csv",
+		);
+		expect(csvFilename(new Date("2026-07-27T10:00:00Z"), true)).toBe(
+			"usertrust-ledger-2026-07-27-filtered.csv",
+		);
+	});
+});


### PR DESCRIPTION
The audit table can now export what the operator is looking at — the **filtered** set, not the whole vault — as a spreadsheet-ready CSV. Closing the books means handing an auditor the receipts.

## Details

- **Formula-injection defense.** `actor` / `model` / `provider` originate in caller-supplied event data, and a leading `=`, `+`, `-`, or `@` makes a cell executable in Excel/Sheets. Those are prefixed with a quote and *always* wrapped — a bare leading apostrophe parses inconsistently across tools.
- **Spreadsheet-native numerics.** Cost columns are emitted bare so Excel/Sheets sum them without coercion; everything free-text is quoted/escaped per RFC 4180.
- **Excel ergonomics.** CRLF line endings plus a UTF-8 BOM (without it Excel reads UTF-8 as latin-1).
- **Self-describing filenames.** `usertrust-ledger-YYYY-MM-DD.csv`, with a `-filtered` marker when a filter is active.
- Export button is disabled when the filtered set is empty.

## Test plan

- `npx vitest run packages/ui` → 42 passing, including injection cases (`=cmd()`, `+1`, `-1`, `@SUM(A1)`), comma/quote escaping, unquoted numerics, and header/row shape
- `npx tsc -b` and `npx biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)