### PR TITLE
feat(budget): agent budgets — cost-center allocation, runway, and budget-aware policy

### DIFF
--- a/packages/core/src/audit/anchor-doctor.ts
+++ b/packages/core/src/audit/anchor-doctor.ts
@@ -194,7 +194,7 @@ function overwriteProbe(probe: string): DoctorCheck {
  */
 export async function doctorS3Sink(
 	cfg: S3ProbeConfig,
-	transport: HttpTransport = httpsTransport,
+	transport: HttpTransport = httpTransport,
 ): Promise<DoctorReport> {
 	const prefix = (cfg.prefix ?? "anchors").replace(/^\/+|\/+$/g, "");
 	const sink = `s3:${cfg.bucket}/${prefix}`;
@@ -380,14 +380,20 @@ function s3Request(
 	return transport({ method, url: target.url, headers: { ...extra, ...signed }, body: payload });
 }
 
-/** Default transport. `http://` endpoints (dev MinIO) require an injected one. */
-async function httpsTransport(opts: {
+/**
+ * Default transport. `http://` is reachable so the loopback endpoints
+ * `parseEndpoint` allows (dev MinIO/LocalStack) are actually probed rather than
+ * degrading to "cannot probe" against a scheme the same module permits.
+ */
+async function httpTransport(opts: {
 	method: string;
 	url: string;
 	headers: Record<string, string>;
 	body: Buffer;
 }): Promise<{ status: number; body: string; headers: Record<string, string> }> {
-	const { request } = await import("node:https");
+	const { request } = await (opts.url.startsWith("http://")
+		? import("node:http")
+		: import("node:https"));
 	return new Promise((resolve, reject) => {
 		const req = request(
 			opts.url,

--- a/packages/core/src/budget/allocation.ts
+++ b/packages/core/src/budget/allocation.ts
@@ -123,6 +123,12 @@ interface AuditOutcome {
 	audited: boolean;
 	/** True when the transfer committed but its audit event could not be written. */
 	auditFailed?: boolean;
+	/**
+	 * The writer's failure message. Present only alongside `auditFailed`, and
+	 * carried so a caller can log WHY the delegation went unproven — a bare flag
+	 * leaves an operator with a committed transfer and nothing to diagnose.
+	 */
+	auditFailureReason?: string;
 }
 
 export interface AllocateResult extends AuditOutcome {
@@ -167,20 +173,23 @@ function isInsufficientBalanceError(err: unknown): err is TBTransferError {
 /**
  * Resolve the parent and cost-center accounts, refusing a self-transfer.
  *
- * The cost-center account is derived rather than looked up so that reclaim and
- * status work in a process that never created the wallet — `getAccountId` reads
- * an in-memory map that only survives within the process that called
- * `createUserWallet`.
+ * BOTH ids are derived, never looked up. `getAccountId` reads an in-process map
+ * that is populated only by a `createUserWallet` call in this same process, so a
+ * lookup rejects before any ledger I/O on a freshly constructed client — even
+ * when the wallet exists in TigerBeetle. `deriveAccountId` is the same pure
+ * SHA-256 of `wallet:${userId}` that `createUserWallet` derives from, so the
+ * derived id IS the account the wallet was created as, in any process. A parent
+ * wallet that genuinely does not exist then fails at commit inside TigerBeetle:
+ * loudly, at the ledger, rather than before reaching it.
  *
  * A derived id that collides with its own parent would produce a transfer that
  * debits and credits one account: a no-op that reports as a funded allocation.
  */
 function resolveAccounts(
-	tb: TrustTBClient,
 	parentUserId: string,
 	childUserId: string,
 ): { parentAccount: bigint; childAccount: bigint } {
-	const parentAccount = tb.getAccountId(parentUserId);
+	const parentAccount = TrustTBClient.deriveAccountId(parentUserId);
 	const childAccount = TrustTBClient.deriveAccountId(childUserId);
 	if (childAccount === parentAccount) {
 		throw new Error("budget: cost center resolves to the parent account");
@@ -216,6 +225,11 @@ async function costCenterBalance(tb: TrustTBClient, accountId: bigint): Promise<
  * {@link AuditOutcome} on the result is the channel instead — and it
  * distinguishes "no writer was supplied" from "the append succeeded", which a
  * lone `auditFailed` flag could not.
+ *
+ * `BudgetAuditWriter` is a public interface, so the thrown value comes from
+ * consumer code and is never discarded: it is warned to the console AND carried
+ * on the outcome. Silence here would leave a committed transfer with no record
+ * of which allocation lost its event, and no reason for the loss.
  */
 async function appendBudgetEvent(
 	auditWriter: BudgetAuditWriter | undefined,
@@ -233,8 +247,15 @@ async function appendBudgetEvent(
 			data: { costCenter, amount, costCenterUserId: childUserId },
 		});
 		return { audited: true };
-	} catch {
-		return { audited: false, auditFailed: true };
+	} catch (err) {
+		const auditFailureReason = err instanceof Error ? err.message : String(err);
+		console.warn("[BUDGET] Transfer committed but its audit event was not written", {
+			kind,
+			costCenterUserId: childUserId,
+			amount,
+			error: auditFailureReason,
+		});
+		return { audited: false, auditFailed: true, auditFailureReason };
 	}
 }
 
@@ -272,7 +293,7 @@ export async function allocateBudget(
 		throw new Error("budget: amount must be a positive integer");
 	}
 
-	const { parentAccount, childAccount } = resolveAccounts(tb, p.parentUserId, childUserId);
+	const { parentAccount, childAccount } = resolveAccounts(p.parentUserId, childUserId);
 
 	// `{ derived: true }` declares the id is an already-derived `parent::costCenter`.
 	// `::` is reserved: ordinary callers are refused it precisely so this namespace
@@ -356,7 +377,7 @@ export async function reclaimBudget(
 	},
 ): Promise<ReclaimResult> {
 	const childUserId = costCenterUserId(p.parentUserId, p.costCenter);
-	const { parentAccount, childAccount } = resolveAccounts(tb, p.parentUserId, childUserId);
+	const { parentAccount, childAccount } = resolveAccounts(p.parentUserId, childUserId);
 
 	const available = await costCenterBalance(tb, childAccount);
 	// Nothing moved, so there is nothing to audit — `audited: false` is the honest

--- a/packages/core/src/budget/allocation.ts
+++ b/packages/core/src/budget/allocation.ts
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * allocation.ts — cost-center allocation and reclaim over the TigerBeetle ledger
+ *
+ * A cost center is a sub-wallet of its parent, nothing more. Its ledger identity
+ * is the derived user id `parent::costCenter` (see {@link costCenterUserId}),
+ * which hashes to a TigerBeetle account exactly as any other wallet does.
+ * Allocation and reclaim are plain immediate transfers between the two accounts.
+ * There is no cost-center registry and no new ledger schema.
+ *
+ * LEDGER INVARIANT (what makes `spent` meaningful): a cost-center wallet receives
+ * funds ONLY via {@link allocateBudget} from its parent, and spends only outward.
+ * Under that invariant `spent = allocated - balance` is exact. Fund a cost center
+ * by any other route and every derived figure — spent, burn rate, runway — is
+ * wrong, silently. {@link getBudgetStatus} clamps `spent` at 0 so an over-funded
+ * child cannot invert the burn rate, but the clamp hides the breach rather than
+ * repairing it.
+ *
+ * NO PRE-CHECK ON THE ALLOCATION PATH (AUD-455): allocation never reads the
+ * parent balance before transferring. A `lookupBalance` + transfer sequence is a
+ * check-then-act race — the balance can change between the two. TigerBeetle
+ * enforces `debits_must_not_exceed_credits` atomically at commit, so the
+ * rejection is the check. Reclaim is deliberately different: it must know how
+ * much to move, so it reads first and treats a stale read as a benign race (see
+ * {@link reclaimBudget}).
+ *
+ * RETRIES ARE NOT SAFE. Neither {@link allocateBudget} nor {@link reclaimBudget}
+ * is idempotent under an ambiguous transport failure: a retry after an
+ * unacknowledged commit double-allocates or double-reclaims. The ledger balance
+ * is the source of truth — read it before retrying. A caller-supplied idempotency
+ * key is the correct fix and is deferred to a follow-up.
+ *
+ * EMPTY WALLETS ARE EXPECTED. An allocation that creates the wallet and then
+ * fails to transfer leaves a zero-balance account behind. That is harmless — a
+ * TigerBeetle account holding nothing costs nothing and the next allocation
+ * reuses it. There is no cleanup path and none is needed.
+ *
+ * AUDIT EVENTS carry `{ costCenter, amount, costCenterUserId }` and nothing else.
+ * Caller input is never spread into the payload: a budget grant is a delegation
+ * worth proving, but the proof must not become a channel for credentials or
+ * prompt text.
+ */
+
+import { CreateTransferStatus } from "tigerbeetle-node";
+import type { AppendEventInput } from "../audit/chain.js";
+import type { TBTransferError } from "../ledger/client.js";
+import { TrustTBClient, XFER_BUDGET_RECLAIM, XFER_SPEND } from "../ledger/client.js";
+import { InsufficientBalanceError } from "../shared/errors.js";
+import { computeRunway, type Runway } from "./runway.js";
+
+// ── Identity ──
+
+const PARENT_USER_ID_PATTERN = /^[a-zA-Z0-9._@-]{1,128}$/;
+const COST_CENTER_PATTERN = /^[a-zA-Z0-9._-]{1,64}$/;
+const SEPARATOR = "::";
+const MAX_DERIVED_ID_LENGTH = 200;
+
+/**
+ * A cost center's ledger identity is a derived sub-wallet of its parent.
+ *
+ * Neither part may contain `:`, so the first `::` splits the derived id
+ * unambiguously and no two distinct `(parentUserId, costCenter)` pairs can
+ * collide. Both patterns also exclude whitespace, control characters, and ANSI
+ * escapes, which keeps the id safe to embed in an audit event and in terminal
+ * output.
+ *
+ * @throws Error when either part is missing, over-long, or outside its charset.
+ */
+export function costCenterUserId(parentUserId: string, costCenter: string): string {
+	if (typeof parentUserId !== "string" || !PARENT_USER_ID_PATTERN.test(parentUserId)) {
+		throw new Error("budget: parentUserId must match /^[a-zA-Z0-9._@-]{1,128}$/");
+	}
+	if (typeof costCenter !== "string" || !COST_CENTER_PATTERN.test(costCenter)) {
+		throw new Error("budget: costCenter must match /^[a-zA-Z0-9._-]{1,64}$/");
+	}
+	const derived = `${parentUserId}${SEPARATOR}${costCenter}`;
+	// Unreachable through the patterns above (128 + 2 + 64 = 194). Kept so that
+	// loosening either bound cannot silently start producing oversized ids.
+	if (derived.length > MAX_DERIVED_ID_LENGTH) {
+		throw new Error(`budget: derived cost-center id exceeds ${MAX_DERIVED_ID_LENGTH} characters`);
+	}
+	return derived;
+}
+
+// ── Types ──
+
+/** Minimal audit surface — accepts the SDK's AuditWriter without depending on it. */
+export interface BudgetAuditWriter {
+	appendEvent(input: AppendEventInput): Promise<unknown>;
+}
+
+export interface AllocateResult {
+	costCenterUserId: string;
+	transferId: string;
+	allocated: number;
+	/** True when the transfer committed but its audit event could not be written. */
+	auditFailed?: boolean;
+}
+
+export interface ReclaimResult {
+	reclaimed: number;
+	/** Null when nothing moved — an empty cost center or a lost race. */
+	transferId: string | null;
+	/** True when the transfer committed but its audit event could not be written. */
+	auditFailed?: boolean;
+}
+
+export interface BudgetStatus {
+	costCenterUserId: string;
+	balance: number;
+	runway: Runway;
+}
+
+// ── Helpers ──
+
+/**
+ * Check whether a caught error is a TigerBeetle insufficient-balance rejection.
+ *
+ * Mirrors the predicate in `ledger/engine.ts`, which is module-private there.
+ * Both must stay in step: they are the only places the SDK decides that a
+ * rejection means "not enough money" rather than "the ledger is broken".
+ */
+function isInsufficientBalanceError(err: unknown): err is TBTransferError {
+	if (err == null || typeof err !== "object") return false;
+	if (!("code" in err) || !("name" in err)) return false;
+	const e = err as { code: number; name: string };
+	return (
+		e.name === "TBTransferError" &&
+		(e.code === CreateTransferStatus.exceeds_credits ||
+			e.code === CreateTransferStatus.overflows_debits ||
+			e.code === CreateTransferStatus.overflows_debits_pending)
+	);
+}
+
+/**
+ * Resolve the parent and cost-center accounts, refusing a self-transfer.
+ *
+ * The cost-center account is derived rather than looked up so that reclaim and
+ * status work in a process that never created the wallet — `getAccountId` reads
+ * an in-memory map that only survives within the process that called
+ * `createUserWallet`.
+ *
+ * A derived id that collides with its own parent would produce a transfer that
+ * debits and credits one account: a no-op that reports as a funded allocation.
+ */
+function resolveAccounts(
+	tb: TrustTBClient,
+	parentUserId: string,
+	childUserId: string,
+): { parentAccount: bigint; childAccount: bigint } {
+	const parentAccount = tb.getAccountId(parentUserId);
+	const childAccount = TrustTBClient.deriveAccountId(childUserId);
+	if (childAccount === parentAccount) {
+		throw new Error("budget: cost center resolves to the parent account");
+	}
+	return { parentAccount, childAccount };
+}
+
+/**
+ * Available balance of a cost-center wallet, or 0 when the wallet does not exist.
+ *
+ * A cost center that was never allocated has no TigerBeetle account at all. That
+ * is an implicit zero rather than an error: with no cost-center registry, "never
+ * allocated" and "allocated then fully reclaimed" are the same observable state,
+ * and a typo'd cost-center name is indistinguishable from an empty one.
+ *
+ * Existence is probed with `lookupAccounts` rather than by matching the message
+ * `lookupBalance` throws, and the balance itself still comes from `lookupBalance`
+ * so its overflow checks are never duplicated or bypassed.
+ */
+async function costCenterBalance(tb: TrustTBClient, accountId: bigint): Promise<number> {
+	const accounts = await tb.lookupAccounts([accountId]);
+	if (accounts.length === 0) return 0;
+	const { available } = await tb.lookupBalance(accountId);
+	return available;
+}
+
+/**
+ * Append an audit event, reporting failure rather than raising it.
+ *
+ * Called only after a transfer has committed. The transfer is authoritative: a
+ * failed append must not unwind it, must not retry it, and must not surface as a
+ * rejection that a caller could mistake for "the money did not move". The
+ * `auditFailed` flag on the result is the channel instead.
+ */
+async function appendBudgetEvent(
+	auditWriter: BudgetAuditWriter | undefined,
+	kind: "budget_allocated" | "budget_reclaimed",
+	parentUserId: string,
+	costCenter: string,
+	amount: number,
+	childUserId: string,
+): Promise<boolean> {
+	if (!auditWriter) return false;
+	try {
+		await auditWriter.appendEvent({
+			kind,
+			actor: parentUserId,
+			data: { costCenter, amount, costCenterUserId: childUserId },
+		});
+		return false;
+	} catch {
+		return true;
+	}
+}
+
+// ── Allocation ──
+
+/**
+ * Move `amount` UT from a parent wallet into one of its cost centers.
+ *
+ * The cost-center wallet is created on demand. `createUserWallet` already treats
+ * TigerBeetle's `exists` status as success and resolves with the existing
+ * account id, so an already-created wallet needs no handling here — and every
+ * rejection it does raise (`exists_with_different_flags` above all, which means
+ * the account is missing its balance enforcement) is a real failure that must
+ * propagate rather than be swallowed.
+ *
+ * NOT SAFE TO BLIND-RETRY: a retry after an unacknowledged commit double-allocates.
+ * The ledger balance is the source of truth — read it before retrying.
+ *
+ * @throws {InsufficientBalanceError} when the parent cannot cover the amount.
+ * @throws Error on an invalid amount or cost-center name, before any ledger I/O.
+ */
+export async function allocateBudget(
+	tb: TrustTBClient,
+	p: {
+		parentUserId: string;
+		costCenter: string;
+		/** UT, positive safe integer. */
+		amount: number;
+		auditWriter?: BudgetAuditWriter;
+	},
+): Promise<AllocateResult> {
+	const childUserId = costCenterUserId(p.parentUserId, p.costCenter);
+	const amount = p.amount;
+	if (!Number.isSafeInteger(amount) || amount <= 0) {
+		throw new Error("budget: amount must be a positive integer");
+	}
+
+	const { parentAccount, childAccount } = resolveAccounts(tb, p.parentUserId, childUserId);
+
+	const createdAccount = await tb.createUserWallet(childUserId);
+	// An explicit `setAccountMapping` override would make allocation fund an
+	// account that reclaim and status — which always derive — never read.
+	if (createdAccount !== childAccount) {
+		throw new Error("budget: cost center account id does not match its derived id");
+	}
+
+	// AUD-455: No pre-check — TB enforces debits_must_not_exceed_credits atomically.
+	// A lookupBalance + immediateTransfer sequence has a TOCTOU race.
+	let transferId: bigint;
+	try {
+		transferId = await tb.immediateTransfer({
+			debitAccountId: parentAccount,
+			creditAccountId: childAccount,
+			amount,
+			code: XFER_SPEND,
+		});
+	} catch (err) {
+		if (isInsufficientBalanceError(err)) {
+			// Fresh lookup for accurate error reporting — after the rejection, so it
+			// reports rather than decides.
+			let available = 0;
+			try {
+				const bal = await tb.lookupBalance(parentAccount);
+				available = bal.available;
+			} catch {
+				// Balance lookup failed — report 0 as fallback
+			}
+			throw new InsufficientBalanceError(p.parentUserId, amount, available);
+		}
+		throw err;
+	}
+
+	const auditFailed = await appendBudgetEvent(
+		p.auditWriter,
+		"budget_allocated",
+		p.parentUserId,
+		p.costCenter,
+		amount,
+		childUserId,
+	);
+
+	return {
+		costCenterUserId: childUserId,
+		transferId: transferId.toString(),
+		allocated: amount,
+		...(auditFailed ? { auditFailed: true } : {}),
+	};
+}
+
+/**
+ * Return a cost center's unspent balance to its parent.
+ *
+ * Optimistic read-then-transfer by design: the amount to move is not known until
+ * it is read. If a concurrent spend or a second reclaim lands between the read
+ * and the transfer, TigerBeetle rejects for insufficient balance — that is the
+ * race resolving correctly, not a failure, and it reports as a zero reclaim.
+ * Every other rejection propagates.
+ *
+ * Only *available* funds move; anything held by a pending transfer stays until
+ * that hold settles or expires. Calling this twice is safe — the second call
+ * finds nothing and moves nothing.
+ *
+ * NOT SAFE TO BLIND-RETRY: a retry after an unacknowledged commit double-reclaims.
+ * The ledger balance is the source of truth — read it before retrying.
+ */
+export async function reclaimBudget(
+	tb: TrustTBClient,
+	p: {
+		parentUserId: string;
+		costCenter: string;
+		auditWriter?: BudgetAuditWriter;
+	},
+): Promise<ReclaimResult> {
+	const childUserId = costCenterUserId(p.parentUserId, p.costCenter);
+	const { parentAccount, childAccount } = resolveAccounts(tb, p.parentUserId, childUserId);
+
+	const available = await costCenterBalance(tb, childAccount);
+	if (available <= 0) return { reclaimed: 0, transferId: null };
+
+	let transferId: bigint;
+	try {
+		transferId = await tb.immediateTransfer({
+			debitAccountId: childAccount,
+			creditAccountId: parentAccount,
+			amount: available,
+			code: XFER_BUDGET_RECLAIM,
+		});
+	} catch (err) {
+		// The balance went stale between the read and the transfer. Benign.
+		if (isInsufficientBalanceError(err)) return { reclaimed: 0, transferId: null };
+		throw err;
+	}
+
+	const auditFailed = await appendBudgetEvent(
+		p.auditWriter,
+		"budget_reclaimed",
+		p.parentUserId,
+		p.costCenter,
+		available,
+		childUserId,
+	);
+
+	return {
+		reclaimed: available,
+		transferId: transferId.toString(),
+		...(auditFailed ? { auditFailed: true } : {}),
+	};
+}
+
+/**
+ * Read a cost center's balance and its runway against a caller-supplied allocation.
+ *
+ * `allocated` and the period bounds are caller state — there is no registry to
+ * read them from — so this is a projection over what the caller believes it
+ * granted, checked against what the ledger actually holds. A cost center that was
+ * never allocated reads as a zero balance rather than an error.
+ *
+ * The wall clock is read here, at the call site, and injected into
+ * {@link computeRunway}, which stays pure.
+ */
+export async function getBudgetStatus(
+	tb: TrustTBClient,
+	p: {
+		parentUserId: string;
+		costCenter: string;
+		allocated: number;
+		periodStartMs: number;
+		periodEndMs?: number;
+		nowMs?: number;
+	},
+): Promise<BudgetStatus> {
+	const childUserId = costCenterUserId(p.parentUserId, p.costCenter);
+	const childAccount = TrustTBClient.deriveAccountId(childUserId);
+	const balance = await costCenterBalance(tb, childAccount);
+
+	return {
+		costCenterUserId: childUserId,
+		balance,
+		runway: computeRunway({
+			allocated: p.allocated,
+			// An over-funded child (see the LEDGER INVARIANT note) would otherwise
+			// yield negative spend. computeRunway normalizes that to 0 as well, so
+			// this clamp is this module's own guarantee rather than the only guard —
+			// spend leaving here is non-negative regardless of what runway does with it.
+			spent: Math.max(0, p.allocated - balance),
+			periodStartMs: p.periodStartMs,
+			periodEndMs: p.periodEndMs,
+			nowMs: p.nowMs ?? Date.now(),
+		}),
+	};
+}

--- a/packages/core/src/budget/allocation.ts
+++ b/packages/core/src/budget/allocation.ts
@@ -4,6 +4,18 @@
 /**
  * allocation.ts — cost-center allocation and reclaim over the TigerBeetle ledger
  *
+ * ⚠️ WARNING — THESE PRIMITIVES SHIP AHEAD OF THEIR METERING CONSUMER. Nothing in
+ * this repository debits a cost-center wallet yet. The metering path spends from
+ * a per-session funded holding account (`createFundedBudgetWallet` in `govern.ts`,
+ * mirrored in `headless.ts`), never from the wallet {@link allocateBudget} funds.
+ * So for a cost center whose agent is genuinely burning budget,
+ * {@link getBudgetStatus} still reports `spent: 0` and `fractionRemaining: 1`,
+ * and a policy tier written against `budgetFractionRemaining` (see `policy/gate.ts`)
+ * would NEVER trip — a governance control that fails open, silently. Allocate,
+ * reclaim, and read are correct and safe to use for delegation and reporting; do
+ * NOT wire a policy tier to them until the spend path debits the cost-center
+ * wallet.
+ *
  * A cost center is a sub-wallet of its parent, nothing more. Its ledger identity
  * is the derived user id `parent::costCenter` (see {@link costCenterUserId}),
  * which hashes to a TigerBeetle account exactly as any other wallet does.
@@ -46,7 +58,7 @@
 import { CreateTransferStatus } from "tigerbeetle-node";
 import type { AppendEventInput } from "../audit/chain.js";
 import type { TBTransferError } from "../ledger/client.js";
-import { TrustTBClient, XFER_BUDGET_RECLAIM, XFER_SPEND } from "../ledger/client.js";
+import { TrustTBClient, XFER_BUDGET_GRANT, XFER_BUDGET_RECLAIM } from "../ledger/client.js";
 import { InsufficientBalanceError } from "../shared/errors.js";
 import { computeRunway, type Runway } from "./runway.js";
 
@@ -60,11 +72,16 @@ const MAX_DERIVED_ID_LENGTH = 200;
 /**
  * A cost center's ledger identity is a derived sub-wallet of its parent.
  *
- * Neither part may contain `:`, so the first `::` splits the derived id
- * unambiguously and no two distinct `(parentUserId, costCenter)` pairs can
- * collide. Both patterns also exclude whitespace, control characters, and ANSI
- * escapes, which keeps the id safe to embed in an audit event and in terminal
- * output.
+ * `::` IS A RESERVED SEPARATOR IN WALLET IDS, and that reservation — enforced by
+ * `TrustTBClient.createUserWallet`, which refuses it to ordinary callers — is
+ * what makes this derivation collision-free. Without it, an integrator wallet
+ * literally named `acme::billing` would hash to the same TigerBeetle account as
+ * `costCenterUserId("acme", "billing")`, and a reclaim on that cost center would
+ * sweep the integrator's balance into `acme`. Given the reservation, and because
+ * neither part below may contain `:`, the first `::` splits the derived id
+ * unambiguously and no two distinct `(parentUserId, costCenter)` pairs collide.
+ * Both patterns also exclude whitespace, control characters, and ANSI escapes,
+ * which keeps the id safe to embed in an audit event and in terminal output.
  *
  * @throws Error when either part is missing, over-long, or outside its charset.
  */
@@ -91,20 +108,33 @@ export interface BudgetAuditWriter {
 	appendEvent(input: AppendEventInput): Promise<unknown>;
 }
 
-export interface AllocateResult {
-	costCenterUserId: string;
-	transferId: string;
-	allocated: number;
+/**
+ * Whether this operation landed in the audit chain.
+ *
+ * `audited` is true only when an `auditWriter` was supplied AND its append
+ * succeeded. It exists because omitting the writer would otherwise be invisible:
+ * an unaudited allocation and a successfully audited one would be byte-identical
+ * results, while the Global Constraint on this work is that a delegation MUST be
+ * provable. `auditFailed` narrows an `audited: false` to the case where a writer
+ * was supplied and threw — the money still moved, and the caller must surface it.
+ */
+interface AuditOutcome {
+	/** True only when a writer was supplied and the append succeeded. */
+	audited: boolean;
 	/** True when the transfer committed but its audit event could not be written. */
 	auditFailed?: boolean;
 }
 
-export interface ReclaimResult {
+export interface AllocateResult extends AuditOutcome {
+	costCenterUserId: string;
+	transferId: string;
+	allocated: number;
+}
+
+export interface ReclaimResult extends AuditOutcome {
 	reclaimed: number;
 	/** Null when nothing moved — an empty cost center or a lost race. */
 	transferId: string | null;
-	/** True when the transfer committed but its audit event could not be written. */
-	auditFailed?: boolean;
 }
 
 export interface BudgetStatus {
@@ -183,7 +213,9 @@ async function costCenterBalance(tb: TrustTBClient, accountId: bigint): Promise<
  * Called only after a transfer has committed. The transfer is authoritative: a
  * failed append must not unwind it, must not retry it, and must not surface as a
  * rejection that a caller could mistake for "the money did not move". The
- * `auditFailed` flag on the result is the channel instead.
+ * {@link AuditOutcome} on the result is the channel instead — and it
+ * distinguishes "no writer was supplied" from "the append succeeded", which a
+ * lone `auditFailed` flag could not.
  */
 async function appendBudgetEvent(
 	auditWriter: BudgetAuditWriter | undefined,
@@ -192,17 +224,17 @@ async function appendBudgetEvent(
 	costCenter: string,
 	amount: number,
 	childUserId: string,
-): Promise<boolean> {
-	if (!auditWriter) return false;
+): Promise<AuditOutcome> {
+	if (!auditWriter) return { audited: false };
 	try {
 		await auditWriter.appendEvent({
 			kind,
 			actor: parentUserId,
 			data: { costCenter, amount, costCenterUserId: childUserId },
 		});
-		return false;
+		return { audited: true };
 	} catch {
-		return true;
+		return { audited: false, auditFailed: true };
 	}
 }
 
@@ -242,7 +274,10 @@ export async function allocateBudget(
 
 	const { parentAccount, childAccount } = resolveAccounts(tb, p.parentUserId, childUserId);
 
-	const createdAccount = await tb.createUserWallet(childUserId);
+	// `{ derived: true }` declares the id is an already-derived `parent::costCenter`.
+	// `::` is reserved: ordinary callers are refused it precisely so this namespace
+	// cannot collide with an integrator's own wallet — see createUserWallet.
+	const createdAccount = await tb.createUserWallet(childUserId, { derived: true });
 	// An explicit `setAccountMapping` override would make allocation fund an
 	// account that reclaim and status — which always derive — never read.
 	if (createdAccount !== childAccount) {
@@ -257,7 +292,11 @@ export async function allocateBudget(
 			debitAccountId: parentAccount,
 			creditAccountId: childAccount,
 			amount,
-			code: XFER_SPEND,
+			// NOT XFER_SPEND (which plan delta D9 called for): the metering path uses
+			// that code for real consumption, so reconciliation summing XFER_SPEND
+			// debits would count a delegation twice — once moving into the cost
+			// center, and again when the cost center spends it.
+			code: XFER_BUDGET_GRANT,
 		});
 	} catch (err) {
 		if (isInsufficientBalanceError(err)) {
@@ -275,7 +314,7 @@ export async function allocateBudget(
 		throw err;
 	}
 
-	const auditFailed = await appendBudgetEvent(
+	const audit = await appendBudgetEvent(
 		p.auditWriter,
 		"budget_allocated",
 		p.parentUserId,
@@ -288,7 +327,7 @@ export async function allocateBudget(
 		costCenterUserId: childUserId,
 		transferId: transferId.toString(),
 		allocated: amount,
-		...(auditFailed ? { auditFailed: true } : {}),
+		...audit,
 	};
 }
 
@@ -320,7 +359,9 @@ export async function reclaimBudget(
 	const { parentAccount, childAccount } = resolveAccounts(tb, p.parentUserId, childUserId);
 
 	const available = await costCenterBalance(tb, childAccount);
-	if (available <= 0) return { reclaimed: 0, transferId: null };
+	// Nothing moved, so there is nothing to audit — `audited: false` is the honest
+	// report, not a failure.
+	if (available <= 0) return { reclaimed: 0, transferId: null, audited: false };
 
 	let transferId: bigint;
 	try {
@@ -332,11 +373,11 @@ export async function reclaimBudget(
 		});
 	} catch (err) {
 		// The balance went stale between the read and the transfer. Benign.
-		if (isInsufficientBalanceError(err)) return { reclaimed: 0, transferId: null };
+		if (isInsufficientBalanceError(err)) return { reclaimed: 0, transferId: null, audited: false };
 		throw err;
 	}
 
-	const auditFailed = await appendBudgetEvent(
+	const audit = await appendBudgetEvent(
 		p.auditWriter,
 		"budget_reclaimed",
 		p.parentUserId,
@@ -348,7 +389,7 @@ export async function reclaimBudget(
 	return {
 		reclaimed: available,
 		transferId: transferId.toString(),
-		...(auditFailed ? { auditFailed: true } : {}),
+		...audit,
 	};
 }
 

--- a/packages/core/src/budget/runway.ts
+++ b/packages/core/src/budget/runway.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * runway.ts — pure budget runway and burn-rate math
+ *
+ * A cost center's runway is a function of four numbers: what it was allocated,
+ * what it has spent, when its period started, and what time it is now. This
+ * module computes exactly that and nothing else.
+ *
+ * PURITY: no clock reads, no I/O, no ledger access. `nowMs` is always injected
+ * by the caller so every result is reproducible and testable. Callers that need
+ * the wall clock read it at their own call site, never in here.
+ *
+ * UNITS: `allocated` and `spent` are UT (usertokens). At every *ledger* call
+ * site they are integers — TigerBeetle balances are integral and the allocation
+ * API validates positive safe integers. `computeRunway` nonetheless tolerates
+ * fractional values so analytics and projection callers can feed it derived or
+ * averaged figures; it never rounds them. `projectedExhaustionMs` is always
+ * rounded to an integer epoch-ms.
+ *
+ * TOTALITY: no field of the returned `Runway` is ever `NaN` or `Infinity`. A
+ * non-finite threshold does not fail loudly downstream — it silently makes every
+ * policy comparison (`lt`/`lte`/`gte`) false, which reads as "no limit tripped"
+ * and would quietly disable the governance this module exists to feed. Degenerate
+ * amounts are therefore normalized rather than propagated (see `computeRunway`).
+ */
+
+const MS_PER_HOUR = 3_600_000;
+
+export interface RunwayInput {
+	/** Total allocated to this cost center for the period, in UT. */
+	allocated: number;
+	/** Spent so far in the period, in UT. Settled + currently held. */
+	spent: number;
+	/** Period start, epoch ms. */
+	periodStartMs: number;
+	/** Period end, epoch ms. Omit for an open-ended allocation. */
+	periodEndMs?: number | undefined;
+	/** Injected clock — never read the clock inside this module. */
+	nowMs: number;
+}
+
+export interface Runway {
+	remaining: number;
+	/** remaining / allocated, clamped 0..1. 0 when allocated is 0. */
+	fractionRemaining: number;
+	/** UT per hour over the elapsed window; 0 before any time has elapsed. */
+	burnRatePerHour: number;
+	/**
+	 * Epoch ms when the budget is projected to hit 0, or null if not projectable.
+	 *
+	 * HONESTY: this is a naive linear extrapolation of the *average* burn rate
+	 * across the whole elapsed window — `remaining / burnRatePerHour`. Early in a
+	 * period the window is tiny, so a single large call dominates the average and
+	 * the projection swings wildly from one read to the next. It is a signal, not
+	 * a measurement. It MUST NOT drive irreversible decisions (killing a run,
+	 * revoking an allocation) without hysteresis — dwell time, or a confirming
+	 * second read — applied at the policy layer. Deliberately unsmoothed here:
+	 * smoothing is a policy choice and belongs where the policy lives.
+	 */
+	projectedExhaustionMs: number | null;
+	/**
+	 * For a bounded period: true when projected exhaustion is at or after
+	 * periodEnd (i.e. the budget lasts). null when there is no period end or
+	 * no projection.
+	 */
+	onPace: boolean | null;
+}
+
+/** Non-finite or negative amounts normalize to 0; finite non-negative pass through. */
+function normalizeAmount(value: number): number {
+	return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function clamp01(value: number): number {
+	if (Number.isNaN(value)) return 0;
+	return Math.min(1, Math.max(0, value));
+}
+
+function projectExhaustion(
+	remaining: number,
+	burnRatePerHour: number,
+	nowMs: number,
+): number | null {
+	// Already exhausted — the projection is "now", not a future estimate.
+	if (remaining === 0) return Math.round(nowMs);
+	// Nothing has been spent over the window, so there is nothing to extrapolate.
+	if (burnRatePerHour === 0) return null;
+	const projected = nowMs + (remaining / burnRatePerHour) * MS_PER_HOUR;
+	return Number.isFinite(projected) ? Math.round(projected) : null;
+}
+
+/**
+ * Compute remaining budget, burn rate, and projected exhaustion for a cost center.
+ *
+ * Input normalization is exact and total:
+ *  - non-finite or negative `allocated` / `spent` → `0`
+ *  - non-finite `periodStartMs` or `nowMs` → throws (a bad clock is a caller bug,
+ *    and silently substituting a value would fabricate a runway)
+ *  - non-finite `periodEndMs` → treated as absent (open-ended, `onPace` is null)
+ *  - `periodEndMs <= periodStartMs` → treated as absent; an empty or inverted
+ *    period cannot be paced against, so `onPace` is null rather than a coin flip
+ *  - `nowMs < periodStartMs` → elapsed window of 0, so burn rate is 0
+ *
+ * @throws Error when `periodStartMs` or `nowMs` is not finite.
+ */
+export function computeRunway(input: RunwayInput): Runway {
+	const { periodStartMs, nowMs } = input;
+	if (!Number.isFinite(periodStartMs) || !Number.isFinite(nowMs)) {
+		throw new Error("runway: periodStartMs and nowMs must be finite");
+	}
+
+	const allocated = normalizeAmount(input.allocated);
+	const spent = normalizeAmount(input.spent);
+	const periodEndMs =
+		input.periodEndMs !== undefined &&
+		Number.isFinite(input.periodEndMs) &&
+		input.periodEndMs > periodStartMs
+			? input.periodEndMs
+			: undefined;
+
+	const remaining = Math.max(0, allocated - spent);
+	const fractionRemaining = allocated <= 0 ? 0 : clamp01(remaining / allocated);
+
+	const elapsedHours = Math.max(0, nowMs - periodStartMs) / MS_PER_HOUR;
+	const rawBurnRate = elapsedHours === 0 ? 0 : spent / elapsedHours;
+	// A sub-ULP elapsed window with an enormous `spent` can overflow the division.
+	// Saturate rather than emit Infinity — see TOTALITY in the module doc comment.
+	const burnRatePerHour = Number.isFinite(rawBurnRate) ? rawBurnRate : Number.MAX_VALUE;
+
+	const projectedExhaustionMs = projectExhaustion(remaining, burnRatePerHour, nowMs);
+	const onPace =
+		periodEndMs === undefined || projectedExhaustionMs === null
+			? null
+			: projectedExhaustionMs >= periodEndMs;
+
+	return { remaining, fractionRemaining, burnRatePerHour, projectedExhaustionMs, onPace };
+}

--- a/packages/core/src/budget/runway.ts
+++ b/packages/core/src/budget/runway.ts
@@ -137,3 +137,27 @@ export function computeRunway(input: RunwayInput): Runway {
 
 	return { remaining, fractionRemaining, burnRatePerHour, projectedExhaustionMs, onPace };
 }
+
+/**
+ * Hours of runway left, or `null` when there is no projection.
+ *
+ * This is the ONLY safe way to derive `budgetRunwayHours` for a `PolicyContext`.
+ * The obvious inline conversion — `(runway.projectedExhaustionMs - nowMs) / 3.6e6`
+ * — coerces the `null` case (nothing spent yet, so nothing to extrapolate from)
+ * to a large NEGATIVE number, and a `budgetRunwayHours lt 12` escalation rule
+ * then fires on a cost center that is merely idle. Null in, null out: an absent
+ * field is the honest input for "unknown", and the policy layer already treats
+ * it as such.
+ *
+ * A projection at or before `nowMs` (the budget is already exhausted) clamps to
+ * `0`. Negative hours would be meaningless and would order wrongly against any
+ * threshold a caller sets.
+ *
+ * @throws Error when `nowMs` is not finite — same contract as {@link computeRunway}.
+ */
+export function runwayHours(runway: Runway, nowMs: number): number | null {
+	if (!Number.isFinite(nowMs)) throw new Error("runway: nowMs must be finite");
+	const { projectedExhaustionMs } = runway;
+	if (projectedExhaustionMs === null) return null;
+	return Math.max(0, (projectedExhaustionMs - nowMs) / MS_PER_HOUR);
+}

--- a/packages/core/src/budget/runway.ts
+++ b/packages/core/src/budget/runway.ts
@@ -64,13 +64,39 @@ export interface Runway {
 	 * For a bounded period: true when projected exhaustion is at or after
 	 * periodEnd (i.e. the budget lasts). null when there is no period end or
 	 * no projection.
+	 *
+	 * An exhausted budget is never on pace. `remaining` of 0 projects exhaustion
+	 * to `now`, so once `now` drifts past `periodEnd` the raw comparison would
+	 * turn true again and report every fully-spent cost center from a closed
+	 * period as healthy. `remaining` of 0 therefore forces false regardless of
+	 * the clock; only the genuinely-unknown cases stay null.
 	 */
 	onPace: boolean | null;
 }
 
-/** Non-finite or negative amounts normalize to 0; finite non-negative pass through. */
-function normalizeAmount(value: number): number {
+/** Non-finite or negative allocations normalize to 0; finite positive pass through. */
+function normalizeAllocated(value: number): number {
 	return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/**
+ * A non-finite spend normalizes to `allocated`, not to 0.
+ *
+ * The asymmetry with {@link normalizeAllocated} is deliberate: both directions
+ * are the fail-CLOSED one. An unusable allocation must not fabricate headroom,
+ * so it reads as "nothing was granted". An unusable spend must not fabricate an
+ * untouched budget — coercing NaN to 0 makes a broken figure (a caller deriving
+ * `spent = costTotal / callCount` with a zero call count, say) byte-identical to
+ * a cost center that has spent nothing, and a `budgetFractionRemaining lt 0.3`
+ * tier then never fires on it. Assume the worst instead: fully consumed.
+ *
+ * A negative spend is a different case — an over-funded cost center holding more
+ * than it was allocated, not a broken figure — and clamps to 0. `allocated` is
+ * already normalized finite, so the result is always finite (see TOTALITY).
+ */
+function normalizeSpent(value: number, allocated: number): number {
+	if (!Number.isFinite(value)) return allocated;
+	return value > 0 ? value : 0;
 }
 
 function clamp01(value: number): number {
@@ -95,7 +121,9 @@ function projectExhaustion(
  * Compute remaining budget, burn rate, and projected exhaustion for a cost center.
  *
  * Input normalization is exact and total:
- *  - non-finite or negative `allocated` / `spent` → `0`
+ *  - non-finite or negative `allocated` → `0`
+ *  - non-finite `spent` → `allocated`, i.e. fully consumed; negative `spent` → `0`
+ *    (see `normalizeSpent` for why the two amounts coerce in opposite directions)
  *  - non-finite `periodStartMs` or `nowMs` → throws (a bad clock is a caller bug,
  *    and silently substituting a value would fabricate a runway)
  *  - non-finite `periodEndMs` → treated as absent (open-ended, `onPace` is null)
@@ -111,8 +139,8 @@ export function computeRunway(input: RunwayInput): Runway {
 		throw new Error("runway: periodStartMs and nowMs must be finite");
 	}
 
-	const allocated = normalizeAmount(input.allocated);
-	const spent = normalizeAmount(input.spent);
+	const allocated = normalizeAllocated(input.allocated);
+	const spent = normalizeSpent(input.spent, allocated);
 	const periodEndMs =
 		input.periodEndMs !== undefined &&
 		Number.isFinite(input.periodEndMs) &&
@@ -130,10 +158,12 @@ export function computeRunway(input: RunwayInput): Runway {
 	const burnRatePerHour = Number.isFinite(rawBurnRate) ? rawBurnRate : Number.MAX_VALUE;
 
 	const projectedExhaustionMs = projectExhaustion(remaining, burnRatePerHour, nowMs);
+	// `remaining > 0` is not redundant with the comparison: an exhausted budget
+	// projects to `now`, which overtakes `periodEnd` once the period closes.
 	const onPace =
 		periodEndMs === undefined || projectedExhaustionMs === null
 			? null
-			: projectedExhaustionMs >= periodEndMs;
+			: remaining > 0 && projectedExhaustionMs >= periodEndMs;
 
 	return { remaining, fractionRemaining, burnRatePerHour, projectedExhaustionMs, onPace };
 }

--- a/packages/core/src/cli/budget.ts
+++ b/packages/core/src/cli/budget.ts
@@ -67,6 +67,32 @@ interface BudgetFlags {
 	periodEndMs: number | undefined;
 }
 
+/** Longest argv value echoed back in an error; the rest is dropped. */
+const MAX_ECHOED_LENGTH = 120;
+
+/**
+ * Make an argv value safe to echo into the operator's terminal.
+ *
+ * Every "invalid value" message below quotes what the caller passed, and the
+ * caller may be an agent. picocolors wraps a string in SGR codes but does not
+ * sanitize it, so `--allocated $'\x1b]0;pwned\x07\x1b[2J'` would emit a real OSC
+ * title-set and a screen-clear into the terminal of whoever ran the command.
+ * C0 controls, DEL, and the C1 range collapse to `?`, and an over-long value is
+ * truncated so a megabyte of argv cannot flood the screen either.
+ *
+ * Only the human branch needs this — `JSON.stringify` escapes control characters
+ * itself — but the sweep happens where the message is built, so both branches
+ * carry the same sanitized text.
+ */
+function forDisplay(raw: string): string {
+	let out = "";
+	for (const ch of raw) {
+		const code = ch.codePointAt(0) as number;
+		out += code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? "?" : ch;
+	}
+	return out.length > MAX_ECHOED_LENGTH ? `${out.slice(0, MAX_ECHOED_LENGTH)}...` : out;
+}
+
 /**
  * Take a flag's value, refusing the flag that follows it.
  *
@@ -85,20 +111,52 @@ function parseAllocated(raw: string): number {
 	// always false — either typo would quietly report a budget nobody granted.
 	// Require the WHOLE value to be a non-negative integer.
 	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(value)) {
-		throw new Error(`Invalid --allocated: ${raw} (non-negative integer required)`);
+		throw new Error(`Invalid --allocated: ${forDisplay(raw)} (non-negative integer required)`);
 	}
 	return value;
 }
 
+/**
+ * Full ISO-8601 date, optionally with a time, and optionally with an offset.
+ *
+ * `Date.parse` is far looser than "ISO-8601": it reads `1000` as the year 1000,
+ * `Dec 25` as this year's Christmas, and pads whitespace away. A typo'd
+ * `--period-start 1000` therefore stretches the elapsed window by a millennium
+ * and turns a real 180 UT/h burn into 1e-4 UT/h — a governance read that
+ * fails open, the same bug class as the `parseInt("1O0")` one above. Requiring
+ * the shape as well as parseability is what makes the flag mean what it says.
+ */
+const ISO_8601 = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+
 function parseIsoMs(flag: string, raw: string): number {
 	const ms = Date.parse(raw);
-	if (!Number.isFinite(ms)) {
-		throw new Error(`Invalid ${flag}: ${raw} (ISO-8601 timestamp required)`);
+	if (!ISO_8601.test(raw) || !Number.isFinite(ms)) {
+		throw new Error(
+			`Invalid ${flag}: ${forDisplay(raw)} (ISO-8601 timestamp required, e.g. 2026-07-27T09:00:00Z)`,
+		);
 	}
 	return ms;
 }
 
-function parseBudgetFlags(argv: string[]): BudgetFlags {
+/**
+ * Parse `--period-start`, refusing a start that has not happened yet.
+ *
+ * The elapsed window is `max(0, now - start)`, so a future start makes it zero,
+ * and a zero window reports a burn rate of 0 UT/h with no projection. A cost
+ * center burning hard would read as idle. A start in the future is a typo, not
+ * a window.
+ */
+function parsePeriodStartMs(raw: string, nowMs: number): number {
+	const ms = parseIsoMs("--period-start", raw);
+	if (ms > nowMs) {
+		throw new Error(
+			`Invalid --period-start: ${forDisplay(raw)} is in the future (it would report a zero burn rate)`,
+		);
+	}
+	return ms;
+}
+
+function parseBudgetFlags(argv: string[], nowMs: number): BudgetFlags {
 	let costCenter: string | undefined;
 	let allocated: number | undefined;
 	let periodStartMs: number | undefined;
@@ -109,12 +167,13 @@ function parseBudgetFlags(argv: string[]): BudgetFlags {
 		const next = (): string | undefined => argv[++i];
 		if (arg === "--cost-center") costCenter = requireValue(arg, next());
 		else if (arg === "--allocated") allocated = parseAllocated(requireValue(arg, next()));
-		else if (arg === "--period-start") periodStartMs = parseIsoMs(arg, requireValue(arg, next()));
+		else if (arg === "--period-start")
+			periodStartMs = parsePeriodStartMs(requireValue(arg, next()), nowMs);
 		else if (arg === "--period-end") periodEndMs = parseIsoMs(arg, requireValue(arg, next()));
 		else if (arg.startsWith("--") && !KNOWN_BUDGET_FLAGS.has(arg)) {
 			// Reject unknown flags rather than ignoring them — a typoed --allocted
 			// must not silently report the runway of an allocation nobody set.
-			throw new Error(`Unknown flag: ${arg}`);
+			throw new Error(`Unknown flag: ${forDisplay(arg)}`);
 		}
 	}
 
@@ -160,9 +219,13 @@ export async function run(rootDir?: string, opts?: CliOptions, args?: string[]):
 		process.exitCode = 1;
 	};
 
+	// Read once, before parsing: `--period-start` is validated against it and the
+	// same instant is the `nowMs` the runway is computed from.
+	const nowMs = Date.now();
+
 	let flags: BudgetFlags;
 	try {
-		flags = parseBudgetFlags(args ?? process.argv.slice(2));
+		flags = parseBudgetFlags(args ?? process.argv.slice(2), nowMs);
 	} catch (err) {
 		fail(err instanceof Error ? err.message : String(err));
 		return;
@@ -176,7 +239,6 @@ export async function run(rootDir?: string, opts?: CliOptions, args?: string[]):
 		return;
 	}
 
-	const nowMs = Date.now();
 	let tb: TrustTBClient | undefined;
 	let status: BudgetStatus;
 	try {

--- a/packages/core/src/cli/budget.ts
+++ b/packages/core/src/cli/budget.ts
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * CLI: usertrust budget — read one cost center's balance and runway
+ *
+ * `usertrust budget --cost-center <name> --allocated <int> [--period-start <iso>]
+ * [--period-end <iso>] [--json]`
+ *
+ * EXPLICIT COST CENTER, NEVER ENUMERATION. There is no cost-center registry: a
+ * cost center exists only as a derived sub-wallet, so "list every cost center" is
+ * unanswerable from the ledger alone — an unfunded name and a typo are the same
+ * observable state. Both the name and the allocation are therefore required, and
+ * a missing one is a usage error rather than a default. Discovery waits for a
+ * registry to discover from.
+ *
+ * `--allocated` IS AN INPUT, NOT A LOOKUP. It is what the caller believes it
+ * granted; the balance is what the ledger actually holds. This command reports
+ * the second against the first, which is exactly why a wrong `--allocated`
+ * yields a wrong `spent` and a wrong runway rather than an error.
+ *
+ * NO PERIOD START MEANS NO WINDOW. Without `--period-start` the elapsed window is
+ * zero by construction, so the burn rate is 0 and there is no projection. That is
+ * the honest answer to "how fast is this burning?" from a caller who has not said
+ * when the period began; inventing a window (midnight, process start) would
+ * fabricate a rate. See the projection-honesty note on `Runway` — the estimate is
+ * a naive linear extrapolation and must not drive irreversible decisions.
+ *
+ * IDENTITY. The parent wallet is `$USERTRUST_USER_ID`, defaulting to `local`.
+ * The derived cost-center id is deliberately absent from the output: the payload
+ * carries no ledger account ids, no vault paths, and no chain metadata, so it is
+ * safe to hand an agent verbatim as the result of a `get_budget()` tool call.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import pc from "picocolors";
+import { type BudgetStatus, getBudgetStatus } from "../budget/allocation.js";
+import { loadConfig } from "../config.js";
+import { TrustTBClient } from "../ledger/client.js";
+import { VAULT_DIR } from "../shared/constants.js";
+import type { CliOptions } from "./init.js";
+
+const USAGE =
+	"Usage: usertrust budget --cost-center <name> --allocated <int> [--period-start <iso>] [--period-end <iso>] [--json]";
+
+/** Parent wallet the cost center hangs off, when the environment does not name one. */
+const DEFAULT_PARENT_USER_ID = "local";
+
+const KNOWN_BUDGET_FLAGS = new Set([
+	// Global flags main.ts passes to every subcommand — rejecting them here would
+	// break `usertrust budget ... --json`, which main.ts forwards verbatim.
+	"--json",
+	"--skip-verify",
+	"--reconfigure",
+	// Budget flags.
+	"--cost-center",
+	"--allocated",
+	"--period-start",
+	"--period-end",
+]);
+
+interface BudgetFlags {
+	costCenter: string;
+	allocated: number;
+	periodStartMs: number | undefined;
+	periodEndMs: number | undefined;
+}
+
+/**
+ * Take a flag's value, refusing the flag that follows it.
+ *
+ * `--cost-center --allocated 5` would otherwise bind `--allocated` as the cost
+ * center: it matches the cost-center charset, so the derivation accepts it and
+ * the command silently reads a wallet nobody named.
+ */
+function requireValue(flag: string, raw: string | undefined): string {
+	if (raw === undefined || raw.startsWith("--")) throw new Error(`${flag} requires a value`);
+	return raw;
+}
+
+function parseAllocated(raw: string): number {
+	const value = Number.parseInt(raw, 10);
+	// parseInt("1O0") === 1 (partial parse, capital O) and NaN comparisons are
+	// always false — either typo would quietly report a budget nobody granted.
+	// Require the WHOLE value to be a non-negative integer.
+	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(value)) {
+		throw new Error(`Invalid --allocated: ${raw} (non-negative integer required)`);
+	}
+	return value;
+}
+
+function parseIsoMs(flag: string, raw: string): number {
+	const ms = Date.parse(raw);
+	if (!Number.isFinite(ms)) {
+		throw new Error(`Invalid ${flag}: ${raw} (ISO-8601 timestamp required)`);
+	}
+	return ms;
+}
+
+function parseBudgetFlags(argv: string[]): BudgetFlags {
+	let costCenter: string | undefined;
+	let allocated: number | undefined;
+	let periodStartMs: number | undefined;
+	let periodEndMs: number | undefined;
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i] as string;
+		const next = (): string | undefined => argv[++i];
+		if (arg === "--cost-center") costCenter = requireValue(arg, next());
+		else if (arg === "--allocated") allocated = parseAllocated(requireValue(arg, next()));
+		else if (arg === "--period-start") periodStartMs = parseIsoMs(arg, requireValue(arg, next()));
+		else if (arg === "--period-end") periodEndMs = parseIsoMs(arg, requireValue(arg, next()));
+		else if (arg.startsWith("--") && !KNOWN_BUDGET_FLAGS.has(arg)) {
+			// Reject unknown flags rather than ignoring them — a typoed --allocted
+			// must not silently report the runway of an allocation nobody set.
+			throw new Error(`Unknown flag: ${arg}`);
+		}
+	}
+
+	const missing: string[] = [];
+	if (costCenter === undefined) missing.push("--cost-center");
+	if (allocated === undefined) missing.push("--allocated");
+	if (costCenter === undefined || allocated === undefined) {
+		throw new Error(`Missing required flag(s): ${missing.join(", ")}. ${USAGE}`);
+	}
+
+	return { costCenter, allocated, periodStartMs, periodEndMs };
+}
+
+/**
+ * An epoch-ms projection on its way to a terminal.
+ *
+ * `new Date(ms).toISOString()` throws RangeError outside ±8.64e15 ms, and a large
+ * balance against a near-zero burn rate lands there routinely. Printing the raw
+ * number beats crashing a read-only command over a projection it already
+ * describes as noisy.
+ */
+function formatExhaustion(ms: number | null): string {
+	if (ms === null) return "not projectable";
+	return Number.isFinite(ms) && Math.abs(ms) <= 8.64e15 ? new Date(ms).toISOString() : `${ms} ms`;
+}
+
+function field(label: string, value: string): string {
+	return `  ${`${label}:`.padEnd(22)}${value}`;
+}
+
+export async function run(rootDir?: string, opts?: CliOptions, args?: string[]): Promise<void> {
+	const root = rootDir ?? process.cwd();
+	const vaultPath = join(root, VAULT_DIR);
+	const json = opts?.json === true;
+
+	// Use process.exitCode (not process.exit) so buffered stdout flushes.
+	const fail = (message: string, humanMessage?: string): void => {
+		if (json) {
+			console.log(JSON.stringify({ command: "budget", success: false, data: { message } }));
+		} else {
+			console.log(humanMessage ?? pc.red(message));
+		}
+		process.exitCode = 1;
+	};
+
+	let flags: BudgetFlags;
+	try {
+		flags = parseBudgetFlags(args ?? process.argv.slice(2));
+	} catch (err) {
+		fail(err instanceof Error ? err.message : String(err));
+		return;
+	}
+
+	if (!existsSync(vaultPath)) {
+		fail(
+			"No trust vault found. Run `usertrust init` first.",
+			`${pc.red("No trust vault found.")} Run \`usertrust init\` first.`,
+		);
+		return;
+	}
+
+	const nowMs = Date.now();
+	let tb: TrustTBClient | undefined;
+	let status: BudgetStatus;
+	try {
+		const config = await loadConfig(undefined, root);
+		tb = new TrustTBClient({
+			addresses: config.tigerbeetle.addresses,
+			clusterId: BigInt(config.tigerbeetle.clusterId),
+		});
+		status = await getBudgetStatus(tb, {
+			parentUserId: process.env.USERTRUST_USER_ID ?? DEFAULT_PARENT_USER_ID,
+			costCenter: flags.costCenter,
+			allocated: flags.allocated,
+			// No --period-start means a zero-length window, hence a zero burn rate.
+			periodStartMs: flags.periodStartMs ?? nowMs,
+			...(flags.periodEndMs !== undefined ? { periodEndMs: flags.periodEndMs } : {}),
+			nowMs,
+		});
+	} catch (err) {
+		fail(err instanceof Error ? err.message : String(err));
+		return;
+	} finally {
+		tb?.destroy();
+	}
+
+	const { balance, runway } = status;
+	// `spent` is derived, not stored: the ledger holds a balance, and what was
+	// spent is whatever the caller's allocation no longer covers. Clamped for the
+	// same reason getBudgetStatus clamps it — an over-funded cost center must not
+	// report negative spend.
+	const spent = Math.max(0, flags.allocated - balance);
+
+	if (json) {
+		console.log(
+			JSON.stringify({
+				command: "budget",
+				success: true,
+				data: {
+					costCenter: flags.costCenter,
+					balance,
+					allocated: flags.allocated,
+					spent,
+					remaining: runway.remaining,
+					fractionRemaining: runway.fractionRemaining,
+					burnRatePerHour: runway.burnRatePerHour,
+					projectedExhaustionMs: runway.projectedExhaustionMs,
+					onPace: runway.onPace,
+				},
+			}),
+		);
+		return;
+	}
+
+	const pct = (runway.fractionRemaining * 100).toFixed(1);
+	console.log(`${pc.bold("Cost center:")} ${flags.costCenter}`);
+	console.log(field("Allocated", `${flags.allocated} UT`));
+	console.log(field("Spent", `${spent} UT`));
+	console.log(field("Balance", `${balance} UT`));
+	console.log(field("Remaining", `${runway.remaining} UT (${pct}%)`));
+	console.log(field("Burn rate", `${runway.burnRatePerHour.toFixed(2)} UT/hour`));
+	console.log(field("Projected exhaustion", formatExhaustion(runway.projectedExhaustionMs)));
+	console.log(field("On pace", runway.onPace === null ? "n/a" : runway.onPace ? "yes" : "no"));
+}

--- a/packages/core/src/cli/budget.ts
+++ b/packages/core/src/cli/budget.ts
@@ -4,8 +4,8 @@
 /**
  * CLI: usertrust budget — read one cost center's balance and runway
  *
- * `usertrust budget --cost-center <name> --allocated <int> [--period-start <iso>]
- * [--period-end <iso>] [--json]`
+ * `usertrust budget --cost-center <name> --allocated <int> [--parent <id>]
+ * [--period-start <iso>] [--period-end <iso>] [--json]`
  *
  * EXPLICIT COST CENTER, NEVER ENUMERATION. There is no cost-center registry: a
  * cost center exists only as a derived sub-wallet, so "list every cost center" is
@@ -26,10 +26,14 @@
  * fabricate a rate. See the projection-honesty note on `Runway` — the estimate is
  * a naive linear extrapolation and must not drive irreversible decisions.
  *
- * IDENTITY. The parent wallet is `$USERTRUST_USER_ID`, defaulting to `local`.
- * The derived cost-center id is deliberately absent from the output: the payload
- * carries no ledger account ids, no vault paths, and no chain metadata, so it is
- * safe to hand an agent verbatim as the result of a `get_budget()` tool call.
+ * IDENTITY. The parent wallet is `--parent`, else `$USERTRUST_USER_ID`, else
+ * `local`, and the resolved id is echoed in both output branches. It has to be:
+ * a cost center read against the wrong parent is not an error but an implicit
+ * zero balance (see `costCenterBalance`), so an unseen parent turns a funded cost
+ * center into a confident "Balance: 0 UT". The DERIVED cost-center id stays
+ * absent from the output — the payload carries no ledger account ids, no vault
+ * paths, and no chain metadata, so it is safe to hand an agent verbatim as the
+ * result of a `get_budget()` tool call.
  */
 
 import { existsSync } from "node:fs";
@@ -42,10 +46,13 @@ import { VAULT_DIR } from "../shared/constants.js";
 import type { CliOptions } from "./init.js";
 
 const USAGE =
-	"Usage: usertrust budget --cost-center <name> --allocated <int> [--period-start <iso>] [--period-end <iso>] [--json]";
+	"Usage: usertrust budget --cost-center <name> --allocated <int> [--parent <id>] [--period-start <iso>] [--period-end <iso>] [--json]";
 
-/** Parent wallet the cost center hangs off, when the environment does not name one. */
+/** Parent wallet the cost center hangs off, when neither the flag nor the environment names one. */
 const DEFAULT_PARENT_USER_ID = "local";
+
+/** Environment fallback for the parent wallet, overridden by `--parent`. */
+const PARENT_ENV_VAR = "USERTRUST_USER_ID";
 
 const KNOWN_BUDGET_FLAGS = new Set([
 	// Global flags main.ts passes to every subcommand — rejecting them here would
@@ -55,12 +62,14 @@ const KNOWN_BUDGET_FLAGS = new Set([
 	"--reconfigure",
 	// Budget flags.
 	"--cost-center",
+	"--parent",
 	"--allocated",
 	"--period-start",
 	"--period-end",
 ]);
 
 interface BudgetFlags {
+	parentUserId: string;
 	costCenter: string;
 	allocated: number;
 	periodStartMs: number | undefined;
@@ -99,40 +108,117 @@ function forDisplay(raw: string): string {
  * `--cost-center --allocated 5` would otherwise bind `--allocated` as the cost
  * center: it matches the cost-center charset, so the derivation accepts it and
  * the command silently reads a wallet nobody named.
+ *
+ * A SINGLE dash is refused for the same reason: `-x` also matches the wallet
+ * charset, so `--parent -x` would read `-x::research` rather than reject a
+ * dropped dash. No value this command accepts — an id, a cost center, a count,
+ * an ISO instant — legitimately begins with `-`.
  */
 function requireValue(flag: string, raw: string | undefined): string {
-	if (raw === undefined || raw.startsWith("--")) throw new Error(`${flag} requires a value`);
+	if (raw === undefined || raw.startsWith("-")) throw new Error(`${flag} requires a value`);
 	return raw;
+}
+
+/**
+ * Mirrors PARENT_USER_ID_PATTERN in budget/allocation.ts, which stays authoritative
+ * — `costCenterUserId` still rejects anything this misses. Checking here buys only
+ * the message: the deep check can quote nothing but its own regex, which is noise
+ * to an operator who never set the value it is complaining about.
+ */
+const PARENT_USER_ID = /^[a-zA-Z0-9._@-]{1,128}$/;
+
+function parseParent(source: string, raw: string): string {
+	if (!PARENT_USER_ID.test(raw)) {
+		throw new Error(
+			`Invalid ${source}: ${forDisplay(raw)} (1-128 characters, letters/digits/. _ @ - only)`,
+		);
+	}
+	return raw;
+}
+
+/**
+ * Resolve the parent wallet: `--parent`, else the environment, else `local`.
+ *
+ * An environment variable set to the empty string — `export USERTRUST_USER_ID=$UNSET`
+ * in a container entrypoint — means the operator named no parent, so it takes the
+ * documented default. Passing "" through (as `??` does, since it substitutes for
+ * null/undefined only) fails the derivation instead, quoting an id charset at
+ * someone who never set an id.
+ */
+function resolveParentUserId(fromFlag: string | undefined): string {
+	if (fromFlag !== undefined) return fromFlag;
+	const fromEnv = process.env[PARENT_ENV_VAR];
+	if (fromEnv === undefined || fromEnv.trim() === "") return DEFAULT_PARENT_USER_ID;
+	// Deliberately validated untrimmed: ` acct_42 ` is a different wallet from
+	// `acct_42`, and quietly trimming into the second one is how a read lands on
+	// a wallet nobody named.
+	return parseParent(`$${PARENT_ENV_VAR}`, fromEnv);
 }
 
 function parseAllocated(raw: string): number {
 	const value = Number.parseInt(raw, 10);
 	// parseInt("1O0") === 1 (partial parse, capital O) and NaN comparisons are
 	// always false — either typo would quietly report a budget nobody granted.
-	// Require the WHOLE value to be a non-negative integer.
-	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(value)) {
-		throw new Error(`Invalid --allocated: ${forDisplay(raw)} (non-negative integer required)`);
+	// Require the WHOLE value to be an integer, and a POSITIVE one: 0 sends
+	// computeRunway down its `allocated <= 0` branch, which reports
+	// fractionRemaining 0 and projects exhaustion at `now`, so a cost center
+	// holding 750 UT prints "Balance: 750 UT" over "Remaining: 0 UT (0.0%)" and
+	// an exhaustion date of this instant — a report that contradicts itself.
+	if (!/^\d+$/.test(raw) || !Number.isSafeInteger(value) || value <= 0) {
+		throw new Error(`Invalid --allocated: ${forDisplay(raw)} (positive integer required)`);
 	}
 	return value;
 }
 
 /**
- * Full ISO-8601 date, optionally with a time, and optionally with an offset.
+ * A full ISO-8601 INSTANT: date, time, and an explicit UTC offset. Nothing looser.
  *
  * `Date.parse` is far looser than "ISO-8601": it reads `1000` as the year 1000,
- * `Dec 25` as this year's Christmas, and pads whitespace away. A typo'd
- * `--period-start 1000` therefore stretches the elapsed window by a millennium
- * and turns a real 180 UT/h burn into 1e-4 UT/h — a governance read that
- * fails open, the same bug class as the `parseInt("1O0")` one above. Requiring
- * the shape as well as parseability is what makes the flag mean what it says.
+ * `0` as 1 January 2000, `5` as May 2001, `Dec 25` as this year's Christmas, and
+ * pads whitespace away. A `--period-start 0` meant as "the start of the period"
+ * therefore opens a ~26-year window and turns a real 450-UT-in-an-hour burn into
+ * 0.00 UT/hour with an exhaustion date centuries out — a governance read that
+ * fails open, the same bug class as the `parseInt("1O0")` one above.
+ *
+ * The offset is REQUIRED and a bare date is refused because both are silently
+ * wrong rather than loudly wrong: a zone-less datetime is read in the HOST's
+ * timezone and a bare date at UTC midnight, so one string names two different
+ * instants on two machines and the window it opens is off by up to a day — which
+ * scales the burn rate by the same factor.
  */
-const ISO_8601 = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+const ISO_8601_INSTANT =
+	/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/**
+ * Whether `year-month-day` is a date that exists.
+ *
+ * `Date.parse` rolls an impossible day over instead of failing: 2026-02-30 comes
+ * back as 2 March, a window silently two days wider than the one asked for. An
+ * out-of-range month, time, or offset needs no check here — for those it does
+ * return NaN.
+ */
+function isRealDate(year: number, month: number, day: number): boolean {
+	if (!Number.isInteger(month) || month < 1 || month > 12) return false;
+	const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+	const maxDay = month === 2 && leap ? 29 : (DAYS_IN_MONTH[month - 1] ?? 0);
+	return day >= 1 && day <= maxDay;
+}
 
 function parseIsoMs(flag: string, raw: string): number {
-	const ms = Date.parse(raw);
-	if (!ISO_8601.test(raw) || !Number.isFinite(ms)) {
+	const parts = ISO_8601_INSTANT.exec(raw);
+	// The space separator is normalized to `T` so the value is read by the spec's
+	// ISO parser rather than by V8's legacy heuristics; the shape is already fixed
+	// by the match, so the substitution is exact.
+	const ms = parts === null ? Number.NaN : Date.parse(raw.replace(" ", "T"));
+	if (
+		parts === null ||
+		!isRealDate(Number(parts[1]), Number(parts[2]), Number(parts[3])) ||
+		!Number.isFinite(ms)
+	) {
 		throw new Error(
-			`Invalid ${flag}: ${forDisplay(raw)} (ISO-8601 timestamp required, e.g. 2026-07-27T09:00:00Z)`,
+			`Invalid ${flag}: ${forDisplay(raw)} (ISO-8601 instant with an explicit timezone required, e.g. 2026-07-27T09:00:00Z)`,
 		);
 	}
 	return ms;
@@ -157,23 +243,38 @@ function parsePeriodStartMs(raw: string, nowMs: number): number {
 }
 
 function parseBudgetFlags(argv: string[], nowMs: number): BudgetFlags {
+	let parent: string | undefined;
 	let costCenter: string | undefined;
 	let allocated: number | undefined;
-	let periodStartMs: number | undefined;
-	let periodEndMs: number | undefined;
+	// The raw text travels with the parsed value so the cross-check below can quote
+	// the bounds back in the form the caller typed them.
+	let periodStart: { raw: string; ms: number } | undefined;
+	let periodEnd: { raw: string; ms: number } | undefined;
 
 	for (let i = 0; i < argv.length; i++) {
 		const arg = argv[i] as string;
-		const next = (): string | undefined => argv[++i];
-		if (arg === "--cost-center") costCenter = requireValue(arg, next());
-		else if (arg === "--allocated") allocated = parseAllocated(requireValue(arg, next()));
-		else if (arg === "--period-start")
-			periodStartMs = parsePeriodStartMs(requireValue(arg, next()), nowMs);
-		else if (arg === "--period-end") periodEndMs = parseIsoMs(arg, requireValue(arg, next()));
-		else if (arg.startsWith("--") && !KNOWN_BUDGET_FLAGS.has(arg)) {
-			// Reject unknown flags rather than ignoring them — a typoed --allocted
-			// must not silently report the runway of an allocation nobody set.
-			throw new Error(`Unknown flag: ${forDisplay(arg)}`);
+		const next = (): string => requireValue(arg, argv[++i]);
+		if (arg === "--cost-center") costCenter = next();
+		else if (arg === "--parent") parent = parseParent(arg, next());
+		else if (arg === "--allocated") allocated = parseAllocated(next());
+		else if (arg === "--period-start") {
+			const raw = next();
+			periodStart = { raw, ms: parsePeriodStartMs(raw, nowMs) };
+		} else if (arg === "--period-end") {
+			const raw = next();
+			periodEnd = { raw, ms: parseIsoMs(arg, raw) };
+		} else if (!KNOWN_BUDGET_FLAGS.has(arg)) {
+			// Reject EVERYTHING unrecognised, not just `--`-prefixed: a dropped dash
+			// (`-period-start 2026-07-01T00:00:00Z`) matches no comparison above, and
+			// falling through drops its VALUE on the next iteration too — the window
+			// then defaults to now and the command exits 0 reporting a 0.00 UT/hour
+			// burn, which is exactly what this guard exists to prevent. A bare
+			// positional is the same failure with no dash at all.
+			throw new Error(
+				arg.startsWith("-")
+					? `Unknown flag: ${forDisplay(arg)}. ${USAGE}`
+					: `Unexpected argument: ${forDisplay(arg)}. ${USAGE}`,
+			);
 		}
 	}
 
@@ -184,7 +285,30 @@ function parseBudgetFlags(argv: string[], nowMs: number): BudgetFlags {
 		throw new Error(`Missing required flag(s): ${missing.join(", ")}. ${USAGE}`);
 	}
 
-	return { costCenter, allocated, periodStartMs, periodEndMs };
+	// An end at or before the start is DISCARDED downstream — computeRunway keeps a
+	// period end only when it is strictly after the start — and `onPace` comes back
+	// null, printing "n/a": indistinguishable from a legitimately open-ended
+	// allocation. Swapped bounds must fail instead, because "unknown" is the one
+	// answer the flag was passed to rule out. Without `--period-start` the window
+	// opens at `now`, so that is the bound the end has to clear.
+	if (periodEnd !== undefined) {
+		const startMs = periodStart?.ms ?? nowMs;
+		if (periodEnd.ms <= startMs) {
+			throw new Error(
+				periodStart === undefined
+					? `Invalid --period-end: ${forDisplay(periodEnd.raw)} is not after now, and no --period-start was given`
+					: `Invalid --period-end: ${forDisplay(periodEnd.raw)} is not after --period-start ${forDisplay(periodStart.raw)}`,
+			);
+		}
+	}
+
+	return {
+		parentUserId: resolveParentUserId(parent),
+		costCenter,
+		allocated,
+		periodStartMs: periodStart?.ms,
+		periodEndMs: periodEnd?.ms,
+	};
 }
 
 /**
@@ -202,6 +326,18 @@ function formatExhaustion(ms: number | null): string {
 
 function field(label: string, value: string): string {
 	return `  ${`${label}:`.padEnd(22)}${value}`;
+}
+
+/**
+ * Argv fallback for a direct `run()` with no explicit args.
+ *
+ * `main.ts` always passes the already-stripped `rest`, but the bare argv still
+ * carries the `budget` subcommand token, which the catch-all unknown-argument
+ * guard would reject — the fallback would fail every time it was used.
+ */
+function processArgs(): string[] {
+	const argv = process.argv.slice(2);
+	return argv[0] === "budget" ? argv.slice(1) : argv;
 }
 
 export async function run(rootDir?: string, opts?: CliOptions, args?: string[]): Promise<void> {
@@ -225,7 +361,7 @@ export async function run(rootDir?: string, opts?: CliOptions, args?: string[]):
 
 	let flags: BudgetFlags;
 	try {
-		flags = parseBudgetFlags(args ?? process.argv.slice(2), nowMs);
+		flags = parseBudgetFlags(args ?? processArgs(), nowMs);
 	} catch (err) {
 		fail(err instanceof Error ? err.message : String(err));
 		return;
@@ -248,7 +384,7 @@ export async function run(rootDir?: string, opts?: CliOptions, args?: string[]):
 			clusterId: BigInt(config.tigerbeetle.clusterId),
 		});
 		status = await getBudgetStatus(tb, {
-			parentUserId: process.env.USERTRUST_USER_ID ?? DEFAULT_PARENT_USER_ID,
+			parentUserId: flags.parentUserId,
 			costCenter: flags.costCenter,
 			allocated: flags.allocated,
 			// No --period-start means a zero-length window, hence a zero burn rate.
@@ -277,6 +413,10 @@ export async function run(rootDir?: string, opts?: CliOptions, args?: string[]):
 				success: true,
 				data: {
 					costCenter: flags.costCenter,
+					// The wallet the balance was read from. A cost center under the wrong
+					// parent reads as an implicit 0, so `balance` cannot be checked by a
+					// caller who cannot see which wallet produced it.
+					parent: flags.parentUserId,
 					balance,
 					allocated: flags.allocated,
 					spent,
@@ -293,6 +433,7 @@ export async function run(rootDir?: string, opts?: CliOptions, args?: string[]):
 
 	const pct = (runway.fractionRemaining * 100).toFixed(1);
 	console.log(`${pc.bold("Cost center:")} ${flags.costCenter}`);
+	console.log(field("Parent wallet", flags.parentUserId));
 	console.log(field("Allocated", `${flags.allocated} UT`));
 	console.log(field("Spent", `${spent} UT`));
 	console.log(field("Balance", `${balance} UT`));

--- a/packages/core/src/cli/budget.ts
+++ b/packages/core/src/cli/budget.ts
@@ -111,11 +111,15 @@ function forDisplay(raw: string): string {
  *
  * A SINGLE dash is refused for the same reason: `-x` also matches the wallet
  * charset, so `--parent -x` would read `-x::research` rather than reject a
- * dropped dash. No value this command accepts — an id, a cost center, a count,
- * an ISO instant — legitimately begins with `-`.
+ * dropped dash. `-cc-` IS a legal cost center, so the refusal costs reach —
+ * hence `--flag=value`, which binds unambiguously and is the way to name one.
+ * The message says so rather than leaving the operator to guess.
  */
-function requireValue(flag: string, raw: string | undefined): string {
-	if (raw === undefined || raw.startsWith("-")) throw new Error(`${flag} requires a value`);
+function requireValue(flag: string, raw: string | undefined, inline: boolean): string {
+	if (raw === undefined || raw === "") throw new Error(`${flag} requires a value`);
+	if (!inline && raw.startsWith("-")) {
+		throw new Error(`${flag} requires a value (write ${flag}=${raw} to pass it literally)`);
+	}
 	return raw;
 }
 
@@ -252,8 +256,15 @@ function parseBudgetFlags(argv: string[], nowMs: number): BudgetFlags {
 	let periodEnd: { raw: string; ms: number } | undefined;
 
 	for (let i = 0; i < argv.length; i++) {
-		const arg = argv[i] as string;
-		const next = (): string => requireValue(arg, argv[++i]);
+		const token = argv[i] as string;
+		// `--flag=value` is split here so the rest of the loop sees one shape. The
+		// inline form is the only way to pass a value beginning with `-`: bound by
+		// `=`, it cannot be a dropped dash, so `requireValue`'s refusal is lifted.
+		const eq = token.startsWith("--") ? token.indexOf("=") : -1;
+		const arg = eq > 2 ? token.slice(0, eq) : token;
+		const inline = eq > 2 ? token.slice(eq + 1) : undefined;
+		const next = (): string =>
+			inline === undefined ? requireValue(arg, argv[++i], false) : requireValue(arg, inline, true);
 		if (arg === "--cost-center") costCenter = next();
 		else if (arg === "--parent") parent = parseParent(arg, next());
 		else if (arg === "--allocated") allocated = parseAllocated(next());

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -12,6 +12,7 @@ const COMMANDS = [
 	"snapshot",
 	"tb",
 	"pricing",
+	"budget",
 	"completions",
 	"secret",
 	"skill",
@@ -100,6 +101,12 @@ switch (command) {
 	case "pricing":
 		await import("./pricing.js").then((m) => m.run(undefined, { json: jsonFlag }));
 		break;
+	case "budget": {
+		// Forwarded verbatim (global flags included) — budget.js accepts them.
+		const rest = argv.slice(argv.indexOf("budget") + 1);
+		await import("./budget.js").then((m) => m.run(undefined, { json: jsonFlag }, rest));
+		break;
+	}
 	case "completions":
 		await import("./completions.js").then((m) => m.run(positional[1], { json: jsonFlag }));
 		break;
@@ -135,6 +142,7 @@ Commands:
   snapshot      Create/restore vault snapshots
   tb            Manage TigerBeetle process
   pricing       Show current rate configuration
+  budget        Show a cost center's balance and runway
   completions   Output shell completion scripts
   secret        Manage vault credentials
   skill         Verify skill manifests

--- a/packages/core/src/cli/verify.ts
+++ b/packages/core/src/cli/verify.ts
@@ -95,6 +95,22 @@ function readPinnedPem(path: string): string {
 	return pem;
 }
 
+// Matching control characters is the entire point here — they are what gets
+// removed from anything echoed back to a terminal.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the intent
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+
+/**
+ * An untrusted field NAME on its way into an error string. Control characters
+ * are stripped before truncation: these strings are printed to a terminal, and
+ * an escape sequence inside a key would let the party under audit repaint the
+ * line its own verdict is printed on.
+ */
+function clipKey(key: string): string {
+	const scrubbed = key.replace(CONTROL_CHARS, "");
+	return scrubbed.length <= 80 ? scrubbed : `${scrubbed.slice(0, 80)}...`;
+}
+
 /**
  * Strict parse of an auditor bundle: `{v:1, records, rekorReceipts?}`. A bundle
  * is untrusted transport, so unknown top-level fields are rejected rather than
@@ -115,7 +131,7 @@ function parseBundle(raw: string): { anchorsRaw: string; receiptsRaw: string[] }
 	}
 	const obj = parsed as Record<string, unknown>;
 	for (const key of Object.keys(obj)) {
-		if (!BUNDLE_KEYS.has(key)) throw new Error(`--bundle: unknown field "${key.slice(0, 80)}"`);
+		if (!BUNDLE_KEYS.has(key)) throw new Error(`--bundle: unknown field "${clipKey(key)}"`);
 	}
 	if (obj.v !== 1) throw new Error("--bundle: unsupported version (expected 1)");
 	if (!Array.isArray(obj.records)) throw new Error("--bundle: records must be an array");

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -580,6 +580,14 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					estimated_cost: estimatedCost,
 					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
 					budget_remaining_after: config.budget - budgetSpent - inFlightHoldTotal - estimatedCost,
+					// P1-BUDGET-TIER-SHADOW: the budget tier fields are trusted-host input.
+					// This path knows no cost-center allocation, so the honest value is
+					// ABSENT — and asserting it here is what stops a request body from
+					// supplying its own `budgetFractionRemaining` and satisfying a tier
+					// that guards frontier spend. An `exists`-guarded rule then simply
+					// does not match; it never matches an attacker's number.
+					budgetFractionRemaining: undefined,
+					budgetRunwayHours: undefined,
 				});
 				if (policyResult.decision === "deny") {
 					const reason =
@@ -1651,6 +1659,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
 					budget_remaining_after: config.budget - budgetSpent - inFlightHoldTotal - action.cost,
 					tier: config.tier,
+					// P1-BUDGET-TIER-SHADOW: trusted-host input, asserted ABSENT here so
+					// `action.params` cannot inject a budget tier's own inputs. See the
+					// same assertion on the LLM path above.
+					budgetFractionRemaining: undefined,
+					budgetRunwayHours: undefined,
 				});
 				if (policyResult.decision === "deny") {
 					const reason =

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -582,6 +582,14 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 					estimated_cost: estCost,
 					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
 					budget_remaining_after: config.budget - budgetSpent - inFlightHoldTotal - estCost,
+					// P1-BUDGET-TIER-SHADOW: the budget tier fields are trusted-host input.
+					// The governor knows no cost-center allocation, so the honest value is
+					// ABSENT — and asserting it here is what stops `params.params` from
+					// supplying its own `budgetFractionRemaining` and satisfying a tier
+					// that guards frontier spend. An `exists`-guarded rule then simply
+					// does not match; it never matches an attacker's number.
+					budgetFractionRemaining: undefined,
+					budgetRunwayHours: undefined,
 				});
 				if (policyResult.decision === "deny") {
 					const reason =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,7 +61,10 @@ export {
 	reclaimBudget,
 } from "./budget/allocation.js";
 export type { Runway, RunwayInput } from "./budget/runway.js";
-export { computeRunway } from "./budget/runway.js";
+// `runwayHours` is the safe derivation of a `budgetRunwayHours` policy field —
+// the naive `(projectedExhaustionMs - nowMs) / 3.6e6` turns "not projectable"
+// into a large negative number and fires escalation rules on an idle budget.
+export { computeRunway, runwayHours } from "./budget/runway.js";
 // Config
 export { defineConfig, loadConfig } from "./config.js";
 // Endpoint classification

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,6 +78,10 @@ export { trust } from "./govern.js";
 export type { Authorization, AuthorizeParams, Governor, SettleParams } from "./headless.js";
 // Headless governance (non-SDK integrations)
 export { createGovernor } from "./headless.js";
+// The ledger client is the required first argument of every budget entry point
+// above. Without it at the root those functions can be imported but never
+// called: the argument is unnameable and unconstructible outside this package.
+export { TrustTBClient } from "./ledger/client.js";
 export type { ModelRates, RateResolution } from "./ledger/pricing.js";
 // Pricing
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,25 @@ export { verifyChain, verifyVault } from "./audit/verify.js";
 export type { BoardReviewResult, BoardStats } from "./board/board.js";
 // Board
 export { createBoard } from "./board/board.js";
+export type {
+	AllocateResult,
+	BudgetAuditWriter,
+	BudgetStatus,
+	ReclaimResult,
+} from "./budget/allocation.js";
+// Agent budgets — delegate a bounded allocation to a named cost center, reclaim
+// what it did not spend, and read its runway. `getBudgetStatus` is the read an
+// agent framework wires as a `get_budget()` tool; it is a plain async function
+// with no framework coupling. Neither allocate nor reclaim is safe to
+// blind-retry — see the module doc comment.
+export {
+	allocateBudget,
+	costCenterUserId,
+	getBudgetStatus,
+	reclaimBudget,
+} from "./budget/allocation.js";
+export type { Runway, RunwayInput } from "./budget/runway.js";
+export { computeRunway } from "./budget/runway.js";
 // Config
 export { defineConfig, loadConfig } from "./config.js";
 // Endpoint classification

--- a/packages/core/src/ledger/client.ts
+++ b/packages/core/src/ledger/client.ts
@@ -314,7 +314,23 @@ export class TrustTBClient {
 		return accountId;
 	}
 
+	/**
+	 * Create (or return) the escrow account for a label.
+	 *
+	 * `::` IS RESERVED — see {@link RESERVED_ID_SEPARATOR}. Escrow labels are hashed
+	 * through the same {@link TrustTBClient.deriveAccountId} namespace as wallets, so
+	 * without this check `ensureEscrowAccount("acme::billing")` would resolve to the
+	 * `billing` cost center of `acme`: TigerBeetle answers `exists` for the already
+	 * created wallet, this returns that wallet's id, and escrow would then debit a
+	 * cost center's budget. The reservation must hold at EVERY door into the
+	 * namespace, not just {@link TrustTBClient.createUserWallet}.
+	 */
 	async ensureEscrowAccount(label: string): Promise<bigint> {
+		if (label.includes(RESERVED_ID_SEPARATOR)) {
+			throw new Error(
+				`Invalid escrow label: "${RESERVED_ID_SEPARATOR}" is reserved for derived cost-center wallets (parent::costCenter)`,
+			);
+		}
 		const accountId = TrustTBClient.deriveAccountId(label);
 		const account: Account = {
 			id: accountId,
@@ -448,7 +464,19 @@ export class TrustTBClient {
 		if (results.length > 0) {
 			const res = results[0];
 			if (!res) throw new Error("Unknown account/transfer error");
-			if (res.status !== CreateTransferStatus.created) {
+			// `exists` IS SUCCESS HERE. transferId is generated above, OUTSIDE the
+			// withReconnect closure, so a retry after a connection error resubmits the
+			// same unique id; TigerBeetle deduplicates on it and answers `exists` only
+			// when every field of the submitted transfer matches the one already
+			// committed (a mismatch is a distinct exists_with_different_* code that
+			// still throws). Receiving it is therefore proof the reservation landed.
+			// Throwing would report a failed reservation against funds TB is already
+			// holding pending — nobody would ever post or void them, and the hold would
+			// sit on the wallet until its timeout expires.
+			if (
+				res.status !== CreateTransferStatus.created &&
+				res.status !== CreateTransferStatus.exists
+			) {
 				throw new TBTransferError(
 					res.status,
 					`Pending transfer failed: ${CreateTransferStatus[res.status] ?? res.status}`,
@@ -480,7 +508,19 @@ export class TrustTBClient {
 		if (results.length > 0) {
 			const res = results[0];
 			if (!res) throw new Error("Unknown account/transfer error");
-			if (res.status !== CreateTransferStatus.created) {
+			// `exists` IS SUCCESS HERE. postId is generated above, OUTSIDE the
+			// withReconnect closure, so a retry after a connection error resubmits the
+			// same unique id; TigerBeetle deduplicates on it and answers `exists` only
+			// when every field of the submitted transfer matches the one already
+			// committed (a mismatch is a distinct exists_with_different_* code that
+			// still throws). Receiving it is therefore proof the debit settled.
+			// Throwing would report a failed settlement for money that moved — and the
+			// governor, seeing failure, would void a pending transfer that is already
+			// posted, leaving the ledger holding a debit its accounting does not.
+			if (
+				res.status !== CreateTransferStatus.created &&
+				res.status !== CreateTransferStatus.exists
+			) {
 				throw new Error(`Post transfer failed: ${CreateTransferStatus[res.status] ?? res.status}`);
 			}
 		}
@@ -509,7 +549,18 @@ export class TrustTBClient {
 		if (results.length > 0) {
 			const res = results[0];
 			if (!res) throw new Error("Unknown account/transfer error");
-			if (res.status !== CreateTransferStatus.created) {
+			// `exists` IS SUCCESS HERE. voidId is generated above, OUTSIDE the
+			// withReconnect closure, so a retry after a connection error resubmits the
+			// same unique id; TigerBeetle deduplicates on it and answers `exists` only
+			// when every field of the submitted transfer matches the one already
+			// committed (a mismatch is a distinct exists_with_different_* code that
+			// still throws). Receiving it is therefore proof the hold was released.
+			// Throwing would fail the caller's cleanup path over a reservation TB has
+			// already returned, and a retry could only ever fail again.
+			if (
+				res.status !== CreateTransferStatus.created &&
+				res.status !== CreateTransferStatus.exists
+			) {
 				throw new Error(`Void transfer failed: ${CreateTransferStatus[res.status] ?? res.status}`);
 			}
 		}

--- a/packages/core/src/ledger/client.ts
+++ b/packages/core/src/ledger/client.ts
@@ -49,6 +49,28 @@ export const XFER_A2A_DELEGATION = 7;
 /** Cost-center budget returned to its parent. Distinct from XFER_REFUND, which
  * reverses a purchase — a reclaim reverses a delegation, not a sale. */
 export const XFER_BUDGET_RECLAIM = 8;
+/**
+ * Budget delegated from a parent wallet into one of its cost centers.
+ *
+ * Deliberately NOT XFER_SPEND: a grant moves usertokens between two wallets the
+ * same owner controls and consumes nothing. Reconciliation that sums XFER_SPEND
+ * debits would otherwise count a delegated budget twice — once moving into the
+ * cost center, and again when the cost center actually spends it.
+ */
+export const XFER_BUDGET_GRANT = 9;
+
+/**
+ * Reserved separator in wallet ids.
+ *
+ * `budget/allocation.ts` derives a cost center's ledger identity as
+ * `parent::costCenter`, and {@link TrustTBClient.deriveAccountId} hashes derived
+ * and ordinary ids identically. An ordinary wallet literally named
+ * `acme::billing` would therefore share one TigerBeetle account with the
+ * `billing` cost center of `acme`, and a reclaim on that cost center would sweep
+ * the wallet's balance into `acme`. Reserving the separator is what makes the
+ * derivation collision-free.
+ */
+const RESERVED_ID_SEPARATOR = "::";
 
 export interface TrustTBClientOptions {
 	addresses: string[];
@@ -182,7 +204,35 @@ export class TrustTBClient {
 		return BigInt(`0x${hash.slice(0, 32)}`);
 	}
 
-	async createUserWallet(userId: string): Promise<bigint> {
+	/**
+	 * Create (or return) the balance-enforced wallet for a user id.
+	 *
+	 * `::` IS RESERVED — see {@link RESERVED_ID_SEPARATOR}. An ordinary caller
+	 * passing `acme::billing` is refused rather than handed the account that the
+	 * `billing` cost center of `acme` derives to, because sharing that account
+	 * would let `reclaimBudget("acme", "billing")` sweep the caller's balance into
+	 * `acme`. The budget path opts in with `{ derived: true }` and reaches this
+	 * only through `costCenterUserId`, whose charsets exclude `:` on both sides —
+	 * so exactly one `(parent, costCenter)` pair maps to each derived id.
+	 *
+	 * @param opts.derived Declares the id is an already-derived `parent::costCenter`.
+	 */
+	async createUserWallet(userId: string, opts?: { derived?: boolean }): Promise<bigint> {
+		const parts = userId.split(RESERVED_ID_SEPARATOR);
+		if (opts?.derived === true) {
+			// Belt to allocation.ts's braces: a derived id is exactly two parts and
+			// neither part may carry a colon of its own.
+			if (parts.length !== 2 || parts.some((part) => part === "" || part.includes(":"))) {
+				throw new Error(
+					`Invalid derived wallet id: expected exactly one "${RESERVED_ID_SEPARATOR}" separating a non-empty parent from a non-empty cost center`,
+				);
+			}
+		} else if (parts.length > 1) {
+			throw new Error(
+				`Invalid userId: "${RESERVED_ID_SEPARATOR}" is reserved for derived cost-center wallets (parent::costCenter)`,
+			);
+		}
+
 		const existing = this.accountMap.get(userId);
 		if (existing) return existing;
 
@@ -497,7 +547,18 @@ export class TrustTBClient {
 		if (results.length > 0) {
 			const res = results[0];
 			if (!res) throw new Error("Unknown account/transfer error");
-			if (res.status !== CreateTransferStatus.created) {
+			// `exists` IS SUCCESS HERE. The transfer id is generated above, OUTSIDE the
+			// withReconnect closure, so a retry after a connection error resubmits the
+			// same unique id; TigerBeetle deduplicates on it and answers `exists`, which
+			// it returns only when every field of the submitted transfer matches the one
+			// already committed (a mismatch is a distinct exists_with_different_* code
+			// that still throws). Receiving it is therefore proof our transfer landed.
+			// Throwing would report failure for money that moved — and a caller retrying
+			// that "failure" would double-allocate.
+			if (
+				res.status !== CreateTransferStatus.created &&
+				res.status !== CreateTransferStatus.exists
+			) {
 				throw new TBTransferError(
 					res.status,
 					`Transfer failed: ${CreateTransferStatus[res.status] ?? res.status}`,

--- a/packages/core/src/ledger/client.ts
+++ b/packages/core/src/ledger/client.ts
@@ -46,6 +46,9 @@ export const XFER_REFUND = 4;
 export const XFER_ALLOCATION = 5;
 export const XFER_TOOL_CALL = 6;
 export const XFER_A2A_DELEGATION = 7;
+/** Cost-center budget returned to its parent. Distinct from XFER_REFUND, which
+ * reverses a purchase — a reclaim reverses a delegation, not a sale. */
+export const XFER_BUDGET_RECLAIM = 8;
 
 export interface TrustTBClientOptions {
 	addresses: string[];

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -340,6 +340,40 @@ export interface PolicyContext extends Record<string, unknown> {
 	timeWindows?: TimeWindow[];
 	/** Optional timestamp override (defaults to now) */
 	timestamp?: string;
+
+	/**
+	 * Budget telemetry for the cost center funding this call. Both fields are
+	 * OPTIONAL and purely additive: they let the existing numeric operators
+	 * express a degradation ladder, so no new operator and no evaluator change
+	 * is involved. Populate them from `getBudgetStatus()` at the call site.
+	 *
+	 * ```ts
+	 * // deny frontier models below 30% of the allocation
+	 * { effect: "deny", enforcement: "hard", conditions: [
+	 *     { field: "budgetFractionRemaining", operator: "exists" },
+	 *     { field: "budgetFractionRemaining", operator: "lt", value: 0.3 },
+	 *     { field: "model", operator: "in", value: ["claude-opus-4-6"] } ] }
+	 * // escalate to a human under 12h of runway (warn + soft = non-blocking)
+	 * { effect: "warn", enforcement: "soft", conditions: [
+	 *     { field: "budgetRunwayHours", operator: "lt", value: 12 } ] }
+	 * ```
+	 *
+	 * IMPORTANT — absent fields are NOT neutral for hard rules. A numeric
+	 * operator on a missing field is `"indeterminate"`, which hard rules treat
+	 * as fail-closed (the condition is skipped and the guard still fires), so a
+	 * HARD budget tier DENIES any context that never populated these fields.
+	 * Lead such a rule with an `exists` condition (as above) when it must only
+	 * apply to budget-aware call sites; soft rules already stay lenient.
+	 */
+
+	/** 0..1 share of the cost center's allocation still available. */
+	budgetFractionRemaining?: number;
+	/**
+	 * Hours until projected exhaustion at the current burn rate. A naive linear
+	 * extrapolation — noisy early in a period, so prefer it for escalation
+	 * rather than irreversible action.
+	 */
+	budgetRunwayHours?: number;
 }
 
 /**

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -345,7 +345,29 @@ export interface PolicyContext extends Record<string, unknown> {
 	 * Budget telemetry for the cost center funding this call. Both fields are
 	 * OPTIONAL and purely additive: they let the existing numeric operators
 	 * express a degradation ladder, so no new operator and no evaluator change
-	 * is involved. Populate them from `getBudgetStatus()` at the call site.
+	 * is involved.
+	 *
+	 * TRUSTED HOST INPUT ONLY. They are governance inputs, so only the host that
+	 * owns the allocation may write them — never a request body. `trust()` and
+	 * `createGovernor()` spread the caller's LLM params into the context and then
+	 * re-assert BOTH fields as `undefined`, so a client posting
+	 * `{"budgetFractionRemaining": 0.95}` cannot make a budget tier look
+	 * satisfied; those SDK paths know no cost-center allocation, so the honest
+	 * value there is "absent". A host that does know the allocation reads it
+	 * itself and calls `evaluatePolicy` with a context it built:
+	 *
+	 * ```ts
+	 * const status = await getBudgetStatus(tb, {
+	 *   parentUserId, costCenter, allocated, periodStartMs,
+	 * });
+	 * const hours = runwayHours(status.runway, nowMs); // null when not projectable
+	 * evaluatePolicy(rules, {
+	 *   model,
+	 *   budgetFractionRemaining: status.runway.fractionRemaining,
+	 *   // omit rather than coerce: null means "no projection", not "0 hours left"
+	 *   ...(hours === null ? {} : { budgetRunwayHours: hours }),
+	 * });
+	 * ```
 	 *
 	 * ```ts
 	 * // deny frontier models below 30% of the allocation
@@ -367,7 +389,14 @@ export interface PolicyContext extends Record<string, unknown> {
 	 */
 
 	/**
-	 * 0..1 share of the cost center's allocation still available.
+	 * 0..1 share of the cost center's allocation still available —
+	 * `getBudgetStatus(...).runway.fractionRemaining`, already clamped to 0..1 by
+	 * `computeRunway`. It is nested under `runway`; the `BudgetStatus` root
+	 * carries only `costCenterUserId`, `balance`, and `runway`.
+	 *
+	 * Declared `| undefined` so a call site under `exactOptionalPropertyTypes`
+	 * can write the field explicitly as `undefined` to overwrite an untrusted
+	 * inbound value; `exists` reads the result as absent either way.
 	 *
 	 * ⚠️ WARNING — A TIER ON THIS FIELD CANNOT FIRE YET. Nothing in this
 	 * repository debits a cost-center wallet: the metering path spends from a
@@ -379,22 +408,26 @@ export interface PolicyContext extends Record<string, unknown> {
 	 * do not rely on the tier until the spend path debits the cost-center wallet.
 	 * See the module doc comment in `budget/allocation.ts`.
 	 */
-	budgetFractionRemaining?: number;
+	budgetFractionRemaining?: number | undefined;
 	/**
 	 * Hours until projected exhaustion at the current burn rate. A naive linear
 	 * extrapolation — noisy early in a period, so prefer it for escalation
 	 * rather than irreversible action.
 	 *
-	 * Derive it with `runwayHours(runway, nowMs)` from `budget/runway.js`, and
-	 * leave the field ABSENT when that returns null. Computing it inline as
-	 * `(runway.projectedExhaustionMs - nowMs) / 3.6e6` coerces the not-projectable
-	 * case to a large negative number, which makes every `lt` threshold match and
-	 * escalates a budget that is merely idle.
+	 * There is no hours field on `BudgetStatus`: derive it with
+	 * `runwayHours(status.runway, nowMs)` from `budget/runway.js`, and leave the
+	 * field ABSENT when that returns null. `Runway` exposes only
+	 * `projectedExhaustionMs: number | null`, and computing hours inline as
+	 * `(projectedExhaustionMs - nowMs) / 3.6e6` coerces the not-projectable case
+	 * — `null`, which is what a period with nothing spent yet reports — to a
+	 * large negative number, which makes every `lt` threshold match and escalates
+	 * a budget that is merely idle.
 	 *
-	 * The metering warning on {@link PolicyContext.budgetFractionRemaining}
-	 * applies to this field too.
+	 * `| undefined` for the same reason as
+	 * {@link PolicyContext.budgetFractionRemaining}, and the metering warning
+	 * there applies to this field too.
 	 */
-	budgetRunwayHours?: number;
+	budgetRunwayHours?: number | undefined;
 }
 
 /**

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -366,12 +366,33 @@ export interface PolicyContext extends Record<string, unknown> {
 	 * apply to budget-aware call sites; soft rules already stay lenient.
 	 */
 
-	/** 0..1 share of the cost center's allocation still available. */
+	/**
+	 * 0..1 share of the cost center's allocation still available.
+	 *
+	 * ⚠️ WARNING — A TIER ON THIS FIELD CANNOT FIRE YET. Nothing in this
+	 * repository debits a cost-center wallet: the metering path spends from a
+	 * per-session funded holding account, not from the wallet `allocateBudget`
+	 * funds. `getBudgetStatus` therefore reports `fractionRemaining: 1` for a
+	 * cost center whose agent is genuinely burning budget, so a
+	 * `budgetFractionRemaining lt 0.3` rule never matches — a governance control
+	 * that fails open. These primitives ship AHEAD of their metering consumer;
+	 * do not rely on the tier until the spend path debits the cost-center wallet.
+	 * See the module doc comment in `budget/allocation.ts`.
+	 */
 	budgetFractionRemaining?: number;
 	/**
 	 * Hours until projected exhaustion at the current burn rate. A naive linear
 	 * extrapolation — noisy early in a period, so prefer it for escalation
 	 * rather than irreversible action.
+	 *
+	 * Derive it with `runwayHours(runway, nowMs)` from `budget/runway.js`, and
+	 * leave the field ABSENT when that returns null. Computing it inline as
+	 * `(runway.projectedExhaustionMs - nowMs) / 3.6e6` coerces the not-projectable
+	 * case to a large negative number, which makes every `lt` threshold match and
+	 * escalates a budget that is merely idle.
+	 *
+	 * The metering warning on {@link PolicyContext.budgetFractionRemaining}
+	 * applies to this field too.
 	 */
 	budgetRunwayHours?: number;
 }

--- a/packages/core/tests/budget/allocation.test.ts
+++ b/packages/core/tests/budget/allocation.test.ts
@@ -38,17 +38,27 @@ import { InsufficientBalanceError } from "../../src/shared/errors.js";
 const PARENT = "user_1";
 const COST_CENTER = "research";
 const CHILD = `${PARENT}::${COST_CENTER}`;
-const PARENT_ACCOUNT = 111n;
-/** Derived with the same static the implementation uses — never hardcoded. */
+/** Both derived with the same static the implementation uses — never hardcoded. */
+const PARENT_ACCOUNT = TrustTBClient.deriveAccountId(PARENT);
 const CHILD_ACCOUNT = TrustTBClient.deriveAccountId(CHILD);
 
 const HOUR = 3_600_000;
 const T0 = 1_800_000_000_000;
 
-/** Create a mock TrustTBClient with vi.fn() methods. */
+/**
+ * Create a mock TrustTBClient with vi.fn() methods.
+ *
+ * `getAccountId` THROWS, exactly as a real client does in a process that never
+ * called `createUserWallet` — its `accountMap` is per-process and nothing in src
+ * populates it for a parent id. A fake that answered the lookup would let this
+ * whole suite pass while every allocate and reclaim rejected before any ledger
+ * I/O in production. Both accounts must be derived; nothing here may be looked up.
+ */
 function createMockTBClient() {
 	return {
-		getAccountId: vi.fn(() => PARENT_ACCOUNT),
+		getAccountId: vi.fn((userId: string): bigint => {
+			throw new Error(`No TigerBeetle account for user: ${userId}`);
+		}),
 		getTreasuryId: vi.fn(() => 1n),
 		lookupBalance: vi.fn(),
 		createPendingTransfer: vi.fn(),
@@ -83,6 +93,23 @@ function createMockAuditWriter() {
 /** Cast helper — the mock implements only the slice of the client this module uses. */
 function asClient(mock: MockTB): TrustTBClient {
 	return mock as unknown as TrustTBClient;
+}
+
+/**
+ * Run `fn` with console.warn silenced, returning what it printed alongside the result.
+ *
+ * The calls are copied out before `mockRestore` runs, which clears them.
+ */
+async function captureWarnings<T>(
+	fn: () => Promise<T>,
+): Promise<{ result: T; warnings: unknown[][] }> {
+	const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+	try {
+		const result = await fn();
+		return { result, warnings: warn.mock.calls.map((call) => [...call] as unknown[]) };
+	} finally {
+		warn.mockRestore();
+	}
 }
 
 describe("costCenterUserId", () => {
@@ -371,16 +398,21 @@ describe("allocateBudget", () => {
 
 	// D8: a cost center that resolves to its own parent would let a transfer debit
 	// and credit the same account — a no-op that reports as a funded allocation.
+	// Both ids are derived, so the collision is forced at the derivation itself:
+	// no pair of real inputs reaches this guard through a 128-bit SHA-256 space.
 	it("refuses to transfer when the cost center resolves to the parent account", async () => {
-		mockTB.getAccountId.mockReturnValueOnce(CHILD_ACCOUNT);
-
-		await expect(
-			allocateBudget(asClient(mockTB), {
-				parentUserId: PARENT,
-				costCenter: COST_CENTER,
-				amount: 500,
-			}),
-		).rejects.toThrow("budget: cost center resolves to the parent account");
+		const derive = vi.spyOn(TrustTBClient, "deriveAccountId").mockReturnValue(CHILD_ACCOUNT);
+		try {
+			await expect(
+				allocateBudget(asClient(mockTB), {
+					parentUserId: PARENT,
+					costCenter: COST_CENTER,
+					amount: 500,
+				}),
+			).rejects.toThrow("budget: cost center resolves to the parent account");
+		} finally {
+			derive.mockRestore();
+		}
 		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
 		expect(mockTB.createUserWallet).not.toHaveBeenCalled();
 	});
@@ -483,12 +515,14 @@ describe("allocateBudget", () => {
 		const audit = createMockAuditWriter();
 		audit.appendEvent.mockRejectedValueOnce(new Error("audit disk full"));
 
-		const result = await allocateBudget(asClient(mockTB), {
-			parentUserId: PARENT,
-			costCenter: COST_CENTER,
-			amount: 500,
-			auditWriter: audit,
-		});
+		const { result } = await captureWarnings(() =>
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+				auditWriter: audit,
+			}),
+		);
 
 		expect(result.transferId).toBe("42");
 		expect(result.allocated).toBe(500);
@@ -509,6 +543,69 @@ describe("allocateBudget", () => {
 		});
 
 		expect(result.auditFailed).toBeUndefined();
+	});
+
+	// A2: `BudgetAuditWriter` is public, so the thrown value is consumer code's.
+	// Discarding it leaves a committed grant whose lost event names neither the
+	// cost center nor the amount nor a reason.
+	it("warns with the event kind, cost center and amount when the audit append throws", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+		audit.appendEvent.mockRejectedValueOnce(new Error("audit disk full"));
+
+		const { result, warnings } = await captureWarnings(() =>
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+				auditWriter: audit,
+			}),
+		);
+
+		expect(warnings).toHaveLength(1);
+		expect(String(warnings[0]?.[0])).toContain("audit event was not written");
+		expect(warnings[0]?.[1]).toEqual({
+			kind: "budget_allocated",
+			costCenterUserId: CHILD,
+			amount: 500,
+			error: "audit disk full",
+		});
+		expect(result.auditFailureReason).toBe("audit disk full");
+	});
+
+	it("carries a non-Error audit rejection through as its string form", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+		audit.appendEvent.mockRejectedValueOnce("writer exploded");
+
+		const { result } = await captureWarnings(() =>
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+				auditWriter: audit,
+			}),
+		);
+
+		expect(result.auditFailed).toBe(true);
+		expect(result.auditFailureReason).toBe("writer exploded");
+	});
+
+	it("leaves auditFailureReason unset and warns nothing on a successful append", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+
+		const { result, warnings } = await captureWarnings(() =>
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+				auditWriter: audit,
+			}),
+		);
+
+		expect(result.auditFailureReason).toBeUndefined();
+		expect(warnings).toHaveLength(0);
 	});
 });
 
@@ -693,11 +790,13 @@ describe("reclaimBudget", () => {
 		const audit = createMockAuditWriter();
 		audit.appendEvent.mockRejectedValueOnce(new Error("audit disk full"));
 
-		const result = await reclaimBudget(asClient(mockTB), {
-			parentUserId: PARENT,
-			costCenter: COST_CENTER,
-			auditWriter: audit,
-		});
+		const { result } = await captureWarnings(() =>
+			reclaimBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				auditWriter: audit,
+			}),
+		);
 
 		expect(result.reclaimed).toBe(320);
 		expect(result.transferId).toBe("77");
@@ -706,12 +805,42 @@ describe("reclaimBudget", () => {
 		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
 	});
 
-	it("refuses to transfer when the cost center resolves to the parent account", async () => {
-		mockTB.getAccountId.mockReturnValueOnce(CHILD_ACCOUNT);
+	// A2: the reclaim direction must report the same way — the amount warned is the
+	// amount that actually moved, not a caller-supplied figure.
+	it("warns with the event kind, cost center and amount when the audit append throws", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+		const audit = createMockAuditWriter();
+		audit.appendEvent.mockRejectedValueOnce(new Error("chain sealed"));
 
-		await expect(
-			reclaimBudget(asClient(mockTB), { parentUserId: PARENT, costCenter: COST_CENTER }),
-		).rejects.toThrow("budget: cost center resolves to the parent account");
+		const { result, warnings } = await captureWarnings(() =>
+			reclaimBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				auditWriter: audit,
+			}),
+		);
+
+		expect(warnings).toHaveLength(1);
+		expect(String(warnings[0]?.[0])).toContain("audit event was not written");
+		expect(warnings[0]?.[1]).toEqual({
+			kind: "budget_reclaimed",
+			costCenterUserId: CHILD,
+			amount: 320,
+			error: "chain sealed",
+		});
+		expect(result.auditFailureReason).toBe("chain sealed");
+	});
+
+	it("refuses to transfer when the cost center resolves to the parent account", async () => {
+		const derive = vi.spyOn(TrustTBClient, "deriveAccountId").mockReturnValue(CHILD_ACCOUNT);
+		try {
+			await expect(
+				reclaimBudget(asClient(mockTB), { parentUserId: PARENT, costCenter: COST_CENTER }),
+			).rejects.toThrow("budget: cost center resolves to the parent account");
+		} finally {
+			derive.mockRestore();
+		}
 		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
 	});
 
@@ -720,6 +849,71 @@ describe("reclaimBudget", () => {
 			reclaimBudget(asClient(mockTB), { parentUserId: PARENT, costCenter: "a::b" }),
 		).rejects.toThrow(/costCenter/);
 		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
+	});
+});
+
+// A1: the whole money path is dead in a fresh process if either account is looked
+// up. `accountMap` is per-process and nothing in src populates it for a parent id,
+// so a lookup rejects with "No TigerBeetle account for user" BEFORE any transfer —
+// a wallet that exists in TigerBeetle is unreachable. Both ids must be derived.
+describe("fresh client with an empty accountMap", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("allocates without consulting the client account map", async () => {
+		mockTB.createUserWallet.mockResolvedValueOnce(TrustTBClient.deriveAccountId("local::research"));
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+
+		const result = await allocateBudget(asClient(mockTB), {
+			parentUserId: "local",
+			costCenter: "research",
+			amount: 500,
+		});
+
+		expect(result.allocated).toBe(500);
+		expect(mockTB.getAccountId).not.toHaveBeenCalled();
+		expect(mockTB.immediateTransfer).toHaveBeenCalledWith({
+			debitAccountId: TrustTBClient.deriveAccountId("local"),
+			creditAccountId: TrustTBClient.deriveAccountId("local::research"),
+			amount: 500,
+			code: XFER_BUDGET_GRANT,
+		});
+	});
+
+	it("reclaims without consulting the client account map", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: "local",
+			costCenter: "research",
+		});
+
+		expect(result.reclaimed).toBe(320);
+		expect(mockTB.getAccountId).not.toHaveBeenCalled();
+		expect(mockTB.immediateTransfer).toHaveBeenCalledWith({
+			debitAccountId: TrustTBClient.deriveAccountId("local::research"),
+			creditAccountId: TrustTBClient.deriveAccountId("local"),
+			amount: 320,
+			code: XFER_BUDGET_RECLAIM,
+		});
+	});
+
+	// The parent account is credited at the id its wallet was CREATED as — the same
+	// pure hash `createUserWallet` derives from. A parent that truly has no wallet
+	// then fails inside TigerBeetle at commit, not before any I/O.
+	it("credits the parent at the id createUserWallet would have derived", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+
+		await reclaimBudget(asClient(mockTB), { parentUserId: PARENT, costCenter: COST_CENTER });
+
+		const call = mockTB.immediateTransfer.mock.calls[0]?.[0] as { creditAccountId: bigint };
+		expect(call.creditAccountId).toBe(PARENT_ACCOUNT);
 	});
 });
 
@@ -837,9 +1031,6 @@ describe("getBudgetStatus", () => {
 	});
 
 	it("does not require the parent to be in the client account map", async () => {
-		mockTB.getAccountId.mockImplementationOnce(() => {
-			throw new Error("No TigerBeetle account for user: user_1");
-		});
 		mockTB.lookupBalance.mockResolvedValueOnce({ available: 750, pending: 0, total: 750 });
 
 		const status = await getBudgetStatus(asClient(mockTB), {
@@ -851,6 +1042,7 @@ describe("getBudgetStatus", () => {
 		});
 
 		expect(status.balance).toBe(750);
+		expect(mockTB.getAccountId).not.toHaveBeenCalled();
 	});
 
 	it("rejects an invalid cost-center name before any ledger I/O", async () => {

--- a/packages/core/tests/budget/allocation.test.ts
+++ b/packages/core/tests/budget/allocation.test.ts
@@ -27,7 +27,12 @@ import {
 	reclaimBudget,
 } from "../../src/budget/allocation.js";
 import { computeRunway } from "../../src/budget/runway.js";
-import { TrustTBClient, XFER_BUDGET_RECLAIM, XFER_SPEND } from "../../src/ledger/client.js";
+import {
+	TrustTBClient,
+	XFER_BUDGET_GRANT,
+	XFER_BUDGET_RECLAIM,
+	XFER_SPEND,
+} from "../../src/ledger/client.js";
 import { InsufficientBalanceError } from "../../src/shared/errors.js";
 
 const PARENT = "user_1";
@@ -183,19 +188,22 @@ describe("allocateBudget", () => {
 			amount: 500,
 		});
 
-		expect(mockTB.createUserWallet).toHaveBeenCalledWith(CHILD);
+		// `{ derived: true }` is the opt-in past the reserved-`::` guard on ordinary
+		// wallet ids — without it the cost-center wallet cannot be created at all.
+		expect(mockTB.createUserWallet).toHaveBeenCalledWith(CHILD, { derived: true });
 		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
 		const call = mockTB.immediateTransfer.mock.calls[0]?.[0];
 		expect(call).toEqual({
 			debitAccountId: PARENT_ACCOUNT,
 			creditAccountId: CHILD_ACCOUNT,
 			amount: 500,
-			code: XFER_SPEND,
+			code: XFER_BUDGET_GRANT,
 		});
 		expect(result).toEqual({
 			costCenterUserId: CHILD,
 			transferId: "42",
 			allocated: 500,
+			audited: false,
 		});
 	});
 
@@ -431,7 +439,17 @@ describe("allocateBudget", () => {
 		expect(Object.keys(event.data).sort()).toEqual(["amount", "costCenter", "costCenterUserId"]);
 	});
 
-	it("emits no audit event when no writer is supplied", async () => {
+	// The allocation direction must NOT reuse the metering path's spend code:
+	// reconciliation summing XFER_SPEND debits would count a delegation twice,
+	// once moving into the cost center and again when the cost center spends it.
+	it("moves the grant under a code distinct from a metered spend", () => {
+		expect(XFER_BUDGET_GRANT).not.toBe(XFER_SPEND);
+		expect(XFER_BUDGET_GRANT).not.toBe(XFER_BUDGET_RECLAIM);
+	});
+
+	// Money must not move with no audit AND no signal: without an explicit
+	// `audited`, an unaudited allocation is byte-identical to an audited one.
+	it("reports audited: false when no writer is supplied, and emits no event", async () => {
 		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
 
 		const result = await allocateBudget(asClient(mockTB), {
@@ -440,6 +458,22 @@ describe("allocateBudget", () => {
 			amount: 500,
 		});
 
+		expect(result.audited).toBe(false);
+		expect(result.auditFailed).toBeUndefined();
+	});
+
+	it("reports audited: true when the append lands in the chain", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+
+		const result = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+			auditWriter: audit,
+		});
+
+		expect(result.audited).toBe(true);
 		expect(result.auditFailed).toBeUndefined();
 	});
 
@@ -458,6 +492,7 @@ describe("allocateBudget", () => {
 
 		expect(result.transferId).toBe("42");
 		expect(result.allocated).toBe(500);
+		expect(result.audited).toBe(false);
 		expect(result.auditFailed).toBe(true);
 		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
 	});
@@ -500,10 +535,11 @@ describe("reclaimBudget", () => {
 			amount: 320,
 			code: XFER_BUDGET_RECLAIM,
 		});
-		expect(result).toEqual({ reclaimed: 320, transferId: "77" });
+		expect(result).toEqual({ reclaimed: 320, transferId: "77", audited: false });
 	});
 
 	it("uses a transfer code distinct from allocation", () => {
+		expect(XFER_BUDGET_RECLAIM).not.toBe(XFER_BUDGET_GRANT);
 		expect(XFER_BUDGET_RECLAIM).not.toBe(XFER_SPEND);
 	});
 
@@ -527,7 +563,7 @@ describe("reclaimBudget", () => {
 			costCenter: COST_CENTER,
 		});
 
-		expect(result).toEqual({ reclaimed: 0, transferId: null });
+		expect(result).toEqual({ reclaimed: 0, transferId: null, audited: false });
 		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
 	});
 
@@ -547,7 +583,7 @@ describe("reclaimBudget", () => {
 		});
 
 		expect(first.reclaimed).toBe(320);
-		expect(second).toEqual({ reclaimed: 0, transferId: null });
+		expect(second).toEqual({ reclaimed: 0, transferId: null, audited: false });
 		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
 	});
 
@@ -559,7 +595,7 @@ describe("reclaimBudget", () => {
 			costCenter: COST_CENTER,
 		});
 
-		expect(result).toEqual({ reclaimed: 0, transferId: null });
+		expect(result).toEqual({ reclaimed: 0, transferId: null, audited: false });
 		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
 		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
 	});
@@ -577,7 +613,7 @@ describe("reclaimBudget", () => {
 			costCenter: COST_CENTER,
 		});
 
-		expect(result).toEqual({ reclaimed: 0, transferId: null });
+		expect(result).toEqual({ reclaimed: 0, transferId: null, audited: false });
 	});
 
 	it("treats every balance-rejection code as the benign race", async () => {
@@ -591,7 +627,7 @@ describe("reclaimBudget", () => {
 				costCenter: COST_CENTER,
 			});
 
-			expect(result).toEqual({ reclaimed: 0, transferId: null });
+			expect(result).toEqual({ reclaimed: 0, transferId: null, audited: false });
 		}
 	});
 
@@ -622,7 +658,7 @@ describe("reclaimBudget", () => {
 		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
 		const audit = createMockAuditWriter();
 
-		await reclaimBudget(asClient(mockTB), {
+		const result = await reclaimBudget(asClient(mockTB), {
 			parentUserId: PARENT,
 			costCenter: COST_CENTER,
 			auditWriter: audit,
@@ -633,6 +669,22 @@ describe("reclaimBudget", () => {
 			actor: PARENT,
 			data: { costCenter: COST_CENTER, amount: 320, costCenterUserId: CHILD },
 		});
+		expect(result.audited).toBe(true);
+		expect(result.auditFailed).toBeUndefined();
+	});
+
+	it("reports audited: false when money moves with no writer supplied", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+
+		expect(result.reclaimed).toBe(320);
+		expect(result.audited).toBe(false);
+		expect(result.auditFailed).toBeUndefined();
 	});
 
 	it("reports auditFailed without re-transferring when the audit append throws", async () => {
@@ -649,6 +701,7 @@ describe("reclaimBudget", () => {
 
 		expect(result.reclaimed).toBe(320);
 		expect(result.transferId).toBe("77");
+		expect(result.audited).toBe(false);
 		expect(result.auditFailed).toBe(true);
 		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
 	});

--- a/packages/core/tests/budget/allocation.test.ts
+++ b/packages/core/tests/budget/allocation.test.ts
@@ -1,0 +1,814 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock tigerbeetle-node — allocation.ts reaches CreateTransferStatus through
+// ledger/client.js, which is a real (unmocked) module in these tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(),
+	AccountFlags: { debits_must_not_exceed_credits: 1 << 2, history: 1 << 5 },
+	TransferFlags: { pending: 1, post_pending_transfer: 2, void_pending_transfer: 4 },
+	CreateAccountStatus: { created: 4294967295, exists: 1, exists_with_different_flags: 2 },
+	CreateTransferStatus: {
+		created: 4294967295,
+		exceeds_credits: 22,
+		overflows_debits: 30,
+		overflows_debits_pending: 31,
+	},
+	amount_max: (1n << 128n) - 1n,
+}));
+
+import type { AppendEventInput } from "../../src/audit/chain.js";
+import {
+	allocateBudget,
+	costCenterUserId,
+	getBudgetStatus,
+	reclaimBudget,
+} from "../../src/budget/allocation.js";
+import { computeRunway } from "../../src/budget/runway.js";
+import { TrustTBClient, XFER_BUDGET_RECLAIM, XFER_SPEND } from "../../src/ledger/client.js";
+import { InsufficientBalanceError } from "../../src/shared/errors.js";
+
+const PARENT = "user_1";
+const COST_CENTER = "research";
+const CHILD = `${PARENT}::${COST_CENTER}`;
+const PARENT_ACCOUNT = 111n;
+/** Derived with the same static the implementation uses — never hardcoded. */
+const CHILD_ACCOUNT = TrustTBClient.deriveAccountId(CHILD);
+
+const HOUR = 3_600_000;
+const T0 = 1_800_000_000_000;
+
+/** Create a mock TrustTBClient with vi.fn() methods. */
+function createMockTBClient() {
+	return {
+		getAccountId: vi.fn(() => PARENT_ACCOUNT),
+		getTreasuryId: vi.fn(() => 1n),
+		lookupBalance: vi.fn(),
+		createPendingTransfer: vi.fn(),
+		postTransfer: vi.fn(),
+		voidTransfer: vi.fn(),
+		immediateTransfer: vi.fn(),
+		lookupTransfer: vi.fn(),
+		// Non-empty by default: the cost-center wallet exists.
+		lookupAccounts: vi.fn(async () => [{}]),
+		createUserWallet: vi.fn(async () => CHILD_ACCOUNT),
+		createTreasury: vi.fn(),
+		setTreasuryId: vi.fn(),
+		setAccountMapping: vi.fn(),
+		ping: vi.fn(),
+		destroy: vi.fn(),
+	};
+}
+
+type MockTB = ReturnType<typeof createMockTBClient>;
+
+/** Build a rejection with TigerBeetle's exact TBTransferError shape (name + numeric code). */
+function tbTransferError(message: string, code: number): Error {
+	const err = new Error(message);
+	Object.assign(err, { name: "TBTransferError", code });
+	return err;
+}
+
+function createMockAuditWriter() {
+	return { appendEvent: vi.fn(async (_input: AppendEventInput): Promise<unknown> => ({})) };
+}
+
+/** Cast helper — the mock implements only the slice of the client this module uses. */
+function asClient(mock: MockTB): TrustTBClient {
+	return mock as unknown as TrustTBClient;
+}
+
+describe("costCenterUserId", () => {
+	it("derives `parent::costCenter`", () => {
+		expect(costCenterUserId(PARENT, COST_CENTER)).toBe(CHILD);
+	});
+
+	it("accepts a single-character cost center and parent", () => {
+		expect(costCenterUserId("a", "b")).toBe("a::b");
+	});
+
+	it("accepts both parts at their maximum length", () => {
+		const parent = "p".repeat(128);
+		const cc = "c".repeat(64);
+		const derived = costCenterUserId(parent, cc);
+		expect(derived).toBe(`${parent}::${cc}`);
+		// 128 + 2 + 64 — the component bounds keep the derived id under the 200 cap.
+		expect(derived.length).toBe(194);
+	});
+
+	it("rejects an empty cost center or parent", () => {
+		expect(() => costCenterUserId(PARENT, "")).toThrow(/costCenter/);
+		expect(() => costCenterUserId("", COST_CENTER)).toThrow(/parentUserId/);
+	});
+
+	it("rejects either part one character past its maximum", () => {
+		expect(() => costCenterUserId(PARENT, "c".repeat(65))).toThrow(/costCenter/);
+		expect(() => costCenterUserId("p".repeat(129), COST_CENTER)).toThrow(/parentUserId/);
+	});
+
+	it("rejects an embedded `::` in either part so the derived id stays unambiguous", () => {
+		expect(() => costCenterUserId(PARENT, "a::b")).toThrow(/costCenter/);
+		expect(() => costCenterUserId("user::sub", COST_CENTER)).toThrow(/parentUserId/);
+	});
+
+	it("rejects a bare colon in either part", () => {
+		expect(() => costCenterUserId(PARENT, "a:b")).toThrow(/costCenter/);
+		expect(() => costCenterUserId("user:1", COST_CENTER)).toThrow(/parentUserId/);
+	});
+
+	it("rejects a slash in the cost center", () => {
+		expect(() => costCenterUserId(PARENT, "research/sub")).toThrow(/costCenter/);
+	});
+
+	it("rejects embedded newlines and ANSI escapes in either part", () => {
+		for (const bad of ["cc\nx", "cc\r\nx", "\u001b[31mcc", "cc x", "cc "]) {
+			expect(() => costCenterUserId(PARENT, bad)).toThrow(/costCenter/);
+		}
+		for (const bad of ["user\nx", "user\r\nx", "\u001b[31muser", "user x", "user "]) {
+			expect(() => costCenterUserId(bad, COST_CENTER)).toThrow(/parentUserId/);
+		}
+	});
+
+	it("rejects a trailing newline (the classic anchored-regex bypass)", () => {
+		expect(() => costCenterUserId(PARENT, `${COST_CENTER}\n`)).toThrow(/costCenter/);
+		expect(() => costCenterUserId(`${PARENT}\n`, COST_CENTER)).toThrow(/parentUserId/);
+	});
+
+	it("accepts leading and trailing punctuation from the allowed set", () => {
+		// Deliberate: `.` and `-` carry no meaning here — the derived id is hashed
+		// into an account id and embedded in JSON, never used as a filesystem path.
+		expect(costCenterUserId(".user.", "-cc-")).toBe(".user.::-cc-");
+		expect(costCenterUserId("a@b.com", "cc.v2")).toBe("a@b.com::cc.v2");
+	});
+
+	it("rejects `@` in the cost center but allows it in the parent", () => {
+		expect(costCenterUserId("a@b.com", COST_CENTER)).toBe(`a@b.com::${COST_CENTER}`);
+		expect(() => costCenterUserId(PARENT, "cc@v2")).toThrow(/costCenter/);
+	});
+
+	it("rejects non-string input from untyped JS callers", () => {
+		expect(() => costCenterUserId(PARENT, 123 as unknown as string)).toThrow(/costCenter/);
+		expect(() => costCenterUserId(null as unknown as string, COST_CENTER)).toThrow(/parentUserId/);
+	});
+
+	it("never collides across distinct (parent, costCenter) pairs", () => {
+		const pairs: Array<[string, string]> = [
+			["a", "b"],
+			["a.b", "c"],
+			["a", "b.c"],
+			["ab", "c"],
+			["a-b", "c"],
+		];
+		const derived = pairs.map(([p, c]) => costCenterUserId(p, c));
+		expect(new Set(derived).size).toBe(pairs.length);
+	});
+});
+
+describe("allocateBudget", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("creates the cost-center wallet then transfers parent -> child", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+
+		const result = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		});
+
+		expect(mockTB.createUserWallet).toHaveBeenCalledWith(CHILD);
+		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
+		const call = mockTB.immediateTransfer.mock.calls[0]?.[0];
+		expect(call).toEqual({
+			debitAccountId: PARENT_ACCOUNT,
+			creditAccountId: CHILD_ACCOUNT,
+			amount: 500,
+			code: XFER_SPEND,
+		});
+		expect(result).toEqual({
+			costCenterUserId: CHILD,
+			transferId: "42",
+			allocated: 500,
+		});
+	});
+
+	it("creates the wallet before transferring", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+
+		await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		});
+
+		const created = mockTB.createUserWallet.mock.invocationCallOrder[0] as number;
+		const transferred = mockTB.immediateTransfer.mock.invocationCallOrder[0] as number;
+		expect(created).toBeLessThan(transferred);
+	});
+
+	// AUD-455: the TOCTOU invariant. A balance read before the transfer would be a
+	// check-then-act race; TigerBeetle enforces debits_must_not_exceed_credits atomically.
+	it("never reads the parent balance before transferring", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+
+		await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		});
+
+		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-positive, fractional, or unsafe amount before any ledger I/O", async () => {
+		for (const amount of [0, -1, -0.5, 1.5, Number.NaN, Number.POSITIVE_INFINITY, 2 ** 53]) {
+			await expect(
+				allocateBudget(asClient(mockTB), {
+					parentUserId: PARENT,
+					costCenter: COST_CENTER,
+					amount,
+				}),
+			).rejects.toThrow("budget: amount must be a positive integer");
+		}
+		expect(mockTB.createUserWallet).not.toHaveBeenCalled();
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+	});
+
+	it("rejects an invalid cost-center name before any ledger I/O", async () => {
+		for (const costCenter of ["a::b", "research/sub", "", "c".repeat(65)]) {
+			await expect(
+				allocateBudget(asClient(mockTB), { parentUserId: PARENT, costCenter, amount: 500 }),
+			).rejects.toThrow(/costCenter/);
+		}
+		expect(mockTB.createUserWallet).not.toHaveBeenCalled();
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+	});
+
+	it("translates a TigerBeetle insufficient-balance rejection into InsufficientBalanceError", async () => {
+		mockTB.immediateTransfer.mockRejectedValueOnce(
+			tbTransferError("Transfer failed: exceeds_credits", 22),
+		);
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 10, pending: 0, total: 10 });
+
+		const err = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		}).catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		expect((err as InsufficientBalanceError).message).toContain("500");
+		expect((err as InsufficientBalanceError).message).toContain("10");
+	});
+
+	it("reads the balance only AFTER the transfer is rejected, for the error message", async () => {
+		mockTB.immediateTransfer.mockRejectedValueOnce(
+			tbTransferError("Transfer failed: exceeds_credits", 22),
+		);
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 10, pending: 0, total: 10 });
+
+		await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		}).catch(() => undefined);
+
+		const transferred = mockTB.immediateTransfer.mock.invocationCallOrder[0] as number;
+		const lookedUp = mockTB.lookupBalance.mock.invocationCallOrder[0] as number;
+		expect(transferred).toBeLessThan(lookedUp);
+	});
+
+	it("reports 0 available when the post-rejection balance lookup also fails", async () => {
+		mockTB.immediateTransfer.mockRejectedValueOnce(
+			tbTransferError("Transfer failed: exceeds_credits", 22),
+		);
+		mockTB.lookupBalance.mockRejectedValueOnce(new Error("TB unreachable"));
+
+		const err = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		}).catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		expect((err as InsufficientBalanceError).available).toBe(0);
+	});
+
+	it("translates every TigerBeetle balance-rejection code", async () => {
+		for (const code of [22, 30, 31]) {
+			vi.clearAllMocks();
+			mockTB.immediateTransfer.mockRejectedValueOnce(tbTransferError("Transfer failed", code));
+			mockTB.lookupBalance.mockResolvedValueOnce({ available: 0, pending: 0, total: 0 });
+			await expect(
+				allocateBudget(asClient(mockTB), {
+					parentUserId: PARENT,
+					costCenter: COST_CENTER,
+					amount: 500,
+				}),
+			).rejects.toThrow(InsufficientBalanceError);
+		}
+	});
+
+	it("propagates a non-balance transfer rejection unchanged", async () => {
+		mockTB.immediateTransfer.mockRejectedValueOnce(new Error("Connection refused"));
+
+		await expect(
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+			}),
+		).rejects.toThrow("Connection refused");
+		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
+	});
+
+	// D10: `createUserWallet` absorbs CreateAccountStatus.exists internally and
+	// resolves with the existing id, so an already-created wallet is observationally
+	// identical to a fresh one. There is no rejection to catch here.
+	it("proceeds normally when the cost-center wallet already exists", async () => {
+		mockTB.createUserWallet.mockResolvedValueOnce(CHILD_ACCOUNT);
+		mockTB.immediateTransfer.mockResolvedValueOnce(43n);
+
+		const result = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		});
+
+		expect(result.transferId).toBe("43");
+		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
+	});
+
+	it("propagates a wallet-creation failure that is NOT `exists` and issues no transfer", async () => {
+		mockTB.createUserWallet.mockRejectedValueOnce(
+			new Error("Failed to create account: exists_with_different_flags"),
+		);
+
+		await expect(
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+			}),
+		).rejects.toThrow("exists_with_different_flags");
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+	});
+
+	// D8: a cost center that resolves to its own parent would let a transfer debit
+	// and credit the same account — a no-op that reports as a funded allocation.
+	it("refuses to transfer when the cost center resolves to the parent account", async () => {
+		mockTB.getAccountId.mockReturnValueOnce(CHILD_ACCOUNT);
+
+		await expect(
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+			}),
+		).rejects.toThrow("budget: cost center resolves to the parent account");
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+		expect(mockTB.createUserWallet).not.toHaveBeenCalled();
+	});
+
+	it("refuses to transfer when the created wallet id differs from the derived id", async () => {
+		// A poisoned accountMap (setAccountMapping) would make allocate fund an
+		// account that reclaim and status never read.
+		mockTB.createUserWallet.mockResolvedValueOnce(999n);
+
+		await expect(
+			allocateBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+				amount: 500,
+			}),
+		).rejects.toThrow("budget: cost center account id does not match its derived id");
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+	});
+
+	it("emits a budget_allocated audit event with a closed payload", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+
+		await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+			auditWriter: audit,
+		});
+
+		expect(audit.appendEvent).toHaveBeenCalledOnce();
+		expect(audit.appendEvent).toHaveBeenCalledWith({
+			kind: "budget_allocated",
+			actor: PARENT,
+			data: { costCenter: COST_CENTER, amount: 500, costCenterUserId: CHILD },
+		});
+	});
+
+	// D6: the payload is constructed literally — caller input is never spread in.
+	it("never leaks unexpected caller fields into the audit payload", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+
+		await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+			auditWriter: audit,
+			apiKey: "sk-secret",
+			prompt: "free-form text",
+		} as unknown as Parameters<typeof allocateBudget>[1]);
+
+		const event = audit.appendEvent.mock.calls[0]?.[0] as unknown as {
+			data: Record<string, unknown>;
+		};
+		expect(Object.keys(event.data).sort()).toEqual(["amount", "costCenter", "costCenterUserId"]);
+	});
+
+	it("emits no audit event when no writer is supplied", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+
+		const result = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+		});
+
+		expect(result.auditFailed).toBeUndefined();
+	});
+
+	// D5: the transfer is authoritative. A failed audit append must never re-transfer.
+	it("reports auditFailed without re-transferring when the audit append throws", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+		audit.appendEvent.mockRejectedValueOnce(new Error("audit disk full"));
+
+		const result = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+			auditWriter: audit,
+		});
+
+		expect(result.transferId).toBe("42");
+		expect(result.allocated).toBe(500);
+		expect(result.auditFailed).toBe(true);
+		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
+	});
+
+	it("leaves auditFailed unset when the audit append succeeds", async () => {
+		mockTB.immediateTransfer.mockResolvedValueOnce(42n);
+		const audit = createMockAuditWriter();
+
+		const result = await allocateBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			amount: 500,
+			auditWriter: audit,
+		});
+
+		expect(result.auditFailed).toBeUndefined();
+	});
+});
+
+describe("reclaimBudget", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("moves exactly the available balance child -> parent under the reclaim code", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+
+		expect(mockTB.immediateTransfer).toHaveBeenCalledWith({
+			debitAccountId: CHILD_ACCOUNT,
+			creditAccountId: PARENT_ACCOUNT,
+			amount: 320,
+			code: XFER_BUDGET_RECLAIM,
+		});
+		expect(result).toEqual({ reclaimed: 320, transferId: "77" });
+	});
+
+	it("uses a transfer code distinct from allocation", () => {
+		expect(XFER_BUDGET_RECLAIM).not.toBe(XFER_SPEND);
+	});
+
+	it("excludes held funds — it reclaims available, not total", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 200, pending: 100, total: 300 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+
+		expect(result.reclaimed).toBe(200);
+	});
+
+	it("returns a zero reclaim and issues no transfer on an empty cost center", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 0, pending: 0, total: 0 });
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+
+		expect(result).toEqual({ reclaimed: 0, transferId: null });
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+	});
+
+	it("is safe to call twice — the second call moves nothing", async () => {
+		mockTB.lookupBalance
+			.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 })
+			.mockResolvedValueOnce({ available: 0, pending: 0, total: 0 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+
+		const first = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+		const second = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+
+		expect(first.reclaimed).toBe(320);
+		expect(second).toEqual({ reclaimed: 0, transferId: null });
+		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
+	});
+
+	it("treats a never-allocated cost center as an implicit zero", async () => {
+		mockTB.lookupAccounts.mockResolvedValueOnce([]);
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+
+		expect(result).toEqual({ reclaimed: 0, transferId: null });
+		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+	});
+
+	// D3: reclaim is optimistic read-then-transfer. A concurrent spend or a second
+	// reclaim landing between the two is a benign race, not a failure.
+	it("returns a zero reclaim when the balance goes stale before the transfer", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 100, pending: 0, total: 100 });
+		mockTB.immediateTransfer.mockRejectedValueOnce(
+			tbTransferError("Transfer failed: exceeds_credits", 22),
+		);
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+		});
+
+		expect(result).toEqual({ reclaimed: 0, transferId: null });
+	});
+
+	it("treats every balance-rejection code as the benign race", async () => {
+		for (const code of [22, 30, 31]) {
+			vi.clearAllMocks();
+			mockTB.lookupBalance.mockResolvedValueOnce({ available: 100, pending: 0, total: 100 });
+			mockTB.immediateTransfer.mockRejectedValueOnce(tbTransferError("Transfer failed", code));
+
+			const result = await reclaimBudget(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: COST_CENTER,
+			});
+
+			expect(result).toEqual({ reclaimed: 0, transferId: null });
+		}
+	});
+
+	it("rethrows any rejection that is not an insufficient balance", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 100, pending: 0, total: 100 });
+		mockTB.immediateTransfer.mockRejectedValueOnce(new Error("Connection refused"));
+
+		await expect(
+			reclaimBudget(asClient(mockTB), { parentUserId: PARENT, costCenter: COST_CENTER }),
+		).rejects.toThrow("Connection refused");
+	});
+
+	it("does not emit an audit event for a zero reclaim", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 0, pending: 0, total: 0 });
+		const audit = createMockAuditWriter();
+
+		await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			auditWriter: audit,
+		});
+
+		expect(audit.appendEvent).not.toHaveBeenCalled();
+	});
+
+	it("emits a budget_reclaimed audit event with a closed payload", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+		const audit = createMockAuditWriter();
+
+		await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			auditWriter: audit,
+		});
+
+		expect(audit.appendEvent).toHaveBeenCalledWith({
+			kind: "budget_reclaimed",
+			actor: PARENT,
+			data: { costCenter: COST_CENTER, amount: 320, costCenterUserId: CHILD },
+		});
+	});
+
+	it("reports auditFailed without re-transferring when the audit append throws", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 320, pending: 0, total: 320 });
+		mockTB.immediateTransfer.mockResolvedValueOnce(77n);
+		const audit = createMockAuditWriter();
+		audit.appendEvent.mockRejectedValueOnce(new Error("audit disk full"));
+
+		const result = await reclaimBudget(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			auditWriter: audit,
+		});
+
+		expect(result.reclaimed).toBe(320);
+		expect(result.transferId).toBe("77");
+		expect(result.auditFailed).toBe(true);
+		expect(mockTB.immediateTransfer).toHaveBeenCalledOnce();
+	});
+
+	it("refuses to transfer when the cost center resolves to the parent account", async () => {
+		mockTB.getAccountId.mockReturnValueOnce(CHILD_ACCOUNT);
+
+		await expect(
+			reclaimBudget(asClient(mockTB), { parentUserId: PARENT, costCenter: COST_CENTER }),
+		).rejects.toThrow("budget: cost center resolves to the parent account");
+		expect(mockTB.immediateTransfer).not.toHaveBeenCalled();
+	});
+
+	it("rejects an invalid cost-center name before any ledger I/O", async () => {
+		await expect(
+			reclaimBudget(asClient(mockTB), { parentUserId: PARENT, costCenter: "a::b" }),
+		).rejects.toThrow(/costCenter/);
+		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
+	});
+});
+
+describe("getBudgetStatus", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("returns the balance and a runway consistent with computeRunway", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 750, pending: 0, total: 750 });
+
+		const status = await getBudgetStatus(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			allocated: 1000,
+			periodStartMs: T0,
+			nowMs: T0 + 5 * HOUR,
+		});
+
+		expect(status.costCenterUserId).toBe(CHILD);
+		expect(status.balance).toBe(750);
+		expect(status.runway).toEqual(
+			computeRunway({
+				allocated: 1000,
+				spent: 250,
+				periodStartMs: T0,
+				nowMs: T0 + 5 * HOUR,
+			}),
+		);
+	});
+
+	it("derives spent as allocated minus balance", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 400, pending: 0, total: 400 });
+
+		const status = await getBudgetStatus(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			allocated: 1000,
+			periodStartMs: T0,
+			nowMs: T0 + HOUR,
+		});
+
+		expect(status.runway.remaining).toBe(400);
+		expect(status.runway.burnRatePerHour).toBe(600);
+	});
+
+	// D4: an over-funded child (funded outside allocateBudget) must not report
+	// negative spend, which would invert the burn rate.
+	it("clamps spent to zero when the child holds more than it was allocated", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 1500, pending: 0, total: 1500 });
+
+		const status = await getBudgetStatus(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			allocated: 1000,
+			periodStartMs: T0,
+			nowMs: T0 + HOUR,
+		});
+
+		expect(status.balance).toBe(1500);
+		expect(status.runway.burnRatePerHour).toBe(0);
+		expect(status.runway.remaining).toBe(1000);
+		expect(status.runway.fractionRemaining).toBe(1);
+	});
+
+	// D11: never-allocated is an implicit zero, not a throw.
+	it("returns a zero balance for a cost center that was never allocated", async () => {
+		mockTB.lookupAccounts.mockResolvedValueOnce([]);
+
+		const status = await getBudgetStatus(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: "never-used",
+			allocated: 1000,
+			periodStartMs: T0,
+			nowMs: T0 + HOUR,
+		});
+
+		expect(status.balance).toBe(0);
+		expect(status.runway.remaining).toBe(0);
+		expect(status.runway.fractionRemaining).toBe(0);
+		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
+	});
+
+	it("passes the period end through so onPace is computed", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 990, pending: 0, total: 990 });
+
+		const status = await getBudgetStatus(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			allocated: 1000,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + HOUR,
+		});
+
+		expect(status.runway.onPace).toBe(true);
+	});
+
+	it("reads the wall clock at this call site when nowMs is omitted", async () => {
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 500, pending: 0, total: 500 });
+		vi.spyOn(Date, "now").mockReturnValue(T0 + 2 * HOUR);
+
+		const status = await getBudgetStatus(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			allocated: 1000,
+			periodStartMs: T0,
+		});
+
+		expect(status.runway.burnRatePerHour).toBe(250);
+		vi.restoreAllMocks();
+	});
+
+	it("does not require the parent to be in the client account map", async () => {
+		mockTB.getAccountId.mockImplementationOnce(() => {
+			throw new Error("No TigerBeetle account for user: user_1");
+		});
+		mockTB.lookupBalance.mockResolvedValueOnce({ available: 750, pending: 0, total: 750 });
+
+		const status = await getBudgetStatus(asClient(mockTB), {
+			parentUserId: PARENT,
+			costCenter: COST_CENTER,
+			allocated: 1000,
+			periodStartMs: T0,
+			nowMs: T0 + HOUR,
+		});
+
+		expect(status.balance).toBe(750);
+	});
+
+	it("rejects an invalid cost-center name before any ledger I/O", async () => {
+		await expect(
+			getBudgetStatus(asClient(mockTB), {
+				parentUserId: PARENT,
+				costCenter: "bad/name",
+				allocated: 1000,
+				periodStartMs: T0,
+			}),
+		).rejects.toThrow(/costCenter/);
+		expect(mockTB.lookupAccounts).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/tests/budget/public-budget-api.test-d.ts
+++ b/packages/core/tests/budget/public-budget-api.test-d.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * F1 — the budget write API must be callable from the *published* package root.
+ *
+ * These imports resolve through `packages/core/package.json` `exports` into the
+ * emitted `dist/*.d.ts`, not through `src/`, so a name the package root fails to
+ * re-export is a compile error here even when the source module exports it. That
+ * is the point: all three entry points take a `TrustTBClient` as their required
+ * first argument, and a consumer who cannot name or construct that argument
+ * cannot call them at all.
+ *
+ * Enforced by `npm run typecheck`, which builds `dist` (`tsc -b`) before running
+ * `tsc -p packages/core/tsconfig.type-tests.json`. Run against a missing or stale
+ * `dist`, this file reports a module-resolution failure rather than a pass.
+ */
+
+import type {
+	AllocateResult,
+	BudgetAuditWriter,
+	BudgetStatus,
+	ReclaimResult,
+	Runway,
+} from "usertrust";
+import { allocateBudget, getBudgetStatus, reclaimBudget, TrustTBClient } from "usertrust";
+
+type Assert<T extends true> = T;
+type Extends<A, B> = A extends B ? true : false;
+
+// Value position on purpose: a type-only re-export of the class would satisfy the
+// annotations below but leave `new TrustTBClient(...)` — the only way a consumer
+// obtains the first argument — a compile error.
+declare const addresses: string[];
+const tb = new TrustTBClient({ addresses });
+
+declare const writer: BudgetAuditWriter;
+
+export const _allocate: Promise<AllocateResult> = allocateBudget(tb, {
+	parentUserId: "acme",
+	costCenter: "research",
+	amount: 1_000,
+	auditWriter: writer,
+});
+
+export const _reclaim: Promise<ReclaimResult> = reclaimBudget(tb, {
+	parentUserId: "acme",
+	costCenter: "research",
+	auditWriter: writer,
+});
+
+export const _status: Promise<BudgetStatus> = getBudgetStatus(tb, {
+	parentUserId: "acme",
+	costCenter: "research",
+	allocated: 1_000,
+	periodStartMs: 0,
+});
+
+export type _StatusCarriesRunway = Assert<Extends<Awaited<typeof _status>, { runway: Runway }>>;

--- a/packages/core/tests/budget/public-budget-api.test.ts
+++ b/packages/core/tests/budget/public-budget-api.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import * as usertrust from "usertrust";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The runtime half of the F1 guard; `public-budget-api.test-d.ts` covers the
+ * emitted `dist` types. `allocateBudget`, `reclaimBudget` and `getBudgetStatus`
+ * all require a `TrustTBClient` as their first argument, so re-exporting them
+ * without the class ships an API no consumer can call. Asserting the value
+ * binding — not just the type — is what rules out a `export type { ... }`
+ * re-export, which would type-check while leaving nothing to construct.
+ *
+ * The namespace import is deliberate: a named import of a missing export is an
+ * ESM link error, which fails the whole file instead of this assertion.
+ */
+describe("public budget API surface", () => {
+	it("exports the budget entry points from the package root", () => {
+		expect(typeof usertrust.allocateBudget).toBe("function");
+		expect(typeof usertrust.reclaimBudget).toBe("function");
+		expect(typeof usertrust.getBudgetStatus).toBe("function");
+	});
+
+	it("exports the TrustTBClient those entry points require as a constructible value", () => {
+		expect(typeof usertrust.TrustTBClient).toBe("function");
+		expect(typeof usertrust.TrustTBClient?.prototype).toBe("object");
+	});
+});

--- a/packages/core/tests/budget/runway.test.ts
+++ b/packages/core/tests/budget/runway.test.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { describe, expect, it } from "vitest";
+import { computeRunway } from "../../src/budget/runway.js";
+
+const HOUR = 3_600_000;
+const T0 = 1_800_000_000_000;
+
+describe("computeRunway", () => {
+	it("computes remaining, fraction, and burn rate over the elapsed window", () => {
+		const r = computeRunway({
+			allocated: 1000,
+			spent: 250,
+			periodStartMs: T0,
+			nowMs: T0 + 5 * HOUR,
+		});
+		expect(r.remaining).toBe(750);
+		expect(r.fractionRemaining).toBeCloseTo(0.75);
+		expect(r.burnRatePerHour).toBeCloseTo(50);
+		expect(r.projectedExhaustionMs).toBe(T0 + 5 * HOUR + 15 * HOUR);
+	});
+
+	it("returns zero burn and no projection before any time elapses", () => {
+		const r = computeRunway({ allocated: 100, spent: 0, periodStartMs: T0, nowMs: T0 });
+		expect(r.burnRatePerHour).toBe(0);
+		expect(r.projectedExhaustionMs).toBeNull();
+		expect(r.onPace).toBeNull();
+	});
+
+	it("reports exhaustion at now when the budget is already spent", () => {
+		const r = computeRunway({
+			allocated: 100,
+			spent: 100,
+			periodStartMs: T0,
+			nowMs: T0 + HOUR,
+		});
+		expect(r.remaining).toBe(0);
+		expect(r.fractionRemaining).toBe(0);
+		expect(r.projectedExhaustionMs).toBe(T0 + HOUR);
+	});
+
+	it("flags on-pace against a bounded period", () => {
+		const slow = computeRunway({
+			allocated: 1000,
+			spent: 10,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + HOUR,
+		});
+		expect(slow.onPace).toBe(true);
+		const fast = computeRunway({
+			allocated: 1000,
+			spent: 500,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + HOUR,
+		});
+		expect(fast.onPace).toBe(false);
+	});
+
+	it("never returns NaN or Infinity for degenerate input", () => {
+		for (const input of [
+			{ allocated: 0, spent: 0, periodStartMs: T0, nowMs: T0 },
+			{ allocated: -5, spent: -5, periodStartMs: T0, nowMs: T0 - HOUR },
+			{ allocated: 100, spent: 500, periodStartMs: T0, nowMs: T0 + HOUR },
+		]) {
+			const r = computeRunway(input);
+			for (const v of [r.remaining, r.fractionRemaining, r.burnRatePerHour]) {
+				expect(Number.isFinite(v)).toBe(true);
+			}
+			expect(r.fractionRemaining).toBeGreaterThanOrEqual(0);
+			expect(r.fractionRemaining).toBeLessThanOrEqual(1);
+		}
+	});
+
+	// ── D1: exact numeric normalization ──
+
+	it("coerces non-finite allocated to 0", () => {
+		for (const allocated of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+			const r = computeRunway({ allocated, spent: 0, periodStartMs: T0, nowMs: T0 + HOUR });
+			expect(r.remaining).toBe(0);
+			expect(r.fractionRemaining).toBe(0);
+			expect(r.burnRatePerHour).toBe(0);
+		}
+	});
+
+	it("coerces negative allocated to 0", () => {
+		const r = computeRunway({ allocated: -5, spent: 0, periodStartMs: T0, nowMs: T0 + HOUR });
+		expect(r.remaining).toBe(0);
+		expect(r.fractionRemaining).toBe(0);
+	});
+
+	it("coerces non-finite spent to 0", () => {
+		for (const spent of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+			const r = computeRunway({ allocated: 100, spent, periodStartMs: T0, nowMs: T0 + HOUR });
+			expect(r.remaining).toBe(100);
+			expect(r.fractionRemaining).toBe(1);
+			expect(r.burnRatePerHour).toBe(0);
+			expect(r.projectedExhaustionMs).toBeNull();
+		}
+	});
+
+	it("coerces negative spent to 0", () => {
+		const r = computeRunway({ allocated: 100, spent: -50, periodStartMs: T0, nowMs: T0 + HOUR });
+		expect(r.remaining).toBe(100);
+		expect(r.fractionRemaining).toBe(1);
+		expect(r.burnRatePerHour).toBe(0);
+	});
+
+	it("throws when periodStartMs is not finite", () => {
+		for (const periodStartMs of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+			expect(() => computeRunway({ allocated: 100, spent: 10, periodStartMs, nowMs: T0 })).toThrow(
+				"runway: periodStartMs and nowMs must be finite",
+			);
+		}
+	});
+
+	it("throws when nowMs is not finite", () => {
+		for (const nowMs of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+			expect(() => computeRunway({ allocated: 100, spent: 10, periodStartMs: T0, nowMs })).toThrow(
+				"runway: periodStartMs and nowMs must be finite",
+			);
+		}
+	});
+
+	it("treats a non-finite periodEndMs as absent so onPace is null", () => {
+		for (const periodEndMs of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+			const r = computeRunway({
+				allocated: 1000,
+				spent: 10,
+				periodStartMs: T0,
+				periodEndMs,
+				nowMs: T0 + HOUR,
+			});
+			expect(r.projectedExhaustionMs).not.toBeNull();
+			expect(r.onPace).toBeNull();
+		}
+	});
+
+	it("treats periodEndMs at or before periodStartMs as absent so onPace is null", () => {
+		for (const periodEndMs of [T0, T0 - HOUR]) {
+			const r = computeRunway({
+				allocated: 1000,
+				spent: 10,
+				periodStartMs: T0,
+				periodEndMs,
+				nowMs: T0 + HOUR,
+			});
+			expect(r.projectedExhaustionMs).not.toBeNull();
+			expect(r.onPace).toBeNull();
+		}
+		// Sanity: one millisecond past the start is a real period and does yield a verdict.
+		const bounded = computeRunway({
+			allocated: 1000,
+			spent: 10,
+			periodStartMs: T0,
+			periodEndMs: T0 + 1,
+			nowMs: T0 + HOUR,
+		});
+		expect(bounded.onPace).toBe(true);
+	});
+
+	it("tolerates fractional allocated/spent for analytics reads", () => {
+		const r = computeRunway({
+			allocated: 100.5,
+			spent: 25.25,
+			periodStartMs: T0,
+			nowMs: T0 + 2 * HOUR,
+		});
+		expect(r.remaining).toBeCloseTo(75.25);
+		expect(r.fractionRemaining).toBeCloseTo(75.25 / 100.5);
+		expect(r.burnRatePerHour).toBeCloseTo(12.625);
+		expect(Number.isInteger(r.projectedExhaustionMs)).toBe(true);
+	});
+
+	it("returns an integer projectedExhaustionMs", () => {
+		const r = computeRunway({
+			allocated: 1000,
+			spent: 7,
+			periodStartMs: T0,
+			nowMs: T0 + 3 * HOUR,
+		});
+		expect(Number.isInteger(r.projectedExhaustionMs)).toBe(true);
+	});
+
+	// ── Boundaries ──
+
+	it("treats a clock behind the period start as a zero-length elapsed window", () => {
+		const r = computeRunway({
+			allocated: 100,
+			spent: 50,
+			periodStartMs: T0,
+			nowMs: T0 - HOUR,
+		});
+		expect(r.remaining).toBe(50);
+		expect(r.burnRatePerHour).toBe(0);
+		expect(r.projectedExhaustionMs).toBeNull();
+	});
+
+	it("counts exhaustion exactly at periodEnd as on pace", () => {
+		// burn 500/h with 500 remaining projects exhaustion to exactly T0 + 2h.
+		const r = computeRunway({
+			allocated: 1000,
+			spent: 500,
+			periodStartMs: T0,
+			periodEndMs: T0 + 2 * HOUR,
+			nowMs: T0 + HOUR,
+		});
+		expect(r.projectedExhaustionMs).toBe(T0 + 2 * HOUR);
+		expect(r.onPace).toBe(true);
+	});
+
+	it("clamps fractionRemaining to 0 when spend exceeds the allocation", () => {
+		const r = computeRunway({
+			allocated: 100,
+			spent: 500,
+			periodStartMs: T0,
+			nowMs: T0 + HOUR,
+		});
+		expect(r.remaining).toBe(0);
+		expect(r.fractionRemaining).toBe(0);
+		expect(r.burnRatePerHour).toBe(500);
+	});
+
+	it("is pure — repeated calls agree and the input is not mutated", () => {
+		const input = {
+			allocated: 1000,
+			spent: 250,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + 5 * HOUR,
+		};
+		const snapshot = { ...input };
+		expect(computeRunway(input)).toEqual(computeRunway(input));
+		expect(input).toEqual(snapshot);
+	});
+});

--- a/packages/core/tests/budget/runway.test.ts
+++ b/packages/core/tests/budget/runway.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 Usertools, Inc.
 
 import { describe, expect, it } from "vitest";
-import { computeRunway } from "../../src/budget/runway.js";
+import { computeRunway, type Runway, runwayHours } from "../../src/budget/runway.js";
 
 const HOUR = 3_600_000;
 const T0 = 1_800_000_000_000;
@@ -234,5 +234,58 @@ describe("computeRunway", () => {
 		const snapshot = { ...input };
 		expect(computeRunway(input)).toEqual(computeRunway(input));
 		expect(input).toEqual(snapshot);
+	});
+});
+
+describe("runwayHours", () => {
+	/** A Runway with only the field runwayHours reads, so each case is explicit. */
+	function runway(projectedExhaustionMs: number | null): Runway {
+		return {
+			remaining: 0,
+			fractionRemaining: 0,
+			burnRatePerHour: 0,
+			projectedExhaustionMs,
+			onPace: null,
+		};
+	}
+
+	it("converts a projection into hours from now", () => {
+		expect(runwayHours(runway(T0 + 12 * HOUR), T0)).toBe(12);
+		expect(runwayHours(runway(T0 + 90 * 60_000), T0)).toBe(1.5);
+	});
+
+	// The whole reason this function exists: the naive inline conversion,
+	// (projectedExhaustionMs - nowMs) / 3.6e6, coerces null to a large NEGATIVE
+	// number, so a `budgetRunwayHours lt 12` rule escalates a merely-idle budget.
+	it("returns null when the runway is not projectable", () => {
+		expect(runwayHours(runway(null), T0)).toBeNull();
+	});
+
+	it("never returns a negative — an already-exhausted projection clamps to 0", () => {
+		expect(runwayHours(runway(T0 - 5 * HOUR), T0)).toBe(0);
+		expect(runwayHours(runway(T0), T0)).toBe(0);
+	});
+
+	it("reads a real computeRunway result end to end", () => {
+		// 250 UT spent over 5h => 50 UT/h, 750 remaining => 15h of runway.
+		const spending = computeRunway({
+			allocated: 1000,
+			spent: 250,
+			periodStartMs: T0,
+			nowMs: T0 + 5 * HOUR,
+		});
+		expect(runwayHours(spending, T0 + 5 * HOUR)).toBeCloseTo(15);
+
+		// Nothing spent yet: no burn rate, so no projection, so no runway figure.
+		const idle = computeRunway({ allocated: 1000, spent: 0, periodStartMs: T0, nowMs: T0 + HOUR });
+		expect(idle.projectedExhaustionMs).toBeNull();
+		expect(runwayHours(idle, T0 + HOUR)).toBeNull();
+	});
+
+	it("rejects a non-finite clock, matching computeRunway's contract", () => {
+		expect(() => runwayHours(runway(T0 + HOUR), Number.NaN)).toThrow("nowMs must be finite");
+		expect(() => runwayHours(runway(T0 + HOUR), Number.POSITIVE_INFINITY)).toThrow(
+			"nowMs must be finite",
+		);
 	});
 });

--- a/packages/core/tests/budget/runway.test.ts
+++ b/packages/core/tests/budget/runway.test.ts
@@ -64,6 +64,7 @@ describe("computeRunway", () => {
 			{ allocated: 0, spent: 0, periodStartMs: T0, nowMs: T0 },
 			{ allocated: -5, spent: -5, periodStartMs: T0, nowMs: T0 - HOUR },
 			{ allocated: 100, spent: 500, periodStartMs: T0, nowMs: T0 + HOUR },
+			{ allocated: 1000, spent: Number.NaN, periodStartMs: T0, nowMs: T0 + HOUR },
 		]) {
 			const r = computeRunway(input);
 			for (const v of [r.remaining, r.fractionRemaining, r.burnRatePerHour]) {
@@ -91,13 +92,54 @@ describe("computeRunway", () => {
 		expect(r.fractionRemaining).toBe(0);
 	});
 
-	it("coerces non-finite spent to 0", () => {
+	// A non-finite spend is unusable, and the fail-closed reading of an unusable
+	// spend is "fully consumed" — the opposite direction from `allocated`.
+	it("reads a non-finite spent as fully consumed, not as untouched", () => {
 		for (const spent of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
 			const r = computeRunway({ allocated: 100, spent, periodStartMs: T0, nowMs: T0 + HOUR });
-			expect(r.remaining).toBe(100);
-			expect(r.fractionRemaining).toBe(1);
-			expect(r.burnRatePerHour).toBe(0);
-			expect(r.projectedExhaustionMs).toBeNull();
+			expect(r.remaining).toBe(0);
+			expect(r.fractionRemaining).toBe(0);
+			expect(Number.isFinite(r.burnRatePerHour)).toBe(true);
+			expect(r.projectedExhaustionMs).toBe(T0 + HOUR);
+		}
+	});
+
+	// The failure this guards: `spent = costTotal / callCount` with a zero call
+	// count yields NaN, and a NaN spend that read as 0 would hand a hard
+	// `budgetFractionRemaining lt 0.3` tier a full 1.0 and never fire.
+	it("does not make a NaN spend indistinguishable from a zero spend", () => {
+		const broken = computeRunway({
+			allocated: 1000,
+			spent: 0 / 0,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + HOUR,
+		});
+		const untouched = computeRunway({
+			allocated: 1000,
+			spent: 0,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + HOUR,
+		});
+		expect(broken).not.toEqual(untouched);
+		expect(broken.fractionRemaining).toBe(0);
+		expect(broken.fractionRemaining).toBeLessThan(0.3);
+		expect(untouched.fractionRemaining).toBe(1);
+	});
+
+	it("keeps a non-finite spent finite in every field, including burn rate", () => {
+		for (const allocated of [0, 100, Number.MAX_VALUE]) {
+			const r = computeRunway({
+				allocated,
+				spent: Number.NaN,
+				periodStartMs: T0,
+				nowMs: T0 + HOUR,
+			});
+			for (const v of [r.remaining, r.fractionRemaining, r.burnRatePerHour]) {
+				expect(Number.isFinite(v)).toBe(true);
+			}
+			expect(Number.isInteger(r.projectedExhaustionMs)).toBe(true);
 		}
 	});
 
@@ -209,6 +251,67 @@ describe("computeRunway", () => {
 		});
 		expect(r.projectedExhaustionMs).toBe(T0 + 2 * HOUR);
 		expect(r.onPace).toBe(true);
+	});
+
+	// ── D2: an exhausted budget is never on pace ──
+
+	it("reports an exhausted budget as off pace after the period has ended", () => {
+		const r = computeRunway({
+			allocated: 1000,
+			spent: 1000,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + 48 * HOUR,
+		});
+		expect(r.remaining).toBe(0);
+		expect(r.fractionRemaining).toBe(0);
+		// Exhaustion projects to `now`, which is past periodEnd — the raw
+		// comparison would read that as "the budget lasted".
+		expect(r.projectedExhaustionMs).toBe(T0 + 48 * HOUR);
+		expect(r.onPace).toBe(false);
+	});
+
+	it("reports an exhausted budget as off pace while the period is still open", () => {
+		const r = computeRunway({
+			allocated: 1000,
+			spent: 1000,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + HOUR,
+		});
+		expect(r.remaining).toBe(0);
+		expect(r.onPace).toBe(false);
+	});
+
+	it("still reports a healthy budget as on pace past the period end", () => {
+		// 10 UT over 48h => ~0.21 UT/h, 990 remaining => ~4752h of runway.
+		const r = computeRunway({
+			allocated: 1000,
+			spent: 10,
+			periodStartMs: T0,
+			periodEndMs: T0 + 24 * HOUR,
+			nowMs: T0 + 48 * HOUR,
+		});
+		expect(r.remaining).toBe(990);
+		expect(r.onPace).toBe(true);
+	});
+
+	it("keeps onPace null for an exhausted budget with no usable period end", () => {
+		const openEnded = computeRunway({
+			allocated: 1000,
+			spent: 1000,
+			periodStartMs: T0,
+			nowMs: T0 + 48 * HOUR,
+		});
+		expect(openEnded.onPace).toBeNull();
+		const inverted = computeRunway({
+			allocated: 1000,
+			spent: 1000,
+			periodStartMs: T0,
+			periodEndMs: T0 - HOUR,
+			nowMs: T0 + 48 * HOUR,
+		});
+		expect(inverted.onPace).toBeNull();
 	});
 
 	it("clamps fractionRemaining to 0 when spend exceeds the allocation", () => {

--- a/packages/core/tests/cli/budget.test.ts
+++ b/packages/core/tests/cli/budget.test.ts
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * CLI: `usertrust budget` — flag validation, exit codes, and output shape.
+ *
+ * TigerBeetle is mocked at module level (the pattern in tests/ledger/engine.test.ts
+ * and tests/budget/allocation.test.ts). The command drives the real TrustTBClient
+ * and the real getBudgetStatus; only the network driver is faked. What these tests
+ * assert is therefore the payload the command actually emits rather than a
+ * restatement of it.
+ *
+ * Only `Date` is faked. Faking setTimeout as well would risk hanging on the fs
+ * promises `loadConfig` awaits, and nothing on this path waits for a timer.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Fake ledger state, mutated per test before the command runs. */
+const ledger = vi.hoisted(() => ({
+	/** Empty means the cost-center wallet does not exist — an implicit zero balance. */
+	accounts: [] as Array<{ credits_posted: bigint; debits_posted: bigint; debits_pending: bigint }>,
+}));
+
+vi.mock("tigerbeetle-node", () => ({
+	createClient: () => ({
+		lookupAccounts: async () => ledger.accounts,
+		createAccounts: async () => [],
+		createTransfers: async () => [],
+		lookupTransfers: async () => [],
+		destroy: () => {},
+	}),
+	AccountFlags: { debits_must_not_exceed_credits: 1 << 2, history: 1 << 5 },
+	TransferFlags: { pending: 1, post_pending_transfer: 2, void_pending_transfer: 4 },
+	CreateAccountStatus: { created: 4294967295, exists: 1, exists_with_different_flags: 2 },
+	CreateTransferStatus: {
+		created: 4294967295,
+		exceeds_credits: 22,
+		overflows_debits: 30,
+		overflows_debits_pending: 31,
+	},
+	amount_max: (1n << 128n) - 1n,
+}));
+
+import { run } from "../../src/cli/budget.js";
+import { COMMANDS } from "../../src/cli/main.js";
+
+const HOUR = 3_600_000;
+const NOW = 1_800_000_000_000;
+const FIVE_HOURS_AGO = new Date(NOW - 5 * HOUR).toISOString();
+
+/**
+ * The exact payload contract from plan delta D12, sorted. Asserting the whole key
+ * set — not just the presence of each field — is what stops a ledger account id or
+ * a vault path from leaking into a payload an agent is handed.
+ */
+const DATA_KEYS = [
+	"allocated",
+	"balance",
+	"burnRatePerHour",
+	"costCenter",
+	"fractionRemaining",
+	"onPace",
+	"projectedExhaustionMs",
+	"remaining",
+	"spent",
+];
+
+let tempDir: string;
+let logOutput: string[];
+
+function makeVault(): void {
+	mkdirSync(join(tempDir, ".usertrust", "audit"), { recursive: true });
+	writeFileSync(
+		join(tempDir, ".usertrust", "usertrust.config.json"),
+		JSON.stringify({
+			budget: 50_000,
+			tigerbeetle: { addresses: ["127.0.0.1:3001"], clusterId: 0 },
+		}),
+		"utf-8",
+	);
+}
+
+function setBalance(available: number): void {
+	ledger.accounts = [{ credits_posted: BigInt(available), debits_posted: 0n, debits_pending: 0n }];
+}
+
+function jsonOut(): { command: string; success: boolean; data: Record<string, unknown> } {
+	const line = logOutput.find((l) => l.startsWith("{"));
+	expect(line).toBeDefined();
+	return JSON.parse(line as string);
+}
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), "trust-budget-cli-"));
+	logOutput = [];
+	ledger.accounts = [];
+	vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+		logOutput.push(args.map(String).join(" "));
+	});
+	vi.useFakeTimers({ toFake: ["Date"] });
+	vi.setSystemTime(NOW);
+	// process.exitCode is undefined until something sets it; pin it so "still 0"
+	// is a real assertion that the command reported success.
+	process.exitCode = 0;
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	// The command sets process.exitCode on a failure verdict; reset it so a
+	// deliberate failure does not leak into the vitest worker's own exit code.
+	process.exitCode = 0;
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("usertrust budget — JSON payload", () => {
+	it("emits exactly the documented fields and the runway they describe", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+		]);
+
+		const out = jsonOut();
+		expect(out.command).toBe("budget");
+		expect(out.success).toBe(true);
+		expect(Object.keys(out.data).sort()).toEqual(DATA_KEYS);
+		expect(out.data.costCenter).toBe("research");
+		expect(out.data.balance).toBe(750);
+		expect(out.data.allocated).toBe(1000);
+		expect(out.data.spent).toBe(250);
+		expect(out.data.remaining).toBe(750);
+		expect(out.data.fractionRemaining).toBeCloseTo(0.75);
+		expect(out.data.burnRatePerHour).toBeCloseTo(50);
+		expect(out.data.projectedExhaustionMs).toBe(NOW + 15 * HOUR);
+		expect(out.data.onPace).toBeNull();
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("reads a never-allocated cost center as an implicit zero balance", async () => {
+		makeVault();
+		// ledger.accounts stays empty — the wallet was never created.
+
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"never-funded",
+			"--allocated",
+			"1000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+		]);
+
+		const out = jsonOut();
+		expect(out.success).toBe(true);
+		expect(out.data.balance).toBe(0);
+		expect(out.data.spent).toBe(1000);
+		expect(out.data.remaining).toBe(0);
+		expect(out.data.fractionRemaining).toBe(0);
+		// Already exhausted projects to now, not to a future estimate.
+		expect(out.data.projectedExhaustionMs).toBe(NOW);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("reports zero burn and no projection when no period start is supplied", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, ["--cost-center", "research", "--allocated", "1000"]);
+
+		const out = jsonOut();
+		expect(out.success).toBe(true);
+		expect(out.data.burnRatePerHour).toBe(0);
+		expect(out.data.projectedExhaustionMs).toBeNull();
+		expect(out.data.onPace).toBeNull();
+	});
+
+	it("flags on-pace against a bounded period in both directions", async () => {
+		makeVault();
+		const periodEnd = new Date(NOW + 24 * HOUR).toISOString();
+
+		setBalance(990); // spent 10 over 5h => 2 UT/h, 990 remaining => 495h of runway
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+			"--period-end",
+			periodEnd,
+		]);
+		expect(jsonOut().data.onPace).toBe(true);
+
+		logOutput = [];
+		setBalance(500); // spent 500 over 5h => 100 UT/h, 500 remaining => 5h of runway
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+			"--period-end",
+			periodEnd,
+		]);
+		expect(jsonOut().data.onPace).toBe(false);
+	});
+});
+
+describe("usertrust budget — flag validation", () => {
+	it("rejects an unknown flag before it ever looks for a vault", async () => {
+		// No vault in tempDir: a typo must fail as a typo, not as a missing vault.
+		await run(tempDir, { json: false }, ["--cost-centre", "research", "--allocated", "1000"]);
+
+		expect(logOutput.join("\n")).toMatch(/Unknown flag: --cost-centre/);
+		expect(logOutput.join("\n")).not.toMatch(/usertrust init/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("accepts the global flags main.ts passes to every subcommand", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--json",
+			"--skip-verify",
+			"--reconfigure",
+		]);
+
+		expect(jsonOut().success).toBe(true);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("requires --cost-center and --allocated, naming what is missing", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--allocated", "1000"]);
+		expect(logOutput.join("\n")).toMatch(/--cost-center/);
+		expect(logOutput.join("\n")).toMatch(/Usage: usertrust budget/);
+		expect(process.exitCode).toBe(1);
+
+		logOutput = [];
+		process.exitCode = 0;
+		await run(tempDir, { json: false }, ["--cost-center", "research"]);
+		expect(logOutput.join("\n")).toMatch(/--allocated/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("rejects an --allocated value that is not a whole non-negative integer", async () => {
+		makeVault();
+		// "1O0" is a capital O: parseInt partial-parses it to 1, which would silently
+		// report a 1 UT allocation as if the caller had asked for it.
+		for (const bad of [
+			"1O0",
+			"1.5",
+			"-5",
+			"1e3",
+			" 12",
+			"12 ",
+			"",
+			"0x10",
+			"99999999999999999999",
+		]) {
+			logOutput = [];
+			process.exitCode = 0;
+			await run(tempDir, { json: false }, ["--cost-center", "research", "--allocated", bad]);
+			expect(logOutput.join("\n")).toMatch(/--allocated/);
+			expect(process.exitCode).toBe(1);
+		}
+	});
+
+	it("rejects a period bound that Date.parse cannot read", async () => {
+		makeVault();
+
+		for (const flag of ["--period-start", "--period-end"]) {
+			logOutput = [];
+			process.exitCode = 0;
+			await run(tempDir, { json: false }, [
+				"--cost-center",
+				"research",
+				"--allocated",
+				"1000",
+				flag,
+				"yesterday",
+			]);
+			expect(logOutput.join("\n")).toMatch(new RegExp(`Invalid ${flag}`));
+			expect(process.exitCode).toBe(1);
+		}
+	});
+
+	it("refuses to swallow the next flag as a missing value", async () => {
+		makeVault();
+
+		// Without a guard, `--allocated` becomes the cost-center name: it matches the
+		// cost-center charset, so it would be accepted as a real name.
+		await run(tempDir, { json: false }, ["--cost-center", "--allocated", "1000"]);
+
+		expect(logOutput.join("\n")).toMatch(/--cost-center requires a value/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("rejects a cost-center name outside the derivation charset", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--cost-center", "team/research", "--allocated", "1000"]);
+
+		expect(logOutput.join("\n")).toMatch(/costCenter must match/);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+describe("usertrust budget — human output", () => {
+	it("exits 1 with the standard message when no vault is found", async () => {
+		await run(tempDir, { json: false }, ["--cost-center", "research", "--allocated", "1000"]);
+
+		expect(logOutput.join("\n")).toMatch(/usertrust init/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("carries every runway field", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+		]);
+
+		const combined = logOutput.join("\n");
+		expect(combined).toContain("research");
+		expect(combined).toMatch(/Allocated:\s+1000 UT/);
+		expect(combined).toMatch(/Spent:\s+250 UT/);
+		expect(combined).toMatch(/Balance:\s+750 UT/);
+		expect(combined).toMatch(/Remaining:\s+750 UT \(75\.0%\)/);
+		expect(combined).toMatch(/Burn rate:\s+50\.00 UT\/hour/);
+		expect(combined).toContain(new Date(NOW + 15 * HOUR).toISOString());
+		expect(combined).toMatch(/On pace:/);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("prints raw milliseconds when the projection falls outside Date range", async () => {
+		makeVault();
+		// 1 UT spent over 5h against a near-max remaining balance projects ~3e22 ms
+		// away. `new Date(that).toISOString()` throws RangeError beyond ±8.64e15.
+		setBalance(9_007_199_254_739_999);
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"9007199254740000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+		]);
+
+		// A raw number (here in exponential notation) rather than a RangeError.
+		const combined = logOutput.join("\n");
+		expect(combined).toMatch(/Projected exhaustion:\s+[0-9.e+]+ ms$/m);
+		expect(process.exitCode).toBe(0);
+	});
+});
+
+describe("usertrust budget — dispatch", () => {
+	it("is a registered command so `did you mean` can suggest it", () => {
+		expect(COMMANDS).toContain("budget");
+	});
+});

--- a/packages/core/tests/cli/budget.test.ts
+++ b/packages/core/tests/cli/budget.test.ts
@@ -64,6 +64,7 @@ const DATA_KEYS = [
 	"costCenter",
 	"fractionRemaining",
 	"onPace",
+	"parent",
 	"projectedExhaustionMs",
 	"remaining",
 	"spent",
@@ -71,6 +72,8 @@ const DATA_KEYS = [
 
 let tempDir: string;
 let logOutput: string[];
+/** Restored per test: the parent wallet falls back to this variable, so a real one leaks in. */
+let savedParentEnv: string | undefined;
 
 function makeVault(): void {
 	mkdirSync(join(tempDir, ".usertrust", "audit"), { recursive: true });
@@ -98,6 +101,8 @@ beforeEach(() => {
 	tempDir = mkdtempSync(join(tmpdir(), "trust-budget-cli-"));
 	logOutput = [];
 	ledger.accounts = [];
+	savedParentEnv = process.env.USERTRUST_USER_ID;
+	delete process.env.USERTRUST_USER_ID;
 	vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
 		logOutput.push(args.map(String).join(" "));
 	});
@@ -111,6 +116,8 @@ beforeEach(() => {
 afterEach(() => {
 	vi.useRealTimers();
 	vi.restoreAllMocks();
+	if (savedParentEnv === undefined) delete process.env.USERTRUST_USER_ID;
+	else process.env.USERTRUST_USER_ID = savedParentEnv;
 	// The command sets process.exitCode on a failure verdict; reset it so a
 	// deliberate failure does not leak into the vitest worker's own exit code.
 	process.exitCode = 0;
@@ -227,6 +234,45 @@ describe("usertrust budget — flag validation", () => {
 		expect(process.exitCode).toBe(1);
 	});
 
+	// A dropped dash matches no comparison in the parser, and letting it fall
+	// through drops its VALUE on the next iteration too: the window would default
+	// to now and the command would exit 0 reporting a 0.00 UT/hour burn.
+	it("rejects a single-dash flag instead of dropping it and its value", async () => {
+		makeVault();
+		setBalance(500);
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"-period-start",
+			FIVE_HOURS_AGO,
+		]);
+
+		expect(logOutput.join("\n")).toMatch(/Unknown flag: -period-start/);
+		expect(logOutput.join("\n")).not.toMatch(/Burn rate/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("rejects a bare positional argument", async () => {
+		makeVault();
+		setBalance(500);
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"research",
+		]);
+
+		expect(logOutput.join("\n")).toMatch(/Unexpected argument: research/);
+		expect(logOutput.join("\n")).toMatch(/Usage: usertrust budget/);
+		expect(logOutput.join("\n")).not.toMatch(/Burn rate/);
+		expect(process.exitCode).toBe(1);
+	});
+
 	it("accepts the global flags main.ts passes to every subcommand", async () => {
 		makeVault();
 		setBalance(750);
@@ -283,6 +329,25 @@ describe("usertrust budget — flag validation", () => {
 		}
 	});
 
+	// 0 sends computeRunway down its `allocated <= 0` branch: fractionRemaining 0
+	// and an exhaustion projection of "now". Against a cost center holding 750 UT
+	// the report contradicts itself — "Balance: 750 UT" over "Remaining: 0 UT
+	// (0.0%)" and an exhaustion date of this instant.
+	it("rejects a zero --allocated rather than reporting an exhausted budget", async () => {
+		makeVault();
+		setBalance(750);
+
+		for (const bad of ["0", "00", "0000"]) {
+			logOutput = [];
+			process.exitCode = 0;
+			await run(tempDir, { json: false }, ["--cost-center", "research", "--allocated", bad]);
+			expect(logOutput.join("\n")).toMatch(/Invalid --allocated/);
+			expect(logOutput.join("\n")).toMatch(/positive integer/);
+			expect(logOutput.join("\n")).not.toMatch(/Balance/);
+			expect(process.exitCode).toBe(1);
+		}
+	});
+
 	it("rejects a period bound that Date.parse cannot read", async () => {
 		makeVault();
 
@@ -314,6 +379,12 @@ describe("usertrust budget — flag validation", () => {
 				"1000",
 				"2026",
 				"1",
+				// Date.parse("0") is 1 Jan 2000 and Date.parse("5") is May 2001 — both
+				// finite, so shape is the only thing that catches them. A caller passing
+				// `--period-start 0` to mean "the start of the period" would otherwise
+				// open a ~26-year window and report a hard burn as 0.00 UT/hour.
+				"0",
+				"5",
 				"Dec 25",
 				"Mar 2026",
 				"2026-07",
@@ -321,6 +392,8 @@ describe("usertrust budget — flag validation", () => {
 				"2026-07-27 ",
 				"2026/07/27",
 				"07/27/2026",
+				// An epoch-ms value is not an ISO-8601 instant, however real it looks.
+				"1800000000000",
 			]) {
 				logOutput = [];
 				process.exitCode = 0;
@@ -343,14 +416,15 @@ describe("usertrust budget — flag validation", () => {
 		setBalance(750);
 
 		for (const good of [
-			"2026-07-27",
-			"2026-07-27T09:00",
-			"2026-07-27T09:00:00",
-			"2026-07-27T09:00:00.500",
+			"2026-07-27T09:00Z",
 			"2026-07-27T09:00:00Z",
+			"2026-07-27T09:00:00.5Z",
 			"2026-07-27T09:00:00.500Z",
 			"2026-07-27T09:00:00+02:00",
+			"2026-07-27T09:00:00-05:00",
 			"2026-07-27 09:00:00Z",
+			// 2024 is a leap year; 2026 is not (see the impossible-date cases below).
+			"2024-02-29T00:00:00Z",
 		]) {
 			logOutput = [];
 			process.exitCode = 0;
@@ -364,6 +438,58 @@ describe("usertrust budget — flag validation", () => {
 			]);
 			expect(jsonOut().success).toBe(true);
 			expect(process.exitCode).toBe(0);
+		}
+	});
+
+	// A zone-less datetime is read in the HOST's timezone and a bare date at UTC
+	// midnight, so one string names two different instants on two machines and the
+	// window it opens is off by up to a day — which scales the burn rate by the
+	// same factor. An instant has to say which zone it is in.
+	it("rejects a period bound with no explicit timezone", async () => {
+		makeVault();
+
+		for (const flag of ["--period-start", "--period-end"]) {
+			for (const bad of [
+				"2026-07-27",
+				"2026-07-27T09:00",
+				"2026-07-27T09:00:00",
+				"2026-07-27T09:00:00.500",
+			]) {
+				logOutput = [];
+				process.exitCode = 0;
+				await run(tempDir, { json: false }, [
+					"--cost-center",
+					"research",
+					"--allocated",
+					"1000",
+					flag,
+					bad,
+				]);
+				expect(logOutput.join("\n")).toMatch(new RegExp(`Invalid ${flag}`));
+				expect(logOutput.join("\n")).toMatch(/explicit timezone/);
+				expect(process.exitCode).toBe(1);
+			}
+		}
+	});
+
+	// Date.parse rolls an impossible day over rather than failing: 2026-02-30 comes
+	// back as 2 March, a window silently two days wider than the one asked for.
+	it("rejects a period bound naming a date that does not exist", async () => {
+		makeVault();
+
+		for (const bad of ["2026-02-30T00:00:00Z", "2026-02-29T00:00:00Z", "2026-04-31T00:00:00Z"]) {
+			logOutput = [];
+			process.exitCode = 0;
+			await run(tempDir, { json: false }, [
+				"--cost-center",
+				"research",
+				"--allocated",
+				"1000",
+				"--period-start",
+				bad,
+			]);
+			expect(logOutput.join("\n")).toMatch(/Invalid --period-start/);
+			expect(process.exitCode).toBe(1);
 		}
 	});
 
@@ -406,6 +532,57 @@ describe("usertrust budget — flag validation", () => {
 		expect(process.exitCode).toBe(0);
 	});
 
+	// computeRunway keeps a period end only when it is strictly after the start, so
+	// swapped bounds are silently DISCARDED and `onPace` prints "n/a" — the same
+	// output as a legitimately open-ended allocation, and the one answer the flag
+	// was passed to rule out.
+	it("rejects a --period-end that is not strictly after --period-start", async () => {
+		makeVault();
+		setBalance(750);
+		const earlier = new Date(NOW - 10 * HOUR).toISOString();
+
+		// Swapped bounds, in both argument orders, plus a zero-length period.
+		for (const argv of [
+			["--period-start", FIVE_HOURS_AGO, "--period-end", earlier],
+			["--period-end", earlier, "--period-start", FIVE_HOURS_AGO],
+			["--period-start", FIVE_HOURS_AGO, "--period-end", FIVE_HOURS_AGO],
+		]) {
+			logOutput = [];
+			process.exitCode = 0;
+			await run(tempDir, { json: false }, [
+				"--cost-center",
+				"research",
+				"--allocated",
+				"1000",
+				...argv,
+			]);
+			expect(logOutput.join("\n")).toMatch(/Invalid --period-end/);
+			expect(logOutput.join("\n")).toMatch(/not after --period-start/);
+			expect(logOutput.join("\n")).not.toMatch(/On pace/);
+			expect(process.exitCode).toBe(1);
+		}
+	});
+
+	// With no --period-start the window opens at `now`, so a past end is inverted
+	// against it and would be discarded just as silently.
+	it("rejects a past --period-end when no --period-start was given", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-end",
+			FIVE_HOURS_AGO,
+		]);
+
+		expect(logOutput.join("\n")).toMatch(/Invalid --period-end/);
+		expect(logOutput.join("\n")).toMatch(/no --period-start was given/);
+		expect(process.exitCode).toBe(1);
+	});
+
 	it("refuses to swallow the next flag as a missing value", async () => {
 		makeVault();
 
@@ -423,6 +600,161 @@ describe("usertrust budget — flag validation", () => {
 		await run(tempDir, { json: false }, ["--cost-center", "team/research", "--allocated", "1000"]);
 
 		expect(logOutput.join("\n")).toMatch(/costCenter must match/);
+		expect(process.exitCode).toBe(1);
+	});
+});
+
+/**
+ * The parent wallet decides which account the balance is read from, and reading the
+ * wrong one is not an error: `costCenterBalance` reports a wallet that does not
+ * exist as an implicit 0 by design. A cost center funded under `acct_42` therefore
+ * prints a confident "Balance: 0 UT / Spent: 1000 UT" when the command resolves a
+ * different parent — so the parent must be settable, and must be visible in both
+ * output branches.
+ */
+describe("usertrust budget — parent wallet", () => {
+	it("defaults to local and says so in both output branches", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, ["--cost-center", "research", "--allocated", "1000"]);
+		expect(jsonOut().data.parent).toBe("local");
+
+		logOutput = [];
+		await run(tempDir, { json: false }, ["--cost-center", "research", "--allocated", "1000"]);
+		expect(logOutput.join("\n")).toMatch(/Parent wallet:\s+local/);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("reads the parent from --parent and echoes the resolved id", async () => {
+		makeVault();
+		setBalance(1000);
+
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--parent",
+			"acct_42",
+		]);
+		expect(jsonOut().data.parent).toBe("acct_42");
+		expect(jsonOut().success).toBe(true);
+
+		logOutput = [];
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--parent",
+			"acct_42",
+		]);
+		expect(logOutput.join("\n")).toMatch(/Parent wallet:\s+acct_42/);
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("takes --parent over the environment", async () => {
+		makeVault();
+		setBalance(750);
+		process.env.USERTRUST_USER_ID = "from-env";
+
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--parent",
+			"from-flag",
+		]);
+
+		expect(jsonOut().data.parent).toBe("from-flag");
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("falls back to the environment when no --parent is given", async () => {
+		makeVault();
+		setBalance(750);
+		process.env.USERTRUST_USER_ID = "from-env";
+
+		await run(tempDir, { json: true }, ["--cost-center", "research", "--allocated", "1000"]);
+
+		expect(jsonOut().data.parent).toBe("from-env");
+		expect(process.exitCode).toBe(0);
+	});
+
+	// `export USERTRUST_USER_ID=$SOME_UNSET_VAR` in a container entrypoint sets the
+	// variable to "". `??` substitutes for null/undefined only, so the empty string
+	// used to reach the derivation and fail there, quoting an internal id charset at
+	// an operator who never set the variable.
+	it("treats an empty or whitespace-only environment value as unset", async () => {
+		makeVault();
+		setBalance(750);
+
+		for (const empty of ["", " ", "\t\n"]) {
+			logOutput = [];
+			process.exitCode = 0;
+			process.env.USERTRUST_USER_ID = empty;
+			await run(tempDir, { json: true }, ["--cost-center", "research", "--allocated", "1000"]);
+			expect(jsonOut().success).toBe(true);
+			expect(jsonOut().data.parent).toBe("local");
+			expect(process.exitCode).toBe(0);
+		}
+	});
+
+	it("rejects a --parent outside the wallet-id charset, naming the flag", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--parent",
+			"acct 42",
+		]);
+
+		expect(logOutput.join("\n")).toMatch(/Invalid --parent: acct 42/);
+		expect(logOutput.join("\n")).not.toMatch(/parentUserId must match/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("rejects a non-empty but invalid environment value, naming the variable", async () => {
+		makeVault();
+		process.env.USERTRUST_USER_ID = "acct 42";
+
+		await run(tempDir, { json: false }, ["--cost-center", "research", "--allocated", "1000"]);
+
+		expect(logOutput.join("\n")).toMatch(/Invalid \$USERTRUST_USER_ID: acct 42/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("requires a value for --parent rather than swallowing the next flag", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--parent", "--cost-center", "research"]);
+
+		expect(logOutput.join("\n")).toMatch(/--parent requires a value/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	// `-x` matches the wallet charset, so a single-dash token would otherwise bind
+	// as the parent id and the command would confidently report on `-x::research`.
+	it("refuses a single-dash token as the --parent value", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--parent", "-x", "--cost-center", "research"]);
+
+		expect(logOutput.join("\n")).toMatch(/--parent requires a value/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("refuses a single-dash token as the --cost-center value", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--cost-center", "-x", "--allocated", "1000"]);
+
+		expect(logOutput.join("\n")).toMatch(/--cost-center requires a value/);
 		expect(process.exitCode).toBe(1);
 	});
 });
@@ -611,5 +943,32 @@ describe("usertrust budget — human output", () => {
 describe("usertrust budget — dispatch", () => {
 	it("is a registered command so `did you mean` can suggest it", () => {
 		expect(COMMANDS).toContain("budget");
+	});
+
+	// main.ts always passes the stripped `rest`, but the documented argv fallback
+	// still sees the `budget` subcommand token — which the catch-all unknown-argument
+	// guard would reject, making the default path fail every time it was taken.
+	it("drops the subcommand token when falling back to process.argv", async () => {
+		makeVault();
+		const argv = process.argv;
+		process.argv = [
+			"node",
+			"usertrust",
+			"budget",
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+		];
+		try {
+			await run(tempDir, { json: true });
+		} finally {
+			process.argv = argv;
+		}
+
+		const payload = JSON.parse(logOutput.join("\n"));
+		expect(payload.success).toBe(true);
+		expect(payload.data.costCenter).toBe("research");
+		expect(process.exitCode).not.toBe(1);
 	});
 });

--- a/packages/core/tests/cli/budget.test.ts
+++ b/packages/core/tests/cli/budget.test.ts
@@ -302,6 +302,110 @@ describe("usertrust budget — flag validation", () => {
 		}
 	});
 
+	// Date.parse is far looser than "ISO-8601": it reads "1000" as the year 1000
+	// and "Dec 25" as a date. A typo'd --period-start 1000 stretches the elapsed
+	// window by a millennium, turning a real 180 UT/h burn into 1e-4 UT/h — a
+	// governance read that fails open, exactly like the parseInt("1O0") case.
+	it("rejects a period bound that parses but is not a full ISO-8601 timestamp", async () => {
+		makeVault();
+
+		for (const flag of ["--period-start", "--period-end"]) {
+			for (const bad of [
+				"1000",
+				"2026",
+				"1",
+				"Dec 25",
+				"Mar 2026",
+				"2026-07",
+				" 2026-07-27",
+				"2026-07-27 ",
+				"2026/07/27",
+				"07/27/2026",
+			]) {
+				logOutput = [];
+				process.exitCode = 0;
+				await run(tempDir, { json: false }, [
+					"--cost-center",
+					"research",
+					"--allocated",
+					"1000",
+					flag,
+					bad,
+				]);
+				expect(logOutput.join("\n")).toMatch(new RegExp(`Invalid ${flag}`));
+				expect(process.exitCode).toBe(1);
+			}
+		}
+	});
+
+	it("accepts the ISO-8601 forms callers actually pass", async () => {
+		makeVault();
+		setBalance(750);
+
+		for (const good of [
+			"2026-07-27",
+			"2026-07-27T09:00",
+			"2026-07-27T09:00:00",
+			"2026-07-27T09:00:00.500",
+			"2026-07-27T09:00:00Z",
+			"2026-07-27T09:00:00.500Z",
+			"2026-07-27T09:00:00+02:00",
+			"2026-07-27 09:00:00Z",
+		]) {
+			logOutput = [];
+			process.exitCode = 0;
+			await run(tempDir, { json: true }, [
+				"--cost-center",
+				"research",
+				"--allocated",
+				"1000",
+				"--period-start",
+				good,
+			]);
+			expect(jsonOut().success).toBe(true);
+			expect(process.exitCode).toBe(0);
+		}
+	});
+
+	// A start after now makes the elapsed window zero, so the burn rate is 0 and
+	// there is no projection: a hard-burning cost center would read as idle.
+	it("rejects a --period-start in the future", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-start",
+			new Date(NOW + HOUR).toISOString(),
+		]);
+
+		expect(logOutput.join("\n")).toMatch(/Invalid --period-start/);
+		expect(logOutput.join("\n")).toMatch(/future/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("accepts a --period-end in the future — a bounded period has not ended yet", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+			"--period-end",
+			new Date(NOW + 24 * HOUR).toISOString(),
+		]);
+
+		expect(jsonOut().success).toBe(true);
+		expect(process.exitCode).toBe(0);
+	});
+
 	it("refuses to swallow the next flag as a missing value", async () => {
 		makeVault();
 
@@ -320,6 +424,132 @@ describe("usertrust budget — flag validation", () => {
 
 		expect(logOutput.join("\n")).toMatch(/costCenter must match/);
 		expect(process.exitCode).toBe(1);
+	});
+});
+
+/**
+ * Every "invalid value" message quotes what the caller passed, and the caller may
+ * be an agent. picocolors wraps a string in SGR codes but does not sanitize it, so
+ * an unsanitized message hands raw OSC/CSI bytes straight to the terminal of
+ * whoever ran the command: `\x1b]0;pwned\x07` retitles the window, `\x1b[2J`
+ * clears it.
+ *
+ * The human branch is asserted against the injected sequences rather than
+ * against the ESC byte alone: picocolors legitimately emits SGR codes when
+ * colour is enabled, and an SGR code is not an injection. The `--json` branch is
+ * never colourised, so the stronger "no ESC anywhere" assertion holds outright
+ * there.
+ */
+describe("usertrust budget — terminal safety", () => {
+	/** ESC and BEL by name — a raw control byte in a source file is invisible. */
+	const ESC = "\u001b";
+	const BEL = "\u0007";
+	/** An OSC title-set + BEL, a screen clear, and a CSI cursor move. */
+	const ESCAPES = `${ESC}]0;pwned${BEL}${ESC}[2J${ESC}[1;1H`;
+
+	/** The injected control sequences, none of which may survive into output. */
+	function expectNoInjection(output: string): void {
+		expect(output).not.toContain(`${ESC}]`);
+		expect(output).not.toContain(`${ESC}[2J`);
+		expect(output).not.toContain(`${ESC}[1;1H`);
+		expect(output).not.toContain(BEL);
+	}
+
+	it("neutralises an OSC/CSI payload in an --allocated value", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--cost-center", "research", "--allocated", ESCAPES]);
+
+		const combined = logOutput.join("\n");
+		expect(combined).toMatch(/Invalid --allocated/);
+		expectNoInjection(combined);
+		// Swept, not dropped: the operator still sees that something was passed.
+		expect(combined).toContain("?");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("neutralises an OSC/CSI payload in a period bound", async () => {
+		makeVault();
+
+		for (const flag of ["--period-start", "--period-end"]) {
+			logOutput = [];
+			process.exitCode = 0;
+			await run(tempDir, { json: false }, [
+				"--cost-center",
+				"research",
+				"--allocated",
+				"1000",
+				flag,
+				`2026-07-27${ESCAPES}`,
+			]);
+			expectNoInjection(logOutput.join("\n"));
+			expect(process.exitCode).toBe(1);
+		}
+	});
+
+	it("neutralises an OSC/CSI payload in an unknown flag", async () => {
+		await run(tempDir, { json: false }, [`--${ESCAPES}`, "x"]);
+
+		const combined = logOutput.join("\n");
+		expect(combined).toMatch(/Unknown flag/);
+		expectNoInjection(combined);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("truncates an over-long value instead of flooding the screen", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"9".repeat(5000),
+		]);
+
+		const combined = logOutput.join("\n");
+		expect(combined).toContain("...");
+		expect(combined.length).toBeLessThan(400);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("keeps the --json failure branch parseable and escape-free", async () => {
+		makeVault();
+
+		await run(tempDir, { json: true }, ["--cost-center", "research", "--allocated", ESCAPES]);
+
+		const line = logOutput.find((l) => l.startsWith("{")) as string;
+		const parsed = JSON.parse(line) as {
+			command: string;
+			success: boolean;
+			data: { message: string };
+		};
+		expect(parsed.command).toBe("budget");
+		expect(parsed.success).toBe(false);
+		expect(parsed.data.message).toMatch(/Invalid --allocated/);
+		// The JSON branch is never colourised, so no ESC byte is legitimate here.
+		expect(line).not.toContain(ESC);
+		expect(parsed.data.message).not.toContain(ESC);
+		expectNoInjection(line);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("still round-trips a successful --json payload unchanged", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, [
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+			"--period-start",
+			FIVE_HOURS_AGO,
+		]);
+
+		const out = jsonOut();
+		expect(out.success).toBe(true);
+		expect(Object.keys(out.data).sort()).toEqual(DATA_KEYS);
+		expect(out.data.costCenter).toBe("research");
 	});
 });
 

--- a/packages/core/tests/cli/budget.test.ts
+++ b/packages/core/tests/cli/budget.test.ts
@@ -757,6 +757,71 @@ describe("usertrust budget — parent wallet", () => {
 		expect(logOutput.join("\n")).toMatch(/--cost-center requires a value/);
 		expect(process.exitCode).toBe(1);
 	});
+
+	it("points at the inline form rather than leaving the operator guessing", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--parent", "-cc-", "--cost-center", "research"]);
+
+		expect(logOutput.join("\n")).toMatch(/write --parent=-cc- to pass it literally/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	// `-cc-` is a legal parent id and a legal cost center. The space-separated form
+	// cannot accept it without also accepting a dropped dash, so `=` is the way in.
+	it("accepts a leading-dash parent through --parent=", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, [
+			"--parent=-cc-",
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+		]);
+
+		const out = jsonOut();
+		expect(out.success).toBe(true);
+		expect(out.data.parent).toBe("-cc-");
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("accepts a leading-dash cost center through --cost-center=", async () => {
+		makeVault();
+		setBalance(750);
+
+		await run(tempDir, { json: true }, ["--cost-center=-cc-", "--allocated", "1000"]);
+
+		const out = jsonOut();
+		expect(out.success).toBe(true);
+		expect(out.data.costCenter).toBe("-cc-");
+		expect(process.exitCode).toBe(0);
+	});
+
+	it("rejects an inline form with no value", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, ["--cost-center=", "--allocated", "1000"]);
+
+		expect(logOutput.join("\n")).toMatch(/--cost-center requires a value/);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("still rejects an unknown flag written in the inline form", async () => {
+		makeVault();
+
+		await run(tempDir, { json: false }, [
+			"--nope=1",
+			"--cost-center",
+			"research",
+			"--allocated",
+			"1000",
+		]);
+
+		expect(logOutput.join("\n")).toMatch(/Unknown flag: --nope/);
+		expect(process.exitCode).toBe(1);
+	});
 });
 
 /**

--- a/packages/core/tests/harden/anchoring/anchor-bundle-terminal-injection.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-bundle-terminal-injection.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * HARDEN — `--bundle` is untrusted transport and its unknown-field rejection
+ * echoes the offending key to a terminal. JSON permits control characters in
+ * object keys, so an un-scrubbed key lets the party under audit erase the line
+ * the verdict prints on and forge a passing run. Both CLIs carry the guard:
+ * core's, and the zero-dependency standalone verifier's (which cannot import
+ * from core, so the helper is duplicated there by design).
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { run as verifyRun } from "../../../src/cli/verify.js";
+
+// ESC[2K erases the line the verdict would be printed on and the CR returns
+// the cursor to its start — that pair is what turns an error message into a
+// forged "VERIFIED". The trailing NUL is what a truncate-only fix leaves behind.
+const ERASE_LINE = "\u001b[2K";
+const HOSTILE_KEY = `records${ERASE_LINE}\rVERIFIED\u0000`;
+const SCRUBBED = 'unknown field "records[2KVERIFIED"';
+
+const origArgv = process.argv;
+const dirs: string[] = [];
+
+function bundleWithHostileKey(): { dir: string; path: string } {
+	const dir = mkdtempSync(join(tmpdir(), "bundle-ctl-"));
+	dirs.push(dir);
+	const path = join(dir, "bundle.json");
+	writeFileSync(path, JSON.stringify({ v: 1, records: [], [HOSTILE_KEY]: 1 }), "utf-8");
+	return { dir, path };
+}
+
+afterEach(() => {
+	process.argv = origArgv;
+	process.exitCode = 0;
+	vi.restoreAllMocks();
+	for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("HARDEN: an unknown bundle key cannot repaint the terminal", () => {
+	it("core `usertrust verify --bundle` strips control characters from the echoed key", async () => {
+		const { dir, path } = bundleWithHostileKey();
+		const lines: string[] = [];
+		vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			lines.push(args.map(String).join(" "));
+		});
+		process.argv = ["node", "usertrust", "--bundle", path];
+
+		await verifyRun(dir);
+
+		const out = lines.join("\n");
+		expect(out).toContain(SCRUBBED);
+		expect(out).not.toContain(ERASE_LINE);
+		expect(out).not.toContain("\r");
+		expect(out).not.toContain("\u0000");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("standalone `usertrust-verify --bundle` strips control characters from the echoed key", () => {
+		const { dir, path } = bundleWithHostileKey();
+		const repoRoot = join(import.meta.dirname, "..", "..", "..", "..", "..");
+		const cli = join(repoRoot, "packages", "verify", "src", "cli.ts");
+
+		const res = spawnSync("npx", ["tsx", cli, dir, "--bundle", path], {
+			cwd: repoRoot,
+			encoding: "utf-8",
+		});
+
+		expect(res.status).toBe(1);
+		expect(res.stderr).toContain(SCRUBBED);
+		expect(res.stderr).not.toContain(ERASE_LINE);
+		expect(res.stderr).not.toContain("\r");
+		expect(res.stderr).not.toContain("\u0000");
+	}, 30_000);
+});

--- a/packages/core/tests/harden/anchoring/anchor-p2-transport.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-p2-transport.test.ts
@@ -63,6 +63,34 @@ describe("default transport (localhost http dev allowance)", () => {
 		expect(seen.auth).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
 	});
 
+	it("s3 doctor probes an http:// loopback endpoint through the real transport", async () => {
+		const seen: string[] = [];
+		let answered = 0;
+		const port = await startServer((req, res) => {
+			seen.push(req.method ?? "");
+			// The probe object is written, then the store refuses both mutations —
+			// the shape an append-only sink is supposed to have.
+			const status = answered++ === 0 ? 200 : 403;
+			req.resume();
+			req.on("end", () => {
+				res.writeHead(status);
+				res.end();
+			});
+		});
+		vi.stubEnv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE");
+		vi.stubEnv("AWS_SECRET_ACCESS_KEY", "secret");
+
+		const rep = await doctorS3Sink({
+			bucket: "probe-bucket",
+			region: "us-east-1",
+			endpoint: `http://127.0.0.1:${port}`,
+		});
+
+		expect(seen).toEqual(["PUT", "DELETE", "PUT"]);
+		expect(rep.checks.map((c) => c.name)).toEqual(["delete-denied", "overwrite-denied"]);
+		expect(rep.checks.every((c) => c.status === "pass")).toBe(true);
+	});
+
 	it("rekor sink surfaces a non-201 through the real transport without leaking headers", async () => {
 		const s = await makeAnchoredVault(2);
 		const record = await anchorOnce(s);

--- a/packages/core/tests/ledger/client.test.ts
+++ b/packages/core/tests/ledger/client.test.ts
@@ -47,6 +47,8 @@ vi.mock("tigerbeetle-node", () => ({
 		exceeds_credits: 22,
 		overflows_debits: 30,
 		overflows_debits_pending: 31,
+		// The real binding's value — a transfer with this id already committed.
+		exists: 46,
 	},
 	amount_max: (1n << 128n) - 1n,
 }));
@@ -147,6 +149,39 @@ describe("TrustTBClient", () => {
 			const id = await client.createUserWallet("user_reconnect");
 			expect(typeof id).toBe("bigint");
 			expect(mockCreateAccounts).toHaveBeenCalledTimes(2);
+		});
+
+		// `::` is the separator costCenterUserId derives with, and deriveAccountId
+		// hashes derived and ordinary ids identically — so an ordinary wallet named
+		// `acme::billing` would SHARE an account with the `billing` cost center of
+		// `acme`, and reclaiming that cost center would sweep this wallet into `acme`.
+		it("refuses an ordinary wallet id containing the reserved separator", async () => {
+			await expect(client.createUserWallet("acme::billing")).rejects.toThrow(/reserved/);
+			await expect(client.createUserWallet("a::b::c")).rejects.toThrow(/reserved/);
+			expect(mockCreateAccounts).not.toHaveBeenCalled();
+		});
+
+		it("still accepts every ordinary id that does not use the separator", async () => {
+			mockCreateAccounts.mockResolvedValue([]);
+			for (const userId of ["acme-billing", "acme:billing", "a.b@c.com", "user_1"]) {
+				const id = await client.createUserWallet(userId);
+				expect(id).toBe(TrustTBClient.deriveAccountId(userId));
+			}
+		});
+
+		it("creates a derived cost-center wallet only under the explicit opt-in", async () => {
+			mockCreateAccounts.mockResolvedValueOnce([]);
+			const id = await client.createUserWallet("acme::billing", { derived: true });
+			expect(id).toBe(TrustTBClient.deriveAccountId("acme::billing"));
+		});
+
+		it("refuses an opt-in id that is not a well-formed `parent::costCenter`", async () => {
+			for (const bad of ["acme", "a::b::c", "::billing", "acme::", "a:x::b"]) {
+				await expect(client.createUserWallet(bad, { derived: true })).rejects.toThrow(
+					/derived wallet id/,
+				);
+			}
+			expect(mockCreateAccounts).not.toHaveBeenCalled();
 		});
 	});
 
@@ -350,6 +385,44 @@ describe("TrustTBClient", () => {
 			});
 			expect(typeof id).toBe("bigint");
 			expect(mockCreateTransfers).toHaveBeenCalledTimes(2);
+		});
+
+		// The id is generated OUTSIDE the withReconnect closure, so the retry
+		// resubmits the same id and TigerBeetle answers `exists`. Throwing there
+		// would report failure for money that actually moved — and a caller
+		// retrying that "failure" would double-spend.
+		it("treats `exists` on a reconnect retry as the committed transfer it is", async () => {
+			mockCreateTransfers
+				.mockRejectedValueOnce(new Error("connection refused"))
+				.mockResolvedValueOnce([{ status: 46 }]);
+
+			const id = await client.immediateTransfer({
+				debitAccountId: 1n,
+				creditAccountId: 2n,
+				amount: 500,
+				code: XFER_PURCHASE,
+				transferId: 4242n,
+			});
+
+			expect(id).toBe(4242n);
+			expect(mockCreateTransfers).toHaveBeenCalledTimes(2);
+			// Same id on both attempts — that identity is what makes `exists` proof.
+			expect(mockCreateTransfers.mock.calls[0]?.[0][0].id).toBe(4242n);
+			expect(mockCreateTransfers.mock.calls[1]?.[0][0].id).toBe(4242n);
+		});
+
+		// `exists` means every field matched; a mismatch is a distinct code and is
+		// still a hard failure.
+		it("still throws when the id exists with different terms", async () => {
+			mockCreateTransfers.mockResolvedValueOnce([{ status: 39 }]); // exists_with_different_amount
+			await expect(
+				client.immediateTransfer({
+					debitAccountId: 1n,
+					creditAccountId: 2n,
+					amount: 500,
+					code: XFER_PURCHASE,
+				}),
+			).rejects.toThrow(TBTransferError);
 		});
 	});
 

--- a/packages/core/tests/ledger/client.test.ts
+++ b/packages/core/tests/ledger/client.test.ts
@@ -185,6 +185,64 @@ describe("TrustTBClient", () => {
 		});
 	});
 
+	// Cost-center wallets are hashed through the SAME `wallet:` namespace as
+	// ordinary ids, so nothing about the hash keeps them apart — the `::`
+	// reservation is the entire separation. These pin that the reservation holds at
+	// every door into the namespace, which is what makes it sufficient.
+	describe("cost-center namespace reservation", () => {
+		// Spelled out rather than imported from budget/allocation.ts so this proof
+		// does not silently follow a change in the derivation it is meant to police.
+		const PARENT = "acme";
+		const COST_CENTER = "billing";
+		const DERIVED = `${PARENT}::${COST_CENTER}`;
+
+		it("hashes an ordinary id to a cost-center account only if it IS the derived id", () => {
+			const target = TrustTBClient.deriveAccountId(DERIVED);
+			// Every near-miss an ordinary caller could reach for lands elsewhere; the
+			// literal derived string is the sole preimage, and that string is reserved.
+			for (const near of [
+				PARENT,
+				COST_CENTER,
+				"acme:billing",
+				"acme:::billing",
+				"acmebilling",
+				"acme::billing ",
+				"Acme::billing",
+			]) {
+				expect(TrustTBClient.deriveAccountId(near)).not.toBe(target);
+			}
+			expect(TrustTBClient.deriveAccountId(DERIVED)).toBe(target);
+		});
+
+		it("refuses the derived id to an ordinary createUserWallet caller", async () => {
+			await expect(client.createUserWallet(DERIVED)).rejects.toThrow(/reserved/);
+			expect(mockCreateAccounts).not.toHaveBeenCalled();
+			// And the refusal precedes the account map, so no id is cached either.
+			expect(() => client.getAccountId(DERIVED)).toThrow("No TigerBeetle account for user");
+		});
+
+		// The other door into deriveAccountId. Without the reservation here, an
+		// escrow label of `acme::billing` resolves to the cost center's wallet —
+		// TigerBeetle answers `exists` for the already-created account, this hands
+		// back its id, and escrow proceeds to debit a cost center's budget.
+		it("refuses the derived id to an ordinary ensureEscrowAccount caller", async () => {
+			await expect(client.ensureEscrowAccount(DERIVED)).rejects.toThrow(/reserved/);
+			expect(mockCreateAccounts).not.toHaveBeenCalled();
+		});
+
+		it("still accepts ordinary escrow labels", async () => {
+			mockCreateAccounts.mockResolvedValueOnce([]);
+			const id = await client.ensureEscrowAccount("escrow:session-1");
+			expect(id).toBe(TrustTBClient.deriveAccountId("escrow:session-1"));
+		});
+
+		it("hands the derived account only to the explicit `{ derived: true }` opt-in", async () => {
+			mockCreateAccounts.mockResolvedValueOnce([]);
+			const id = await client.createUserWallet(DERIVED, { derived: true });
+			expect(id).toBe(TrustTBClient.deriveAccountId(DERIVED));
+		});
+	});
+
 	describe("createPendingTransfer", () => {
 		it("creates transfer and returns transfer ID", async () => {
 			mockCreateTransfers.mockResolvedValueOnce([]);
@@ -252,6 +310,44 @@ describe("TrustTBClient", () => {
 			const transfer = mockCreateTransfers.mock.calls[0]?.[0][0];
 			expect(transfer.timeout).toBe(300);
 		});
+
+		// The id is generated OUTSIDE the withReconnect closure, so the retry
+		// resubmits the same id and TigerBeetle answers `exists`. Throwing there
+		// would report a failed reservation against funds TB is already holding —
+		// the caller would never post or void them.
+		it("treats `exists` on a reconnect retry as the committed reservation it is", async () => {
+			mockCreateTransfers
+				.mockRejectedValueOnce(new Error("connection refused"))
+				.mockResolvedValueOnce([{ status: 46 }]);
+
+			const id = await client.createPendingTransfer({
+				debitAccountId: 1n,
+				creditAccountId: 2n,
+				amount: 100,
+				code: XFER_SPEND,
+			});
+
+			expect(typeof id).toBe("bigint");
+			expect(mockCreateTransfers).toHaveBeenCalledTimes(2);
+			// Same id on both attempts — that identity is what makes `exists` proof.
+			const first = mockCreateTransfers.mock.calls[0]?.[0][0].id;
+			expect(mockCreateTransfers.mock.calls[1]?.[0][0].id).toBe(first);
+			expect(id).toBe(first);
+		});
+
+		// `exists` means every field matched; a mismatch is a distinct code and is
+		// still a hard failure.
+		it("still throws when the pending id exists with different terms", async () => {
+			mockCreateTransfers.mockResolvedValueOnce([{ status: 39 }]); // exists_with_different_amount
+			await expect(
+				client.createPendingTransfer({
+					debitAccountId: 1n,
+					creditAccountId: 2n,
+					amount: 100,
+					code: XFER_SPEND,
+				}),
+			).rejects.toThrow(TBTransferError);
+		});
 	});
 
 	describe("postTransfer", () => {
@@ -284,6 +380,31 @@ describe("TrustTBClient", () => {
 			const transfer = mockCreateTransfers.mock.calls[0]?.[0][0];
 			expect(transfer.amount).toBe(42n);
 		});
+
+		// This is the live metering settlement path (govern.ts postPendingSpend).
+		// The post id is generated OUTSIDE the withReconnect closure, so the retry
+		// resubmits the same id and TigerBeetle answers `exists`. Throwing there
+		// would report a failed settlement for a spend that committed — the governor
+		// would leave the entry in pendingMap and then void an already-posted
+		// transfer, so the ledger holds the debit and the governor does not.
+		it("treats `exists` on a reconnect retry as the settled post it is", async () => {
+			mockCreateTransfers
+				.mockRejectedValueOnce(new Error("ECONNRESET"))
+				.mockResolvedValueOnce([{ status: 46 }]);
+
+			const id = await client.postTransfer(123n);
+
+			expect(typeof id).toBe("bigint");
+			expect(mockCreateTransfers).toHaveBeenCalledTimes(2);
+			const first = mockCreateTransfers.mock.calls[0]?.[0][0].id;
+			expect(mockCreateTransfers.mock.calls[1]?.[0][0].id).toBe(first);
+			expect(id).toBe(first);
+		});
+
+		it("still throws when the post id exists with different terms", async () => {
+			mockCreateTransfers.mockResolvedValueOnce([{ status: 39 }]); // exists_with_different_amount
+			await expect(client.postTransfer(123n)).rejects.toThrow("Post transfer failed");
+		});
 	});
 
 	describe("voidTransfer", () => {
@@ -301,6 +422,28 @@ describe("TrustTBClient", () => {
 		it("throws when error array element is undefined", async () => {
 			mockCreateTransfers.mockResolvedValueOnce([undefined]);
 			await expect(client.voidTransfer(123n)).rejects.toThrow("Unknown account/transfer error");
+		});
+
+		// The void id is generated OUTSIDE the withReconnect closure, so the retry
+		// resubmits the same id and TigerBeetle answers `exists`. Throwing there
+		// would fail the caller's cleanup path over a hold TB already released.
+		it("treats `exists` on a reconnect retry as the released hold it is", async () => {
+			mockCreateTransfers
+				.mockRejectedValueOnce(new Error("socket hang up"))
+				.mockResolvedValueOnce([{ status: 46 }]);
+
+			const id = await client.voidTransfer(123n);
+
+			expect(typeof id).toBe("bigint");
+			expect(mockCreateTransfers).toHaveBeenCalledTimes(2);
+			const first = mockCreateTransfers.mock.calls[0]?.[0][0].id;
+			expect(mockCreateTransfers.mock.calls[1]?.[0][0].id).toBe(first);
+			expect(id).toBe(first);
+		});
+
+		it("still throws when the void id exists with different terms", async () => {
+			mockCreateTransfers.mockResolvedValueOnce([{ status: 40 }]); // exists_with_different_flags
+			await expect(client.voidTransfer(123n)).rejects.toThrow("Void transfer failed");
 		});
 	});
 

--- a/packages/core/tests/policy/budget-tier.test.ts
+++ b/packages/core/tests/policy/budget-tier.test.ts
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Budget-aware policy tiers (T3).
+ *
+ * Two things are pinned here:
+ *
+ * 1. `budgetFractionRemaining` and `budgetRunwayHours` are declared, typed,
+ *    OPTIONAL numbers on PolicyContext, so a tier ladder is expressible with the
+ *    operators that already exist (`lt`/`lte`/`gte` + `in`). No new operator.
+ *
+ * 2. The evaluator does NOT special-case them. A budget field resolves through
+ *    the same dot-notation path as any other caller-supplied field, and an
+ *    ABSENT budget field inherits the existing indeterminate split unchanged:
+ *    hard rules fail CLOSED (the guard still fires), soft rules stay lenient.
+ *    Both directions are asserted against the live evaluator rather than
+ *    assumed, and a differential case proves the new names get no special
+ *    handling.
+ *
+ * `escalate` is not a PolicyEffect — the union is `deny | warn`. The escalation
+ * tier is therefore expressed as `effect: "warn"` + `enforcement: "soft"`, which
+ * is the "surface it to a human, do not block" signal the gate already emits.
+ *
+ * SECURITY (D17): never log a whole PolicyContext in test or debug output.
+ * PolicyContext extends `Record<string, unknown>` and upstream callers populate
+ * it with request-shaped data — prompt text, tool arguments, actor identifiers.
+ * Dumping one into CI output can leak secrets that are hard to unpublish.
+ * Assert on individual fields; never `console.log(ctx)` or snapshot a context.
+ */
+
+import { describe, expect, it } from "vitest";
+import { evaluatePolicy, type GateRule, type PolicyContext } from "../../src/policy/gate.js";
+import type { PolicyEnforcement } from "../../src/shared/types.js";
+
+// ---------------------------------------------------------------------------
+// The tier ladder under test
+// ---------------------------------------------------------------------------
+
+/** Tier 1 — hard stop: no frontier model once the allocation is nearly gone. */
+const DENY_FRONTIER_BELOW_30: GateRule = {
+	id: "budget-tier-frontier",
+	name: "frontier-model-below-30pct",
+	description: "Frontier models are blocked below 30% of the cost center's allocation",
+	effect: "deny",
+	enforcement: "hard",
+	severity: "high",
+	conditions: [
+		{ field: "budgetFractionRemaining", operator: "lt", value: 0.3 },
+		{ field: "model", operator: "in", value: ["claude-opus-4-6"] },
+	],
+};
+
+/** Tier 2 — escalate: warn a human when less than half a day of runway is left. */
+const ESCALATE_BELOW_12H: GateRule = {
+	id: "budget-tier-runway",
+	name: "runway-below-12h",
+	description: "Under 12h of projected runway — escalate before continuing",
+	effect: "warn",
+	enforcement: "soft",
+	severity: "medium",
+	conditions: [{ field: "budgetRunwayHours", operator: "lt", value: 12 }],
+};
+
+/** A rule that touches no budget field at all — the "behaves as today" control. */
+const DENY_PII: GateRule = {
+	id: "pii-block",
+	name: "pii-block",
+	effect: "deny",
+	enforcement: "hard",
+	conditions: [{ field: "containsPii", operator: "eq", value: true }],
+};
+
+// ---------------------------------------------------------------------------
+// Tier 1 — budgetFractionRemaining gates a model class
+// ---------------------------------------------------------------------------
+
+describe("budgetFractionRemaining tier", () => {
+	it("denies a frontier call at 0.2 remaining", () => {
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0.2,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.decision).toBe("deny");
+		expect(result.hardViolations.map((v) => v.name)).toEqual(["frontier-model-below-30pct"]);
+		expect(result.reasons).toEqual([
+			"[budget-tier-frontier] Frontier models are blocked below 30% of the cost center's allocation",
+		]);
+	});
+
+	it("does not match at 0.9 remaining", () => {
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0.9,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.decision).toBe("allow");
+		expect(result.matched).toHaveLength(0);
+		expect(result.reasons).toEqual([]);
+	});
+
+	it("does not match a cheap model even when the budget is nearly gone", () => {
+		// Both conditions are ANDed: the tier gates a model CLASS, not all spend.
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0.05,
+			model: "claude-haiku-4-5",
+		});
+
+		expect(result.decision).toBe("allow");
+		expect(result.matched).toHaveLength(0);
+	});
+
+	it("treats the threshold as strict — exactly 0.3 does not match", () => {
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0.3,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.decision).toBe("allow");
+		expect(result.matched).toHaveLength(0);
+	});
+
+	it("denies at an exhausted budget (0 remaining)", () => {
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.decision).toBe("deny");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tier 2 — budgetRunwayHours escalates
+// ---------------------------------------------------------------------------
+
+describe("budgetRunwayHours tier", () => {
+	it("escalates below 12h of runway without blocking the call", () => {
+		const result = evaluatePolicy([ESCALATE_BELOW_12H], { budgetRunwayHours: 6 });
+
+		expect(result.decision).toBe("allow");
+		expect(result.hasWarnings).toBe(true);
+		expect(result.softViolations.map((v) => v.name)).toEqual(["runway-below-12h"]);
+		expect(result.hardViolations).toEqual([]);
+		expect(result.reasons).toEqual([
+			"[WARN] [budget-tier-runway] Under 12h of projected runway — escalate before continuing",
+		]);
+	});
+
+	it("stays quiet with plenty of runway", () => {
+		const result = evaluatePolicy([ESCALATE_BELOW_12H], { budgetRunwayHours: 48 });
+
+		expect(result.decision).toBe("allow");
+		expect(result.hasWarnings).toBe(false);
+		expect(result.matched).toHaveLength(0);
+	});
+
+	it("escalates and denies independently on the same context", () => {
+		// The full ladder: a frontier call at 5% budget with 2h of runway trips
+		// both tiers — deny wins the decision, the warning still surfaces.
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30, ESCALATE_BELOW_12H], {
+			budgetFractionRemaining: 0.05,
+			budgetRunwayHours: 2,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.decision).toBe("deny");
+		expect(result.hasWarnings).toBe(true);
+		expect(result.matched.map((m) => m.name)).toEqual([
+			"frontier-model-below-30pct",
+			"runway-below-12h",
+		]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Absent budget fields — the existing behaviour, pinned rather than assumed
+// ---------------------------------------------------------------------------
+
+describe("absent budget fields", () => {
+	it("does not match a SOFT budget rule when the field is absent", () => {
+		// `lt` on a missing field is indeterminate; soft rules stay lenient.
+		const result = evaluatePolicy([ESCALATE_BELOW_12H], { model: "claude-opus-4-6" });
+
+		expect(result.matched).toHaveLength(0);
+		expect(result.hasWarnings).toBe(false);
+		expect(result.decision).toBe("allow");
+	});
+
+	it("MATCHES a HARD budget rule when the field is absent (fail closed)", () => {
+		// Pinned, not assumed. `evaluateFieldCondition` returns "indeterminate"
+		// for a numeric operator on a missing field, and `ruleMatches` SKIPS an
+		// indeterminate condition for hard rules so the guard still fires. A hard
+		// budget tier therefore DENIES on a context that never populated budget
+		// data — the caller must supply the field or gate the rule with `exists`.
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], { model: "claude-opus-4-6" });
+
+		expect(result.decision).toBe("deny");
+		expect(result.hardViolations.map((v) => v.name)).toEqual(["frontier-model-below-30pct"]);
+	});
+
+	it("lets an `exists` guard keep a hard tier from firing on a budget-less context", () => {
+		// `exists` returns a real boolean (never indeterminate), so it short-
+		// circuits the rule before the fail-closed numeric condition is reached.
+		// This is the pattern the PolicyContext doc comment points callers at.
+		const guarded: GateRule = {
+			id: "budget-tier-guarded",
+			name: "guarded-frontier-tier",
+			effect: "deny",
+			enforcement: "hard",
+			conditions: [
+				{ field: "budgetFractionRemaining", operator: "exists" },
+				{ field: "budgetFractionRemaining", operator: "lt", value: 0.3 },
+			],
+		};
+
+		expect(evaluatePolicy([guarded], { model: "claude-opus-4-6" }).decision).toBe("allow");
+		expect(evaluatePolicy([guarded], { budgetFractionRemaining: 0.2 }).decision).toBe("deny");
+		expect(evaluatePolicy([guarded], { budgetFractionRemaining: 0.9 }).decision).toBe("allow");
+	});
+
+	it("treats an absent budget field identically to any other absent field", () => {
+		// Differential: the same rule shape pointed at a budget field and at a
+		// field name the evaluator has never heard of. Identical verdicts under
+		// BOTH enforcement levels prove the new names get no special handling —
+		// this is what "behaves exactly as today" means for the evaluator.
+		const enforcements: PolicyEnforcement[] = ["hard", "soft"];
+
+		for (const enforcement of enforcements) {
+			const onBudgetField: GateRule = {
+				name: "probe",
+				effect: "deny",
+				enforcement,
+				conditions: [{ field: "budgetFractionRemaining", operator: "lt", value: 0.3 }],
+			};
+			const onUnknownField: GateRule = {
+				name: "probe",
+				effect: "deny",
+				enforcement,
+				conditions: [{ field: "someFieldNobodyDeclared", operator: "lt", value: 0.3 }],
+			};
+
+			const budget = evaluatePolicy([onBudgetField], { model: "claude-opus-4-6" });
+			const unknown = evaluatePolicy([onUnknownField], { model: "claude-opus-4-6" });
+
+			expect(budget.decision).toBe(unknown.decision);
+			expect(budget.matched).toHaveLength(unknown.matched.length);
+			expect(budget.reasons).toEqual(unknown.reasons);
+		}
+	});
+
+	it("leaves non-budget rules working on a context with no budget fields", () => {
+		expect(evaluatePolicy([DENY_PII], { containsPii: true }).decision).toBe("deny");
+		expect(evaluatePolicy([DENY_PII], { containsPii: false }).decision).toBe("allow");
+		expect(evaluatePolicy([DENY_PII], { containsPii: false }).matched).toHaveLength(0);
+	});
+
+	it("evaluates a mixed rule set unchanged when no budget data is supplied", () => {
+		// A soft budget tier alongside an unrelated hard rule: the budget tier is
+		// silent, the unrelated rule decides — exactly as before this change.
+		const result = evaluatePolicy([ESCALATE_BELOW_12H, DENY_PII], { containsPii: true });
+
+		expect(result.decision).toBe("deny");
+		expect(result.hasWarnings).toBe(false);
+		expect(result.matched.map((m) => m.name)).toEqual(["pii-block"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Type surface
+// ---------------------------------------------------------------------------
+
+describe("PolicyContext budget fields", () => {
+	it("exposes both fields as typed optional numbers", () => {
+		const ctx: PolicyContext = { budgetFractionRemaining: 0.42, budgetRunwayHours: 7.5 };
+
+		// These assignments only compile because the fields are DECLARED as
+		// `number | undefined`. Without the declaration they fall through the
+		// `Record<string, unknown>` index signature and resolve to `unknown`,
+		// which is not assignable to `number`.
+		const fraction: number = ctx.budgetFractionRemaining ?? 1;
+		const runway: number = ctx.budgetRunwayHours ?? Number.POSITIVE_INFINITY;
+
+		expect(fraction).toBeCloseTo(0.42);
+		expect(runway).toBeCloseTo(7.5);
+	});
+
+	it("keeps both fields optional", () => {
+		const ctx: PolicyContext = { scope: ["llm:*"] };
+
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+	});
+});

--- a/packages/core/tests/policy/budget-tier.test.ts
+++ b/packages/core/tests/policy/budget-tier.test.ts
@@ -18,6 +18,12 @@
  *    assumed, and a differential case proves the new names get no special
  *    handling.
  *
+ * 3. The three SDK call sites treat both fields as trusted-host input: the
+ *    caller's request body is spread into the PolicyContext, so a body carrying
+ *    `budgetFractionRemaining` must not survive into the evaluator. Each call
+ *    site is driven end to end with an attacker-shaped body and the context the
+ *    evaluator actually received is inspected.
+ *
  * `escalate` is not a PolicyEffect — the union is `deny | warn`. The escalation
  * tier is therefore expressed as `effect: "warn"` + `enforcement: "soft"`, which
  * is the "surface it to a human, do not block" signal the gate already emits.
@@ -29,9 +35,39 @@
  * Assert on individual fields; never `console.log(ctx)` or snapshot a context.
  */
 
-import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trust } from "../../src/govern.js";
+import { createGovernor } from "../../src/headless.js";
 import { evaluatePolicy, type GateRule, type PolicyContext } from "../../src/policy/gate.js";
 import type { PolicyEnforcement } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// The evaluator itself is REAL — this only records the context each call site
+// hands it, so the trust-boundary tests can assert on what the gate actually
+// saw rather than on a decision that could be right for the wrong reason.
+vi.mock("../../src/policy/gate.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/policy/gate.js")>();
+	return { ...actual, evaluatePolicy: vi.fn(actual.evaluatePolicy) };
+});
 
 // ---------------------------------------------------------------------------
 // The tier ladder under test
@@ -291,5 +327,172 @@ describe("PolicyContext budget fields", () => {
 
 		expect(ctx.budgetFractionRemaining).toBeUndefined();
 		expect(ctx.budgetRunwayHours).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Call-site trust boundary — a request body cannot supply budget telemetry
+// ---------------------------------------------------------------------------
+
+/**
+ * Every call site spreads the caller's request body into the PolicyContext
+ * FIRST so trusted governance fields can be re-asserted over it. A budget tier
+ * is only a control if its inputs are on the trusted side of that line: a body
+ * of `{"model":"claude-opus-4-6","budgetFractionRemaining":0.95}` must not be
+ * able to answer the very question the tier asks.
+ *
+ * The probe is a hard `exists` deny on each field — it fires if and only if the
+ * caller's value reached the evaluator, so a bypass shows up as a denial and a
+ * regression cannot hide behind a rule that happened not to match.
+ */
+const PROBE_MARKER = "budget-tier-trust-boundary";
+
+const PROBE_BODY_FIELDS = {
+	budgetFractionRemaining: 0.95,
+	budgetRunwayHours: 999,
+	probe_marker: PROBE_MARKER,
+};
+
+const PROBE_RULES = [
+	{
+		name: "probe-fraction-reached-evaluator",
+		effect: "deny",
+		enforcement: "hard",
+		conditions: [{ field: "budgetFractionRemaining", operator: "exists" }],
+	},
+	{
+		name: "probe-runway-reached-evaluator",
+		effect: "deny",
+		enforcement: "hard",
+		conditions: [{ field: "budgetRunwayHours", operator: "exists" }],
+	},
+];
+
+function makeProbeVault(): string {
+	const base = join(tmpdir(), `budget-tier-${randomUUID()}`);
+	const usertrustDir = join(base, ".usertrust");
+	mkdirSync(join(usertrustDir, "policies"), { recursive: true });
+	writeFileSync(
+		join(usertrustDir, "policies", "probe.json"),
+		JSON.stringify({ rules: PROBE_RULES }),
+	);
+	writeFileSync(
+		join(usertrustDir, "usertrust.config.json"),
+		JSON.stringify({ budget: 100_000, policies: "./policies/probe.json" }),
+	);
+	return base;
+}
+
+function makeAnthropicMock() {
+	return {
+		messages: {
+			create: vi.fn(async (_body: Record<string, unknown>) => ({
+				id: "msg_probe",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			})),
+		},
+	};
+}
+
+/** The single context the evaluator saw for the probe call. */
+function probeContext(): PolicyContext {
+	const contexts = vi
+		.mocked(evaluatePolicy)
+		.mock.calls.map(([, ctx]) => ctx)
+		.filter((ctx) => ctx.probe_marker === PROBE_MARKER);
+
+	const ctx = contexts[0];
+	if (ctx === undefined) {
+		throw new Error("the policy evaluator never saw the probe call");
+	}
+	// More than one would make the assertions below ambiguous about which call
+	// site is under test.
+	expect(contexts).toHaveLength(1);
+	return ctx;
+}
+
+describe("budget fields are trusted-host input at every call site", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = makeProbeVault();
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+	});
+
+	it("strips body-supplied budget fields on the trust() LLM path", async () => {
+		const client = makeAnthropicMock();
+		const governed = await trust(client, { dryRun: true, vaultBase });
+
+		await governed.messages.create({
+			model: "claude-opus-4-6",
+			max_tokens: 64,
+			messages: [{ role: "user", content: "hello" }],
+			...PROBE_BODY_FIELDS,
+		});
+
+		const ctx = probeContext();
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+		// The rest of the body DID land in the context — proof the probe fields
+		// travelled the same spread and were overwritten, not simply dropped by a
+		// call that never reached the gate.
+		expect(ctx.probe_marker).toBe(PROBE_MARKER);
+		expect(ctx.model).toBe("claude-opus-4-6");
+		// The `exists` probes did not fire, so the provider call went out.
+		expect(client.messages.create).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
+	});
+
+	it("strips params-supplied budget fields on the governAction path", async () => {
+		const governed = await trust(makeAnthropicMock(), { dryRun: true, vaultBase });
+		const execute = vi.fn(async () => "executed");
+
+		await governed.governAction(
+			{ kind: "tool_use", name: "probe_tool", cost: 25, params: { ...PROBE_BODY_FIELDS } },
+			execute,
+		);
+
+		const ctx = probeContext();
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+		expect(ctx.probe_marker).toBe(PROBE_MARKER);
+		expect(ctx.action_name).toBe("probe_tool");
+		expect(execute).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
+	});
+
+	it("strips params-supplied budget fields on the headless authorize path", async () => {
+		const gov = await createGovernor({ dryRun: true, vaultBase });
+
+		const auth = await gov.authorize({
+			model: "claude-opus-4-6",
+			estimatedInputTokens: 10,
+			maxOutputTokens: 10,
+			params: { ...PROBE_BODY_FIELDS },
+		});
+
+		const ctx = probeContext();
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+		expect(ctx.probe_marker).toBe(PROBE_MARKER);
+		expect(ctx.model).toBe("claude-opus-4-6");
+		// The `exists` probes did not fire, so authorization was granted.
+		expect(auth.transferId).toMatch(/^tx_/);
+
+		await gov.destroy();
 	});
 });

--- a/packages/verify/src/cli.ts
+++ b/packages/verify/src/cli.ts
@@ -89,6 +89,22 @@ function readPinnedPem(path: string): string {
 	return pem;
 }
 
+// Matching control characters is the entire point here — they are what gets
+// removed from anything echoed back to a terminal.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping them is the intent
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+
+/**
+ * An untrusted field NAME on its way into an error string. Control characters
+ * are stripped before truncation: these strings are printed to a terminal, and
+ * an escape sequence inside a key would let the party under audit repaint the
+ * line its own verdict is printed on.
+ */
+function clipKey(key: string): string {
+	const scrubbed = key.replace(CONTROL_CHARS, "");
+	return scrubbed.length <= 80 ? scrubbed : `${scrubbed.slice(0, 80)}...`;
+}
+
 /**
  * Strict parse of an auditor bundle: `{v:1, records, rekorReceipts?}`. A bundle
  * is untrusted transport, so unknown top-level fields are rejected rather than
@@ -109,7 +125,7 @@ function parseBundle(raw: string): { anchorsRaw: string; receiptsRaw: string[] }
 	}
 	const obj = parsed as Record<string, unknown>;
 	for (const key of Object.keys(obj)) {
-		if (!BUNDLE_KEYS.has(key)) throw new Error(`--bundle: unknown field "${key.slice(0, 80)}"`);
+		if (!BUNDLE_KEYS.has(key)) throw new Error(`--bundle: unknown field "${clipKey(key)}"`);
 	}
 	if (obj.v !== 1) throw new Error("--bundle: unsupported version (expected 1)");
 	if (!Array.isArray(obj.records)) throw new Error("--bundle: records must be an array");


### PR DESCRIPTION
## Summary

Agent budgets for intermediate-value work: a parent wallet funds named **cost centers**, spend draws them down, and policy rules can read how much runway is left.

- **`budget/runway.ts`** — pure math. Remaining, fraction remaining, burn rate, projected exhaustion, on-pace. Never returns `NaN` or `Infinity`.
- **`budget/allocation.ts`** — `allocateBudget` / `reclaimBudget` / `getBudgetStatus` over derived `parent::costCenter` wallets. `::` is reserved so an ordinary caller cannot land on a cost-center account.
- **`policy/gate.ts`** — optional `budgetFractionRemaining` / `budgetRunwayHours` on `PolicyContext`, so a rule can degrade a model tier as a budget drains. The evaluator is untouched.
- **`cli/budget.ts`** — `usertrust budget`, human and `--json`.

Also folds in the two issues from the retroactive Codex review of #57, since both are small and audit-CLI adjacent.

Closes #61
Closes #62

## Review history

This branch was reviewed three times and the findings are the bulk of the diff.

A security review produced 8 fixes (`313c4ca`). An xhigh multi-agent review then produced **15 verified defects**, each independently reproduced before being accepted and re-verified after the fix by an adversarial agent that reconstructed the original failure rather than trusting the fix report. The four that mattered most:

1. **The money path was dead.** `resolveAccounts` looked the parent up through an in-process `accountMap` that nothing populates for a parent id, so `allocateBudget` and `reclaimBudget` threw before any transfer in any fresh process. `getBudgetStatus` derived instead and silently worked, which hid it. Every allocate/reclaim test stubbed `getAccountId`, so 65 tests passed over a feature that could not run. The fake now throws.
2. **A policy bypass.** `budgetFractionRemaining` was populated only by the caller's request body, so a client could send `budgetFractionRemaining: 0.95` and walk through a hard budget-tier deny rule.
3. **A ledger accounting hole.** The `exists`-is-success guard covered `immediateTransfer` but not `postTransfer` / `createPendingTransfer` / `voidTransfer` — the live metering path. A socket reset made the governor report a failed settlement for a spend the ledger had taken.
4. **Six fail-open CLI paths**, including a `$USERTRUST_USER_ID` mismatch that printed `Remaining: 0 UT (0.0%)` for a fully funded cost center.

Two defects introduced by the fixes themselves (`--parent -x` binding a dropped dash as a wallet id; the argv fallback rejecting its own subcommand token) were caught by the verify pass and are fixed here too.

**Known trade, taken deliberately:** the budget path now derives the parent unconditionally, so a consumer who overrode a mapping via `setAccountMapping` is ignored here while `ledger/engine.ts` still honours it. `setAccountMapping` is called nowhere in `src`. Flagged so it is a decision rather than an accident.

## Test plan

- `npx tsc -b` — clean
- `npx biome check packages/` — clean
- `npx vitest run` — **2419 passed / 4 skipped (175 files)**, up from 2369 on master
- Every fix carries a regression test demonstrated to fail before it and pass after; the blocker is additionally pinned end-to-end against a real `TrustTBClient` driving a stateful fake TigerBeetle from a second, empty-`accountMap` client instance
- `packages/verify` parity: the control-character helper is duplicated there by design, and the zero-dependency constraint is unchanged

## Files changed

`budget/{runway,allocation}.ts` · `policy/gate.ts` · `govern.ts` · `headless.ts` · `ledger/client.ts` · `cli/{budget,main,verify}.ts` · `audit/anchor-doctor.ts` · `index.ts` · `packages/verify/src/cli.ts` · tests under `tests/{budget,cli,ledger,policy,harden}`
