### PR TITLE
fix(repo): declare npm as the package manager; ignore typescript semver-majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,12 @@ updates:
       prefix: "deps"
       prefix-development: "deps(dev)"
     open-pull-requests-limit: 10
+    ignore:
+      # A TypeScript major is a deliberate compiler migration, never a weekly bump (#60, #69).
+      # update-types is load-bearing: a bare dependency-name ignores ALL updates for the
+      # package, including security updates. Do not "simplify" it away.
+      - dependency-name: typescript
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -707,8 +707,22 @@ Real, verified, and worth knowing before you touch the surrounding code.
 - **`package-lock.json` lags the package versions.** The release workflow commits only
   `packages/*/package.json`, so the lockfile records the previous version numbers. Harmless in
   practice; do not "fix" it by hand mid-PR.
-- **`packageManager` says pnpm; everything else is npm.** The root carries `package-lock.json` and
-  no `pnpm-lock.yaml`, and CI runs `npm ci`. Use npm.
+- **`packageManager` is npm — keep it npm.** The *name* is what matters: Dependabot selects its
+  updater from this field, and while it declared pnpm (with no root `pnpm-lock.yaml`) it produced
+  manifest-only bumps whose stale `package-lock.json` failed `npm ci` in every CI job (#60, #69).
+  The pinned version+hash is regenerated with `corepack use npm@<version>` — bump it freely, just
+  never change the name back. `dependabot.yml` also ignores TypeScript semver-majors — a TS major
+  is a deliberate compiler migration, never a weekly bump. That ignore is updater-wide (evaluated
+  before grouping), and it also mutes the security-update PR in the one case where a fix ships
+  only in an ignored major (the Dependabot alert still fires; in-major fixes are unaffected).
+- **Vercel builds `site/` with pnpm, not npm.** `site/` carries two lockfiles, and production
+  installs from the one the pre-merge gate never tests: the deploy log shows `Detected
+  pnpm-lock.yaml` → `pnpm run build`, while the gate above runs `npm ci` against
+  `site/package-lock.json`. They are different trees — the pnpm lockfile resolves with
+  `autoInstallPeers: true`, so an unmet peer passes silently there and hard-fails under npm — and
+  the dependency graph reads the pnpm file as authoritative: 29 of the repo's 40 open Dependabot
+  alerts point at it. Dependabot updates both in tandem (#65, #70). Deleting the pnpm lockfile
+  flips production to npm — a deliberate deploy-behavior change; never do it casually.
 - **`server` pins zod 3 while `core` pins zod 4.** In a git worktree without its own
   `node_modules`, resolution walks up to the hoisted zod 4 and `packages/server/src/wire.ts` fails
   to compile (`z.record` arity). That is a worktree artifact, not a real failure — run typechecks

--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
 		"typescript": "^5.9.0",
 		"vitest": "^4.0.0"
 	},
-	"packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a"
+	"packageManager": "npm@10.9.2+sha512.8ab88f10f224a0c614cb717a7f7c30499014f77134120e9c1f0211ea3cf3397592cbe483feb38e0c4b3be1c54e347292c76a1b5edb94a3289d5448484ab8ac81"
 }


### PR DESCRIPTION
## Summary

- **Root `package.json`**: `packageManager` was `pnpm@10.27.0+sha512.…` in an npm-lockfile repo. Dependabot selects its updater from this field — with pnpm declared and no root `pnpm-lock.yaml` it produced manifest-only bumps, so every root dev-group PR (#60, closed; #69, currently red) arrived with a stale `package-lock.json` and all four CI jobs died at `npm ci` before testing any code. Now `npm@10.9.2+sha512.…` (corepack-generated pin; regenerate with `corepack use npm@<version>`).
- **`.github/dependabot.yml`**: ignores TypeScript semver-majors — a TS major (5.9 → 7) is a deliberate compiler migration, never a weekly bump; #60 and #69 both tried to carry it. `update-types` is load-bearing (a bare `dependency-name` would suppress security updates too); an inline comment records that. In-major security fixes still flow; only a fix shipping exclusively in an ignored major raises no PR (the alert still fires).
- **`AGENTS.md`**: the `packageManager` Known-drift bullet now records the failure the pnpm value caused, and a new bullet documents a fact review surfaced while validating this change: **Vercel production builds `site/` with pnpm from `site/pnpm-lock.yaml`** (deploy log: `Detected pnpm-lock.yaml` → `pnpm run build`) while the pre-merge site gate exercises `site/package-lock.json` — two different trees (`autoInstallPeers: true` on the pnpm side), with 29 of 40 open Dependabot alerts attributing to the pnpm file.

## Validation

- `npx biome check` clean (39 pre-existing warnings, documented); `js-yaml` parses the Dependabot config; full local suite green (typecheck, lint, 2433 tests).
- Syntax-level only for `dependabot.yml` — the schema check runs server-side, and the *real* validation is the next Dependabot run. **After merge: comment `@dependabot recreate` on #69** so the group regenerates with a lockfile and without the TS major. If the recreated PR is still manifest-only, the next lever is removing the `packageManager` field entirely.

## Files changed

- `package.json` — `packageManager` field only
- `.github/dependabot.yml` — ignore rule + comment
- `AGENTS.md` — two Known-drift bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)