### PR TITLE
feat(site): mobile and accessibility pass

### DIFF
--- a/site/app/components/before-after.tsx
+++ b/site/app/components/before-after.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AnimatePresence, motion, useInView } from "motion/react";
+import { AnimatePresence, motion, useInView, useReducedMotion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { ScrollReveal } from "./scroll-reveal";
 
@@ -217,7 +217,13 @@ function CodePanel({
 						</div>
 					))}
 				</div>
-				<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden flex-1">
+				<pre
+					// The gutter is a sibling, so scrolling here and not on the rounded shell
+					// keeps the line numbers pinned while the code moves. min-w-0 because a
+					// flex item is otherwise sized to its content: the panel would widen past
+					// a 375px viewport instead of scrolling inside it.
+					className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto min-w-0 flex-1"
+				>
 					<code>
 						{lines.map((line, i) => (
 							// biome-ignore lint/suspicious/noArrayIndexKey: static code lines
@@ -269,6 +275,25 @@ export function BeforeAfter() {
 	const sectionRef = useRef<HTMLDivElement>(null);
 	const inView = useInView(sectionRef, { once: true, amount: 0.2 });
 	const [showAfter, setShowAfter] = useState(false);
+	/*
+	 * The panel swap is a full-panel scale plus a brightness flash, and it also
+	 * fires on its own after 2s — motion the reader never asked for. Under
+	 * prefers-reduced-motion the duration drops to 0 so the panels still swap,
+	 * they just do not travel.
+	 *
+	 * useReducedMotion rather than matchMedia in render: matchMedia does not exist
+	 * on the server, so reading it during render would throw there and hydrate
+	 * mismatched here.
+	 *
+	 * Two things the hook does NOT do, in motion@12: it does not react to the OS
+	 * setting changing mid-session (it snapshots once via useState — upstream's own
+	 * TODO), and it returns null on the server rather than a boolean. Neither bites:
+	 * null is falsy, so SSR renders the full duration, and `transition` is never
+	 * serialized into the DOM, so there is nothing for hydration to disagree about.
+	 * If mid-session reactivity is ever wanted, it needs a real listener — do not
+	 * assume the hook already provides one.
+	 */
+	const shouldReduceMotion = useReducedMotion();
 
 	// Auto-flip from Before to After after 2s of being in view
 	useEffect(() => {
@@ -278,7 +303,7 @@ export function BeforeAfter() {
 	}, [inView]);
 
 	return (
-		<section className="relative py-24 sm:py-32 px-6">
+		<section className="relative py-24 sm:py-32 safe-x">
 			<div className="max-w-5xl mx-auto" ref={sectionRef}>
 				{/* Section header */}
 				<div className="text-center mb-14">
@@ -304,11 +329,17 @@ export function BeforeAfter() {
 
 				{/* Animated toggle pills */}
 				<ScrollReveal delay={0.3}>
+					{/*
+					 * The pills are a two-state toggle, not navigation: without aria-pressed a
+					 * screen reader announces two ordinary buttons and never says which panel
+					 * is currently on screen — including after the 2s auto-flip moves it.
+					 */}
 					<div className="flex items-center justify-center gap-2 mb-8">
 						<button
 							type="button"
+							aria-pressed={!showAfter}
 							onClick={() => setShowAfter(false)}
-							className={`px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 ${
+							className={`focus-ring inline-flex min-h-[44px] items-center justify-center px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 ${
 								!showAfter
 									? "bg-danger/10 border border-danger/30 text-danger/80 shadow-[0_0_20px_rgba(239,68,68,0.1)]"
 									: "border border-white/[0.06] text-white/30 hover:text-white/50"
@@ -318,15 +349,20 @@ export function BeforeAfter() {
 						</button>
 						<motion.span
 							animate={{ x: showAfter ? 4 : -4 }}
-							transition={{ type: "spring", stiffness: 300, damping: 20 }}
+							transition={
+								shouldReduceMotion
+									? { duration: 0 }
+									: { type: "spring", stiffness: 300, damping: 20 }
+							}
 							className="text-white/20 text-lg"
 						>
 							→
 						</motion.span>
 						<button
 							type="button"
+							aria-pressed={showAfter}
 							onClick={() => setShowAfter(true)}
-							className={`px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 ${
+							className={`focus-ring inline-flex min-h-[44px] items-center justify-center px-4 py-2 rounded-lg text-xs font-bold uppercase tracking-wider transition-all duration-300 ${
 								showAfter
 									? "bg-ut/10 border border-ut/30 text-ut shadow-[0_0_20px_rgba(52,211,153,0.1)]"
 									: "border border-white/[0.06] text-white/30 hover:text-white/50"
@@ -346,7 +382,7 @@ export function BeforeAfter() {
 								initial={{ opacity: 0, scale: 0.97, y: 10 }}
 								animate={{ opacity: 1, scale: 1, y: 0 }}
 								exit={{ opacity: 0, scale: 1.02, filter: "brightness(2)" }}
-								transition={{ duration: 0.5, ease: "easeInOut" }}
+								transition={{ duration: shouldReduceMotion ? 0 : 0.5, ease: "easeInOut" }}
 								className="relative rounded-xl border border-danger/20 overflow-hidden"
 								style={{
 									background: "rgba(239,68,68,0.02)",
@@ -377,7 +413,7 @@ export function BeforeAfter() {
 								initial={{ opacity: 0, scale: 0.97, y: 10 }}
 								animate={{ opacity: 1, scale: 1, y: 0 }}
 								exit={{ opacity: 0, scale: 0.97, y: -10 }}
-								transition={{ duration: 0.4, ease: "easeInOut" }}
+								transition={{ duration: shouldReduceMotion ? 0 : 0.4, ease: "easeInOut" }}
 								className="relative rounded-xl border border-ut/20"
 								style={{
 									background: "rgba(52,211,153,0.03)",

--- a/site/app/components/built-for.tsx
+++ b/site/app/components/built-for.tsx
@@ -21,7 +21,7 @@ const useCases = [
 
 export function BuiltFor() {
 	return (
-		<section className="relative py-20 sm:py-24 px-6">
+		<section className="relative py-20 sm:py-24 safe-x">
 			<div className="max-w-5xl mx-auto">
 				<div className="text-center mb-12">
 					<ScrollReveal>

--- a/site/app/components/byok.tsx
+++ b/site/app/components/byok.tsx
@@ -13,7 +13,7 @@ const providers = [
 
 export function BYOK() {
 	return (
-		<section className="relative py-24 sm:py-28 px-6 border-t border-b border-white/[0.06]">
+		<section className="relative py-24 sm:py-28 safe-x border-t border-b border-white/[0.06]">
 			<div className="max-w-5xl mx-auto flex flex-col items-center gap-10 text-center">
 				<div className="flex flex-col gap-4 max-w-lg">
 					<ScrollReveal>

--- a/site/app/components/code-example.tsx
+++ b/site/app/components/code-example.tsx
@@ -4,7 +4,7 @@ import { TypewriterCode } from "./typewriter-code";
 
 export function CodeExample() {
 	return (
-		<section id="code" className="relative py-24 sm:py-32 px-6">
+		<section id="code" className="relative py-24 sm:py-32 safe-x">
 			<div className="max-w-5xl mx-auto">
 				<div className="grid lg:grid-cols-2 gap-12 lg:gap-16 items-center">
 					{/* Left: copy */}

--- a/site/app/components/copy-command.tsx
+++ b/site/app/components/copy-command.tsx
@@ -27,7 +27,7 @@ export function CopyCommand() {
 		<button
 			type="button"
 			onClick={handleCopy}
-			className="gradient-border group relative flex w-full items-center justify-between gap-4 rounded-xl border border-white/[0.06] px-5 py-3.5 cursor-pointer hover:border-ut/30 hover:shadow-[0_0_20px_rgba(52,211,153,0.1)] transition-all duration-200"
+			className="focus-ring gradient-border group relative flex w-full items-center justify-between gap-4 rounded-xl border border-white/[0.06] px-5 py-3.5 cursor-pointer hover:border-ut/30 hover:shadow-[0_0_20px_rgba(52,211,153,0.1)] transition-all duration-200"
 			style={{ background: "rgba(255,255,255,0.06)" }}
 			aria-label="Copy install command"
 		>

--- a/site/app/components/cta.tsx
+++ b/site/app/components/cta.tsx
@@ -3,7 +3,7 @@ import { ScrollReveal } from "./scroll-reveal";
 
 export function CTA() {
 	return (
-		<section className="relative py-32 sm:py-40 px-6">
+		<section className="relative py-32 sm:py-40 safe-x">
 			<div className="max-w-[640px] mx-auto">
 				<div className="shimmer-border flex flex-col items-center gap-8 text-center p-8 sm:p-12 rounded-2xl border border-white/[0.04] bg-white/[0.01]">
 					<div className="flex flex-col gap-4">
@@ -28,7 +28,7 @@ export function CTA() {
 						<div className="flex flex-wrap items-center justify-center gap-3">
 							<a
 								href="#code"
-								className="inline-flex items-center justify-center gap-2.5 px-6 py-3 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_30px_rgba(52,211,153,0.3),0_0_80px_rgba(52,211,153,0.12)] hover:shadow-[0_0_40px_rgba(52,211,153,0.4),0_0_100px_rgba(52,211,153,0.2)]"
+								className="focus-ring inline-flex items-center justify-center gap-2.5 px-6 py-3 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_30px_rgba(52,211,153,0.3),0_0_80px_rgba(52,211,153,0.12)] hover:shadow-[0_0_40px_rgba(52,211,153,0.4),0_0_100px_rgba(52,211,153,0.2)]"
 							>
 								Start Trusting
 							</a>
@@ -37,7 +37,7 @@ export function CTA() {
 								href="https://github.com/usertools-ai/usertrust"
 								target="_blank"
 								rel="noopener noreferrer"
-								className="inline-flex items-center justify-center gap-2 px-6 py-3 min-h-[44px] border border-white/[0.12] rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.05] hover:text-white hover:border-white/20 hover:shadow-[0_0_20px_rgba(255,255,255,0.04)] transition-all duration-200"
+								className="focus-ring inline-flex items-center justify-center gap-2 px-6 py-3 min-h-[44px] border border-white/[0.12] rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.05] hover:text-white hover:border-white/20 hover:shadow-[0_0_20px_rgba(255,255,255,0.04)] transition-all duration-200"
 							>
 								<GitHubIcon className="w-4 h-4" />
 								View on GitHub

--- a/site/app/components/features.tsx
+++ b/site/app/components/features.tsx
@@ -197,7 +197,7 @@ function SpotlightCard({ children, className }: { children: React.ReactNode; cla
 
 export function Features() {
 	return (
-		<section id="features" className="relative py-24 sm:py-32 px-6">
+		<section id="features" className="relative py-24 sm:py-32 safe-x">
 			<div className="max-w-5xl mx-auto flex flex-col gap-12">
 				{/* Header */}
 				<div className="flex flex-col gap-4 max-w-xl">

--- a/site/app/components/footer.tsx
+++ b/site/app/components/footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
 	return (
 		<footer className="relative">
 			<div className="h-px bg-gradient-to-r from-transparent via-ut/15 to-transparent" />
-			<div className="max-w-5xl mx-auto px-6 py-12">
+			<div className="max-w-5xl mx-auto safe-x py-12">
 				<div className="grid grid-cols-2 sm:grid-cols-4 gap-8 mb-10">
 					{/* Brand column */}
 					<div className="col-span-2 sm:col-span-1 flex flex-col gap-3">
@@ -14,39 +14,47 @@ export function Footer() {
 						</p>
 					</div>
 
-					{/* Product */}
-					<div className="flex flex-col gap-2.5">
+					{/*
+					 * Link rows are 44px tall for the touch target, and the column carries no
+					 * `gap` because those rows already supply the separation — a gap on top of
+					 * them stacks two spacings and doubles the footer's height on a phone.
+					 *
+					 * `items-end`, not `items-center`: `.animated-underline::after` is pinned to
+					 * `bottom: -2px` of the anchor box, so centring the label inside a 44px row
+					 * strands the hover underline 12px beneath the word it belongs to.
+					 */}
+					<div className="flex flex-col">
 						<span className="text-xs font-medium text-white/50 uppercase tracking-wider">
 							Product
 						</span>
 						<a
 							href="#features"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							Features
 						</a>
 						<a
 							href="#how"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							How it works
 						</a>
 						<a
 							href="#code"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							Quick start
 						</a>
 						<a
 							href="/docs"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							Docs
 						</a>
 					</div>
 
 					{/* Resources */}
-					<div className="flex flex-col gap-2.5">
+					<div className="flex flex-col">
 						<span className="text-xs font-medium text-white/50 uppercase tracking-wider">
 							Resources
 						</span>
@@ -54,7 +62,7 @@ export function Footer() {
 							href="https://github.com/usertools-ai/usertrust"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							GitHub
 						</a>
@@ -62,7 +70,7 @@ export function Footer() {
 							href="https://www.npmjs.com/package/usertrust"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							npm
 						</a>
@@ -70,14 +78,14 @@ export function Footer() {
 							href="https://github.com/usertools-ai/usertrust/blob/master/LICENSE"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							License
 						</a>
 					</div>
 
 					{/* Company */}
-					<div className="flex flex-col gap-2.5">
+					<div className="flex flex-col">
 						<span className="text-xs font-medium text-white/50 uppercase tracking-wider">
 							Company
 						</span>
@@ -85,7 +93,7 @@ export function Footer() {
 							href="https://usertools.ai"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="animated-underline text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
+							className="focus-ring animated-underline flex min-h-[44px] items-end text-sm text-white/30 hover:text-white/70 transition-colors duration-200"
 						>
 							Usertools
 						</a>
@@ -100,7 +108,7 @@ export function Footer() {
 							href="https://usertools.ai"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="text-white/30 hover:text-ut transition-colors duration-200"
+							className="focus-ring text-white/30 hover:text-ut transition-colors duration-200"
 						>
 							usertools.ai
 						</a>
@@ -108,7 +116,7 @@ export function Footer() {
 					<div className="flex items-center gap-4">
 						<a
 							href="#top"
-							className="text-xs text-white/20 hover:text-ut transition-colors duration-200"
+							className="focus-ring inline-flex min-h-[44px] items-center text-xs text-white/20 hover:text-ut transition-colors duration-200"
 						>
 							Back to top ↑
 						</a>
@@ -116,7 +124,7 @@ export function Footer() {
 							href="https://github.com/usertools-ai/usertrust"
 							target="_blank"
 							rel="noopener noreferrer"
-							className="flex items-center gap-1.5 text-xs text-white/20 hover:text-white/50 transition-colors duration-200"
+							className="focus-ring inline-flex min-h-[44px] items-center gap-1.5 text-xs text-white/20 hover:text-white/50 transition-colors duration-200"
 						>
 							<GitHubIcon className="w-3.5 h-3.5" />
 							Star on GitHub

--- a/site/app/components/governance-receipt.tsx
+++ b/site/app/components/governance-receipt.tsx
@@ -205,7 +205,14 @@ export function GovernanceReceipt() {
 						)}
 					</div>
 
-					<pre className="p-3 sm:p-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden">
+					<pre
+						// The rounded shell above keeps overflow-hidden — it is what clips the
+						// content to the rounded border — so the scroll container has to be this
+						// element instead. At
+						// 375px the receipt's longest lines are otherwise clipped unreachably
+						// rather than merely off-screen.
+						className="p-3 sm:p-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto"
+					>
 						<code>
 							{RECEIPT_LINES.map((line, i) => {
 								const indent = INDENTS[i] ?? 0;

--- a/site/app/components/hero.tsx
+++ b/site/app/components/hero.tsx
@@ -56,7 +56,10 @@ export function Hero({ downloads, stars }: { downloads: string; stars: string })
 	return (
 		<section
 			ref={sectionRef}
-			className="relative min-h-screen flex flex-col items-center justify-start text-center px-6 pt-[18vh]"
+			// 100dvh, not 100vh: iOS Safari measures vh against the viewport with the
+			// toolbar retracted, so a 100vh hero is taller than what is on screen and
+			// the page jerks as the toolbar hides.
+			className="relative min-h-[100dvh] flex flex-col items-center justify-start text-center safe-x pt-[18dvh]"
 			style={{ zIndex: 1 }}
 		>
 			{/* Bliss background — scroll-fades */}
@@ -142,7 +145,7 @@ export function Hero({ downloads, stars }: { downloads: string; stars: string })
 				>
 					<a
 						href="#code"
-						className="inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_20px_rgba(52,211,153,0.3),0_0_60px_rgba(52,211,153,0.1)]"
+						className="focus-ring inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-ut text-brand-bg rounded-lg text-sm font-semibold hover:bg-ut/90 active:scale-[0.98] transition-all duration-150 shadow-[0_0_20px_rgba(52,211,153,0.3),0_0_60px_rgba(52,211,153,0.1)]"
 					>
 						Start Trusting
 					</a>
@@ -150,7 +153,7 @@ export function Hero({ downloads, stars }: { downloads: string; stars: string })
 						href="https://github.com/usertools-ai/usertrust"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.10] hover:text-white transition-all duration-150"
+						className="focus-ring inline-flex items-center justify-center gap-2 px-5 py-2.5 min-h-[44px] bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium text-white/80 hover:bg-white/[0.10] hover:text-white transition-all duration-150"
 					>
 						View on GitHub
 					</a>

--- a/site/app/components/hero.tsx
+++ b/site/app/components/hero.tsx
@@ -59,6 +59,11 @@ export function Hero({ downloads, stars }: { downloads: string; stars: string })
 			// 100dvh, not 100vh: iOS Safari measures vh against the viewport with the
 			// toolbar retracted, so a 100vh hero is taller than what is on screen and
 			// the page jerks as the toolbar hides.
+			//
+			// No vh fallback, deliberately. dvh is Safari 15.4+, while the emitted
+			// stylesheet already uses @property and color-mix() — Tailwind v4's own
+			// floor, Safari 16.4+. Any engine that can parse this CSS supports dvh, and
+			// Lightning CSS strips a paired vh declaration as provably dead.
 			className="relative min-h-[100dvh] flex flex-col items-center justify-start text-center safe-x pt-[18dvh]"
 			style={{ zIndex: 1 }}
 		>

--- a/site/app/components/how-it-works.tsx
+++ b/site/app/components/how-it-works.tsx
@@ -70,7 +70,7 @@ function ArchAnnotation({
 /* ------------------------------------------------------------------ */
 export function HowItWorks() {
 	return (
-		<section id="how" className="relative py-24 sm:py-32 px-4 sm:px-6">
+		<section id="how" className="relative py-24 sm:py-32 px-4 sm:safe-x">
 			<div className="max-w-5xl mx-auto">
 				{/* Header */}
 				<div className="text-center mb-12 sm:mb-20">

--- a/site/app/components/nav.tsx
+++ b/site/app/components/nav.tsx
@@ -51,6 +51,53 @@ export function Nav() {
 		return () => document.removeEventListener("mousedown", handleClick);
 	}, [open]);
 
+	/*
+	 * Lock the page behind the open menu. Without this the body scrolls under the
+	 * dropdown on iOS and the menu appears to drift; the `[overscroll-behavior:contain]`
+	 * on the dropdown stops the scroll chaining back to the body once the menu's own
+	 * list hits its end. The previous inline value is restored rather than cleared, so
+	 * a lock owned by something else outlives this one.
+	 */
+	useEffect(() => {
+		if (!open) return;
+		const previous = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.body.style.overflow = previous;
+		};
+	}, [open]);
+
+	/*
+	 * Close on the way up to desktop. The dropdown is `md:hidden`, so crossing the
+	 * breakpoint while open hides the menu but leaves `open` true — and with it the body
+	 * scroll lock, on a viewport with no visible way to release it.
+	 */
+	useEffect(() => {
+		const mq = window.matchMedia("(min-width: 768px)");
+		const onChange = (e: MediaQueryListEvent) => {
+			if (e.matches) setOpen(false);
+		};
+		mq.addEventListener("change", onChange);
+		return () => mq.removeEventListener("change", onChange);
+	}, []);
+
+	/*
+	 * Escape closes, and focus returns to the button that opened it — otherwise a
+	 * keyboard user who dismisses the menu is left with focus on a removed node and
+	 * tabbing restarts from the top of the document.
+	 */
+	useEffect(() => {
+		if (!open) return;
+		function handleKey(e: KeyboardEvent) {
+			if (e.key === "Escape") {
+				setOpen(false);
+				buttonRef.current?.focus();
+			}
+		}
+		document.addEventListener("keydown", handleKey);
+		return () => document.removeEventListener("keydown", handleKey);
+	}, [open]);
+
 	const links = [
 		{ href: "#code", label: "Code" },
 		{ href: "#features", label: "Features" },
@@ -66,10 +113,10 @@ export function Nav() {
 					: "bg-brand-bg/80 backdrop-blur-[16px] border-white/[0.06]"
 			}`}
 		>
-			<div className="flex items-center justify-between px-6 py-4">
+			<div className="flex items-center justify-between safe-x py-4">
 				<a
 					href="/"
-					className={`inline-flex items-center px-4 py-2.5 border rounded-full text-sm font-medium tracking-tight transition-all duration-300 ${
+					className={`focus-ring inline-flex min-h-[44px] items-center px-4 py-2.5 border rounded-full text-sm font-medium tracking-tight transition-all duration-300 ${
 						scrolled
 							? "border-ut/30 text-ut shadow-[0_0_20px_rgba(52,211,153,0.1)]"
 							: "border-white/20 hover:border-ut/50 hover:text-ut animate-[pulse-glow_4s_ease-in-out_infinite]"
@@ -84,13 +131,20 @@ export function Nav() {
 							<a
 								key={link.href}
 								href={link.href}
-								className={`relative hover:text-white transition-colors duration-200 ${
+								className={`focus-ring relative inline-flex min-h-[44px] items-center hover:text-white transition-colors duration-200 ${
 									activeSection === link.href ? "text-ut" : ""
 								}`}
 							>
 								{link.label}
 								{activeSection === link.href && (
-									<span className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-ut" />
+									/*
+									 * `bottom-1.5`, not `-bottom-1.5`: the link box is 44px tall for the
+									 * touch target while its text line is only 20px, so an offset measured
+									 * outside the box lands 12px below the label instead of under it. This
+									 * value is tied to the `min-h-[44px]` above — change one and the dot
+									 * detaches from the word it marks.
+									 */
+									<span className="absolute bottom-1.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-ut" />
 								)}
 							</a>
 						))}
@@ -100,7 +154,7 @@ export function Nav() {
 						href="https://github.com/usertools-ai/usertrust"
 						target="_blank"
 						rel="noopener noreferrer"
-						className="inline-flex items-center gap-2 px-3.5 py-1.5 bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium hover:bg-white/[0.10] hover:border-white/20 transition-all duration-200"
+						className="focus-ring inline-flex min-h-[44px] items-center gap-2 px-3.5 py-1.5 bg-white/[0.06] border border-white/10 rounded-lg text-sm font-medium hover:bg-white/[0.10] hover:border-white/20 transition-all duration-200"
 					>
 						<GitHubIcon className="w-4 h-4" />
 						GitHub
@@ -111,9 +165,17 @@ export function Nav() {
 						ref={buttonRef}
 						type="button"
 						onClick={() => setOpen((prev) => !prev)}
-						className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-lg border border-white/10 bg-white/[0.06] hover:bg-white/[0.10] transition-colors duration-200"
+						className="focus-ring md:hidden inline-flex items-center justify-center w-11 h-11 rounded-lg border border-white/10 bg-white/[0.06] hover:bg-white/[0.10] transition-colors duration-200"
 						aria-label={open ? "Close menu" : "Open menu"}
 						aria-expanded={open}
+						/*
+						 * Only while the menu exists: the dropdown is conditionally rendered, so a
+						 * constant aria-controls would be an IDREF resolving to nothing whenever
+						 * the menu is closed — validators flag it and assistive tech ignores it.
+						 * `undefined` omits the attribute entirely; `aria-expanded` alone is a
+						 * complete disclosure pattern in the meantime.
+						 */
+						aria-controls={open ? "mobile-menu" : undefined}
 					>
 						<svg
 							width="18"
@@ -180,11 +242,20 @@ export function Nav() {
 				</div>
 			</div>
 
-			{/* Mobile dropdown */}
+			{/*
+			 * Mobile dropdown. No `pb-4` here on purpose: `.safe-bottom` owns the bottom
+			 * padding with a 1rem floor, and stacking both just doubles the padding —
+			 * `.safe-bottom` is unlayered while Tailwind's `pb-4` sits in `@layer utilities`,
+			 * so the safe-area value wins the cascade either way. `max-h` plus
+			 * `overflow-y-auto` keep the menu reachable when the viewport is short enough that
+			 * four 44px links and the header exceed it, and `[overscroll-behavior:contain]` is
+			 * what stops that inner scroll chaining out to the locked body.
+			 */}
 			{open && (
 				<div
 					ref={menuRef}
-					className="md:hidden border-t border-white/[0.06] bg-brand-bg/95 backdrop-blur-[16px] px-6 pb-4 pt-2"
+					id="mobile-menu"
+					className="md:hidden safe-bottom safe-x border-t border-white/[0.06] bg-brand-bg/95 backdrop-blur-[16px] pt-2 [overscroll-behavior:contain] max-h-[calc(100dvh-4.81rem)] overflow-y-auto"
 				>
 					<div className="flex flex-col gap-1">
 						{links.map((link) => (
@@ -192,7 +263,7 @@ export function Nav() {
 								key={link.href}
 								href={link.href}
 								onClick={() => setOpen(false)}
-								className={`block px-3 py-2.5 text-sm font-medium rounded-lg hover:text-white hover:bg-white/[0.06] transition-colors duration-200 ${
+								className={`focus-ring flex min-h-[44px] items-center px-3 py-2.5 text-sm font-medium rounded-lg hover:text-white hover:bg-white/[0.06] transition-colors duration-200 ${
 									activeSection === link.href ? "text-ut" : "text-white/60"
 								}`}
 							>

--- a/site/app/components/typewriter-code.tsx
+++ b/site/app/components/typewriter-code.tsx
@@ -165,7 +165,13 @@ export function TypewriterCode() {
 								</div>
 							))}
 						</div>
-						<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden flex-1">
+						<pre
+							// The sizer is what gives the absolutely-positioned overlay below its
+							// height, so its overflow has to match the overlay's: a clipping sizer
+							// under a scrolling overlay is short by the scrollbar's height and the
+							// last code line lands outside the box.
+							className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto min-w-0 flex-1"
+						>
 							<code>
 								{allChars.current.map((c, i) =>
 									c.char === "\n" ? <br key={`h${i}`} /> : <span key={`h${i}`}>{c.char}</span>,
@@ -182,7 +188,13 @@ export function TypewriterCode() {
 								</div>
 							))}
 						</div>
-						<pre className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-hidden flex-1">
+						<pre
+							// The gutter is a sibling, so scrolling here and not on the rounded
+							// shell keeps the line numbers pinned while the code moves. min-w-0
+							// because a flex item is otherwise sized to its content: the panel
+							// would widen past a 375px viewport instead of scrolling inside it.
+							className="py-3 sm:py-5 px-3 sm:px-5 text-xs sm:text-sm font-mono leading-relaxed overflow-x-auto min-w-0 flex-1"
+						>
 							<code>
 								{rendered.map((c, i) =>
 									c.char === "\n" ? (

--- a/site/app/docs/layout.tsx
+++ b/site/app/docs/layout.tsx
@@ -1,8 +1,34 @@
 import { DocsLayout } from "fumadocs-ui/layouts/docs";
 import { RootProvider } from "fumadocs-ui/provider/next";
+import type { Viewport } from "next";
 import type { ReactNode } from "react";
 import { baseOptions } from "@/lib/layout.shared";
 import { source } from "@/lib/source";
+
+/*
+ * Docs opts out of the root layout's `viewportFit: "cover"`.
+ *
+ * `cover` exists for the marketing page, whose hero is sized in `dvh` and needs
+ * to paint under the iOS toolbar. Docs gains nothing from it and pays for it:
+ * fumadocs' navbar is `position: fixed`, so the `body` safe-area padding in
+ * globals.css cannot reach it, and fumadocs ships no safe-area handling of its
+ * own — in landscape on a notched device its logo and search control would sit
+ * under the cutout. Reverting to the default `auto` makes the browser inset the
+ * layout viewport itself, which is the correct behaviour for a page with no
+ * edge-to-edge art direction.
+ *
+ * `viewportFit` must be set to `"auto"` explicitly, not omitted: Next merges a
+ * nested viewport export into the parent's field by field, so an absent field
+ * inherits rather than clears. Verified in the emitted meta tag, which is the
+ * only way to tell the two apart.
+ */
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	viewportFit: "auto",
+	themeColor: "#0a0a1a",
+	colorScheme: "dark",
+};
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return (

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -84,14 +84,30 @@
 	}
 }
 
-/* Smooth scroll */
+/* Document scrolling */
 html {
 	scroll-behavior: smooth;
+	/*
+	 * The nav is `fixed top-0`, so an anchor jump lands underneath it without
+	 * this. 5rem clears the real header: the bar is py-4 (2rem) around a logo
+	 * pill, which this pass grew to a 44px tap target (2.75rem), plus the 1px border-b: 77px ≈ 4.81rem.
+	 * The nav dropdown's max-h subtracts the same figure — keep them in step. Re-measure
+	 * if the nav padding changes — a value shorter than the header silently
+	 * reintroduces the bug.
+	 */
+	scroll-padding-top: 5rem;
 }
 
 /* Custom scrollbar */
 ::-webkit-scrollbar {
 	width: 6px;
+	/*
+	 * `width` styles the vertical bar only. The code panels scroll horizontally
+	 * (overflow-x-auto), and without a height they get the ~15px platform default
+	 * on Windows and Linux Chrome. macOS overlay scrollbars hide it, so this does
+	 * not reproduce locally.
+	 */
+	height: 6px;
 }
 ::-webkit-scrollbar-track {
 	background: transparent;
@@ -380,4 +396,48 @@ html {
 	.glow-ring {
 		animation: none;
 	}
+}
+
+/*
+ * Inert unless `viewportFit: "cover"` is set in layout.tsx — iOS resolves
+ * env(safe-area-inset-*) to 0px otherwise. max() keeps a floor on devices with
+ * no inset (all of Android, desktop).
+ */
+@utility safe-bottom {
+	padding-bottom: max(1rem, env(safe-area-inset-bottom));
+}
+
+/*
+ * One focus treatment for every interactive element. :focus-visible rather than
+ * :focus so a mouse click leaves no ring behind, while keyboard and
+ * switch-control users get an unmissable one. The offset lifts the ring clear of
+ * the element's own border on the dark background.
+ *
+ * No border-radius here: setting it would change the element's real shape on
+ * focus, not round the outline. Modern engines already follow the element's own
+ * radius when drawing an outline.
+ */
+.focus-ring:focus-visible {
+	outline: 2px solid var(--color-ut);
+	outline-offset: 2px;
+}
+
+/*
+ * Horizontal safe-area inset, a drop-in for `px-6`. `viewport-fit: cover`
+ * extends the layout viewport under the display cutout, so in landscape on a
+ * notched device the inset is ~44-59px against 24px of content padding, and
+ * `body` carries `overflow-x-hidden` — occluded content is unreachable rather
+ * than merely clipped. Both insets are 0 in portrait and on any device without a
+ * cutout, where `max()` resolves to the same 1.5rem `px-6` gave.
+ *
+ * This belongs on the SECTION, never on `body`. A section's full-bleed
+ * decoration is `absolute inset-0`, which resolves against the padding box and
+ * so still reaches both screen edges; padding `body` instead shrinks the box the
+ * section itself is laid out in, letting the page background show as bars beside
+ * the hero image on exactly the devices this exists for. The fixed nav carries
+ * it directly, since a fixed element resolves against the viewport.
+ */
+@utility safe-x {
+	padding-left: max(1.5rem, env(safe-area-inset-left));
+	padding-right: max(1.5rem, env(safe-area-inset-right));
 }

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import localFont from "next/font/local";
 import { NoiseOverlay } from "./components/noise-overlay";
 import { ScrollProgress } from "./components/scroll-progress";
@@ -59,6 +59,23 @@ export const metadata: Metadata = {
 		images: [{ url: "/og", width: 1200, height: 630 }],
 	},
 	icons: { icon: "/favicon.svg" },
+};
+
+/*
+ * `viewportFit: "cover"` is what makes `env(safe-area-inset-*)` resolve to real
+ * values on iOS; without it they are 0px and every safe-area utility in
+ * globals.css silently does nothing. themeColor paints the iOS status bar and
+ * Android chrome to match the page rather than flashing white on load.
+ *
+ * themeColor and colorScheme belong here, not on `metadata` — both carry
+ * `@deprecated Use the new viewport configuration instead` on `Metadata`.
+ */
+export const viewport: Viewport = {
+	width: "device-width",
+	initialScale: 1,
+	viewportFit: "cover",
+	themeColor: "#0a0a1a",
+	colorScheme: "dark",
 };
 
 const jsonLd = {


### PR DESCRIPTION
## Summary

Mobile and accessibility pass against the redesigned site — the work issue #49 was opened to redo after PR #36 went stale against the redesign.

Baseline at `0dae0e7`, verified rather than assumed: **zero** `focus-visible` occurrences site-wide, **zero** `dvh`, **zero** `viewport-fit`, and `overflow-x-hidden` on all three code panels. Every keyboard stop on the site was invisible.

Closes #49

## What changed

**Viewport** — `Viewport` export with `viewport-fit=cover`, `themeColor`, `colorScheme`. Docs opts back out to `auto`: it has no edge-to-edge art direction, and fumadocs' navbar is `position: fixed` with no safe-area handling, so it would sit under the cutout with nothing able to pad it.

**Focus** — every `<a>` and `<button>` in `site/app/**` carries `.focus-ring`. Emerald on `#0a0a1a` at ~9:1, with a 2px offset so the ring stays readable on the `bg-ut` primary buttons where a flush ring would be emerald-on-emerald.

**Touch targets** — hamburger, nav links and the before/after toggles brought to 44px. The nav active-dot moved from `-bottom-1.5` to `bottom-1.5` as a consequence: the link box is now 44px around a 20px text line, so an outside offset landed 12px below the label.

**Nav menu** — body scroll-lock (restoring the previous inline value, not clearing it), `overscroll-behavior: contain`, Escape-to-close with focus returned to the hamburger, and close-on-resize past `md` so the lock cannot strand on a viewport with no way to release it. `aria-controls` is emitted only while the menu exists.

**Hero** — `100dvh` instead of `100vh`, with the top padding moved to `dvh` in step.

**Code panels** — horizontal scroll instead of clipping. At 375px the longest lines were unreachable, not merely off-screen.

**Before/after** — `aria-pressed` and `prefers-reduced-motion` via `useReducedMotion`.

Tailwind v4's preflight already emits `-webkit-text-size-adjust` and `-webkit-tap-highlight-color`, so point 3 of the issue was partly satisfied by the framework and is not restated here.

## Review audit trail

**Plan review (GPT-5.4)** — 9 accepted, 3 rejected. Accepted: `window.matchMedia` in render (replaced with `useReducedMotion`, which the component already imported), `border-radius` in the focus rule (it would change the element's real shape rather than round the outline), unused safe-area utilities, brittle greps inflated by their own comments, `min-w-0` prescribed universally, and a resize path that stranded the scroll lock. **Rejected** its headline finding that `themeColor` may not belong on `Viewport` — verified against the installed Next types, where `Metadata.themeColor` carries `@deprecated Use the new viewport configuration instead`; following it would have adopted the deprecated field.

**Implementation** — five tasks, each gated by a fresh adversarial reviewer that re-ran the failure scenario rather than trusting the report. Two findings worth recording: the implementer correctly skipped two CSS declarations the plan prescribed, having proved Tailwind's preflight already emits them; and `min-w-0` landed only on the two `<pre>` elements with real flex parents, correctly omitted from the block-level one.

**Security review** — no findings. Verified no dependency added, the one `dangerouslySetInnerHTML` is pre-existing and untouched, and all five scroll-lock exit paths reach a matching effect cleanup.

**Code review** — 9 findings, all fixed. The significant one: putting the horizontal inset on `body` de-full-bleeds the hero photo, because a section's `absolute inset-0` decoration resolves against the padding box and stays edge-to-edge, whereas padding `body` shrinks the box the section is laid out in — black bars beside the hero image in landscape, on exactly the devices the inset was added for. Moved to the sections. Also fixed: horizontal scrollbars had no `height` (`width` styles the vertical bar only, so Windows/Linux would get the ~15px default inside a 6px design), a dangling `aria-controls` IDREF, `pt-[18vh]` beside `min-h-[100dvh]`, and three comments that stated things which were not true.

`safe-x` and `safe-bottom` are registered with `@utility` rather than written as bare classes — a bare class is unlayered, and unlayered beats `@layer utilities` regardless of specificity, so either would have silently overridden any `px-*` on the same element.

## Test plan

- `npm run lint` → 0 · `npm run typecheck` → 0
- `npx next build` from clean → 28/28 static pages, zero warnings
- `npm test` → 2422 passed. The two failures are `cli/secret.test.ts` (issue #52, the documented load-sensitive scrypt flake); it passes 13/13 in isolation and this diff touches nothing under `packages/`
- Emitted meta verified per route: `/` → `viewport-fit=cover`, `/docs` → `viewport-fit=auto`, `theme-color` preserved on both
- Compiled CSS verified: `.safe-x`/`.safe-bottom` land in `@layer utilities`, `::-webkit-scrollbar` carries `width:6px;height:6px`, no `body` padding
- Focus-ring coverage scripted over every `<a>`/`<button>` opening tag in `site/app/**/*.tsx` — zero uncovered

**Not done:** a real-device pass. `site/` is linted by CI but never typechecked or built by it, so the `next build` above is the compensating gate — but body-level `overflow: hidden` is the least reliable scroll-lock on iOS Safari specifically, and that is the one claim here I could not verify from this environment.
