### PR TITLE
fix(anchor): verify the rotation-handoff signature on resume

### DIFF
--- a/packages/core/src/audit/anchor.ts
+++ b/packages/core/src/audit/anchor.ts
@@ -1023,7 +1023,25 @@ export function resumeAnchorMirror(rootDir: string, latestRecordRaw: string): An
 		idKey !== null &&
 		record.keyId === identity.keyId &&
 		verifySignatureRaw("ed25519", anchorSigningPreimage(record), idKey, record.sig);
-	const handoffOk = record.rotation !== undefined && record.rotation.nextKeyId === identity.keyId;
+	// A rotation handoff is signed by the SUPERSEDED key, so it cannot verify
+	// under the current epoch key. Authenticate it against the key that actually
+	// signed it, looked up in this vault's own key history. The hole this closes
+	// was an UNVERIFIED accept, not an unsigned field: the old code matched
+	// `record.rotation.nextKeyId` against the current keyId and accepted the
+	// record on that alone, never checking `record.sig` at all — so anyone who
+	// knows the public vaultId (`anchor status` prints it) could self-sign a
+	// record naming that keyId as its successor and seed a fork off it.
+	// `rotation` IS covered by the signature — anchorSigningPreimage is
+	// canonicalize(record − sig) — which is what stops the block from being
+	// grafted onto a genuine record. Do not narrow that pre-image.
+	let handoffOk = false;
+	if (!sigOk && record.rotation !== undefined && record.rotation.nextKeyId === identity.keyId) {
+		const signer = identity.keyHistory?.find((entry) => entry.keyId === record.keyId);
+		const signerKey = signer === undefined ? null : publicKeyFromSpkiBase64(signer.publicKeySpki);
+		handoffOk =
+			signerKey !== null &&
+			verifySignatureRaw("ed25519", anchorSigningPreimage(record), signerKey, record.sig);
+	}
 	if (!sigOk && !handoffOk) {
 		throw new Error(
 			"resume: record does not verify under this vault's current anchor key — fetch the STORE'S newest record",

--- a/packages/core/tests/harden/anchoring/anchor-xreview-regressions.test.ts
+++ b/packages/core/tests/harden/anchoring/anchor-xreview-regressions.test.ts
@@ -23,7 +23,11 @@ import {
 	readAnchorIdentity,
 	resumeAnchorMirror,
 } from "../../../src/audit/anchor.js";
-import { anchorPayloadHash, parseAnchorRecord } from "../../../src/audit/anchor-verify.js";
+import {
+	type AnchorRecord,
+	anchorPayloadHash,
+	parseAnchorRecord,
+} from "../../../src/audit/anchor-verify.js";
 import { canonicalize } from "../../../src/audit/canonical.js";
 import { createAuditWriter } from "../../../src/audit/chain.js";
 import { exitCodeForAnchored } from "../../../src/audit/verify.js";
@@ -379,6 +383,115 @@ describe("finding 11: resume validates the supplied record cryptographically", (
 		await anchorOnce(s); // high-water 2
 		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
 		expect(() => resumeAnchorMirror(s.root, canonicalize(r1))).toThrow(/high-water/);
+	});
+
+	it("rejects a forged rotation handoff naming the victim's key as the successor", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const victimKeyId = readAnchorIdentity(s.root)?.keyId;
+		expect(victimKeyId).toBeDefined();
+		const attacker = await makeAnchoredVault(1);
+		// A rotation record naming the victim's CURRENT key as the successor.
+		// The payload is r1's, so `forged.keyId` is the VICTIM's key — it IS in
+		// the victim's keyHistory and the lookup SUCCEEDS. What kills the forgery
+		// is the Ed25519 check that follows: the attacker's signature does not
+		// verify under the key the record names as its signer.
+		const { sig: _sig, ...payload } = r1;
+		const forged = signRecord(
+			{
+				...payload,
+				rotation: {
+					nextKeyId: victimKeyId as string,
+					nextPublicKeySpki: readAnchorIdentity(attacker.root)?.publicKeySpki as string,
+				},
+			},
+			attacker.keyFile,
+		);
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		expect(() => resumeAnchorMirror(s.root, canonicalize(forged))).toThrow(
+			/does not verify under this vault's current anchor key/,
+		);
+	});
+
+	it("rejects a handoff whose signer key is absent from the vault's key history", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const victimKeyId = readAnchorIdentity(s.root)?.keyId as string;
+		const attacker = await makeAnchoredVault(1);
+		const attackerIdentity = readAnchorIdentity(attacker.root);
+		// Same handoff shape, but the record also CLAIMS the attacker's keyId — a
+		// key this vault has never anchored under. The keyHistory lookup returns
+		// undefined, so there is no key to verify against; that branch must fail
+		// closed rather than fall through to an unauthenticated accept.
+		const { sig: _sig, ...payload } = r1;
+		const forged = signRecord(
+			{
+				...payload,
+				keyId: attackerIdentity?.keyId as string,
+				rotation: {
+					nextKeyId: victimKeyId,
+					nextPublicKeySpki: attackerIdentity?.publicKeySpki as string,
+				},
+			},
+			attacker.keyFile,
+		);
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		expect(() => resumeAnchorMirror(s.root, canonicalize(forged))).toThrow(
+			/does not verify under this vault's current anchor key/,
+		);
+	});
+
+	it("rejects a rotation block grafted onto a genuine record (rotation is inside the pre-image)", async () => {
+		const s = await makeAnchoredVault(3);
+		const r1 = await anchorOnce(s);
+		const attacker = await makeAnchoredVault(1);
+		// Anchor records are public, so an attacker starts from a GENUINE one and
+		// only adds a handoff INTO this vault's current keyId — deliberately NOT
+		// re-signed, because the whole point is that r1's own signature no longer
+		// covers the modified content. Nothing else stops this: the signer is in
+		// keyHistory and the record sits AT the high-water, so if `rotation` ever
+		// left the signing pre-image the graft would resume clean and publish an
+		// attacker-chosen nextPublicKeySpki for this vault's current keyId as the
+		// mirror tail. anchorSigningPreimage — canonicalize(record − sig) — is
+		// what forbids that, and it lives in anchor-verify.ts, a file mirrored
+		// into packages/verify and therefore under independent change pressure.
+		const grafted: AnchorRecord = {
+			...r1,
+			rotation: {
+				nextKeyId: readAnchorIdentity(s.root)?.keyId as string,
+				nextPublicKeySpki: readAnchorIdentity(attacker.root)?.publicKeySpki as string,
+			},
+		};
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		expect(() => resumeAnchorMirror(s.root, canonicalize(grafted))).toThrow(
+			/does not verify under this vault's current anchor key/,
+		);
+	});
+
+	it("still accepts a genuine rotation handoff signed by the superseded key", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await rotateOnce(s); // rotation record is signed by the OLD key
+		const rotationRecord = storeRecords(s).at(-1);
+		expect(rotationRecord?.rotation).toBeDefined();
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		const resumed = resumeAnchorMirror(s.root, canonicalize(rotationRecord as AnchorRecord));
+		expect(resumed.anchorSeq).toBe(rotationRecord?.anchorSeq);
+	});
+
+	it("fails closed on a handoff when the identity predates keyHistory", async () => {
+		const s = await makeAnchoredVault(3);
+		await anchorOnce(s);
+		await rotateOnce(s);
+		const rotationRecord = storeRecords(s).at(-1);
+		// Simulate a pre-keyHistory identity: strip the field entirely.
+		const idPath = join(s.vaultPath, "audit", "anchors", "identity.json");
+		const { keyHistory: _kh, ...legacy } = JSON.parse(readFileSync(idPath, "utf-8"));
+		writeFileSync(idPath, JSON.stringify(legacy));
+		unlinkSync(join(s.vaultPath, "audit", "anchors", "anchors.jsonl"));
+		expect(() => resumeAnchorMirror(s.root, canonicalize(rotationRecord as AnchorRecord))).toThrow(
+			/does not verify under this vault's current anchor key/,
+		);
 	});
 });
 

--- a/packages/ui/src/server/server.ts
+++ b/packages/ui/src/server/server.ts
@@ -138,7 +138,23 @@ export async function createUiServer(
 			}
 		}
 
-		const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+		// Node accepts an absolute-form request target (RFC 9112 §3.2.2) and hands
+		// it to the handler verbatim in `req.url`, so a client controls the whole
+		// string `new URL` parses — `GET http://foo:999999/`, `http://%/`,
+		// `http://[::1/` all throw here. Unguarded, that throw escapes the handler
+		// with no response written: the connection hangs and, since nothing in
+		// `packages/ui` installs an `uncaughtException` handler, the process dies.
+		// The Host guard above does not cover this — the Host *header* is
+		// independent of the request *target*, and a real loopback Host walks
+		// straight through it. This runs before every route, so it is the only
+		// place the whole surface can be closed at once.
+		let url: URL;
+		try {
+			url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+		} catch {
+			sendJson(res, 400, { error: "malformed request target" });
+			return;
+		}
 		if (url.pathname === "/api/summary" && req.method === "GET") {
 			sendJson(res, 200, state.summary);
 			return;
@@ -220,7 +236,23 @@ export async function createUiServer(
 			return;
 		}
 		if (url.pathname.startsWith("/api/verify/") && req.method === "GET") {
-			const txId = decodeURIComponent(url.pathname.slice("/api/verify/".length));
+			// `decodeURIComponent` throws URIError on malformed percent-encoding
+			// (`%`, `%zz`, `%E0%A4%A`). `new URL` does NOT reject those — it carries
+			// an invalid escape through to `pathname` untouched — so the guard above
+			// cannot stand in for this one, and this one cannot stand in for that:
+			// they cover disjoint inputs and both are required. Unwrapped inside a
+			// request handler, this throw escapes to the top level and terminates the
+			// usertrust-ui process. The catch stays around this call alone:
+			// `verifyTransaction` reports found/valid through its result object rather
+			// than by throwing, so widening the catch would relabel a genuine server
+			// fault (an unreadable vault) as a client 400.
+			let txId: string;
+			try {
+				txId = decodeURIComponent(url.pathname.slice("/api/verify/".length));
+			} catch {
+				sendJson(res, 400, { error: "malformed percent-encoding in transaction id" });
+				return;
+			}
 			const result = verifyTransaction(vaultPath, txId);
 			sendJson(res, result.found ? 200 : 404, result);
 			return;

--- a/packages/ui/tests/verify-endpoint.test.ts
+++ b/packages/ui/tests/verify-endpoint.test.ts
@@ -2,11 +2,43 @@
 // Copyright 2026 Usertools, Inc.
 
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createAuditWriter } from "../../core/src/audit/chain.js";
 import { createUiServer, type UiServer } from "../src/server/server.js";
+
+/**
+ * Sends a request line `fetch` cannot express. An absolute-form request target
+ * (RFC 9112 §3.2.2) is only reachable over a raw socket: `fetch` always emits
+ * origin-form, so no `fetch`-based test can cover the guard this exercises.
+ * Rejects rather than hanging when the server writes nothing back — that
+ * silence is exactly the pre-fix symptom, and a bare vitest timeout would not
+ * say so.
+ */
+function rawRequest(port: number, raw: string, timeoutMs = 2000): Promise<string> {
+	return new Promise((resolvePromise, reject) => {
+		let received = "";
+		const socket = connect(port, "127.0.0.1", () => socket.write(raw));
+		const timer = setTimeout(() => {
+			socket.destroy();
+			reject(new Error(`no response within ${timeoutMs}ms (received ${JSON.stringify(received)})`));
+		}, timeoutMs);
+		socket.on("data", (chunk: Buffer) => {
+			received += chunk.toString("utf-8");
+			if (!received.includes("\r\n\r\n")) return;
+			clearTimeout(timer);
+			socket.destroy();
+			resolvePromise(received);
+		});
+		socket.on("error", (err) => {
+			clearTimeout(timer);
+			socket.destroy();
+			reject(err);
+		});
+	});
+}
 
 describe("GET /api/verify/:txId", () => {
 	let tempDir: string;
@@ -48,4 +80,34 @@ describe("GET /api/verify/:txId", () => {
 		const body = (await res.json()) as { found: boolean };
 		expect(body.found).toBe(false);
 	});
+
+	it("returns 400 for malformed percent-encoding instead of crashing", async () => {
+		ui = await createUiServer(tempDir, { port: 0 });
+		const res = await fetch(`http://127.0.0.1:${ui.port}/api/verify/%E0%A4%A`);
+		expect(res.status).toBe(400);
+		// The process must still be serving afterwards.
+		const after = await fetch(`http://127.0.0.1:${ui.port}/api/tail`);
+		expect(after.status).toBe(200);
+	});
+
+	// The `decodeURIComponent` guard above closes only the routed path. `new URL`
+	// runs first, on `req.url` verbatim, and Node accepts an absolute-form request
+	// target — so these never reach a route at all. The Host header is valid
+	// loopback in every case: the header is independent of the target, which is
+	// why the DNS-rebinding guard does not cover this.
+	it.each(["http://foo:999999/", "http://%/", "http://[::1/"])(
+		"400s an unparseable request target (%s) instead of crashing",
+		async (target) => {
+			ui = await createUiServer(tempDir, { port: 0 });
+			const raw = await rawRequest(
+				ui.port,
+				`GET ${target} HTTP/1.1\r\nHost: 127.0.0.1:${ui.port}\r\nConnection: close\r\n\r\n`,
+			);
+			expect(raw.startsWith("HTTP/1.1 400 ")).toBe(true);
+			expect(raw).toContain("malformed request target");
+			// The process must still be serving afterwards.
+			const after = await fetch(`http://127.0.0.1:${ui.port}/api/summary`);
+			expect(after.status).toBe(200);
+		},
+	);
 });


### PR DESCRIPTION
## Summary

Two fixes found by a repository-wide code review. Both were reproduced against the current code before being fixed, and both carry regression tests that fail against the old implementation.

### 1. `resumeAnchorMirror` accepted a rotation handoff without verifying its signature

`packages/core/src/audit/anchor.ts` — `resumeAnchorMirror` installs the supplied record as the vault's trusted mirror tail, and the next emission chains from it. The handoff branch accepted that record on one plaintext comparison:

```ts
const handoffOk = record.rotation !== undefined && record.rotation.nextKeyId === identity.keyId;
```

`verifySignatureRaw` was never called on this path. `vaultId` is public — `anchor status` prints it — so a record naming the current key as its successor was accepted on its own say-so, which is exactly what the comment above the check says the check exists to prevent.

The branch itself is legitimate and stays: a rotation record is signed by the **superseded** key, so by construction it cannot verify under the current epoch key. It is now authenticated against the key that actually signed it, looked up by `record.keyId` in the vault's own `identity.keyHistory`. An identity minted before `keyHistory` existed has no provenance to check against, so resume fails closed rather than falling back.

`rotation` is inside the signed pre-image (`anchorSigningPreimage` is `canonicalize(record − sig)`), which is what stops a handoff block being grafted onto an otherwise genuine record.

### 2. Two unguarded throws in the UI server killed the process

`packages/ui/src/server/server.ts` — both escaped the request handler with no response written, and nothing in `packages/ui` installs an `uncaughtException` handler, so a single request terminated `usertrust-ui`.

- **`new URL(req.url)`** — Node accepts an absolute-form request target (RFC 9112 §3.2.2) and hands it to the handler verbatim, so a client controls the entire string being parsed. `GET http://foo:999999/`, `http://%/` and `http://[::1/` all throw. The existing Host guard does not cover this: the Host *header* is independent of the request *target*, and a genuine loopback Host walks straight through.
- **`decodeURIComponent`** on the `/api/verify/` path segment — throws `URIError` on malformed percent-encoding (`%`, `%zz`, `%E0%A4%A`). `new URL` does *not* reject those; it carries an invalid escape through to `pathname` untouched. The two guards cover disjoint inputs and both are required.

Both now return `400`. The second catch deliberately wraps only the `decodeURIComponent` call — `verifyTransaction` reports found/valid through its result object rather than by throwing, so a wider catch would relabel a genuine server fault as a client error.

## Test plan

- `npm run typecheck` → 0 · `npm run lint` → 0
- New regression tests: 29 passing across `anchor-xreview-regressions.test.ts` and `verify-endpoint.test.ts`; each was confirmed to fail against the pre-fix code
- Full suite runs in CI. Note `packages/core/tests/cli/secret.test.ts` is a known load-sensitive flake under coverage (#52) and is unrelated to this change

## Provenance

Found during a repository-wide review, then verified: the review's own findings were checked adversarially before any fix was written, and a P1 in the first attempt at *this* fix was caught and corrected before it reached here.
