### PR TITLE
fix(release): add usertrust-ui to the npm publish lockstep

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,6 +75,7 @@ jobs:
             cd packages/openclaw && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
             cd packages/server && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
             cd packages/acs-adapter && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
+            cd packages/ui && npm version ${{ inputs.version }} --no-git-tag-version && cd ../..
           fi
           VERSION=$(node -p 'require("./packages/core/package.json").version')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -103,10 +104,14 @@ jobs:
       - name: Build usertrust-acs-adapter
         run: cd packages/acs-adapter && npx tsc -b
 
+      # ui ships a bundled front end, so it needs vite as well as tsc.
+      - name: Build usertrust-ui
+        run: cd packages/ui && npm run build
+
       # ── Verify builds ──
       - name: Verify dist directories exist
         run: |
-          for pkg in core verify openclaw server acs-adapter; do
+          for pkg in core verify openclaw server acs-adapter ui; do
             if [ ! -d "packages/${pkg}/dist" ]; then
               echo "::error::packages/${pkg}/dist not found after build"
               exit 1
@@ -125,7 +130,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          for entry in core:usertrust verify:usertrust-verify openclaw:usertrust-openclaw server:usertrust-server acs-adapter:usertrust-acs-adapter; do
+          for entry in core:usertrust verify:usertrust-verify openclaw:usertrust-openclaw server:usertrust-server acs-adapter:usertrust-acs-adapter ui:usertrust-ui; do
             dir="${entry%%:*}"; pkg="${entry##*:}"
             version=$(node -p "require('./packages/${dir}/package.json').version")
             if [ -n "$(npm view "${pkg}@${version}" version 2>/dev/null || true)" ]; then

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "usertrust-ui",
-	"version": "1.5.0",
+	"version": "2.0.0",
 	"description": "Local web UI for usertrust vaults: filterable audit ledger, live tail, trends, verification.",
 	"license": "Apache-2.0",
 	"author": "Usertools, Inc. <hello@usertools.ai> (https://usertrust.ai)",


### PR DESCRIPTION
`usertrust-ui` was introduced (#55, #56) after the publish lockstep was last extended (#45), so it was never wired into `publish.yml`. Consequence: **v2.0.0 shipped five packages and left ui behind** — still at 1.5.0, never published — which stranded the visual ledger and the just-merged CSV export (#58) on master where nobody can install them.

## Changes

- Wires `ui` into all four lockstep points in `publish.yml`: version bump, build, dist verification, publish loop.
- Uses `npm run build` for ui rather than a bare `tsc` — it ships a bundled front end, so it needs vite too.
- Bumps `packages/ui` 1.5.0 → 2.0.0 so it lands in step with its siblings.

## Follow-up after merge

The publish loop already skips versions present on the registry, so a `republish` run publishes only the missing package and won't touch the five live ones:

```
gh workflow run Release -f version=patch -f dry_run=false -f republish=true
```

## Test plan

- `cd packages/ui && npm run build` → `dist/server/main.js` present (verified locally)
- `npx biome check` clean
- CI: typecheck + lint + full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)