### PR TITLE
fix(server): migrate to zod 4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -828,10 +828,6 @@ Real, verified, and worth knowing before you touch the surrounding code.
   the dependency graph reads the pnpm file as authoritative: 29 of the repo's 40 open Dependabot
   alerts point at it. Dependabot updates both in tandem (#65, #70). Deleting the pnpm lockfile
   flips production to npm — a deliberate deploy-behavior change; never do it casually.
-- **`server` pins zod 3 while `core` pins zod 4.** In a git worktree without its own
-  `node_modules`, resolution walks up to the hoisted zod 4 and `packages/server/src/wire.ts` fails
-  to compile (`z.record` arity). That is a worktree artifact, not a real failure — run typechecks
-  from a checkout with its own installed dependencies.
 - **`biome.json` has a `**/scripts/**` lint override for a directory that no longer exists.** Nine
   of the pre-existing warnings are `suppressions/unused` — inline `biome-ignore` comments for rules
   the config already disables. Three sit in two `site/app/components/` files (`before-after.tsx`

--- a/package-lock.json
+++ b/package-lock.json
@@ -3584,19 +3584,10 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"usertrust": "*",
-				"zod": "^3.23.0"
+				"zod": "^4.4.3"
 			},
 			"bin": {
 				"usertrust-server": "dist/cli/main.js"
-			}
-		},
-		"packages/server/node_modules/zod": {
-			"version": "3.25.76",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"packages/ui": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,6 @@
 	],
 	"dependencies": {
 		"usertrust": "*",
-		"zod": "^3.23.0"
+		"zod": "^4.4.3"
 	}
 }

--- a/packages/server/src/wire.ts
+++ b/packages/server/src/wire.ts
@@ -9,7 +9,7 @@ export const AuthorizeRequestSchema = z.object({
 	estimatedInputTokens: z.number().int().nonnegative().optional(),
 	maxOutputTokens: z.number().int().positive().optional(),
 	messages: z.array(z.unknown()).optional(),
-	params: z.record(z.unknown()).optional(),
+	params: z.record(z.string(), z.unknown()).optional(),
 	actor: z.string().optional(),
 });
 

--- a/packages/server/tests/wire.test.ts
+++ b/packages/server/tests/wire.test.ts
@@ -20,6 +20,20 @@ describe("request schemas", () => {
 		).toThrow();
 	});
 
+	it("parses params as a string-keyed record and rejects non-record values", () => {
+		// Pins the zod-4 `z.record(z.string(), z.unknown())` arity migration:
+		// zod 3's `z.record(V)` inferred string keys by default; zod 4 requires
+		// the key schema explicitly. These cases confirm zod-3 acceptance
+		// semantics carried over exactly.
+		expect(AuthorizeRequestSchema.parse({ model: "m", params: {} }).params).toEqual({});
+		expect(AuthorizeRequestSchema.parse({ model: "m", params: { a: 1 } }).params).toEqual({
+			a: 1,
+		});
+		expect(() => AuthorizeRequestSchema.parse({ model: "m", params: "x" })).toThrow();
+		expect(() => AuthorizeRequestSchema.parse({ model: "m", params: [] })).toThrow();
+		expect(() => AuthorizeRequestSchema.parse({ model: "m", params: null })).toThrow();
+	});
+
 	it("accepts settle and abort by transferId", () => {
 		expect(SettleRequestSchema.parse({ transferId: "tx_1", outputTokens: 5 }).transferId).toBe(
 			"tx_1",


### PR DESCRIPTION
## Summary
- `packages/server` zod `^3.23.0` → `^4.4.3`, matching core's pin verbatim — npm now dedupes to one hoisted zod repo-wide, retiring the AGENTS.md worktree-resolution drift (bullet removed in-PR).
- One code change forced: `wire.ts` `z.record(z.unknown())` → `z.record(z.string(), z.unknown())` (TS2554 under zod 4; runtime-identical semantics, verified empirically against both call shapes). `config.ts` audited: zero zod-4 breakers.
- New wire tests pin record acceptance (`{}`, `{a:1}` accept; string/array/null reject).
- zod types are `usertrust-server` public API (emitted d.ts imports zod; schemas re-exported as values) — which is why this dependency major rides the v3.0.0 window.
- Supersedes the zod half of Dependabot #73 (which can't fix the code); #73 will rebase down to its minimatch patch.

## Validation
Typecheck clean (fails TS2554 on #73's equivalent today); server suite 53/53; full suite 2471 green; three independent reviews (code, security, ToB differential) — zero findings; security review empirically confirmed all zod-4 parse deltas at the wire boundary are stricter-direction only, and no error-shape change reaches HTTP clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)