### PR TITLE
feat(budget): spend routing, withCostCenter attribution, and scarcity visibility (envelopes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ are not.
 | Anchoring | `audit/{anchor,anchor-verify,anchor-doctor,rekor,rekor-verify,sigv4}.ts` |
 | Policy | `policy/{gate,default-rules,pii,injection,canary,decay}.ts` |
 | Board | `board/{board,director,concerns}.ts` |
-| Budget | `budget/{allocation,runway}.ts` |
+| Budget | `budget/{allocation,attribution,context,runway}.ts` |
 | Runtime | `resilience/{circuit,scope}.ts`, `memory/patterns.ts`, `snapshot/checkpoint.ts` |
 | Other | `anomaly/`, `export/`, `supply-chain/`, `vault/`, `shared/`, `cli/` |
 
@@ -82,8 +82,11 @@ are not.
 4. **Policy gate.** `evaluatePolicy(mergePolicies(DEFAULT_RULES, userRules), context)`. Then PII
    (`warn` / `redact` / `block`), then injection detection.
 5. **PENDING hold.** `engine.spendPending({ transferId, amount: estimatedCost })` creates a
-   TigerBeetle pending transfer debiting a funded, `debits_must_not_exceed_credits` holding wallet
-   and crediting the treasury. Over-budget is rejected *by the ledger*, atomically, and surfaces as
+   TigerBeetle pending transfer debiting a funded, `debits_must_not_exceed_credits` wallet and
+   crediting the treasury. Which wallet is `params.debitAccountId ?? holdingId`: the per-session
+   holding wallet by default, the `(parent, cost center)` **envelope** wallet on an attributed call
+   (see the attribution invariant below). Both carry that same flag, so the enforcement claim is
+   identical either way. Over-budget is rejected *by the ledger*, atomically, and surfaces as
    `InsufficientBalanceError`. Mutex released.
 6. **Forward** to the provider.
 7. **Extract usage**, compute the actual cost via `costFromRates`.
@@ -241,15 +244,18 @@ source-parity test — widen the charset in `shared/ids.ts` and copy it across, 
 the ledger accepts. That drift was introduced once already during the issue-#64 work, which is why
 the parity test exists.
 
-*One static, three call sites.* Creation (`createCostCenterWallet`), the transfer path
-(`resolveAccounts`, for `allocateBudget` and `reclaimBudget`), and the read path (`getBudgetStatus`,
-which bypasses `resolveAccounts` because a read has no parent account to resolve and no
-self-transfer to refuse) must all go through `deriveCostCenterAccountId`. `createCostCenterWallet`
-deliberately writes no `accountMap` entry: the id is derived, never looked up, and a cache would
-only be a second source of truth that a client in another process does not share.
-*Prevents:* one of the three drifting from the others — a hand-rolled join, a second hash, a cached
-id — so allocation funds an account that reclaim and status never read: every cost center reporting
-a zero balance forever, a governance read that fails open.
+*One static, five call sites.* Creation (`createCostCenterWallet`), the transfer path
+(`resolveAccounts`, for `allocateBudget` and `reclaimBudget`), the per-envelope read path
+(`getBudgetStatus`, which bypasses `resolveAccounts` because a read has no parent account to
+resolve and no self-transfer to refuse), the batched read path (`budgetContext`, same reasoning),
+and the spend path (`resolveEnvelope` in `govern.ts`, shared by both governors) must all go through
+`deriveCostCenterAccountId`. `createCostCenterWallet` deliberately writes no `accountMap` entry: the
+id is derived, never looked up, and a cache would only be a second source of truth that a client in
+another process does not share.
+*Prevents:* one of the five drifting from the others — a hand-rolled join, a second hash, a cached
+id — so allocation funds an account that reclaim, status and the hold never read: every cost center
+reporting a zero balance forever, a governance read that fails open, and — now that
+`resolveEnvelope` is on the list — a PENDING hold debiting an account nobody allocated to.
 
 *The `parent::costCenter` string is a display and audit label, never an account id.*
 `costCenterUserId` builds it and `data.costCenterUserId` carries it into the audit chain; no money is
@@ -264,6 +270,76 @@ both pairs on one *account*.)
 
 *128-bit truncation is a ~64-bit birthday bound*, the same bound `deriveAccountId` already accepts:
 a collision needs on the order of 2^64 distinct cost centers, which no plausible deployment reaches.
+
+**Cost-center attribution comes from CODE STRUCTURE, never from request content.** A governed call
+debits a cost-center envelope only because it executed inside a `withCostCenter(cc, fn, opts?)`
+scope (`budget/attribution.ts`), carried by the repo's one `AsyncLocalStorage`. That scope is
+*dynamic, not lexical* — a helper the callback calls, and any continuation awaited inside it, is
+attributed too, which is the whole reason attribution rides ALS rather than a threaded parameter.
+Both halves of the envelope id are structural, never caller text: `cc` comes from the scope and is
+validated against `COST_CENTER_PATTERN` at scope entry, pre-I/O; `parentUserId` is declared once, on
+`TrustConfigSchema` and `TrustOpts` (`GovernorOpts` inherits it), is validated by
+`parentUserIdRefusal` at parse time, and is **operator-trusted** on the same boundary as `budget`
+and `customRates` — whoever constructs a governor already holds the TigerBeetle client. Never derive
+either half from end-user or request data, and never add a request-body path into `cost_center`: all
+three policy sites re-assert it *after* the caller-params spread, `undefined` included (see the
+re-assertion table below). An active scope with no `parentUserId` **throws** in `resolveEnvelope`,
+at the governor's entry point, before the circuit breaker and before any I/O. There is deliberately
+no fallback to the session holding wallet.
+*Prevents:* an agent relabelling its own calls onto the fattest envelope and draining a budget that
+was never delegated to it — which is the entire reason to attribute spend at all. The
+silent-fallback variant is quieter and no better: the caller believes the spend came out of the
+envelope, the envelope's balance never moves, `getBudgetStatus` keeps reporting a full allocation,
+and every policy tier keyed on `budgetFractionRemaining` fails open. Nothing in the system reports
+that; only the throw does.
+
+*One ALS read per call, at the governor's synchronous entry point — closure or handle capture
+everywhere after.* The storage is module-private, and there are exactly **three** legitimate
+`getCurrentCostCenter()` call sites: `interceptCall` and `governActionImpl` in `govern.ts`, and
+`authorize` in `headless.ts`. Each is the top of an entry point the caller invokes synchronously
+from inside its own scope, so the caller's async context is still the current one there. Everything
+downstream reads that single capture — `trust()` by closure (the five `MessageStream` emitter
+listeners, `createGovernedStream`'s completion/error/chunk callbacks, the non-stream settle, the
+outer-catch void), `createGovernor()` off `Authorization.envelope`. Same propagation shape as
+`rateResolution` under "price once", for the same reason.
+*Prevents:* a read from inside a terminal silently answering with a *later, unrelated* call's scope,
+or with nothing — never loudly. `AsyncLocalStorage` follows a chain of async continuations; it does
+**not** follow an `EventEmitter` listener from its `on()`-time context into its `emit()`-time
+context, because `emit()` runs listeners synchronously in whatever context called `emit()`, and the
+SDK's SSE-pump ticks fire strictly after the entry point has returned.
+`tests/budget/attribution.test.ts` pins exactly that as a negative case. Headless is the starker
+version of the same rule: `settle()` routinely runs on a different task, after the scope has exited,
+so there is no store to read at all — it reads `auth.envelope`, which is what guarantees an
+attributed hold gets an attributed settle.
+
+*Every audit record an attributed call emits carries `costCenter`, from that same capture* — not
+from params, and on the failure terminals as well as the settle ones (`llm_call`, `<action.kind>`,
+`llm_call_failed`, `<action.kind>_failed`, `stream_partial_delivery`, `settlement_ambiguous`,
+`injection_detected`, `anomaly_detected`). An attributed hold must leave an attributed forensic
+trail whichever way it ends. Unattributed calls spread an empty object, so their records stay
+byte-identical to what they were before envelopes existed.
+
+*One field, two spellings, deliberately.* The policy context spells it `cost_center` — snake_case,
+beside `estimated_cost`, `budget_remaining` and `action_kind`, because a rule file is what reads it
+— while every TypeScript surface spells the same thing `costCenter`: the audit data above,
+`TrustReceipt.budget.costCenter`, `EnvelopeStatus.costCenter`, and `withCostCenter`'s own argument.
+`policy/gate.ts` states this where the field is declared. Do not "unify" them.
+
+*The two visibility surfaces are OBSERVATIONS, never authority.* `receipt.budget` (push, on settled
+receipts only) and `budgetContext()`'s `EnvelopeStatus` (pull, batched) both report the envelope's
+ledger `available` **read at call time**, so both race every concurrent settlement against the same
+envelope — by design, exactly as any balance read races the ledger it reads from. Neither says what
+*this* call cost (that is `receipt.cost`), and neither is verifier-derivable: `TrustReceipt` is
+never persisted into the vault and `packages/verify` never sees either shape, so nothing recomputes
+these numbers from the chain. The attribution *label* is in the chain (the `costCenter` field on the
+records above); the balance snapshot is not, and must never be presented as if it were.
+`EnvelopeStatus.remaining` is the **raw ledger balance**, not `allocated − spent`: `spent` is
+derived back out of it as `max(0, allocated − remaining)`, so the two agree only under the ledger
+invariant that a cost-center wallet is funded solely via `allocateBudget`. Fund one any other way
+and `remaining` stays honest while `spent`, `fraction` and `runwayHours` silently do not.
+`receipt.budget` is also allowed to be simply ABSENT — unattributed call, unsettled (estimated)
+stream handle, or a post-settle read that did not answer. That read failing is deliberately silent:
+a receipt is a report, and degrading a report must never unwind or re-decide committed money.
 
 **1 usertoken = $0.0001 USD, everywhere.** All pricing rates are usertokens per 1,000 LLM tokens.
 This constant is duplicated in `packages/verify` on purpose.
@@ -428,8 +504,8 @@ not assume they are the same:
 
 | Call site | Re-asserted after the spread |
 |---|---|
-| `govern.ts` — LLM path | `model`, `tier`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `budgetFractionRemaining`, `budgetRunwayHours` |
-| `govern.ts` — `governAction` | `action_kind`, `action_name`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `tier`, `budgetFractionRemaining`, `budgetRunwayHours` (**no `model`**) |
+| `govern.ts` — LLM path | `model`, `tier`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `budgetFractionRemaining`, `budgetRunwayHours`, `cost_center` |
+| `govern.ts` — `governAction` | `action_kind`, `action_name`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `tier`, `budgetFractionRemaining`, `budgetRunwayHours`, `cost_center` (**no `model`**) |
 | `headless.ts` — `authorize` | same set as the LLM path |
 
 The obligation runs in **both** directions. New governance field on `PolicyContext` → re-assert it
@@ -440,6 +516,35 @@ that spreads last, or that re-asserts a subset, is the failure below.
 a hard deny rule. Asserting `undefined` means the rule simply does not match — fail closed, rather
 than matching a number the caller chose. (An `exists`-guard alone makes this *worse*: only the
 attacker's request satisfies it.)
+
+**Four of those fields are ENVELOPE-SCOPED on a call that actually places an envelope hold — the
+gate always describes the wallet the hold will debit.** A set `cost_center` is necessary but not
+sufficient. On a call inside a `withCostCenter` scope that will actually place a ledger hold,
+`budget_remaining` is that envelope's live TigerBeetle `available` (one batched read at
+authorize), and `budgetFractionRemaining` / `budgetRunwayHours` are computed from it against the
+`{ allocated, periodStartMs }` the scope declared — or are explicitly `undefined` when it declared
+none, because there is no cost-center registry and the SDK will not invent an envelope's size.
+Every other call keeps the session numbers, unchanged: unattributed, dry-run and no-engine calls
+place no envelope hold, so there is no envelope truth to be had.
+
+Two consequences that are easy to "tidy" into bugs:
+
+- **`budget_remaining_after` is UNFLOORED on both paths.** It is `budget_remaining − estimate` and
+  it must be allowed to go negative. `block-budget-overshoot` is the non-disableable hard `lt 0`
+  deny, so flooring the field at zero would structurally disarm that rule — on attributed calls
+  first, and it would fork one field's semantics across the two paths.
+- **An attributed call whose envelope balance cannot be read is REFUSED**, with the
+  ledger-unavailable classification, *before* the gate: no mutex taken, `evaluatePolicy` never runs,
+  no hold attempted. Not a fall back to the session numbers — the overshoot rule would then clear
+  the call against a wallet its money never came from, in the one record an auditor reads. Not
+  "continue with the fields absent" either — an indeterminate `budget_remaining_after` makes that
+  same hard rule deny anyway, naming the wrong cause. Refusing costs almost no availability: the
+  preflight and the hold share one TigerBeetle transport, under the client's own reconnect
+  machinery, so a read that genuinely failed means the hold was doomed too.
+
+The preflight itself is a *report*, not a check-then-act: it is taken outside the budget mutex, a
+stale answer can only under-deny, and TigerBeetle's atomic `debits_must_not_exceed_credits`
+rejection of the hold remains the whole enforcement.
 
 **Policy regexes are structurally ReDoS-guarded.** Patterns over 200 characters, with adjacent
 nested quantifiers (`a+*`), or with a quantified group whose body contains a quantifier or
@@ -780,6 +885,10 @@ Real, verified, and worth knowing before you touch the surrounding code.
   which is what the runtime actually uses. The live engine is built by a `createTBEngine` factory
   that is **duplicated** between `govern.ts` and `headless.ts` — change both in lockstep.
   `createLedgerEngine`, promised in comments in both files, does not exist anywhere in the repo.
+  That lockstep is now mechanically pinned: `tests/harden/engine-factory-parity.test.ts` extracts
+  `createTBEngine`, `isTBInsufficientBalance` and `isTBDebitAccountNotFound` from both files, strips
+  comments and blank lines (the two copies carry deliberately different prose), and requires the
+  code to be identical. Fix a failure there by copying the edit across, never by relaxing the test.
 - **`packages/core/bin/govern.ts` is dead code** — outside `include: ["src"]` and outside
   `files: ["dist"]`. The live CLI is `src/cli/main.ts`.
 - **Remote-governance ("proxy") mode is removed.** `connectProxy()` always throws and `TrustOpts.proxy`
@@ -793,9 +902,15 @@ Real, verified, and worth knowing before you touch the surrounding code.
   carrying the authorize-time resolution the way `trust()` does. Same inputs, so the same answer
   today; but the guarantee rests on `resolveRates` staying a pure function of
   `(model, endpointClass, config)`, whereas on the `trust()` path it rests on nothing at all.
-- **The `core/src/budget/` primitives ship ahead of their consumer.** Nothing in the repo debits a
-  cost-center wallet yet, so `getBudgetStatus` reports `spent: 0` for a burning agent and a policy
-  tier keyed on `budgetFractionRemaining` would fail open.
+- **The `core/src/budget/` primitives now have a consumer, but only for ATTRIBUTED traffic.** A
+  governed call made inside a `withCostCenter(cc, fn)` scope places its PENDING hold against the
+  very wallet `allocateBudget` funds, so `getBudgetStatus` and `budgetContext` report that cost
+  center's real `spent`, and a policy tier keyed on `budgetFractionRemaining` trips on real burn —
+  the gap this bullet used to record is closed for that traffic. A call made outside every scope
+  still spends from the per-session funded holding wallet, unchanged and deliberately so, which
+  means an agent that never opens a scope still reads as `spent: 0` while it burns the session
+  budget. That residue is an INSTRUMENTATION gap, not an enforcement one: the session wallet's own
+  `debits_must_not_exceed_credits` bounds that spend either way.
 - **`packages/openclaw` is not typechecked by CI.** It is absent from the root `tsconfig.json`
   references and is not `composite`, so neither `tsc -b` nor `npm run typecheck` covers it. Type
   errors there surface only at release time.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,7 +300,7 @@ everywhere after.* The storage is module-private, and there are exactly **three*
 from inside its own scope, so the caller's async context is still the current one there. Everything
 downstream reads that single capture — `trust()` by closure (the five `MessageStream` emitter
 listeners, `createGovernedStream`'s completion/error/chunk callbacks, the non-stream settle, the
-outer-catch void), `createGovernor()` off `Authorization.envelope`. Same propagation shape as
+outer-catch void), `createGovernor()` off its own internal per-call record. Same propagation shape as
 `rateResolution` under "price once", for the same reason.
 *Prevents:* a read from inside a terminal silently answering with a *later, unrelated* call's scope,
 or with nothing — never loudly. `AsyncLocalStorage` follows a chain of async continuations; it does
@@ -309,8 +309,29 @@ context, because `emit()` runs listeners synchronously in whatever context calle
 SDK's SSE-pump ticks fire strictly after the entry point has returned.
 `tests/budget/attribution.test.ts` pins exactly that as a negative case. Headless is the starker
 version of the same rule: `settle()` routinely runs on a different task, after the scope has exited,
-so there is no store to read at all — it reads `auth.envelope`, which is what guarantees an
-attributed hold gets an attributed settle.
+so there is no store to read at all — `authorize` stores an immutable capture in `activeAuths`,
+keyed by `transferId`, and `settle`/`abort` read the attribution from **that**, which is what
+guarantees an attributed hold gets an attributed settle.
+*Not from the `Authorization` handle*, which is the caller's own object: `activeAuths` holds that
+same reference, so establishing `has(transferId)` and then reading `auth.costCenter`/`auth.envelope`
+let a caller relabel the settle/abort audit record and the receipt between the two phases — and,
+since the receipt's balance snapshot reads whatever account the envelope names, put an arbitrary
+account's balance on a receipt. `Authorization.costCenter` / `.envelope` remain on the handle as
+reporting, frozen, and the governor never reads them back.
+
+*The session's own accounting tracks SESSION-WALLET money only.* `budgetSpent` and the in-flight
+hold total describe the per-session holding wallet — they gate every unattributed call, they are
+what `receipt.budgetRemaining` reports, and `budgetSpent` is persisted and re-seeds that wallet as
+`max(0, budget − budgetSpent)` on the next run. An attributed hold debits the envelope and never
+touches the holding wallet, so both governors skip those counters (and the persist) for it, on the
+increment and the matching release alike.
+*Prevents:* charging the session for money it never paid — unattributed calls hard-denied against a
+wallet TigerBeetle would still have held against, attributed receipts reporting a session remaining
+decremented by envelope money, and the shortfall surviving the restart. Fail-closed, so it is a
+silent over-deny rather than a loss, which is exactly why nothing else reports it. The flag is
+recorded where the hold actually lands, not inferred from the scope: a dry-run or engine-less
+attributed call places no envelope hold at all, and the session numbers stay its only — and honest —
+accounting, matching the numbers its policy gate saw.
 
 *Every audit record an attributed call emits carries `costCenter`, from that same capture* — not
 from params, and on the failure terminals as well as the settle ones (`llm_call`, `<action.kind>`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -555,17 +555,27 @@ Two consequences that are easy to "tidy" into bugs:
   deny, so flooring the field at zero would structurally disarm that rule — on attributed calls
   first, and it would fork one field's semantics across the two paths.
 - **An attributed call whose envelope balance cannot be read is REFUSED**, with the
-  ledger-unavailable classification, *before* the gate: no mutex taken, `evaluatePolicy` never runs,
-  no hold attempted. Not a fall back to the session numbers — the overshoot rule would then clear
-  the call against a wallet its money never came from, in the one record an auditor reads. Not
-  "continue with the fields absent" either — an indeterminate `budget_remaining_after` makes that
-  same hard rule deny anyway, naming the wrong cause. Refusing costs almost no availability: the
-  preflight and the hold share one TigerBeetle transport, under the client's own reconnect
-  machinery, so a read that genuinely failed means the hold was doomed too.
+  ledger-unavailable classification, *before* the gate: `evaluatePolicy` never runs and no hold is
+  attempted. The read now runs INSIDE the budget mutex (see the paragraph below), so the refusal
+  releases the lock on its way out — but the gate and the hold are still never reached. Not a fall
+  back to the session numbers — the overshoot rule would then clear the call against a wallet its
+  money never came from, in the one record an auditor reads. Not "continue with the fields absent"
+  either — an indeterminate `budget_remaining_after` makes that same hard rule deny anyway, naming
+  the wrong cause. Refusing costs almost no availability: the preflight and the hold share one
+  TigerBeetle transport, under the client's own reconnect machinery, so a read that genuinely failed
+  means the hold was doomed too.
 
-The preflight itself is a *report*, not a check-then-act: it is taken outside the budget mutex, a
-stale answer can only under-deny, and TigerBeetle's atomic `debits_must_not_exceed_credits`
-rejection of the hold remains the whole enforcement.
+The preflight is a *report* that feeds the policy tiers, and it is taken INSIDE the budget mutex —
+the same lock that serialises the hold. That is what lets the envelope's fractional/runway tiers
+(`budgetFractionRemaining`, `budgetRunwayHours`) be enforced under single-governor concurrency: a
+concurrent attributed call to the same envelope cannot slip its hold between this read and the gate,
+so the second call gates on a balance that already reflects the first hold — exactly as the session
+path's budget check reads in-process counters mutated under this same mutex. Cross-governor
+(multi-process) concurrency still relies only on TigerBeetle's atomic `debits_must_not_exceed_credits`
+rejection of the hold — an OVERSHOOT, never a fractional/runway tier — the same limitation the
+session path has, and a stale cross-process read can still only under-deny. Moving the read under the
+lock is not check-then-act: the money decision stays the hold's atomic rejection; the read only makes
+the policy record consistent with the wallet the hold will debit.
 
 **Policy regexes are structurally ReDoS-guarded.** Patterns over 200 characters, with adjacent
 nested quantifiers (`a+*`), or with a quantified group whose body contains a quantifier or

--- a/packages/core/src/budget/allocation.ts
+++ b/packages/core/src/budget/allocation.ts
@@ -4,17 +4,19 @@
 /**
  * allocation.ts — cost-center allocation and reclaim over the TigerBeetle ledger
  *
- * ⚠️ WARNING — THESE PRIMITIVES SHIP AHEAD OF THEIR METERING CONSUMER. Nothing in
- * this repository debits a cost-center wallet yet. The metering path spends from
- * a per-session funded holding account (`createFundedBudgetWallet` in `govern.ts`,
- * mirrored in `headless.ts`), never from the wallet {@link allocateBudget} funds.
- * So for a cost center whose agent is genuinely burning budget,
- * {@link getBudgetStatus} still reports `spent: 0` and `fractionRemaining: 1`,
- * and a policy tier written against `budgetFractionRemaining` (see `policy/gate.ts`)
- * would NEVER trip — a governance control that fails open, silently. Allocate,
- * reclaim, and read are correct and safe to use for delegation and reporting; do
- * NOT wire a policy tier to them until the spend path debits the cost-center
- * wallet.
+ * THE METERING CONSUMER EXISTS — but only for ATTRIBUTED traffic. A governed call
+ * made inside a `withCostCenter(cc, fn)` scope (see `budget/attribution.ts`) places
+ * its PENDING hold against the wallet {@link allocateBudget} funds, so
+ * {@link getBudgetStatus} reports that cost center's real `spent` and a policy tier
+ * on `budgetFractionRemaining` (see `policy/gate.ts`) trips on real burn.
+ *
+ * Calls made OUTSIDE every scope still spend from the per-session funded holding
+ * account (`createFundedBudgetWallet` in `govern.ts`, mirrored in `headless.ts`) —
+ * that path is unchanged and deliberately so. The consequence to keep in mind:
+ * these figures measure attributed spend, so an agent that never opens a scope
+ * still reports `spent: 0` here while burning the session budget. That is a gap in
+ * INSTRUMENTATION, not in enforcement — the session wallet's own
+ * `debits_must_not_exceed_credits` bounds it either way.
  *
  * A cost center is a sub-wallet of its parent, nothing more. Its TigerBeetle
  * account is `TrustTBClient.deriveCostCenterAccountId(parent, costCenter)` — a

--- a/packages/core/src/budget/attribution.ts
+++ b/packages/core/src/budget/attribution.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * budget/attribution.ts — the `withCostCenter()` attribution scope.
+ *
+ * Attribution comes from CODE STRUCTURE, never from request content: a governed
+ * call is attributed to a cost center only because it executed lexically inside a
+ * `withCostCenter(cc, fn)` call, propagated by `node:async_hooks`'
+ * `AsyncLocalStorage` — the repo's first use of it. Nothing an agent's request
+ * body can carry (a `cost_center` field, a header, a tool argument) can forge or
+ * override this: the store is keyed off the calling code's own async execution
+ * context, which caller-supplied text never touches.
+ * *Prevents:* an agent relabeling its own calls to drain the fattest envelope —
+ * the exact failure a request-content-derived attribution scheme would open.
+ *
+ * ALS DISCIPLINE (the invariant this file establishes, see AGENTS.md): storage is
+ * module-private — nothing outside this file may read or write it — and a
+ * governor may call {@link getCurrentCostCenter} exactly ONCE per call, at the top
+ * of its own synchronous entry point (`interceptCall`, headless `authorize`).
+ * Every terminal, listener, and `finally` after that point must read a closure
+ * capture of that one read, never call {@link getCurrentCostCenter} itself. The
+ * reason is mechanical, not stylistic: `AsyncLocalStorage` context follows a
+ * *chain of async continuations* (awaits, promise `.then`s, timers, microtasks
+ * scheduled while the store is active) — it does NOT follow an `EventEmitter`
+ * listener from its `on()`-time context into its `emit()`-time context, because
+ * `emit()` invokes listeners synchronously in whatever context calls `emit()`.
+ * SDK stream consumption is emitter-shaped (`streamEvent` / `finalMessage` /
+ * `error` / `end`), and those ticks fire on the SDK's own pump, strictly after
+ * the governor's synchronous entry point has already returned. A `getStore()`
+ * call from inside one of those listeners would silently see the WRONG scope (a
+ * later, unrelated call's) or no scope at all — never a loud failure. This file's
+ * own test suite pins that exact hazard as a negative case so the failure mode
+ * stays documented next to the primitive that makes it possible, not just in a
+ * comment a future edit can drift away from.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { COST_CENTER_PATTERN } from "../shared/ids.js";
+
+/**
+ * Envelope metadata captured alongside a scope (D4). Optional because there is no
+ * cost-center registry: a caller that only wants attribution (routing the spend to
+ * the right envelope) need not also state the envelope's size. When present, it is
+ * what lets `govern.ts`/`headless.ts` compute `budgetFractionRemaining` and
+ * `budgetRunwayHours` for the active envelope; when absent, those policy fields
+ * are asserted explicitly `undefined` rather than guessed at (fail closed — an
+ * `exists`-guarded tier simply does not match, never matches a fabricated number).
+ */
+export interface CostCenterScopeOpts {
+	/** UT, finite, >= 0. Not validated against a real allocation — see above. */
+	allocated: number;
+	/** Finite epoch ms. */
+	periodStartMs: number;
+	/** Finite epoch ms when present; absent means an open-ended period. */
+	periodEndMs?: number | undefined;
+}
+
+/**
+ * The record threaded through one `withCostCenter` scope. Frozen at construction
+ * (see {@link withCostCenter}) so a caller holding a reference — intentionally or
+ * by mistake — cannot mutate it and have that mutation observed by a later
+ * `getCurrentCostCenter()` read in the same or a nested scope.
+ */
+export interface CostCenterAttribution {
+	readonly costCenter: string;
+	readonly allocated?: number | undefined;
+	readonly periodStartMs?: number | undefined;
+	readonly periodEndMs?: number | undefined;
+}
+
+// Module-private. This is the ONE mutable module-level piece of state this file
+// owns, and the ALS-discipline invariant above exists entirely to keep every read
+// of it confined to a governor's single synchronous entry point.
+const costCenterStorage = new AsyncLocalStorage<CostCenterAttribution>();
+
+/**
+ * Run `fn` with `costCenter` attributed for every governed call `fn` makes,
+ * directly or through any `await`, timer, or microtask it schedules while it is
+ * still executing. Nesting is native `AsyncLocalStorage` stack behavior: the
+ * innermost active `withCostCenter` wins, and exiting it — by returning OR by
+ * throwing/rejecting — restores whatever scope (or no scope) was active before it
+ * was entered.
+ *
+ * Validation runs before any of `fn` executes (fail-fast, pre-I/O): an invalid
+ * `costCenter` or a non-finite `opts` field must never reach a call already in
+ * flight, and `costCenter` becomes an audit-event field and a display label
+ * downstream — `canonicalize` (audit) throws on `NaN`/`Infinity`, so a non-finite
+ * `opts` number is refused HERE rather than surfacing as an audit-write failure
+ * three call frames away. The rejection message is deliberately distinct from the
+ * two other costCenter charset-door messages in this repo
+ * (`ledger/client.ts`'s `"Invalid costCenter: ..."` and
+ * `budget/allocation.ts`'s `"budget: costCenter ..."`) so a caller can tell which
+ * door refused their id from the message alone.
+ *
+ * @throws Error when `costCenter` fails {@link COST_CENTER_PATTERN}, or when
+ * `opts` is present and `allocated` is not a finite number `>= 0`, or
+ * `periodStartMs`/`periodEndMs` (when given) is not a finite number.
+ */
+export function withCostCenter<T>(costCenter: string, fn: () => T, opts?: CostCenterScopeOpts): T {
+	if (typeof costCenter !== "string" || !COST_CENTER_PATTERN.test(costCenter)) {
+		throw new Error(
+			`withCostCenter: costCenter must match ${COST_CENTER_PATTERN.source}, got ${JSON.stringify(
+				costCenter,
+			)}`,
+		);
+	}
+	if (opts !== undefined) {
+		if (!Number.isFinite(opts.allocated) || opts.allocated < 0) {
+			throw new Error("withCostCenter: opts.allocated must be a finite number >= 0");
+		}
+		if (!Number.isFinite(opts.periodStartMs)) {
+			throw new Error("withCostCenter: opts.periodStartMs must be a finite number");
+		}
+		if (opts.periodEndMs !== undefined && !Number.isFinite(opts.periodEndMs)) {
+			throw new Error("withCostCenter: opts.periodEndMs must be a finite number when present");
+		}
+	}
+
+	const store: CostCenterAttribution = Object.freeze({ costCenter, ...opts });
+	return costCenterStorage.run(store, fn);
+}
+
+/**
+ * Read the active scope's attribution, or `undefined` outside any scope.
+ *
+ * INTERNAL ONLY (D8) — not re-exported from `index.ts` this ship. `govern.ts` and
+ * `headless.ts` import it directly by relative path. Per the ALS-discipline
+ * invariant documented at the top of this file, each of them may call this
+ * exactly once, at the very top of its own synchronous entry point, and must
+ * thread the result through as a closure/handle capture from there — never call
+ * this again inside a terminal, a stream emitter listener, or a `finally` block.
+ */
+export function getCurrentCostCenter(): CostCenterAttribution | undefined {
+	return costCenterStorage.getStore();
+}

--- a/packages/core/src/budget/attribution.ts
+++ b/packages/core/src/budget/attribution.ts
@@ -117,7 +117,33 @@ export function withCostCenter<T>(costCenter: string, fn: () => T, opts?: CostCe
 		}
 	}
 
-	const store: CostCenterAttribution = Object.freeze({ costCenter, ...opts });
+	// BUILT FIELD BY FIELD, NEVER SPREAD. `opts` is METADATA about the envelope;
+	// the positional `costCenter` above — the only one validated against
+	// COST_CENTER_PATTERN — is what decides WHICH envelope a governed call debits.
+	// A blanket `{ costCenter, ...opts }` puts the spread AFTER the validated field,
+	// so a `costCenter` key riding on `opts` silently wins, and TypeScript never
+	// objects: its excess-property check fires only for object LITERALS, so any
+	// variable of a wider shape passes. `EnvelopeDescriptor` (`budgetContext`'s
+	// argument, `{ costCenter, allocated, periodStartMs, periodEndMs? }`) is exactly
+	// such a shape — structurally assignable to `CostCenterScopeOpts` and carrying
+	// its own `costCenter` — so `withCostCenter("research", fn, someDescriptor)`
+	// would type-check and reroute the entire spend: the descriptor's envelope
+	// debited, its label in the audit chain, its balance in the policy gate.
+	// Enumerating the three known fields also means no UNKNOWN key can enter the
+	// store at all, so nothing downstream can ever read caller data out of it.
+	const store: CostCenterAttribution = Object.freeze({
+		costCenter,
+		...(opts === undefined
+			? {}
+			: {
+					allocated: opts.allocated,
+					periodStartMs: opts.periodStartMs,
+					// Spread-omission, not `periodEndMs: undefined`: absent means an
+					// open-ended period, and under exactOptionalPropertyTypes the two are
+					// different types.
+					...(opts.periodEndMs === undefined ? {} : { periodEndMs: opts.periodEndMs }),
+				}),
+	});
 	return costCenterStorage.run(store, fn);
 }
 

--- a/packages/core/src/budget/context.ts
+++ b/packages/core/src/budget/context.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * budget/context.ts — `budgetContext()`, the scarcity READ API for an agent's own envelopes.
+ *
+ * This is the PULL half of visibility (the design's other half, `receipt.budget`, is a
+ * PUSH on the settled receipt — see `govern.ts`/`headless.ts`). A caller who wants to
+ * see where it stands across every envelope it holds — before deciding whether to make
+ * another call, not after one already happened — awaits this once.
+ *
+ * READ-ONLY, LIKE `getBudgetStatus`: no transfer, so no `resolveAccounts` and no
+ * self-transfer refusal (there is nothing to refuse — a read cannot debit and credit the
+ * same account). Unlike `getBudgetStatus`, which reads one cost center per call via
+ * `costCenterBalance` (up to two `lookupAccounts`/`lookupBalance` round trips), this reads
+ * an entire batch — the parent plus every envelope — in exactly ONE
+ * {@link TrustTBClient.lookupBalances} round trip.
+ *
+ * DERIVE, NEVER LOOK UP: this is the FOURTH call site of the one-static invariant
+ * (`createCostCenterWallet`, `resolveAccounts`, `getBudgetStatus`, and now this) —
+ * `TrustTBClient.deriveAccountId` for the parent, `TrustTBClient.deriveCostCenterAccountId`
+ * for each envelope. Never `getAccountId`, never a cache, never a hand-rolled join of the
+ * `parent::costCenter` label. A join or a cache here would be a second source of truth
+ * that a client in another process does not share — see AGENTS.md's "Budget account ids
+ * are derived, never looked up."
+ *
+ * OBSERVATIONAL, NOT AUTHORITATIVE (A8): every number this returns is a snapshot read at
+ * call time. It can race a concurrent settlement — a hold posting, another caller
+ * spending from the same envelope, a reclaim — landing between the ledger read and the
+ * caller observing the returned object. That is by design, the same way any balance read
+ * races the ledger it reads from. It reports "what the ledger holds right now", never "the
+ * result of a specific spend", and it is not part of the audit chain: `packages/verify`
+ * never sees this shape, and nothing here is a hash pre-image. See `receipt.budget` for
+ * the analogous push-side snapshot and its own read-failure-degrades-safely contract.
+ */
+
+import { TrustTBClient } from "../ledger/client.js";
+import { parentUserIdRefusal } from "../shared/ids.js";
+import { costCenterUserId } from "./allocation.js";
+import { computeRunway, runwayHours } from "./runway.js";
+
+/**
+ * Amplification guard on the batch size. `envelopes` drives both the id list handed to
+ * `lookupBalances` and a `computeRunway` call per entry — an unbounded array turns one
+ * `budgetContext` call into unbounded ledger and CPU work per caller. 128 is generous for
+ * a single agent's own envelope set and arbitrary beyond that; it is named so a future
+ * adjustment has exactly one place to change, never a magic number re-typed at the door.
+ */
+export const MAX_ENVELOPES = 128;
+
+/**
+ * One envelope to read, as the caller's own bookkeeping — there is no cost-center
+ * registry (see `budget/allocation.ts`'s module doc), so `allocated` and the period
+ * bounds are supplied here, not read from the ledger. Mirrors `getBudgetStatus`'s
+ * per-call params, batched.
+ */
+export interface EnvelopeDescriptor {
+	costCenter: string;
+	/** UT. Non-finite or negative reads as zero — see {@link EnvelopeStatus} below. */
+	allocated: number;
+	/** Epoch ms. Must be finite — `computeRunway` throws otherwise; see its doc comment. */
+	periodStartMs: number;
+	/** Epoch ms when present; absent means an open-ended period. */
+	periodEndMs?: number | undefined;
+}
+
+/**
+ * One envelope's scarcity snapshot.
+ *
+ * CLAMP SEMANTICS (A5), pinned by tests — read this before touching the arithmetic below:
+ *  - `remaining` is the envelope's ledger `available` balance at read time, or `0` when
+ *    the envelope has no TigerBeetle account at all (never allocated, or fully reclaimed
+ *    — the same implicit-zero equivalence `getBudgetStatus` documents). It can never be
+ *    negative: `lookupBalances` already floors `available` at 0 upstream, in the ONE
+ *    place that computation lives (`ledger/client.ts`'s `accountBalance`).
+ *  - `spent = max(0, allocated − remaining)` — the same clamp `getBudgetStatus` applies,
+ *    for the same reason: an over-funded envelope (funded outside `allocateBudget`, which
+ *    the LEDGER INVARIANT in `allocation.ts` calls a breach) must not invert into negative
+ *    spend.
+ *  - `fraction = clamp(remaining / allocated, 0, 1)`, and `allocated <= 0` reads as
+ *    `fraction: 0` — no headroom, not a division by zero. A non-finite or negative
+ *    `allocated` on the descriptor normalizes to `0` before any of the above runs (the
+ *    same normalization `runway.ts`'s `normalizeAllocated` applies), so a malformed
+ *    descriptor cannot produce a non-finite `spent`, `remaining`, or `fraction` — Runway
+ *    TOTALITY holds for this whole batch, not only for what `computeRunway` itself
+ *    returns.
+ *
+ * RUNWAY TYPING (A6): `runwayHours` follows `budget/runway.ts`'s `runwayHours()` function
+ * verbatim — `number | null`, `null` meaning "not projectable" (nothing spent yet in the
+ * window). This is a DIFFERENT convention from the `budgetRunwayHours` POLICY field
+ * `govern.ts`/`headless.ts` assert into `PolicyContext` (which uses explicit `undefined`
+ * for "no D4 allocation metadata was supplied to the active scope"). Two surfaces, two
+ * pre-existing conventions — do not unify them.
+ */
+export interface EnvelopeStatus {
+	costCenter: string;
+	/** Normalized per the clamp semantics above — never non-finite or negative. */
+	allocated: number;
+	spent: number;
+	remaining: number;
+	/** 0..1 inclusive. */
+	fraction: number;
+	runwayHours: number | null;
+}
+
+/** The full scarcity picture `budgetContext` returns: the parent wallet plus every
+ * requested envelope, all read from the SAME `lookupBalances` round trip. */
+export interface BudgetContext {
+	/** `remaining` here is the parent's own ledger `available` balance — implicit zero
+	 * (no account) reads as 0, symmetric with every envelope below. There is no
+	 * `allocated`/`spent`/`fraction` for the parent: those are envelope-relative
+	 * concepts and the parent is not itself an envelope. */
+	parent: { remaining: number };
+	envelopes: EnvelopeStatus[];
+}
+
+/** Non-finite or negative allocations read as zero. Mirrors `runway.ts`'s
+ * `normalizeAllocated`, which is module-private there — duplicated here (not imported)
+ * because this file's `spent`/`fraction` are computed from the caller-truth `remaining`
+ * BEFORE `computeRunway` ever normalizes anything, so this module needs its own safe
+ * `allocated` a step earlier than `computeRunway` provides one. */
+function safeAllocated(value: number): number {
+	return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+/** `Math.min(1, Math.max(0, value))`, named for what A5 calls it — `fraction` can
+ * legitimately exceed 1 before clamping (an over-funded envelope's raw
+ * `remaining / allocated`), so the clamp needs both bounds, unlike `spent`'s
+ * one-sided floor. */
+function clampFraction(value: number): number {
+	return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Read the parent's balance and every requested envelope's scarcity, in one round trip.
+ *
+ * VALIDATION DOORS, all pre-I/O (A3): `parentUserId` is refused by the same
+ * `parentUserIdRefusal` every other budget door uses — checked once up front so an empty
+ * `envelopes` array cannot skip it (a bad parent id still drives the parent's own account
+ * derivation and read below). Every descriptor's `costCenter` is validated through
+ * {@link costCenterUserId} — the same per-entry door `getBudgetStatus` uses, reused rather
+ * than re-implementing the charset check — which incidentally re-validates `parentUserId`
+ * per entry too (cheap and pure; harmless once the top-level check has already passed).
+ * A duplicate `costCenter` across descriptors throws: two entries resolve to the same
+ * envelope account, so a duplicate could only mean caller confusion, never two distinct
+ * envelopes to report. `envelopes.length` over {@link MAX_ENVELOPES} throws before any of
+ * the above runs — the amplification guard fires first, cheapest check first.
+ *
+ * @throws Error when `parentUserId` fails `parentUserIdRefusal`, any `costCenter` fails
+ * {@link costCenterUserId}'s validation, `envelopes` contains a duplicate `costCenter`, or
+ * `envelopes.length` exceeds {@link MAX_ENVELOPES} — all before any ledger I/O.
+ * @throws Error (from `computeRunway`) when a descriptor's `periodStartMs`, or `nowMs`
+ * (explicit or the wall clock read here), is not finite — see AGENTS.md: "a bad clock is a
+ * caller bug, and silently substituting a value would fabricate a runway." This check runs
+ * per-entry inside the batch, after the `lookupBalances` read, mirroring `getBudgetStatus`.
+ */
+export async function budgetContext(
+	tb: TrustTBClient,
+	parentUserId: string,
+	envelopes: EnvelopeDescriptor[],
+	nowMs?: number,
+): Promise<BudgetContext> {
+	if (envelopes.length > MAX_ENVELOPES) {
+		throw new Error(
+			`budgetContext: envelopes.length (${envelopes.length}) exceeds the ${MAX_ENVELOPES} cap`,
+		);
+	}
+
+	const parentRefusal = parentUserIdRefusal(parentUserId);
+	if (parentRefusal !== null) {
+		throw new Error(`budget: parentUserId ${parentRefusal}`);
+	}
+
+	const seen = new Set<string>();
+	for (const envelope of envelopes) {
+		// Throws pre-I/O on an invalid costCenter (or, redundantly but harmlessly, on
+		// the parentUserId already checked above).
+		costCenterUserId(parentUserId, envelope.costCenter);
+		if (seen.has(envelope.costCenter)) {
+			throw new Error(`budgetContext: duplicate costCenter descriptor: "${envelope.costCenter}"`);
+		}
+		seen.add(envelope.costCenter);
+	}
+
+	// ONE clock read for the whole batch — every envelope's runway is computed against
+	// the same instant, so two envelopes in one response never disagree about "now".
+	const clock = nowMs ?? Date.now();
+
+	const parentAccount = TrustTBClient.deriveAccountId(parentUserId);
+	const childAccounts = envelopes.map((envelope) =>
+		TrustTBClient.deriveCostCenterAccountId(parentUserId, envelope.costCenter),
+	);
+
+	// The ONE round trip: parent + every envelope, together. `lookupBalances` dedupes
+	// its input and omits any account TigerBeetle does not return — that omission IS
+	// the implicit-zero reading below, for the parent exactly as for every envelope.
+	const balances = await tb.lookupBalances([parentAccount, ...childAccounts]);
+
+	const envelopeStatuses: EnvelopeStatus[] = envelopes.map((envelope, i) => {
+		const remaining = balances.get(childAccounts[i] as bigint) ?? 0;
+		const allocated = safeAllocated(envelope.allocated);
+		const spent = Math.max(0, allocated - remaining);
+		const fraction = allocated <= 0 ? 0 : clampFraction(remaining / allocated);
+
+		// Reused, not reimplemented: computeRunway/runwayHours already own the burn-rate
+		// and projection math (and its own TOTALITY guarantees) — this call exists only
+		// to get runwayHours, since remaining/spent/fraction above are already final.
+		const runway = computeRunway({
+			allocated,
+			spent,
+			periodStartMs: envelope.periodStartMs,
+			periodEndMs: envelope.periodEndMs,
+			nowMs: clock,
+		});
+
+		return {
+			costCenter: envelope.costCenter,
+			allocated,
+			spent,
+			remaining,
+			fraction,
+			runwayHours: runwayHours(runway, clock),
+		};
+	});
+
+	return {
+		parent: { remaining: balances.get(parentAccount) ?? 0 },
+		envelopes: envelopeStatuses,
+	};
+}

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -1318,11 +1318,16 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				// that drifts the moment another process spends from the same envelope.
 				// It observes; it never decides. A read that fails omits the block —
 				// this runs after the money committed, and a report must never unwind
-				// or re-decide a settlement.
-				const streamBudget = envelopeReceiptBudget(
-					envelope,
-					await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
-				);
+				// or re-decide a settlement. It is a POST-SETTLEMENT observation, so it
+				// is attached ONLY when `settled` — an ambiguous settlement (POST
+				// rejected) may still be pending and be posted or voided later, making
+				// the balance transient; we do not even read the ledger for it then.
+				const streamBudget = settled
+					? envelopeReceiptBudget(
+							envelope,
+							await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
+						)
+					: undefined;
 
 				const streamReceipt: TrustReceipt = {
 					transferId,
@@ -1950,11 +1955,15 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 
 				const budgetRemaining = config.budget - budgetSpent - inFlightHoldTotal;
 				// D7 (see the streaming settle above for the full rationale): a
-				// post-settle observation of the envelope, omitted when it cannot be read.
-				const settledBudget = envelopeReceiptBudget(
-					envelope,
-					await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
-				);
+				// post-settle observation of the envelope, omitted when it cannot be read
+				// AND when the settlement is ambiguous — a settled:false receipt must not
+				// carry a snapshot the contract defines as post-settlement.
+				const settledBudget = settled
+					? envelopeReceiptBudget(
+							envelope,
+							await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
+						)
+					: undefined;
 
 				const receipt: TrustReceipt = {
 					transferId,
@@ -2407,12 +2416,15 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 
 				const budgetRemaining = config.budget - budgetSpent - inFlightHoldTotal;
 				// D7 (see the LLM path for the full rationale): a post-settle observation
-				// of the envelope, omitted when it cannot be read. It reports; it never
-				// re-decides a settlement that already committed.
-				const actionBudget = envelopeReceiptBudget(
-					envelope,
-					await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
-				);
+				// of the envelope, omitted when it cannot be read AND when the settlement
+				// is ambiguous. It reports; it never re-decides a settlement that already
+				// committed, and it is never attached to a settled:false receipt.
+				const actionBudget = settled
+					? envelopeReceiptBudget(
+							envelope,
+							await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
+						)
+					: undefined;
 
 				const receipt: TrustReceipt = {
 					transferId,

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -408,14 +408,26 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 }
 
 // ── Cost-center envelope plumbing ─────────────────────────────────────────────
+//
+// SHARED WITH `headless.ts`, ON PURPOSE. The helpers below are `export`ed for one
+// consumer — `createGovernor()` — and for one reason: both governors must resolve,
+// gate on, refuse and report the SAME envelope by the SAME arithmetic. A third
+// copy alongside the two `createTBEngine` copies is exactly the drift AGENTS.md
+// records as a hazard, and here it would be a MONEY drift: D1's throw, A2's
+// pre-gate refusal, A7's unfloored `budget_remaining_after` and D5's label re-wrap
+// each decide whether a spend happens and which wallet it names. One copy, one
+// answer. Nothing here reaches the package's public API — `index.ts` re-exports by
+// name and `dist/govern.js` is not an exported subpath — so this widens the module
+// surface, not the product's.
 
 /**
  * What an active `withCostCenter` scope resolves to for THIS governor: the
  * envelope account money moves from, and the label everything human-readable
  * quotes. Derived once per call, at the governor's entry point, and then carried
- * by closure — see {@link resolveEnvelope}.
+ * by closure (`trust()`) or on the `Authorization` handle (`createGovernor()`) —
+ * see {@link resolveEnvelope}.
  */
-interface ResolvedEnvelope {
+export interface ResolvedEnvelope {
 	attribution: CostCenterAttribution;
 	/** The (parent, costCenter) tuple hash. The only thing money is keyed on. */
 	accountId: bigint;
@@ -449,7 +461,7 @@ const ENVELOPE_FUNDING_HINT =
  * `getBudgetStatus` keeps reporting a full balance, and every tier keyed on it
  * fails open. Nothing in the system would report that; only the loud throw does.
  */
-function resolveEnvelope(
+export function resolveEnvelope(
 	attribution: CostCenterAttribution | undefined,
 	parentUserId: string | undefined,
 ): ResolvedEnvelope | undefined {
@@ -486,7 +498,7 @@ function resolveEnvelope(
  * way out. The ledger's own `required`/`available` numbers are carried through
  * unchanged: they are the only figures TigerBeetle actually decided on.
  */
-function asEnvelopeBalanceError(
+export function asEnvelopeBalanceError(
 	err: InsufficientBalanceError,
 	label: string,
 ): InsufficientBalanceError {
@@ -517,7 +529,7 @@ function envelopeFraction(remaining: number, allocated: number): number {
  * envelope has actually paid out, the same clamp `getBudgetStatus` and
  * `budgetContext` apply.
  */
-function envelopeTierFields(
+export function envelopeTierFields(
 	attribution: CostCenterAttribution,
 	remaining: number,
 	nowMs: number,
@@ -599,7 +611,7 @@ async function readEnvelopeBalance(
  * @throws LedgerUnavailableError when an attributed call's envelope balance cannot
  * be read. No hold is placed and the policy gate is never reached.
  */
-async function preflightEnvelopeRemaining(
+export async function preflightEnvelopeRemaining(
 	engine: TrustEngine | null,
 	isDryRun: boolean,
 	envelope: ResolvedEnvelope | undefined,
@@ -621,7 +633,7 @@ async function preflightEnvelopeRemaining(
  * degrading a report must not unwind or re-decide a settlement. A failure omits
  * the block.
  */
-async function snapshotEnvelopeRemaining(
+export async function snapshotEnvelopeRemaining(
 	engine: TrustEngine | null,
 	isDryRun: boolean,
 	envelope: ResolvedEnvelope | undefined,
@@ -640,7 +652,7 @@ async function snapshotEnvelopeRemaining(
  * receipt is a report, and degrading a report must not unwind money that already
  * committed.
  */
-function envelopeReceiptBudget(
+export function envelopeReceiptBudget(
 	envelope: ResolvedEnvelope | undefined,
 	remaining: number | undefined,
 ): TrustReceipt["budget"] | undefined {

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -901,20 +901,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				maxOutputTokens,
 			);
 
-			// Attributed calls only: ONE batched read of the envelope's live
-			// `available`, for the policy numbers below. Deliberately OUTSIDE the
-			// budget mutex — it is a report, not a decision, so serialising every
-			// governed call behind a ledger round trip would buy nothing. A read that
-			// goes stale between here and the hold can only under-deny, and the hold
-			// itself is rejected atomically by TigerBeetle either way.
-			// A2: it is also BEFORE the mutex and before the gate because a read that
-			// FAILED refuses the call outright — no lock taken, no policy evaluation
-			// recorded, no hold attempted.
-			const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
-
 			// AUD-453: Acquire mutex to serialise budget-check + PENDING hold.
-			// This prevents concurrent calls from both passing the budget check
-			// and overshooting the budget.
+			// This prevents concurrent calls from both passing the budget check and
+			// overshooting the budget. The attributed-envelope preflight read is taken
+			// INSIDE this lock (top of the try below), so a concurrent hold to the same
+			// envelope cannot land between the read and the gate — see the note there.
 			const releaseBudgetLock = await budgetMutex.acquire();
 
 			// AUD-460: Track the proxy's transferId separately for settle/void
@@ -936,6 +927,26 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			}
 
 			try {
+				// Attributed calls only: ONE batched read of the envelope's live
+				// `available`, for the policy numbers below. Taken INSIDE the budget mutex
+				// — the same lock that serialises the hold — and BEFORE the gate, so this
+				// call's own hold lands only after the read and a CONCURRENT attributed
+				// call to the SAME envelope cannot slip its hold between this read and the
+				// gate. When the read was OUTSIDE the lock, two such calls both read the
+				// pre-hold balance and the second bypassed a hard scarcity tier
+				// (`budgetFractionRemaining` / `budgetRunwayHours`) the ledger cannot
+				// enforce — TigerBeetle's atomic `debits_must_not_exceed_credits` rejects an
+				// OVERSHOOT but never a fractional/runway tier. Serialising the read under
+				// the hold's lock makes the gate describe the wallet the hold will debit,
+				// exactly as the SESSION path already does (its check reads in-process
+				// counters mutated under this same mutex). Cross-process (multi-governor)
+				// concurrency still relies on TB atomicity — overshoot only — the same
+				// limitation the session path has.
+				// A2: a read that FAILS refuses the call outright — the finally below
+				// releases the mutex and the ledger-unavailable error propagates before the
+				// gate is evaluated or any hold is attempted.
+				const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
+
 				// c. Policy gate
 				// P1-PARAM-SHADOW: caller `params` are spread FIRST so trusted
 				// governance fields (tier/estimated_cost/budget_remaining/
@@ -2114,17 +2125,26 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			const cb = breaker.get(action.kind as unknown as LLMClientKind);
 			cb.allowRequest();
 
-			// Attributed only, and outside the mutex for the same reason as the LLM
-			// path: a report, never a decision — and, per A2, a report whose FAILURE
-			// refuses the action before the gate rather than gating it on the session
-			// wallet its hold would not have touched.
-			const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
-
-			// b. Acquire mutex for budget atomicity
+			// b. Acquire mutex for budget atomicity. The attributed-envelope preflight
+			// read is taken INSIDE this lock (top of the try below) so a concurrent hold
+			// to the same envelope cannot land between the read and the gate — see there.
 			const releaseBudgetLock = await budgetMutex.acquire();
 			let proxyTransferId: string | undefined;
 
 			try {
+				// Attributed only: ONE batched read of the envelope's live `available`,
+				// taken INSIDE the budget mutex and BEFORE the gate, so this action's own
+				// hold lands only after the read and a CONCURRENT attributed action on the
+				// SAME envelope cannot slip its hold between the read and the gate. Outside
+				// the lock, both would read the pre-hold balance and the second would bypass
+				// a hard scarcity tier (`budgetFractionRemaining` / `budgetRunwayHours`) the
+				// ledger cannot enforce — TB rejects an OVERSHOOT, never a fractional/runway
+				// tier. Same in-mutex serialisation the SESSION path already has;
+				// cross-process concurrency still relies on TB atomicity (overshoot only).
+				// A2: a read that FAILS refuses the action — the finally below releases the
+				// mutex and the error propagates before the gate or any hold.
+				const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
+
 				// c. Policy gate — action fields available in context
 				// AUD-467: Caller params spread FIRST so governance fields cannot be shadowed.
 				// P1-BUDGET-PREFLIGHT: budget_remaining_after is the derived field the

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -834,6 +834,30 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			const costCenterAudit: { costCenter?: string } =
 				envelope === undefined ? {} : { costCenter: envelope.attribution.costCenter };
 
+			// ── SESSION accounting tracks SESSION-WALLET money only ──
+			// `budgetSpent` and `inFlightHoldTotal` describe the per-session HOLDING
+			// wallet: they gate every unattributed call, they are what
+			// `receipt.budgetRemaining` reports, and `persistSpendLedger` carries
+			// `budgetSpent` across restarts as the `max(0, budget - budgetSpent)` seed of
+			// that wallet. An ATTRIBUTED hold debits the `(parent, costCenter)` envelope
+			// and never touches the holding wallet, so counting it here charges the
+			// session for money it did not pay: unattributed calls are eventually
+			// hard-denied against a wallet TigerBeetle would still have held against, and
+			// the shortfall survives the restart. Fail-closed — over-deny, never loss —
+			// but silent, which is why it is a bug and not a conservative default.
+			// Set at the point the hold actually lands on the envelope, NOT from the
+			// scope: a dry-run or engine-less attributed call places no envelope hold at
+			// all, so the session numbers stay its only — and honest — accounting,
+			// exactly as they are the only numbers its policy gate saw.
+			let envelopeDebited = false;
+			/** This call's SESSION-wallet share of an amount: all of it, or none. */
+			const sessionShare = (amount: number): number => (envelopeDebited ? 0 : amount);
+			/** AUD-457 persistence, skipped when the session total did not move. */
+			const persistSessionSpend = async (): Promise<void> => {
+				if (envelopeDebited) return;
+				await persistSpendLedger(vaultBase, budgetSpent);
+			};
+
 			const params = (args[0] ?? {}) as Record<string, unknown>;
 			const model = (params.model as string) ?? "unknown";
 			// P3-PROVIDER-BLINDSPOT: normalize the prompt-bearing payload across
@@ -904,7 +928,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (!holdActive) return;
 				holdActive = false;
 				const releaseLock = await budgetMutex.acquire();
-				inFlightHoldTotal -= estimatedCost;
+				// `sessionShare` on BOTH sides: an attributed hold that skipped the
+				// increment must skip the matching decrement, or `inFlightHoldTotal`
+				// drifts negative and hands the session more headroom than its budget.
+				inFlightHoldTotal -= sessionShare(estimatedCost);
 				releaseLock();
 			}
 
@@ -1057,10 +1084,14 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							holdErr instanceof Error ? holdErr.message : String(holdErr),
 						);
 					}
+					// The hold landed. Record WHICH wallet it debited — every session
+					// counter below is conditioned on this one answer.
+					envelopeDebited = envelope !== undefined;
 				}
 
-				// Track in-flight hold cost for accurate budget calculations
-				inFlightHoldTotal += estimatedCost;
+				// Track in-flight hold cost for accurate budget calculations — the
+				// SESSION wallet's share of it, which is nothing once the envelope paid.
+				inFlightHoldTotal += sessionShare(estimatedCost);
 				holdActive = true; // AUD-468: arm the guard
 			} finally {
 				// AUD-453: Release lock after budget check + hold are complete
@@ -1173,17 +1204,19 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (holdActive) {
 					holdActive = false;
 					const releaseLock = await budgetMutex.acquire();
-					inFlightHoldTotal -= estimatedCost;
-					budgetSpent += streamCost;
+					inFlightHoldTotal -= sessionShare(estimatedCost);
+					budgetSpent += sessionShare(streamCost);
 					releaseLock();
 				} else {
 					// Hold already released — still need to record the spend.
 					const releaseLock = await budgetMutex.acquire();
-					budgetSpent += streamCost;
+					budgetSpent += sessionShare(streamCost);
 					releaseLock();
 				}
-				// AUD-457: Persist cumulative spend to disk
-				await persistSpendLedger(vaultBase, budgetSpent);
+				// AUD-457: Persist cumulative spend to disk (session spend only — an
+				// envelope's burn is the ledger's to report, and writing it here would
+				// shrink the next run's holding-wallet seed by money it never paid).
+				await persistSessionSpend();
 				cb.recordSuccess();
 
 				if (proxyConn != null && !isDryRun) {
@@ -1816,12 +1849,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (holdActive) {
 					holdActive = false;
 					const releaseLock = await budgetMutex.acquire();
-					inFlightHoldTotal -= estimatedCost;
-					budgetSpent += actualCost;
+					inFlightHoldTotal -= sessionShare(estimatedCost);
+					budgetSpent += sessionShare(actualCost);
 					releaseLock();
 				}
-				// AUD-457: Persist cumulative spend to disk
-				await persistSpendLedger(vaultBase, budgetSpent);
+				// AUD-457: Persist cumulative spend to disk (session spend only).
+				await persistSessionSpend();
 
 				// g. Circuit breaker: record success
 				cb.recordSuccess();
@@ -2054,6 +2087,17 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			const costCenterAudit: { costCenter?: string } =
 				envelope === undefined ? {} : { costCenter: envelope.attribution.costCenter };
 
+			// Session accounting is SESSION-WALLET-only here for exactly the reasons the
+			// LLM path documents at length — an attributed action's hold debits the
+			// envelope, so charging the session for it over-denies later unattributed
+			// traffic and persists that shortfall across restarts.
+			let envelopeDebited = false;
+			const sessionShare = (amount: number): number => (envelopeDebited ? 0 : amount);
+			const persistSessionSpend = async (): Promise<void> => {
+				if (envelopeDebited) return;
+				await persistSpendLedger(vaultBase, budgetSpent);
+			};
+
 			const actor = action.actor ?? "local";
 			const transferId = trustId("tx");
 
@@ -2188,9 +2232,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							holdErr instanceof Error ? holdErr.message : String(holdErr),
 						);
 					}
+					// The hold landed — record which wallet it debited.
+					envelopeDebited = envelope !== undefined;
 				}
 
-				inFlightHoldTotal += action.cost;
+				inFlightHoldTotal += sessionShare(action.cost);
 			} finally {
 				releaseBudgetLock();
 			}
@@ -2202,9 +2248,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (!holdReleased) {
 					holdReleased = true;
 					const releaseLock = await budgetMutex.acquire();
-					inFlightHoldTotal -= action.cost;
+					// `sessionShare` on both sides: skipping the increment obliges us to
+					// skip the decrement, or the counter drifts negative.
+					inFlightHoldTotal -= sessionShare(action.cost);
 					if (cost !== undefined) {
-						budgetSpent += cost;
+						budgetSpent += sessionShare(cost);
 					}
 					releaseLock();
 				}
@@ -2266,7 +2314,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				// Release in-flight hold and commit budget under mutex — money moves only
 				// AFTER the action is audited.
 				await releaseHoldAndCommit(action.cost);
-				await persistSpendLedger(vaultBase, budgetSpent);
+				await persistSessionSpend();
 
 				// g. Circuit breaker: record success
 				cb.recordSuccess();

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -98,6 +98,16 @@ export interface TrustOpts {
 	/** Tier override. */
 	tier?: string;
 	/**
+	 * This governor's ledger identity — the parent half of the
+	 * `(parentUserId, costCenter)` tuple every cost-center envelope account is
+	 * derived from. Overrides `parentUserId` in the config file, and is validated
+	 * by the same rule at construction (see `TrustConfigSchema.parentUserId`).
+	 *
+	 * SECURITY: TRUSTED-OPERATOR input, same boundary as budget/customRates —
+	 * never derive it from end-user or request data.
+	 */
+	parentUserId?: string | undefined;
+	/**
 	 * Dry-run mode — skips TigerBeetle, audit-chain-only.
 	 * Also enabled by USERTRUST_DRY_RUN=true env var.
 	 */
@@ -126,7 +136,20 @@ export interface TrustOpts {
 
 /** Minimal engine interface for two-phase spend lifecycle. */
 export interface TrustEngine {
-	spendPending(params: { transferId: string; amount: number }): Promise<{ transferId: string }>;
+	/**
+	 * Reserve `amount` as a PENDING debit.
+	 *
+	 * `debitAccountId` is an ALREADY-DERIVED cost-center envelope account: the
+	 * derivation stays in the governor, beside the other authorize-time captures,
+	 * so `TrustTBClient.deriveCostCenterAccountId` keeps the small, audited
+	 * call-site count the "one static" invariant depends on. Omitted → the
+	 * session holding wallet, i.e. exactly the pre-envelope behaviour.
+	 */
+	spendPending(params: {
+		transferId: string;
+		amount: number;
+		debitAccountId?: bigint | undefined;
+	}): Promise<{ transferId: string }>;
 	/**
 	 * Settle a PENDING hold. `actualAmount` posts the true consumed cost (which may
 	 * be less than the reserved estimate); omitting it posts the full pending amount.
@@ -371,10 +394,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		config = TrustConfigSchema.parse({
 			...(raw as Record<string, unknown>),
 			...(opts?.budget !== undefined ? { budget: opts.budget } : {}),
+			...(opts?.parentUserId !== undefined ? { parentUserId: opts.parentUserId } : {}),
 		});
 	} else {
 		config = TrustConfigSchema.parse({
 			budget: opts?.budget ?? DEFAULT_BUDGET,
+			...(opts?.parentUserId !== undefined ? { parentUserId: opts.parentUserId } : {}),
 		});
 	}
 
@@ -2177,6 +2202,12 @@ function isTBInsufficientBalance(err: unknown): boolean {
 	);
 }
 
+/** TigerBeetle's answer when the account being debited does not exist at all. */
+function isTBDebitAccountNotFound(err: unknown): boolean {
+	if (!(err instanceof TBTransferError)) return false;
+	return err.code === CreateTransferStatus.debit_account_not_found;
+}
+
 /**
  * Create a balance-enforcing TrustEngine backed by a real TigerBeetle client.
  *
@@ -2194,6 +2225,17 @@ function isTBInsufficientBalance(err: unknown): boolean {
  * GOVERN-local factory implements the same funded-enforcing contract using the
  * existing `TrustTBClient` primitives. When LEDGER ships `createLedgerEngine`,
  * this factory is a drop-in replacement (identical `TrustEngine` shape).
+ *
+ * LOCKSTEP: `headless.ts` carries a duplicate of this factory and every change
+ * here belongs there verbatim (AGENTS.md, Known drift). `tests/harden/
+ * engine-factory-parity.test.ts` compares the two as source text and fails on a
+ * one-sided edit.
+ *
+ * @internal Exported (below, on its own line) for that seam's tests only —
+ * `index.ts` does not re-export it, so it is not part of the published API. The
+ * headless copy is deliberately NOT exported: `usertrust/headless` IS a package
+ * entry point, and a test-only export there would ship an engine factory to
+ * consumers.
  */
 async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<TrustEngine> {
 	const tbAddresses = config.tigerbeetle.addresses;
@@ -2221,10 +2263,15 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 		async spendPending(params: {
 			transferId: string;
 			amount: number;
+			debitAccountId?: bigint | undefined;
 		}): Promise<{ transferId: string }> {
+			// An ATTRIBUTED hold names its own debit account — the cost-center
+			// envelope the governor derived at authorize. Unattributed holds keep
+			// debiting the session holding wallet, unchanged.
+			const debitAccountId = params.debitAccountId ?? holdingId;
 			try {
 				const tbTransferId = await tbClient.createPendingTransfer({
-					debitAccountId: holdingId,
+					debitAccountId,
 					creditAccountId: treasury,
 					amount: params.amount,
 					code: XFER_SPEND,
@@ -2235,7 +2282,51 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 				// Over-budget reservation → TB rejects the pending debit. Surface as a
 				// budget error so the governor reports a hard DENY, not an outage.
 				if (isTBInsufficientBalance(err)) {
+					// An ATTRIBUTED hold is rejected by the ENVELOPE's own
+					// `debits_must_not_exceed_credits`, so the envelope is the account that
+					// has to be named. Reporting `trust:hold` and the session seed names an
+					// account the hold never touched and prints an `available` that is
+					// routinely GREATER than `required` — a 999-usertoken estimate against a
+					// 10-usertoken envelope under a governor seeded at 100000 reads as an SDK
+					// bug rather than an exhausted cost center, and names no envelope for the
+					// operator to top up.
+					// The balance is re-read AFTER the rejection, so it REPORTS rather than
+					// decides: TigerBeetle's atomic rejection remains the whole enforcement
+					// and no check-then-act enters the money path (budget/allocation.ts does
+					// exactly this on its own rejection path). A failed read reports 0 rather
+					// than fabricating headroom, and never changes the classification.
+					if (params.debitAccountId !== undefined) {
+						let available = 0;
+						try {
+							available = (await tbClient.lookupBalance(params.debitAccountId)).available;
+						} catch {
+							// Reporting only — a failed read must not mask the budget DENY.
+						}
+						throw new InsufficientBalanceError(
+							`envelope:${params.debitAccountId}`,
+							params.amount,
+							available,
+						);
+					}
+					// UNATTRIBUTED holds keep today's answer exactly, down to adding no
+					// ledger round trip: the seed is a number this factory already holds.
 					throw new InsufficientBalanceError("trust:hold", params.amount, seedBudget);
+				}
+				// A never-allocated envelope has no account at all, and TB answers
+				// `debit_account_not_found`. For an ENVELOPE that is a budget answer,
+				// not an outage: no account and a zero balance are the same state
+				// (budget/allocation.ts reads a missing cost-center account as zero,
+				// because never-allocated and fully-reclaimed are indistinguishable).
+				// Classifying it as a ledger outage would tell the caller the ledger
+				// is down when the truth is "this envelope has no funds" — and would
+				// let a retry loop hammer a spend that can never succeed.
+				// The envelope is named by its derived account id: the label
+				// `parent::costCenter` lives in the governor, never here.
+				// UNATTRIBUTED holds keep today's classification exactly. The session
+				// wallet is one THIS factory created moments ago, so its absence
+				// really is an outage.
+				if (params.debitAccountId !== undefined && isTBDebitAccountNotFound(err)) {
+					throw new InsufficientBalanceError(`envelope:${params.debitAccountId}`, params.amount, 0);
 				}
 				throw err;
 			}
@@ -2280,6 +2371,11 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 		},
 	};
 }
+
+// The export sits on its own line on purpose: `export async function …` runs the
+// declaration to 101 columns, Biome wraps it, and the wrapped signature no longer
+// matches headless.ts's copy — which the parity suite compares as source text.
+export { createTBEngine };
 
 // ── Proxy builders ──
 // Each builder intercepts only the `create` / `generateContent` call and

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -35,6 +35,9 @@ import { join } from "node:path";
 import { CreateTransferStatus } from "tigerbeetle-node";
 import { type AuditWriter, createAuditWriter } from "./audit/chain.js";
 import { writeReceipt } from "./audit/rotation.js";
+import { costCenterUserId } from "./budget/allocation.js";
+import { type CostCenterAttribution, getCurrentCostCenter } from "./budget/attribution.js";
+import { computeRunway, runwayHours } from "./budget/runway.js";
 import { classifyEndpoint, detectClientKind } from "./detect.js";
 import { TBTransferError, TrustTBClient, XFER_SPEND } from "./ledger/client.js";
 import {
@@ -158,6 +161,29 @@ export interface TrustEngine {
 	voidPendingSpend(transferId: string): Promise<void>;
 	/** AUD-461: Void all remaining pending transfers on destroy. */
 	voidAllPending?(): Promise<void>;
+	/**
+	 * Read `available` for each account, missing accounts ABSENT from the map — the
+	 * batch semantics of `TrustTBClient.lookupBalances`, which this delegates to
+	 * verbatim in both factories. It is the governor's ONLY window onto a
+	 * cost-center envelope's balance: the TigerBeetle client lives inside the engine
+	 * closure, so without this seam the policy gate could not see the envelope it is
+	 * about to authorize a spend from, and a settled receipt could not report it.
+	 *
+	 * REPORTING ONLY — never enforcement. Nothing decides whether money may move
+	 * from what this returns; TigerBeetle's atomic rejection of the hold is the
+	 * whole enforcement, so a stale read can only under-deny and no check-then-act
+	 * enters the money path.
+	 *
+	 * OPTIONAL only because the interface predates it and an injected test engine
+	 * may omit it. BOTH `createTBEngine` factories implement it — an engine that
+	 * places an attributed hold and cannot report the envelope it debited is
+	 * refused at authorize with `LedgerUnavailableError`, exactly like a read that
+	 * threw (A2). Falling back to session-scoped numbers is NOT an option: the
+	 * overshoot rule would then clear the call against the holding wallet while the
+	 * hold debits the envelope, and the policy record would name a wallet the money
+	 * never came from.
+	 */
+	lookupBalances?(accountIds: bigint[]): Promise<Map<bigint, number>>;
 	destroy?(): void;
 }
 
@@ -381,6 +407,253 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 	}
 }
 
+// ── Cost-center envelope plumbing ─────────────────────────────────────────────
+
+/**
+ * What an active `withCostCenter` scope resolves to for THIS governor: the
+ * envelope account money moves from, and the label everything human-readable
+ * quotes. Derived once per call, at the governor's entry point, and then carried
+ * by closure — see {@link resolveEnvelope}.
+ */
+interface ResolvedEnvelope {
+	attribution: CostCenterAttribution;
+	/** The (parent, costCenter) tuple hash. The only thing money is keyed on. */
+	accountId: bigint;
+	/** `parent::costCenter` — display and audit only, never an account id. */
+	label: string;
+}
+
+/**
+ * The remedy an exhausted ENVELOPE actually needs.
+ *
+ * `InsufficientBalanceError`'s default hint ("Increase the budget in trust()
+ * options…") is not merely unhelpful here, it is wrong: `trust({ budget })` funds
+ * the per-session holding wallet, and an attributed call never debits that wallet.
+ * An operator who follows the default advice raises a number that cannot affect the
+ * rejection and watches the identical call fail again.
+ */
+const ENVELOPE_FUNDING_HINT =
+	"Fund this cost center with allocateBudget(parent, costCenter, amount) — or reclaim from " +
+	"another envelope. Raising the trust()/createGovernor() budget funds the session wallet, " +
+	"which an attributed call never debits.";
+
+/**
+ * Resolve the active scope into the envelope this call will debit, or `undefined`
+ * when no scope is active.
+ *
+ * D1 — an active scope with no governor identity THROWS, at the top of the
+ * governor's entry point, before any I/O: no hold, no audit record, no provider
+ * call. The alternative — quietly falling back to the session holding wallet — is
+ * the failure this whole feature exists to prevent: the caller asked for the spend
+ * to come out of a specific envelope, the envelope is never touched, its
+ * `getBudgetStatus` keeps reporting a full balance, and every tier keyed on it
+ * fails open. Nothing in the system would report that; only the loud throw does.
+ */
+function resolveEnvelope(
+	attribution: CostCenterAttribution | undefined,
+	parentUserId: string | undefined,
+): ResolvedEnvelope | undefined {
+	if (attribution === undefined) return undefined;
+	if (parentUserId === undefined) {
+		throw new Error(
+			`usertrust: withCostCenter("${attribution.costCenter}") is active but this governor has ` +
+				"no parentUserId. A cost-center envelope account is derived from the " +
+				"(parentUserId, costCenter) tuple, so an attributed call cannot be routed without " +
+				"it — and spending it from the session wallet instead would silently un-enforce the " +
+				"envelope. Pass parentUserId to trust()/createGovernor(), or set it in " +
+				"usertrust.config.json.",
+		);
+	}
+	return {
+		attribution,
+		// DERIVE, NEVER LOOK UP (AGENTS.md, Money): the one static, the same one
+		// allocation, reclaim, status and budgetContext go through. Never
+		// `getAccountId`, never a cache, never a hand-rolled join.
+		accountId: TrustTBClient.deriveCostCenterAccountId(parentUserId, attribution.costCenter),
+		// Built by the one builder, which also re-validates both halves — cheap,
+		// pure, and it keeps the label's injectivity argument in a single place.
+		label: costCenterUserId(parentUserId, attribution.costCenter),
+	};
+}
+
+/**
+ * Re-present a ledger rejection of an ATTRIBUTED hold in the caller's own terms.
+ *
+ * The engine names the envelope by its derived account id, because the
+ * `parent::costCenter` label is the governor's and the engine has no parent. An
+ * operator reading a 39-digit account id learns nothing actionable, so the governor
+ * — which does hold both halves — swaps in the label and the envelope remedy on the
+ * way out. The ledger's own `required`/`available` numbers are carried through
+ * unchanged: they are the only figures TigerBeetle actually decided on.
+ */
+function asEnvelopeBalanceError(
+	err: InsufficientBalanceError,
+	label: string,
+): InsufficientBalanceError {
+	return new InsufficientBalanceError(label, err.required, err.available, ENVELOPE_FUNDING_HINT);
+}
+
+/**
+ * 0..1 share of an envelope still available. Mirrors `budget/context.ts`'s clamp
+ * semantics (A5) exactly — `allocated <= 0` is "no headroom" (`0`), never a
+ * division by zero, and an over-funded envelope clamps at 1 rather than reporting
+ * more than a full budget.
+ */
+function envelopeFraction(remaining: number, allocated: number): number {
+	if (!(allocated > 0)) return 0;
+	return Math.min(1, Math.max(0, remaining / allocated));
+}
+
+/**
+ * The two envelope-scoped POLICY tier fields, from the scope's D4 allocation
+ * metadata plus the live balance. Both are explicitly `undefined` when the scope
+ * carried no metadata: there is no cost-center registry, so the governor genuinely
+ * does not know the envelope's size, and a fabricated number is worse than an
+ * absent one (a hard tier then fails closed and fires; a soft tier stays lenient —
+ * the documented indeterminate split, unchanged).
+ *
+ * `spent` is derived from the LIVE balance rather than tracked in process, because
+ * the envelope is shared across processes: `allocated − remaining` is what the
+ * envelope has actually paid out, the same clamp `getBudgetStatus` and
+ * `budgetContext` apply.
+ */
+function envelopeTierFields(
+	attribution: CostCenterAttribution,
+	remaining: number,
+	nowMs: number,
+): { budgetFractionRemaining: number | undefined; budgetRunwayHours: number | undefined } {
+	const { allocated, periodStartMs } = attribution;
+	if (allocated === undefined || periodStartMs === undefined) {
+		return { budgetFractionRemaining: undefined, budgetRunwayHours: undefined };
+	}
+	const runway = computeRunway({
+		allocated,
+		spent: Math.max(0, allocated - remaining),
+		periodStartMs,
+		periodEndMs: attribution.periodEndMs,
+		nowMs,
+	});
+	const hours = runwayHours(runway, nowMs);
+	return {
+		budgetFractionRemaining: envelopeFraction(remaining, allocated),
+		// `runwayHours` answers `null` for "not projectable"; the POLICY convention
+		// for unknown is explicit `undefined` (A6). Two surfaces, two pre-existing
+		// conventions — `budget/context.ts` keeps the `null` one. Do not unify them.
+		budgetRunwayHours: hours ?? undefined,
+	};
+}
+
+/**
+ * The envelope's live `available` — one batched read, missing account read as `0`
+ * (never-allocated and fully-reclaimed are the same observable state, the
+ * implicit-zero equivalence `budget/allocation.ts` documents).
+ *
+ * REPORTS, never decides: TigerBeetle's atomic rejection of the hold is the whole
+ * enforcement, so a stale answer can only under-deny and no check-then-act enters
+ * the money path. Rejects when the engine cannot answer — the two callers below
+ * differ precisely in what they do with that rejection.
+ */
+async function readEnvelopeBalance(
+	engine: TrustEngine,
+	envelope: ResolvedEnvelope,
+): Promise<number> {
+	const read = engine.lookupBalances;
+	if (read == null) {
+		throw new Error(
+			"this TrustEngine cannot read balances (no lookupBalances) — an attributed hold " +
+				"would debit an envelope nothing can report on",
+		);
+	}
+	const balances = await read.call(engine, [envelope.accountId]);
+	return balances.get(envelope.accountId) ?? 0;
+}
+
+/**
+ * The authorize-time preflight: the envelope number the policy gate is about to
+ * be gated on, or `undefined` when this call places no envelope hold at all —
+ * unattributed, dry-run, or a governor with no engine. Those three place no hold
+ * anywhere, so there is no envelope truth to be had and nothing for the session
+ * numbers to contradict; the gate keeps describing exactly what it did before
+ * envelopes existed.
+ *
+ * A2 (corrected) — an ATTRIBUTED call whose envelope cannot be read is REFUSED
+ * here, before the policy gate, with the existing ledger-unavailable
+ * classification. It is the one place in this file where a failed *report* stops a
+ * call, and the reasoning is specific:
+ *
+ *  - Falling back to the SESSION numbers is what the first draft did, and it is
+ *    unsound: `block-budget-overshoot` would then evaluate the holding wallet
+ *    while the hold debits the envelope, and the policy record would say a call
+ *    was cleared against a wallet it never touched. Mixed semantics in the one
+ *    record an auditor reads.
+ *  - Continuing with the fields ABSENT is not "continuing" at all — the hard
+ *    `block-budget-overshoot` rule treats an indeterminate `budget_remaining_after`
+ *    as fail-closed and denies, so the caller gets a policy denial that names the
+ *    wrong cause.
+ *  - Refusing costs almost no availability: the preflight and the hold share one
+ *    TigerBeetle transport (and the client's own reconnect machinery has already
+ *    run underneath), so a read that genuinely failed means the hold was doomed
+ *    anyway. What it buys is an honest classification — the ledger is unreachable,
+ *    and that is what the caller is told.
+ *
+ * @throws LedgerUnavailableError when an attributed call's envelope balance cannot
+ * be read. No hold is placed and the policy gate is never reached.
+ */
+async function preflightEnvelopeRemaining(
+	engine: TrustEngine | null,
+	isDryRun: boolean,
+	envelope: ResolvedEnvelope | undefined,
+): Promise<number | undefined> {
+	if (envelope === undefined || isDryRun || engine == null) return undefined;
+	try {
+		return await readEnvelopeBalance(engine, envelope);
+	} catch (err) {
+		throw new LedgerUnavailableError(
+			`cannot read cost-center envelope ${envelope.label} to authorize an attributed call: ` +
+				(err instanceof Error ? err.message : String(err)),
+		);
+	}
+}
+
+/**
+ * The post-settle snapshot read (D7). Same read, opposite failure policy: it NEVER
+ * throws, because it runs after the money committed and a receipt is a report —
+ * degrading a report must not unwind or re-decide a settlement. A failure omits
+ * the block.
+ */
+async function snapshotEnvelopeRemaining(
+	engine: TrustEngine | null,
+	isDryRun: boolean,
+	envelope: ResolvedEnvelope | undefined,
+): Promise<number | undefined> {
+	if (envelope === undefined || isDryRun || engine == null) return undefined;
+	try {
+		return await readEnvelopeBalance(engine, envelope);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * D7 — the post-settle envelope snapshot a settled receipt carries, or `undefined`
+ * when the call was unattributed or the read did not answer. Never throws: a
+ * receipt is a report, and degrading a report must not unwind money that already
+ * committed.
+ */
+function envelopeReceiptBudget(
+	envelope: ResolvedEnvelope | undefined,
+	remaining: number | undefined,
+): TrustReceipt["budget"] | undefined {
+	if (envelope === undefined || remaining === undefined) return undefined;
+	const { costCenter, allocated } = envelope.attribution;
+	return {
+		costCenter,
+		remaining,
+		// Omitted rather than guessed when the scope stated no allocation (D4).
+		...(allocated === undefined ? {} : { fraction: envelopeFraction(remaining, allocated) }),
+	};
+}
+
 // ── trust() ──
 
 export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClient<T>> {
@@ -527,6 +800,28 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		inFlightCount++;
 
 		try {
+			// ── The ONE AsyncLocalStorage read for this call (ALS discipline) ──
+			// Read HERE, at the top of the governor's synchronous entry point, while
+			// the CALLER's async context is still the current one, and carried by
+			// closure from here on. Every terminal below — the five MessageStream
+			// emitter listeners, createGovernedStream's onComplete/onError, the
+			// non-stream settle, the outer-catch void — runs LATER, on the SDK's SSE
+			// pump tick or the consumer's `for await` tick, in a context this call
+			// never owned. `getCurrentCostCenter()` there would silently answer with a
+			// later call's scope, or with nothing, and would never fail loudly. Same
+			// propagation shape as `rateResolution` ("price once", A3), for the same
+			// reason. `budget/attribution.ts` documents the mechanics and its suite
+			// pins the emitter-tick hazard as a negative case.
+			const attribution = getCurrentCostCenter();
+			const envelope = resolveEnvelope(attribution, config.parentUserId);
+			// Spread into every audit record this call emits (A1: an attributed hold
+			// must leave an attributed forensic trail on the settle AND the void
+			// terminals). Empty when unattributed, so those records stay byte-identical
+			// to what they were before envelopes — and one object decides for all of
+			// them rather than a dozen conditionals drifting apart.
+			const costCenterAudit: { costCenter?: string } =
+				envelope === undefined ? {} : { costCenter: envelope.attribution.costCenter };
+
 			const params = (args[0] ?? {}) as Record<string, unknown>;
 			const model = (params.model as string) ?? "unknown";
 			// P3-PROVIDER-BLINDSPOT: normalize the prompt-bearing payload across
@@ -570,6 +865,17 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				maxOutputTokens,
 			);
 
+			// Attributed calls only: ONE batched read of the envelope's live
+			// `available`, for the policy numbers below. Deliberately OUTSIDE the
+			// budget mutex — it is a report, not a decision, so serialising every
+			// governed call behind a ledger round trip would buy nothing. A read that
+			// goes stale between here and the hold can only under-deny, and the hold
+			// itself is rejected atomically by TigerBeetle either way.
+			// A2: it is also BEFORE the mutex and before the gate because a read that
+			// FAILED refuses the call outright — no lock taken, no policy evaluation
+			// recorded, no hold attempted.
+			const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
+
 			// AUD-453: Acquire mutex to serialise budget-check + PENDING hold.
 			// This prevents concurrent calls from both passing the budget check
 			// and overshooting the budget.
@@ -598,21 +904,48 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				// P1-BUDGET-PREFLIGHT: budget_remaining_after is the derived field the
 				// single-field gate compares against zero to deny a single overshooting
 				// call (the `block-budget-overshoot` default rule).
+				//
+				// ENVELOPE SCOPING: an ATTRIBUTED call is gated on THE ENVELOPE ITS HOLD
+				// WILL DEBIT — `budget_remaining` is that envelope's live ledger
+				// `available`, so `block-budget-exhausted` and `block-budget-overshoot`
+				// become pre-spend guards on the cost center, ahead of the ledger's own
+				// atomic rejection. The gate and the hold therefore always describe the
+				// SAME wallet; the case where they could disagree (an unreadable
+				// envelope) refused the call above rather than reaching here (A2).
+				// `budget_remaining_after` is deliberately UNFLOORED on both paths: it
+				// must be allowed to go NEGATIVE, because `block-budget-overshoot` is a
+				// non-disableable hard `lt 0` deny and flooring it at zero would
+				// structurally disarm that rule on every attributed call.
+				// The session numbers still stand for a call that places no hold at all
+				// (unattributed, dry-run, no engine) — unchanged, and honest, because
+				// nothing debits an envelope on those paths either.
+				const sessionRemaining = config.budget - budgetSpent - inFlightHoldTotal;
+				const gateRemaining = envelopeRemaining ?? sessionRemaining;
+				// P1-BUDGET-TIER-SHADOW: the budget tier fields are trusted-host input,
+				// and asserting them here is what stops a request body from supplying its
+				// own `budgetFractionRemaining` and satisfying a tier that guards frontier
+				// spend. They are now REAL for an attributed call whose scope stated its
+				// allocation (D4) — the case this path could not describe before — and
+				// stay explicitly `undefined` for every other call, where the honest value
+				// is ABSENT: an `exists`-guarded rule then simply does not match, and a
+				// hard rule without that guard fires. Never an attacker's number.
+				const tierFields =
+					envelope !== undefined && envelopeRemaining !== undefined
+						? envelopeTierFields(envelope.attribution, envelopeRemaining, Date.now())
+						: { budgetFractionRemaining: undefined, budgetRunwayHours: undefined };
 				const policyResult = evaluatePolicy(policyRules, {
 					...params,
 					model,
 					tier: config.tier,
 					estimated_cost: estimatedCost,
-					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
-					budget_remaining_after: config.budget - budgetSpent - inFlightHoldTotal - estimatedCost,
-					// P1-BUDGET-TIER-SHADOW: the budget tier fields are trusted-host input.
-					// This path knows no cost-center allocation, so the honest value is
-					// ABSENT — and asserting it here is what stops a request body from
-					// supplying its own `budgetFractionRemaining` and satisfying a tier
-					// that guards frontier spend. An `exists`-guarded rule then simply
-					// does not match; it never matches an attacker's number.
-					budgetFractionRemaining: undefined,
-					budgetRunwayHours: undefined,
+					budget_remaining: gateRemaining,
+					budget_remaining_after: gateRemaining - estimatedCost,
+					budgetFractionRemaining: tierFields.budgetFractionRemaining,
+					budgetRunwayHours: tierFields.budgetRunwayHours,
+					// Structurally un-forgeable: this comes from the caller's own async
+					// execution context, which no request body can reach. Asserted after
+					// the spread like every other trusted field, `undefined` included.
+					cost_center: envelope?.attribution.costCenter,
 				});
 				if (policyResult.decision === "deny") {
 					const reason =
@@ -654,6 +987,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									patterns: injectionResult.patterns,
 									score: injectionResult.score,
 									model,
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {});
@@ -685,6 +1019,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						await engine.spendPending({
 							transferId,
 							amount: estimatedCost,
+							// Attributed → the envelope pays. Unattributed → the key is
+							// OMITTED, not passed as undefined, so the engine's default
+							// (the session holding wallet) is reached by exactly the path
+							// it was before envelopes existed.
+							...(envelope !== undefined ? { debitAccountId: envelope.accountId } : {}),
 						});
 					} catch (holdErr) {
 						// P1-LEDGER-ENFORCE: an over-budget reservation is rejected
@@ -694,7 +1033,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						// its finally (releases the budget lock), and propagates without
 						// a hold to void — exactly mirroring the policy-deny control flow.
 						if (holdErr instanceof InsufficientBalanceError) {
-							throw holdErr;
+							// An attributed rejection is re-presented in the caller's terms:
+							// the `parent::costCenter` label instead of a derived account id,
+							// and the remedy that actually funds an envelope.
+							throw envelope === undefined
+								? holdErr
+								: asEnvelopeBalanceError(holdErr, envelope.label);
 						}
 						// Genuine ledger outage — do NOT forward to provider.
 						throw new LedgerUnavailableError(
@@ -848,6 +1192,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 										postErr instanceof Error
 											? postErr.message.slice(0, 200)
 											: String(postErr).slice(0, 200),
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {
@@ -872,6 +1217,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 										postErr instanceof Error
 											? postErr.message.slice(0, 200)
 											: String(postErr).slice(0, 200),
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {
@@ -894,6 +1240,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						endpointClass: endpoint.class,
 						costBasis: rateResolution.costBasis,
 						rateSource: rateResolution.rateSource,
+						...costCenterAudit,
 					};
 					if (config.pii === "warn" || config.pii === "redact") {
 						const piiResult = redactPII(promptParts);
@@ -921,6 +1268,17 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					);
 				}
 
+				// D7: the envelope snapshot is read AFTER the POST, so it reports what
+				// the cost center actually holds now rather than in-memory arithmetic
+				// that drifts the moment another process spends from the same envelope.
+				// It observes; it never decides. A read that fails omits the block —
+				// this runs after the money committed, and a report must never unwind
+				// or re-decide a settlement.
+				const streamBudget = envelopeReceiptBudget(
+					envelope,
+					await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
+				);
+
 				const streamReceipt: TrustReceipt = {
 					transferId,
 					cost: streamCost,
@@ -940,6 +1298,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						costBasis: rateResolution.costBasis,
 						rateSource: rateResolution.rateSource,
 					},
+					...(streamBudget !== undefined ? { budget: streamBudget } : {}),
 					...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 					// AUD-456: Flag proxy stub receipts
 					...(proxyConn != null ? { proxyStub: true as const } : {}),
@@ -975,6 +1334,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							partialInputTokens: partial.usage.inputTokens,
 							partialOutputTokens: partial.usage.outputTokens,
 							usageReported: partial.usageReported,
+							...costCenterAudit,
 							error: (() => {
 								const raw = error instanceof Error ? error.message : String(error);
 								return config.pii === "warn" || config.pii === "redact"
@@ -1130,6 +1490,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									model,
 									transferId,
 									provider: kind,
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {});
@@ -1331,6 +1692,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 											model,
 											transferId,
 											provider: kind,
+											...costCenterAudit,
 										},
 									})
 									.catch(() => {});
@@ -1396,6 +1758,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						endpointClass: endpoint.class,
 						costBasis: rateResolution.costBasis,
 						rateSource: rateResolution.rateSource,
+						...costCenterAudit,
 					};
 					if (config.pii === "warn" || config.pii === "redact") {
 						const piiResult = redactPII(promptParts);
@@ -1468,6 +1831,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									cost: actualCost,
 									transferId,
 									error: postErr instanceof Error ? postErr.message : String(postErr),
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {
@@ -1496,6 +1860,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 										postErr instanceof Error
 											? postErr.message.slice(0, 200)
 											: String(postErr).slice(0, 200),
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {
@@ -1521,7 +1886,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							kind: "llm_call",
 							subsystem: "trust",
 							actor: "local",
-							data: { model, cost: actualCost, settled, transferId },
+							data: { model, cost: actualCost, settled, transferId, ...costCenterAudit },
 						},
 						config.audit.indexLimit,
 					);
@@ -1539,6 +1904,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				}
 
 				const budgetRemaining = config.budget - budgetSpent - inFlightHoldTotal;
+				// D7 (see the streaming settle above for the full rationale): a
+				// post-settle observation of the envelope, omitted when it cannot be read.
+				const settledBudget = envelopeReceiptBudget(
+					envelope,
+					await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
+				);
 
 				const receipt: TrustReceipt = {
 					transferId,
@@ -1558,6 +1929,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						costBasis: rateResolution.costBasis,
 						rateSource: rateResolution.rateSource,
 					},
+					...(settledBudget !== undefined ? { budget: settledBudget } : {}),
 					...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 					// AUD-456: Flag proxy stub receipts
 					...(proxyConn != null ? { proxyStub: true as const } : {}),
@@ -1614,6 +1986,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									? (redactPII(String(err)).data as string).slice(0, 200)
 									: String(err),
 							transferId,
+							...costCenterAudit,
 						},
 					})
 					.catch(() => {
@@ -1659,12 +2032,28 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 		let callAuditDegraded = false;
 
 		try {
+			// governAction is its OWN governor entry point — a caller invokes it
+			// directly, synchronously, from inside its own `withCostCenter` scope — so
+			// it takes its own single ALS read here and carries the capture through
+			// its terminals, exactly as `interceptCall` does. See the ALS-discipline
+			// note there for why a later read would be wrong.
+			const attribution = getCurrentCostCenter();
+			const envelope = resolveEnvelope(attribution, config.parentUserId);
+			const costCenterAudit: { costCenter?: string } =
+				envelope === undefined ? {} : { costCenter: envelope.attribution.costCenter };
+
 			const actor = action.actor ?? "local";
 			const transferId = trustId("tx");
 
 			// a. Circuit breaker check (keyed by action kind)
 			const cb = breaker.get(action.kind as unknown as LLMClientKind);
 			cb.allowRequest();
+
+			// Attributed only, and outside the mutex for the same reason as the LLM
+			// path: a report, never a decision — and, per A2, a report whose FAILURE
+			// refuses the action before the gate rather than gating it on the session
+			// wallet its hold would not have touched.
+			const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
 
 			// b. Acquire mutex for budget atomicity
 			const releaseBudgetLock = await budgetMutex.acquire();
@@ -1675,20 +2064,35 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				// AUD-467: Caller params spread FIRST so governance fields cannot be shadowed.
 				// P1-BUDGET-PREFLIGHT: budget_remaining_after is the derived field the
 				// block-budget-overshoot default rule compares against zero (a HARD rule
-				// that fails CLOSED if the governor omits it — so it MUST be supplied).
+				// that fails CLOSED if the governor omits it — so it MUST be supplied),
+				// and it is UNFLOORED here for the same reason as on the LLM path: it has
+				// to be able to go negative or that rule can never fire.
+				// ENVELOPE SCOPING: identical to the LLM path — an attributed action is
+				// gated on the envelope its hold will debit, never on the session wallet.
+				const sessionRemaining = config.budget - budgetSpent - inFlightHoldTotal;
+				const gateRemaining = envelopeRemaining ?? sessionRemaining;
+				const tierFields =
+					envelope !== undefined && envelopeRemaining !== undefined
+						? envelopeTierFields(envelope.attribution, envelopeRemaining, Date.now())
+						: { budgetFractionRemaining: undefined, budgetRunwayHours: undefined };
 				const policyResult = evaluatePolicy(policyRules, {
 					...(action.params ?? {}),
 					action_kind: action.kind,
 					action_name: action.name,
 					estimated_cost: action.cost,
-					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
-					budget_remaining_after: config.budget - budgetSpent - inFlightHoldTotal - action.cost,
+					budget_remaining: gateRemaining,
+					budget_remaining_after: gateRemaining - action.cost,
 					tier: config.tier,
-					// P1-BUDGET-TIER-SHADOW: trusted-host input, asserted ABSENT here so
-					// `action.params` cannot inject a budget tier's own inputs. See the
+					// P1-BUDGET-TIER-SHADOW: trusted-host input, asserted after the spread
+					// so `action.params` cannot inject a budget tier's own inputs. REAL for
+					// an attributed action whose scope stated its allocation (D4), and
+					// explicitly `undefined` otherwise — never a caller's number. See the
 					// same assertion on the LLM path above.
-					budgetFractionRemaining: undefined,
-					budgetRunwayHours: undefined,
+					budgetFractionRemaining: tierFields.budgetFractionRemaining,
+					budgetRunwayHours: tierFields.budgetRunwayHours,
+					// Structurally un-forgeable: it comes from this call's own async
+					// execution context, which `action.params` cannot reach.
+					cost_center: envelope?.attribution.costCenter,
 				});
 				if (policyResult.decision === "deny") {
 					const reason =
@@ -1725,6 +2129,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									score: injectionResult.score,
 									actionName: action.name,
 									actionKind: action.kind,
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {});
@@ -1750,12 +2155,22 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						await engine.spendPending({
 							transferId,
 							amount: action.cost,
+							// Attributed → the envelope pays. Unattributed → the key is
+							// OMITTED, not passed as undefined, so the engine's default (the
+							// session holding wallet) is reached by exactly the path it was
+							// before envelopes existed.
+							...(envelope !== undefined ? { debitAccountId: envelope.accountId } : {}),
 						});
 					} catch (holdErr) {
 						// P1-LEDGER-ENFORCE: over-budget reservation → hard budget DENY,
 						// not a ledger-outage misreport.
 						if (holdErr instanceof InsufficientBalanceError) {
-							throw holdErr;
+							// An attributed rejection is re-presented in the caller's terms:
+							// the `parent::costCenter` label instead of a derived account id,
+							// and the remedy that actually funds an envelope.
+							throw envelope === undefined
+								? holdErr
+								: asEnvelopeBalanceError(holdErr, envelope.label);
 						}
 						throw new LedgerUnavailableError(
 							holdErr instanceof Error ? holdErr.message : String(holdErr),
@@ -1813,6 +2228,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							cost: action.cost,
 							settled: true,
 							transferId,
+							...costCenterAudit,
 							...(auditParams != null ? { params: auditParams } : {}),
 						},
 					});
@@ -1864,6 +2280,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 										postErr instanceof Error
 											? postErr.message.slice(0, 200)
 											: String(postErr).slice(0, 200),
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {
@@ -1890,6 +2307,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 										postErr instanceof Error
 											? postErr.message.slice(0, 200)
 											: String(postErr).slice(0, 200),
+									...costCenterAudit,
 								},
 							})
 							.catch(() => {
@@ -1919,6 +2337,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 								cost: action.cost,
 								settled,
 								transferId,
+								...costCenterAudit,
 								...(auditParams != null ? { params: auditParams } : {}),
 							},
 						},
@@ -1927,6 +2346,13 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				}
 
 				const budgetRemaining = config.budget - budgetSpent - inFlightHoldTotal;
+				// D7 (see the LLM path for the full rationale): a post-settle observation
+				// of the envelope, omitted when it cannot be read. It reports; it never
+				// re-decides a settlement that already committed.
+				const actionBudget = envelopeReceiptBudget(
+					envelope,
+					await snapshotEnvelopeRemaining(engine, isDryRun, envelope),
+				);
 
 				const receipt: TrustReceipt = {
 					transferId,
@@ -1940,6 +2366,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					provider: action.kind,
 					timestamp: new Date().toISOString(),
 					actionKind: action.kind,
+					...(actionBudget !== undefined ? { budget: actionBudget } : {}),
 					...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 					...(proxyConn != null ? { proxyStub: true as const } : {}),
 				};
@@ -1983,6 +2410,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 									: raw.slice(0, 200);
 							})(),
 							transferId,
+							...costCenterAudit,
 						},
 					})
 					.catch(() => {
@@ -2330,6 +2758,19 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 				}
 				throw err;
 			}
+		},
+
+		/**
+		 * Delegate verbatim to the client's batch read. MF1: this four-line
+		 * delegation is the whole reason the governor can see an envelope at all.
+		 * Implementing it only on mocks — which the first cut of the threading did —
+		 * leaves every unit test green while PRODUCTION ships attributed calls with
+		 * no envelope-scoped policy numbers and no receipt snapshot: the same
+		 * mock-shadows-production shape AGENTS.md records for the dead budget API.
+		 * A test drives the preflight through THIS factory for that reason.
+		 */
+		async lookupBalances(accountIds: bigint[]): Promise<Map<bigint, number>> {
+			return await tbClient.lookupBalances(accountIds);
 		},
 
 		async postPendingSpend(transferId: string, actualAmount?: number): Promise<void> {

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -74,6 +74,10 @@ import { TrustConfigSchema } from "./shared/types.js";
 /**
  * Options for createGovernor(): TrustOpts plus a governor-wide default
  * endpoint scope (M2 local-model governance).
+ *
+ * The envelope identity `parentUserId` is INHERITED from TrustOpts — one field
+ * and one validation rule across both governors, so a cost center derives the
+ * same account whichever one holds the client.
  */
 export interface GovernorOpts extends TrustOpts {
 	/**
@@ -300,6 +304,12 @@ function isTBInsufficientBalance(err: unknown): boolean {
 	);
 }
 
+/** TigerBeetle's answer when the account being debited does not exist at all. */
+function isTBDebitAccountNotFound(err: unknown): boolean {
+	if (!(err instanceof TBTransferError)) return false;
+	return err.code === CreateTransferStatus.debit_account_not_found;
+}
+
 /**
  * Create a balance-enforcing TrustEngine backed by a real TigerBeetle client.
  *
@@ -317,6 +327,13 @@ function isTBInsufficientBalance(err: unknown): boolean {
  * existing `TrustTBClient` primitives — identical to the GOVERN-local factory in
  * `govern.ts`. When LEDGER ships `createLedgerEngine`, BOTH `trust()` and
  * `createGovernor()` should switch to it in lockstep.
+ *
+ * LOCKSTEP: this is a duplicate of `govern.ts`'s factory and every change there
+ * belongs here verbatim (AGENTS.md, Known drift). `tests/harden/
+ * engine-factory-parity.test.ts` compares the two as source text and fails on a
+ * one-sided edit. It stays UNEXPORTED — `usertrust/headless` is a package entry
+ * point, so exporting it would ship an engine factory to consumers; the seam
+ * tests drive `govern.ts`'s copy by name and this one through `createGovernor()`.
  */
 async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<TrustEngine> {
 	const tbAddresses = config.tigerbeetle.addresses;
@@ -343,10 +360,15 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 		async spendPending(params: {
 			transferId: string;
 			amount: number;
+			debitAccountId?: bigint | undefined;
 		}): Promise<{ transferId: string }> {
+			// An ATTRIBUTED hold names its own debit account — the cost-center
+			// envelope the governor derived at authorize. Unattributed holds keep
+			// debiting the session holding wallet, unchanged.
+			const debitAccountId = params.debitAccountId ?? holdingId;
 			try {
 				const tbTransferId = await tbClient.createPendingTransfer({
-					debitAccountId: holdingId,
+					debitAccountId,
 					creditAccountId: treasury,
 					amount: params.amount,
 					code: XFER_SPEND,
@@ -357,7 +379,51 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 				// Over-budget reservation → TB rejects the pending debit. Surface as a
 				// budget error so the governor reports a hard DENY, not an outage.
 				if (isTBInsufficientBalance(err)) {
+					// An ATTRIBUTED hold is rejected by the ENVELOPE's own
+					// `debits_must_not_exceed_credits`, so the envelope is the account that
+					// has to be named. Reporting `trust:hold` and the session seed names an
+					// account the hold never touched and prints an `available` that is
+					// routinely GREATER than `required` — a 999-usertoken estimate against a
+					// 10-usertoken envelope under a governor seeded at 100000 reads as an SDK
+					// bug rather than an exhausted cost center, and names no envelope for the
+					// operator to top up.
+					// The balance is re-read AFTER the rejection, so it REPORTS rather than
+					// decides: TigerBeetle's atomic rejection remains the whole enforcement
+					// and no check-then-act enters the money path (budget/allocation.ts does
+					// exactly this on its own rejection path). A failed read reports 0 rather
+					// than fabricating headroom, and never changes the classification.
+					if (params.debitAccountId !== undefined) {
+						let available = 0;
+						try {
+							available = (await tbClient.lookupBalance(params.debitAccountId)).available;
+						} catch {
+							// Reporting only — a failed read must not mask the budget DENY.
+						}
+						throw new InsufficientBalanceError(
+							`envelope:${params.debitAccountId}`,
+							params.amount,
+							available,
+						);
+					}
+					// UNATTRIBUTED holds keep today's answer exactly, down to adding no
+					// ledger round trip: the seed is a number this factory already holds.
 					throw new InsufficientBalanceError("trust:hold", params.amount, seedBudget);
+				}
+				// A never-allocated envelope has no account at all, and TB answers
+				// `debit_account_not_found`. For an ENVELOPE that is a budget answer,
+				// not an outage: no account and a zero balance are the same state
+				// (budget/allocation.ts reads a missing cost-center account as zero,
+				// because never-allocated and fully-reclaimed are indistinguishable).
+				// Classifying it as a ledger outage would tell the caller the ledger
+				// is down when the truth is "this envelope has no funds" — and would
+				// let a retry loop hammer a spend that can never succeed.
+				// The envelope is named by its derived account id: the label
+				// `parent::costCenter` lives in the governor, never here.
+				// UNATTRIBUTED holds keep today's classification exactly. The session
+				// wallet is one THIS factory created moments ago, so its absence
+				// really is an outage.
+				if (params.debitAccountId !== undefined && isTBDebitAccountNotFound(err)) {
+					throw new InsufficientBalanceError(`envelope:${params.debitAccountId}`, params.amount, 0);
 				}
 				throw err;
 			}
@@ -422,10 +488,12 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 		config = TrustConfigSchema.parse({
 			...(raw as Record<string, unknown>),
 			...(opts?.budget !== undefined ? { budget: opts.budget } : {}),
+			...(opts?.parentUserId !== undefined ? { parentUserId: opts.parentUserId } : {}),
 		});
 	} else {
 		config = TrustConfigSchema.parse({
 			budget: opts?.budget ?? DEFAULT_BUDGET,
+			...(opts?.parentUserId !== undefined ? { parentUserId: opts.parentUserId } : {}),
 		});
 	}
 

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -132,27 +132,65 @@ export interface Authorization {
 	 * for an unattributed call, which debits the session holding wallet exactly as
 	 * it did before envelopes existed.
 	 *
-	 * READ-ONLY REPORTING for the caller; for the governor it is the settle path's
-	 * ONLY source of truth about attribution. Writing to it does not re-route
-	 * anything — the hold is already placed by the time a caller sees this handle.
+	 * REPORTING ONLY, and the governor does not read it back. Writing to it
+	 * re-routes nothing and relabels nothing: the hold is already placed by the time
+	 * a caller sees this handle, and `settle()`/`abort()` take the attribution from
+	 * the governor's own internal capture keyed by `transferId` — see
+	 * {@link Authorization.envelope}.
 	 */
 	costCenter?: string | undefined;
 	/**
 	 * @internal The resolved envelope — derived account id, `parent::costCenter`
 	 * label, and the scope's D4 allocation metadata — captured ONCE at authorize.
+	 * FROZEN, and the same frozen object the governor keeps internally.
 	 *
-	 * WHY IT LIVES ON THE HANDLE. `trust()` carries attribution by closure because
-	 * its terminals are closures; `createGovernor()` has none — `settle()` and
-	 * `abort()` are separate calls that routinely run on a different task, after
-	 * the `withCostCenter` scope has exited, so there is NO AsyncLocalStorage
-	 * context to read at settle time and a `getCurrentCostCenter()` call there
-	 * would answer with a later, unrelated call's scope or with nothing at all,
-	 * silently. The handle IS this governor's per-call state, and settle/abort read
-	 * only `auth.*` for the same reason `endpoint` is captured here rather than
-	 * re-derived: capture beats re-resolution, and here re-resolution would also
-	 * mean a `resolveEnvelope` throw landing AFTER the money posted.
+	 * WHY THE GOVERNOR DOES NOT READ IT BACK. `trust()` carries attribution by
+	 * closure because its terminals are closures; `createGovernor()` has none —
+	 * `settle()` and `abort()` are separate calls that routinely run on a different
+	 * task, after the `withCostCenter` scope has exited, so there is NO
+	 * AsyncLocalStorage context to read at settle time and a
+	 * `getCurrentCostCenter()` call there would answer with a later, unrelated
+	 * call's scope or with nothing at all, silently. But the HANDLE is not the
+	 * answer either: it is the caller's own object, and `settle()` established only
+	 * that its `transferId` is live. Reading `auth.costCenter`/`auth.envelope` after
+	 * that let a caller relabel the settle/abort audit record and the receipt's
+	 * budget block between the two phases — and, because
+	 * `snapshotEnvelopeRemaining` reads whatever account the envelope names, put an
+	 * arbitrary account's balance on the receipt. So the governor keeps its own
+	 * immutable capture (`AuthorizationCapture` below) keyed by `transferId` and
+	 * reads attribution from THAT; this field exists so the caller can see what
+	 * their call was attributed to, and it is frozen so an in-place edit fails
+	 * loudly rather than looking like it worked.
 	 */
 	envelope?: ResolvedEnvelope | undefined;
+}
+
+/**
+ * @internal The governor's OWN per-call record, keyed by `transferId` in
+ * `activeAuths` — never the caller's `Authorization` object.
+ *
+ * Everything here is decided at authorize, inside the governor, and is
+ * unreachable from caller code afterwards. That is the whole point: an audit
+ * record must come from the authorize-time capture, never from caller input
+ * (AGENTS.md, Audit), and the caller holds a live reference to the handle for the
+ * entire authorize→settle window.
+ */
+interface AuthorizationCapture {
+	readonly proxyTransferId: string | undefined;
+	/** The scope's cost center, or `undefined` for an unattributed call. */
+	readonly costCenter: string | undefined;
+	/** The frozen envelope the hold debited, or `undefined` when unattributed. */
+	readonly envelope: ResolvedEnvelope | undefined;
+	/**
+	 * Whether this hold moved the SESSION wallet's accounting
+	 * (`inFlightHoldTotal`, and `budgetSpent` on settle). False exactly when the
+	 * hold debited a cost-center envelope instead. Recorded here rather than
+	 * re-derived at settle so the release can never be asymmetric with the
+	 * increment — a decrement without its matching increment drives
+	 * `inFlightHoldTotal` negative and hands the session more headroom than its
+	 * budget.
+	 */
+	readonly sessionAccounted: boolean;
 }
 
 /** Parameters for authorizing an LLM call. */
@@ -628,7 +666,8 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 	let destroyed = false;
 	const budgetMutex = new AsyncMutex();
 	let inFlightHoldTotal = 0;
-	const activeAuths = new Map<string, Authorization>();
+	// Keyed by transferId, holding the GOVERNOR's capture — not the caller's handle.
+	const activeAuths = new Map<string, AuthorizationCapture>();
 
 	// Finding-2 (RECON #4): serialized, monotonic spend-ledger persistence.
 	// budgetSpent only ever increases (settle adds actualCost >= 0; authorize and
@@ -734,6 +773,12 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			// Acquire mutex for budget atomicity (AUD-453)
 			const releaseBudgetLock = await budgetMutex.acquire();
 			let proxyTransferId: string | undefined;
+			// Set below, at the point the hold actually lands on the envelope wallet.
+			// Deliberately NOT `envelope !== undefined`: a dry-run or engine-less
+			// attributed call places no envelope hold at all, so the session numbers
+			// remain the only — and the honest — accounting for it, exactly as they are
+			// the only numbers its policy gate saw.
+			let envelopeDebited = false;
 
 			try {
 				// Policy gate — caller params spread FIRST so trusted governance
@@ -847,12 +892,39 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 							holdErr instanceof Error ? holdErr.message : String(holdErr),
 						);
 					}
+					// The hold landed. Record WHICH wallet it debited, for the session
+					// accounting below and for the release on settle/abort.
+					envelopeDebited = envelope !== undefined;
 				}
 
-				inFlightHoldTotal += estCost;
+				// SESSION accounting tracks SESSION-WALLET money only. An attributed hold
+				// debits the `(parentUserId, costCenter)` envelope, so counting it here
+				// would reserve session headroom against money the session wallet never
+				// pays — every later unattributed call gated on a smaller number than the
+				// wallet actually holds, and (via `budgetSpent` on settle) that shortfall
+				// persisted into the next run's holding-wallet seed. The envelope's own
+				// `debits_must_not_exceed_credits` is what bounds an attributed call, and
+				// the policy gate above is already scoped to it.
+				if (!envelopeDebited) {
+					inFlightHoldTotal += estCost;
+				}
 			} finally {
 				releaseBudgetLock();
 			}
+
+			// ONE capture, frozen, shared by the handle and the governor's own record.
+			// Frozen so an in-place edit of the object the caller can see fails loudly
+			// instead of looking like it worked; `attribution` is rebuilt frozen rather
+			// than trusted to have arrived that way, so the guarantee is local to this
+			// file.
+			const captured: ResolvedEnvelope | undefined =
+				envelope === undefined
+					? undefined
+					: Object.freeze({
+							attribution: Object.freeze({ ...envelope.attribution }),
+							accountId: envelope.accountId,
+							label: envelope.label,
+						});
 
 			const auth: Authorization = {
 				transferId,
@@ -861,21 +933,37 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				proxyTransferId,
 				createdAt: Date.now(),
 				endpoint,
-				// The capture, spread-omitted so an unattributed handle keeps exactly the
-				// shape it had before envelopes (exactOptionalPropertyTypes: writing
+				// Spread-omitted so an unattributed handle keeps exactly the shape it had
+				// before envelopes (exactOptionalPropertyTypes: writing
 				// `costCenter: undefined` is a DIFFERENT type from omitting the key).
-				// From here on, `settle()` and `abort()` read only these two fields —
-				// never the store, which by then belongs to whoever is running.
-				...(envelope !== undefined
-					? { costCenter: envelope.attribution.costCenter, envelope }
+				// Reporting only — the governor reads the capture below, never this.
+				...(captured !== undefined
+					? { costCenter: captured.attribution.costCenter, envelope: captured }
 					: {}),
 			};
-			activeAuths.set(transferId, auth);
+			// The GOVERNOR's record. Keyed by transferId and unreachable from caller
+			// code, so `settle()`/`abort()` can never be handed a different cost center
+			// than the one the hold was placed against.
+			activeAuths.set(
+				transferId,
+				Object.freeze({
+					proxyTransferId,
+					costCenter: captured?.attribution.costCenter,
+					envelope: captured,
+					sessionAccounted: !envelopeDebited,
+				}),
+			);
 			return auth;
 		},
 
 		async settle(auth: Authorization, params?: SettleParams): Promise<TrustReceipt> {
-			if (!activeAuths.has(auth.transferId)) {
+			// One `get` where there used to be `has` + a read off the caller's object:
+			// the presence check and the attribution now come from the same internal
+			// record, so liveness and provenance cannot disagree. Semantics are
+			// unchanged — the first terminal claims the entry, every later one is
+			// refused.
+			const capture = activeAuths.get(auth.transferId);
+			if (capture === undefined) {
 				throw new Error(
 					`Authorization ${auth.transferId} is not active (already settled or aborted)`,
 				);
@@ -888,14 +976,14 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			// A1 — forensic continuity: an attributed hold leaves an attributed record
 			// on every terminal, so this spreads onto BOTH `settlement_ambiguous`
 			// records, the `llm_call` event and the rotated receipt below. It comes from
-			// the HANDLE — the authorize-time capture — never from a store read and
-			// never from `params`: by the time settle runs there is usually no
-			// `withCostCenter` scope at all, and `SettleParams` is caller input that must
-			// not be able to relabel a spend after the fact. Unattributed calls spread an
-			// empty object, so those payloads stay byte-identical to what they were
-			// before envelopes.
+			// the GOVERNOR'S CAPTURE — never from a store read, never from `params`, and
+			// never from the handle: by the time settle runs there is usually no
+			// `withCostCenter` scope at all, and everything the caller can reach
+			// (`auth`, `SettleParams`) is caller input that must not be able to relabel a
+			// spend after the fact. Unattributed calls spread an empty object, so those
+			// payloads stay byte-identical to what they were before envelopes.
 			const costCenterAudit: { costCenter?: string } =
-				auth.costCenter === undefined ? {} : { costCenter: auth.costCenter };
+				capture.costCenter === undefined ? {} : { costCenter: capture.costCenter };
 
 			// A3: settlement meters with the endpoint scope CAPTURED AT AUTHORIZE —
 			// SettleParams carries no endpoint field by design.
@@ -917,17 +1005,25 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				usageSource = "estimated";
 			}
 
-			// AUD-453: Acquire mutex for budget atomicity — prevents concurrent
-			// settle() calls from corrupting inFlightHoldTotal or budgetSpent.
-			const releaseLock = await budgetMutex.acquire();
-			try {
-				inFlightHoldTotal -= auth.estimatedCost;
-				budgetSpent += actualCost;
-			} finally {
-				releaseLock();
+			// SESSION accounting, skipped in full when the ENVELOPE paid: this hold was
+			// never counted into `inFlightHoldTotal`, so releasing it here would drive
+			// that counter negative, and `budgetSpent` must not absorb envelope money it
+			// would then persist into the next run's holding-wallet seed. The flag is the
+			// authorize-time record, so the release can never be asymmetric with the
+			// increment.
+			if (capture.sessionAccounted) {
+				// AUD-453: Acquire mutex for budget atomicity — prevents concurrent
+				// settle() calls from corrupting inFlightHoldTotal or budgetSpent.
+				const releaseLock = await budgetMutex.acquire();
+				try {
+					inFlightHoldTotal -= auth.estimatedCost;
+					budgetSpent += actualCost;
+				} finally {
+					releaseLock();
+				}
+				// Finding-2 (RECON #4): serialized monotonic persist — never regresses.
+				await persistSpend();
 			}
-			// Finding-2 (RECON #4): serialized monotonic persist — never regresses.
-			await persistSpend();
 
 			// Circuit breaker: success
 			const cb = breaker.get("headless" as never);
@@ -1046,12 +1142,13 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			// drifts the moment another process spends from the same envelope. It
 			// observes; it never decides. A read that fails OMITS the block — this runs
 			// after the money committed, and a report must never unwind or re-decide a
-			// settlement. Both arguments come from the handle (`auth.envelope`), which
-			// is why a settle running outside every `withCostCenter` scope — the normal
-			// case for this governor — still names the right envelope.
+			// settlement. Both arguments come from the governor's capture, which is why
+			// a settle running outside every `withCostCenter` scope — the normal case for
+			// this governor — still names the right envelope, and why a caller cannot
+			// point this read at an account their call never touched.
 			const settledBudget = envelopeReceiptBudget(
-				auth.envelope,
-				await snapshotEnvelopeRemaining(engine, isDryRun, auth.envelope),
+				capture.envelope,
+				await snapshotEnvelopeRemaining(engine, isDryRun, capture.envelope),
 			);
 
 			const receipt: TrustReceipt = {
@@ -1088,18 +1185,26 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 		},
 
 		async abort(auth: Authorization, error?: unknown): Promise<void> {
-			if (!activeAuths.has(auth.transferId)) {
+			// Same lookup as settle, and the same reason: liveness and attribution come
+			// from one internal record. Still idempotent-silent, unlike settle.
+			const capture = activeAuths.get(auth.transferId);
+			if (capture === undefined) {
 				// Already settled or aborted — idempotent
 				return;
 			}
 			activeAuths.delete(auth.transferId);
 
-			// AUD-453: Acquire mutex for budget atomicity
-			const releaseLock = await budgetMutex.acquire();
-			try {
-				inFlightHoldTotal -= auth.estimatedCost;
-			} finally {
-				releaseLock();
+			// Only the session wallet's own in-flight exposure is released here; an
+			// attributed hold never added to it (see authorize), and the VOID below is
+			// what returns the envelope's funds.
+			if (capture.sessionAccounted) {
+				// AUD-453: Acquire mutex for budget atomicity
+				const releaseLock = await budgetMutex.acquire();
+				try {
+					inFlightHoldTotal -= auth.estimatedCost;
+				} finally {
+					releaseLock();
+				}
 			}
 
 			// Circuit breaker: failure
@@ -1125,8 +1230,9 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			// A1: an attributed hold leaves an attributed record on the VOID terminal
 			// too — forensic continuity, so an auditor reconstructing a cost center's
 			// history sees the calls that were held against it and released, not only
-			// the ones that settled. Read from the handle, like settle: abort commonly
-			// runs from a `catch` block outside the `withCostCenter` scope entirely.
+			// the ones that settled. Read from the capture, like settle: abort commonly
+			// runs from a `catch` block outside the `withCostCenter` scope entirely, and
+			// the handle it is handed there is caller-owned.
 			await audit
 				.appendEvent({
 					kind: "llm_call_failed",
@@ -1141,7 +1247,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 									? String(error).slice(0, 200)
 									: "aborted",
 						source: "headless",
-						...(auth.costCenter === undefined ? {} : { costCenter: auth.costCenter }),
+						...(capture.costCenter === undefined ? {} : { costCenter: capture.costCenter }),
 					},
 				})
 				.catch(() => {});
@@ -1152,10 +1258,10 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			destroyed = true;
 
 			// Void all active authorizations (engine + proxy paths)
-			for (const [txId, auth] of activeAuths) {
+			for (const [txId, capture] of activeAuths) {
 				if (proxyConn != null && !isDryRun) {
 					try {
-						await proxyConn.void(auth.proxyTransferId ?? txId);
+						await proxyConn.void(capture.proxyTransferId ?? txId);
 					} catch {
 						// Best-effort void
 					}

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -44,7 +44,25 @@ import { join } from "node:path";
 import { CreateTransferStatus } from "tigerbeetle-node";
 import { type AuditWriter, createAuditWriter } from "./audit/chain.js";
 import { writeReceipt } from "./audit/rotation.js";
-import type { TrustEngine, TrustOpts } from "./govern.js";
+import { getCurrentCostCenter } from "./budget/attribution.js";
+// The cost-center envelope helpers are SHARED with `govern.ts`, not copied from
+// it (see the block comment above `ResolvedEnvelope` there). D1's throw, A2's
+// pre-gate refusal, A7's unfloored arithmetic and D5's label re-wrap all decide
+// whether a spend happens and which wallet it names — a second copy here would be
+// a money drift the type checker could never catch. `createTBEngine` below stays
+// duplicated because that predates this PR and has its own parity test; nothing
+// says the next shared thing has to repeat the mistake.
+import {
+	asEnvelopeBalanceError,
+	envelopeReceiptBudget,
+	envelopeTierFields,
+	preflightEnvelopeRemaining,
+	type ResolvedEnvelope,
+	resolveEnvelope,
+	snapshotEnvelopeRemaining,
+	type TrustEngine,
+	type TrustOpts,
+} from "./govern.js";
 import { TBTransferError, TrustTBClient, XFER_SPEND } from "./ledger/client.js";
 import {
 	costFromRates,
@@ -108,6 +126,33 @@ export interface Authorization {
 	 * full shape (normalizeEndpoint output), unlike the Partial caller inputs.
 	 */
 	endpoint?: EndpointInfo | undefined;
+	/**
+	 * The cost-center envelope this call's PENDING hold debits, captured from the
+	 * `withCostCenter` scope that was active when `authorize()` was called. Absent
+	 * for an unattributed call, which debits the session holding wallet exactly as
+	 * it did before envelopes existed.
+	 *
+	 * READ-ONLY REPORTING for the caller; for the governor it is the settle path's
+	 * ONLY source of truth about attribution. Writing to it does not re-route
+	 * anything — the hold is already placed by the time a caller sees this handle.
+	 */
+	costCenter?: string | undefined;
+	/**
+	 * @internal The resolved envelope — derived account id, `parent::costCenter`
+	 * label, and the scope's D4 allocation metadata — captured ONCE at authorize.
+	 *
+	 * WHY IT LIVES ON THE HANDLE. `trust()` carries attribution by closure because
+	 * its terminals are closures; `createGovernor()` has none — `settle()` and
+	 * `abort()` are separate calls that routinely run on a different task, after
+	 * the `withCostCenter` scope has exited, so there is NO AsyncLocalStorage
+	 * context to read at settle time and a `getCurrentCostCenter()` call there
+	 * would answer with a later, unrelated call's scope or with nothing at all,
+	 * silently. The handle IS this governor's per-call state, and settle/abort read
+	 * only `auth.*` for the same reason `endpoint` is captured here rather than
+	 * re-derived: capture beats re-resolution, and here re-resolution would also
+	 * mean a `resolveEnvelope` throw landing AFTER the money posted.
+	 */
+	envelope?: ResolvedEnvelope | undefined;
 }
 
 /** Parameters for authorizing an LLM call. */
@@ -160,18 +205,30 @@ export interface Governor {
 	 * Phase 1: Authorize an LLM call.
 	 * Checks budget, evaluates policy, creates PENDING hold.
 	 * Returns an Authorization handle for settle() or abort().
+	 *
+	 * Call it INSIDE a `withCostCenter(cc, fn)` scope to charge the call to that
+	 * cost-center envelope: the hold debits the `(parentUserId, cc)` wallet, the
+	 * policy gate is evaluated against THAT envelope's live balance, and the
+	 * attribution is captured on the returned handle. Attribution is read here and
+	 * only here — see {@link Authorization.envelope}.
 	 */
 	authorize(params: AuthorizeParams): Promise<Authorization>;
 
 	/**
 	 * Phase 2a: Settle a successful call.
 	 * POSTs the pending hold, writes audit event, returns receipt.
+	 *
+	 * Safe to call from anywhere, including a different task with no
+	 * `withCostCenter` scope active: attribution comes from the handle, never from
+	 * the ambient scope at settle time.
 	 */
 	settle(auth: Authorization, params?: SettleParams): Promise<TrustReceipt>;
 
 	/**
 	 * Phase 2b: Abort a failed call.
 	 * VOIDs the pending hold, writes failure audit.
+	 *
+	 * Attribution comes from the handle here too — see settle().
 	 */
 	abort(auth: Authorization, error?: unknown): Promise<void>;
 
@@ -609,6 +666,22 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				throw new Error("Governor has been destroyed");
 			}
 
+			// ── The ONE AsyncLocalStorage read for this call (ALS discipline) ──
+			// Read HERE, at the top of the governor's synchronous entry point, while
+			// the CALLER's async context — the one `withCostCenter` opened — is still
+			// current, and carried on the Authorization handle from here on. This
+			// governor has NO closure spanning authorize→settle, so the handle is what
+			// a closure is on the `trust()` path: `settle()` and `abort()` are separate
+			// calls that routinely run after the scope has already exited, and a store
+			// read there would answer with a later, unrelated call's scope or with
+			// nothing — silently, never loudly. `budget/attribution.ts` documents the
+			// mechanics and pins that hazard as a negative case.
+			// D1 lives inside `resolveEnvelope`: an active scope with no `parentUserId`
+			// throws right here — before the circuit breaker, before rate resolution,
+			// before the mutex, before any I/O at all.
+			const attribution = getCurrentCostCenter();
+			const envelope = resolveEnvelope(attribution, config.parentUserId);
+
 			const model = params.model;
 			const actor = params.actor ?? "local";
 			const messages = params.messages ?? [];
@@ -644,6 +717,20 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			const maxOutputTokens = params.maxOutputTokens ?? 4096;
 			const estCost = costFromRates(rateInfo.rates, estInputTokens, maxOutputTokens);
 
+			// Attributed calls only: ONE batched read of the envelope's live
+			// `available`, for the policy numbers below. Deliberately OUTSIDE the
+			// budget mutex — it is a report, not a decision, so serialising every
+			// authorize behind a ledger round trip would buy nothing. A read that goes
+			// stale between here and the hold can only under-deny, and TigerBeetle
+			// rejects the hold atomically either way.
+			// A2: it is also BEFORE the mutex and before the gate because a read that
+			// FAILED refuses the call outright — no lock taken, no policy evaluation
+			// recorded, no hold attempted. The full rationale lives with the helper in
+			// `govern.ts`; the short version is that gating on the SESSION wallet while
+			// the hold debits the ENVELOPE would clear a call against a wallet the money
+			// never came from, in the one record an auditor reads.
+			const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
+
 			// Acquire mutex for budget atomicity (AUD-453)
 			const releaseBudgetLock = await budgetMutex.acquire();
 			let proxyTransferId: string | undefined;
@@ -656,21 +743,51 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				// field the block-budget-overshoot default rule compares against zero to
 				// deny a single overshooting call PRE-spend. As a HARD rule it fails
 				// CLOSED if omitted, so it MUST be supplied on every evaluation.
+				//
+				// ENVELOPE SCOPING (identical to `trust()`'s two sites — the three-site
+				// re-assertion table in AGENTS.md is a set, not three independent
+				// choices): an ATTRIBUTED call is gated on THE ENVELOPE ITS HOLD WILL
+				// DEBIT. `budget_remaining` is that envelope's live ledger `available`,
+				// so `block-budget-exhausted` and `block-budget-overshoot` become
+				// pre-spend guards on the cost center, ahead of the ledger's own atomic
+				// rejection, and the gate and the hold always describe the SAME wallet —
+				// the case where they could disagree (an unreadable envelope) refused the
+				// call above rather than reaching here (A2).
+				// `budget_remaining_after` is deliberately UNFLOORED on both paths (A7):
+				// it must be allowed to go NEGATIVE, because `block-budget-overshoot` is
+				// a non-disableable hard `lt 0` deny and flooring it at zero would
+				// structurally disarm that rule on every attributed call.
+				// The session numbers still stand for a call that places no envelope hold
+				// at all — unattributed, dry-run, or no engine — which is honest, because
+				// nothing debits an envelope on those paths either.
+				const sessionRemaining = config.budget - budgetSpent - inFlightHoldTotal;
+				const gateRemaining = envelopeRemaining ?? sessionRemaining;
+				// P1-BUDGET-TIER-SHADOW: the budget tier fields are trusted-host input,
+				// and asserting them here is what stops `params.params` from supplying
+				// its own `budgetFractionRemaining` and satisfying a tier that guards
+				// frontier spend. They are now REAL for an attributed call whose scope
+				// stated its allocation (D4) — the case this governor could not describe
+				// before — and stay explicitly `undefined` for every other call, where
+				// the honest value is ABSENT: an `exists`-guarded rule then simply does
+				// not match, and a hard rule without that guard fires. Never an
+				// attacker's number.
+				const tierFields =
+					envelope !== undefined && envelopeRemaining !== undefined
+						? envelopeTierFields(envelope.attribution, envelopeRemaining, Date.now())
+						: { budgetFractionRemaining: undefined, budgetRunwayHours: undefined };
 				const policyResult = evaluatePolicy(policyRules, {
 					...(params.params ?? {}),
 					model,
 					tier: config.tier,
 					estimated_cost: estCost,
-					budget_remaining: config.budget - budgetSpent - inFlightHoldTotal,
-					budget_remaining_after: config.budget - budgetSpent - inFlightHoldTotal - estCost,
-					// P1-BUDGET-TIER-SHADOW: the budget tier fields are trusted-host input.
-					// The governor knows no cost-center allocation, so the honest value is
-					// ABSENT — and asserting it here is what stops `params.params` from
-					// supplying its own `budgetFractionRemaining` and satisfying a tier
-					// that guards frontier spend. An `exists`-guarded rule then simply
-					// does not match; it never matches an attacker's number.
-					budgetFractionRemaining: undefined,
-					budgetRunwayHours: undefined,
+					budget_remaining: gateRemaining,
+					budget_remaining_after: gateRemaining - estCost,
+					budgetFractionRemaining: tierFields.budgetFractionRemaining,
+					budgetRunwayHours: tierFields.budgetRunwayHours,
+					// Structurally un-forgeable: this comes from the caller's own async
+					// execution context, which no request body can reach. Asserted after
+					// the spread like every other trusted field, `undefined` included.
+					cost_center: envelope?.attribution.costCenter,
 				});
 				if (policyResult.decision === "deny") {
 					const reason =
@@ -702,14 +819,28 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 					}
 				} else if (engine != null && !isDryRun) {
 					try {
-						await engine.spendPending({ transferId, amount: estCost });
+						await engine.spendPending({
+							transferId,
+							amount: estCost,
+							// Attributed → the envelope pays. Unattributed → the key is
+							// OMITTED, not passed as undefined, so the engine's default (the
+							// session holding wallet) is reached by exactly the path it was
+							// before envelopes existed.
+							...(envelope !== undefined ? { debitAccountId: envelope.accountId } : {}),
+						});
 					} catch (holdErr) {
 						// P1-LEDGER-ENFORCE: an over-budget reservation is rejected
 						// atomically by the ledger. Surface it as a hard budget DENY —
 						// NOT as "ledger unavailable" (which would misreport a budget cap
 						// as an outage).
 						if (holdErr instanceof InsufficientBalanceError) {
-							throw holdErr;
+							// An attributed rejection is re-presented in the caller's terms:
+							// the `parent::costCenter` label instead of a derived account id,
+							// and the remedy that actually funds an envelope. Unattributed
+							// rejections rethrow the SAME object — nothing on that path moved.
+							throw envelope === undefined
+								? holdErr
+								: asEnvelopeBalanceError(holdErr, envelope.label);
 						}
 						// Genuine ledger outage — do NOT forward to provider.
 						throw new LedgerUnavailableError(
@@ -730,6 +861,14 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				proxyTransferId,
 				createdAt: Date.now(),
 				endpoint,
+				// The capture, spread-omitted so an unattributed handle keeps exactly the
+				// shape it had before envelopes (exactOptionalPropertyTypes: writing
+				// `costCenter: undefined` is a DIFFERENT type from omitting the key).
+				// From here on, `settle()` and `abort()` read only these two fields —
+				// never the store, which by then belongs to whoever is running.
+				...(envelope !== undefined
+					? { costCenter: envelope.attribution.costCenter, envelope }
+					: {}),
 			};
 			activeAuths.set(transferId, auth);
 			return auth;
@@ -745,6 +884,18 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 
 			const model = auth.model;
 			let callAuditDegraded = false;
+
+			// A1 — forensic continuity: an attributed hold leaves an attributed record
+			// on every terminal, so this spreads onto BOTH `settlement_ambiguous`
+			// records, the `llm_call` event and the rotated receipt below. It comes from
+			// the HANDLE — the authorize-time capture — never from a store read and
+			// never from `params`: by the time settle runs there is usually no
+			// `withCostCenter` scope at all, and `SettleParams` is caller input that must
+			// not be able to relabel a spend after the fact. Unattributed calls spread an
+			// empty object, so those payloads stay byte-identical to what they were
+			// before envelopes.
+			const costCenterAudit: { costCenter?: string } =
+				auth.costCenter === undefined ? {} : { costCenter: auth.costCenter };
 
 			// A3: settlement meters with the endpoint scope CAPTURED AT AUTHORIZE —
 			// SettleParams carries no endpoint field by design.
@@ -801,6 +952,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 									postErr instanceof Error
 										? postErr.message.slice(0, 200)
 										: String(postErr).slice(0, 200),
+								...costCenterAudit,
 							},
 						})
 						.catch(() => {
@@ -826,6 +978,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 									postErr instanceof Error
 										? postErr.message.slice(0, 200)
 										: String(postErr).slice(0, 200),
+								...costCenterAudit,
 							},
 						})
 						.catch(() => {
@@ -849,6 +1002,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 						usageSource,
 						...(params?.chunksDelivered != null ? { chunksDelivered: params.chunksDelivered } : {}),
 						source: "headless",
+						...costCenterAudit,
 					},
 				});
 				auditHash = auditEvent.hash;
@@ -869,6 +1023,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 							cost: actualCost,
 							settled,
 							transferId: auth.transferId,
+							...costCenterAudit,
 						},
 					},
 					config.audit.indexLimit,
@@ -885,6 +1040,19 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 					success: true,
 				}).catch(() => {});
 			}
+
+			// D7: the envelope snapshot is read AFTER the POST, so it reports what the
+			// cost center actually holds now rather than in-memory arithmetic that
+			// drifts the moment another process spends from the same envelope. It
+			// observes; it never decides. A read that fails OMITS the block — this runs
+			// after the money committed, and a report must never unwind or re-decide a
+			// settlement. Both arguments come from the handle (`auth.envelope`), which
+			// is why a settle running outside every `withCostCenter` scope — the normal
+			// case for this governor — still names the right envelope.
+			const settledBudget = envelopeReceiptBudget(
+				auth.envelope,
+				await snapshotEnvelopeRemaining(engine, isDryRun, auth.envelope),
+			);
 
 			const receipt: TrustReceipt = {
 				transferId: auth.transferId,
@@ -911,6 +1079,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 						: {}),
 				},
 				...(params?.chunksDelivered != null ? { chunksDelivered: params.chunksDelivered } : {}),
+				...(settledBudget !== undefined ? { budget: settledBudget } : {}),
 				...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 				...(proxyConn != null ? { proxyStub: true as const } : {}),
 			};
@@ -952,7 +1121,12 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				}
 			}
 
-			// Audit the failure
+			// Audit the failure.
+			// A1: an attributed hold leaves an attributed record on the VOID terminal
+			// too — forensic continuity, so an auditor reconstructing a cost center's
+			// history sees the calls that were held against it and released, not only
+			// the ones that settled. Read from the handle, like settle: abort commonly
+			// runs from a `catch` block outside the `withCostCenter` scope entirely.
 			await audit
 				.appendEvent({
 					kind: "llm_call_failed",
@@ -967,6 +1141,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 									? String(error).slice(0, 200)
 									: "aborted",
 						source: "headless",
+						...(auth.costCenter === undefined ? {} : { costCenter: auth.costCenter }),
 					},
 				})
 				.catch(() => {});

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -429,6 +429,19 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 			}
 		},
 
+		/**
+		 * Delegate verbatim to the client's batch read. MF1: this four-line
+		 * delegation is the whole reason the governor can see an envelope at all.
+		 * Implementing it only on mocks — which the first cut of the threading did —
+		 * leaves every unit test green while PRODUCTION ships attributed calls with
+		 * no envelope-scoped policy numbers and no receipt snapshot: the same
+		 * mock-shadows-production shape AGENTS.md records for the dead budget API.
+		 * A test drives the preflight through THIS factory for that reason.
+		 */
+		async lookupBalances(accountIds: bigint[]): Promise<Map<bigint, number>> {
+			return await tbClient.lookupBalances(accountIds);
+		},
+
 		async postPendingSpend(transferId: string, actualAmount?: number): Promise<void> {
 			const tbId = pendingMap.get(transferId);
 			if (tbId === undefined) {

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -757,21 +757,10 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			const maxOutputTokens = params.maxOutputTokens ?? 4096;
 			const estCost = costFromRates(rateInfo.rates, estInputTokens, maxOutputTokens);
 
-			// Attributed calls only: ONE batched read of the envelope's live
-			// `available`, for the policy numbers below. Deliberately OUTSIDE the
-			// budget mutex — it is a report, not a decision, so serialising every
-			// authorize behind a ledger round trip would buy nothing. A read that goes
-			// stale between here and the hold can only under-deny, and TigerBeetle
-			// rejects the hold atomically either way.
-			// A2: it is also BEFORE the mutex and before the gate because a read that
-			// FAILED refuses the call outright — no lock taken, no policy evaluation
-			// recorded, no hold attempted. The full rationale lives with the helper in
-			// `govern.ts`; the short version is that gating on the SESSION wallet while
-			// the hold debits the ENVELOPE would clear a call against a wallet the money
-			// never came from, in the one record an auditor reads.
-			const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
-
-			// Acquire mutex for budget atomicity (AUD-453)
+			// Acquire mutex for budget atomicity (AUD-453). The attributed-envelope
+			// preflight read is taken INSIDE this lock (top of the try below) so a
+			// concurrent hold to the same envelope cannot land between the read and the
+			// gate — see the note there.
 			const releaseBudgetLock = await budgetMutex.acquire();
 			let proxyTransferId: string | undefined;
 			// Set below, at the point the hold actually lands on the envelope wallet.
@@ -782,6 +771,27 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			let envelopeDebited = false;
 
 			try {
+				// Attributed calls only: ONE batched read of the envelope's live
+				// `available`, for the policy numbers below. Taken INSIDE the budget mutex
+				// — the same lock that serialises the hold — and BEFORE the gate, so this
+				// call's own hold lands only after the read and a CONCURRENT attributed
+				// authorize on the SAME envelope cannot slip its hold between this read and
+				// the gate. When the read was OUTSIDE the lock, both read the pre-hold
+				// balance and the second bypassed a hard scarcity tier
+				// (`budgetFractionRemaining` / `budgetRunwayHours`) the ledger cannot
+				// enforce — TigerBeetle rejects an OVERSHOOT, never a fractional/runway
+				// tier. Serialising the read under the hold's lock makes the gate describe
+				// the wallet the hold will debit, exactly as the SESSION path already does.
+				// Cross-process (multi-governor) concurrency still relies on TB atomicity —
+				// overshoot only — the same limitation the session path has. The full
+				// rationale lives with the helper in `govern.ts`.
+				// A2: a read that FAILS refuses the call outright — the finally below
+				// releases the mutex and the ledger-unavailable error propagates before the
+				// gate is evaluated or any hold is attempted; gating on the SESSION wallet
+				// while the hold debits the ENVELOPE would clear the call against a wallet
+				// the money never came from, in the one record an auditor reads.
+				const envelopeRemaining = await preflightEnvelopeRemaining(engine, isDryRun, envelope);
+
 				// Policy gate — caller params spread FIRST so trusted governance
 				// fields (tier/estimated_cost/budget_remaining/budget_remaining_after)
 				// CANNOT be shadowed by attacker-controlled params.

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -127,7 +127,7 @@ export interface Authorization {
 	 */
 	endpoint?: EndpointInfo | undefined;
 	/**
-	 * The cost-center envelope this call's PENDING hold debits, captured from the
+	 * The cost-center this call's PENDING hold debits, captured from the
 	 * `withCostCenter` scope that was active when `authorize()` was called. Absent
 	 * for an unattributed call, which debits the session holding wallet exactly as
 	 * it did before envelopes existed.
@@ -136,33 +136,15 @@ export interface Authorization {
 	 * re-routes nothing and relabels nothing: the hold is already placed by the time
 	 * a caller sees this handle, and `settle()`/`abort()` take the attribution from
 	 * the governor's own internal capture keyed by `transferId` — see
-	 * {@link Authorization.envelope}.
+	 * {@link AuthorizationCapture}, which is where the resolved envelope lives too.
+	 *
+	 * A plain string on purpose. The resolved envelope's `accountId` is a bigint,
+	 * which `JSON.stringify` cannot serialize, so it is kept OFF this public handle
+	 * and only on the internal capture — an attributed handle stays JSON-serializable
+	 * for an integration that logs or transports it, exactly like an unattributed one.
+	 * `settle()`/`abort()` never need the account from here anyway.
 	 */
 	costCenter?: string | undefined;
-	/**
-	 * @internal The resolved envelope — derived account id, `parent::costCenter`
-	 * label, and the scope's D4 allocation metadata — captured ONCE at authorize.
-	 * FROZEN, and the same frozen object the governor keeps internally.
-	 *
-	 * WHY THE GOVERNOR DOES NOT READ IT BACK. `trust()` carries attribution by
-	 * closure because its terminals are closures; `createGovernor()` has none —
-	 * `settle()` and `abort()` are separate calls that routinely run on a different
-	 * task, after the `withCostCenter` scope has exited, so there is NO
-	 * AsyncLocalStorage context to read at settle time and a
-	 * `getCurrentCostCenter()` call there would answer with a later, unrelated
-	 * call's scope or with nothing at all, silently. But the HANDLE is not the
-	 * answer either: it is the caller's own object, and `settle()` established only
-	 * that its `transferId` is live. Reading `auth.costCenter`/`auth.envelope` after
-	 * that let a caller relabel the settle/abort audit record and the receipt's
-	 * budget block between the two phases — and, because
-	 * `snapshotEnvelopeRemaining` reads whatever account the envelope names, put an
-	 * arbitrary account's balance on the receipt. So the governor keeps its own
-	 * immutable capture (`AuthorizationCapture` below) keyed by `transferId` and
-	 * reads attribution from THAT; this field exists so the caller can see what
-	 * their call was attributed to, and it is frozen so an in-place edit fails
-	 * loudly rather than looking like it worked.
-	 */
-	envelope?: ResolvedEnvelope | undefined;
 }
 
 /**
@@ -179,7 +161,26 @@ interface AuthorizationCapture {
 	readonly proxyTransferId: string | undefined;
 	/** The scope's cost center, or `undefined` for an unattributed call. */
 	readonly costCenter: string | undefined;
-	/** The frozen envelope the hold debited, or `undefined` when unattributed. */
+	/**
+	 * The frozen envelope the hold debited, or `undefined` when unattributed. Its
+	 * `accountId` is a bigint, which is the second reason it lives HERE and never on
+	 * the public `Authorization`: keeping it off the handle leaves that handle
+	 * JSON-serializable, and the governor never needs the account from
+	 * caller-reachable state anyway.
+	 *
+	 * WHY THE GOVERNOR READS THIS, NEVER THE HANDLE. `trust()` carries attribution by
+	 * closure because its terminals are closures; `createGovernor()` has none —
+	 * `settle()`/`abort()` are separate calls that routinely run on a different task,
+	 * after the `withCostCenter` scope has exited, so there is NO AsyncLocalStorage
+	 * context to read at settle time and a `getCurrentCostCenter()` call there would
+	 * answer with a later, unrelated call's scope or with nothing at all, silently.
+	 * And the handle is the caller's own object: reading an envelope back off it would
+	 * let a caller relabel the settle/abort audit record and the receipt's budget
+	 * block between the two phases — and, because `snapshotEnvelopeRemaining` reads
+	 * whatever account the envelope names, put an arbitrary account's balance on the
+	 * receipt. So this immutable capture, keyed by `transferId`, is the single source
+	 * of settle-time attribution.
+	 */
 	readonly envelope: ResolvedEnvelope | undefined;
 	/**
 	 * Whether this hold moved the SESSION wallet's accounting
@@ -248,7 +249,7 @@ export interface Governor {
 	 * cost-center envelope: the hold debits the `(parentUserId, cc)` wallet, the
 	 * policy gate is evaluated against THAT envelope's live balance, and the
 	 * attribution is captured on the returned handle. Attribution is read here and
-	 * only here — see {@link Authorization.envelope}.
+	 * only here — see {@link AuthorizationCapture}.
 	 */
 	authorize(params: AuthorizeParams): Promise<Authorization>;
 
@@ -936,10 +937,12 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				// Spread-omitted so an unattributed handle keeps exactly the shape it had
 				// before envelopes (exactOptionalPropertyTypes: writing
 				// `costCenter: undefined` is a DIFFERENT type from omitting the key).
-				// Reporting only — the governor reads the capture below, never this.
-				...(captured !== undefined
-					? { costCenter: captured.attribution.costCenter, envelope: captured }
-					: {}),
+				// Reporting only — the governor reads the capture below, never this. ONLY
+				// the serializable cost-center string rides the handle; the resolved
+				// envelope (bigint account id) stays on the internal capture, so an
+				// attributed handle is still `JSON.stringify`-able for a caller that logs
+				// or transports it.
+				...(captured !== undefined ? { costCenter: captured.attribution.costCenter } : {}),
 			};
 			// The GOVERNOR's record. Keyed by transferId and unreachable from caller
 			// code, so `settle()`/`abort()` can never be handed a different cost center

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -1145,11 +1145,16 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			// settlement. Both arguments come from the governor's capture, which is why
 			// a settle running outside every `withCostCenter` scope — the normal case for
 			// this governor — still names the right envelope, and why a caller cannot
-			// point this read at an account their call never touched.
-			const settledBudget = envelopeReceiptBudget(
-				capture.envelope,
-				await snapshotEnvelopeRemaining(engine, isDryRun, capture.envelope),
-			);
+			// point this read at an account their call never touched. It is a
+			// POST-SETTLEMENT observation, so it is attached ONLY when `settled` — an
+			// ambiguous settlement (POST rejected) leaves the transfer possibly still
+			// pending, so the balance is transient; we do not even read the ledger then.
+			const settledBudget = settled
+				? envelopeReceiptBudget(
+						capture.envelope,
+						await snapshotEnvelopeRemaining(engine, isDryRun, capture.envelope),
+					)
+				: undefined;
 
 			const receipt: TrustReceipt = {
 				transferId: auth.transferId,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,17 @@ export {
 	getBudgetStatus,
 	reclaimBudget,
 } from "./budget/allocation.js";
+// Attribution — `withCostCenter(cc, fn)` routes every governed call `fn` makes to a
+// cost-center envelope via `node:async_hooks` `AsyncLocalStorage`, from code structure
+// rather than request content. `getCurrentCostCenter` stays module-internal (D8): only
+// `govern.ts`/`headless.ts` read it, at exactly one point per call.
+export { withCostCenter } from "./budget/attribution.js";
+export type { BudgetContext, EnvelopeDescriptor, EnvelopeStatus } from "./budget/context.js";
+// The scarcity READ API — an agent's own pull-side view across every envelope it
+// holds, in one ledger round trip. See the module doc comment for how this differs
+// from `getBudgetStatus` (batched, and never a per-envelope registry read) and for
+// the observational (never verifier-derivable) contract its numbers carry.
+export { budgetContext } from "./budget/context.js";
 export type { Runway, RunwayInput } from "./budget/runway.js";
 // `runwayHours` is the safe derivation of a `budgetRunwayHours` policy field —
 // the naive `(projectedExhaustionMs - nowMs) / 3.6e6` turns "not projectable"

--- a/packages/core/src/ledger/client.ts
+++ b/packages/core/src/ledger/client.ts
@@ -71,6 +71,39 @@ export const XFER_BUDGET_GRANT = 9;
 // share preimages. The KAT suite pins these bytes: changing them breaks every known answer.
 const COST_CENTER_DOMAIN_TAG = Buffer.from("usertrust:cost-center:v1", "utf8");
 
+/**
+ * Per-account available/pending/total balance, shared by {@link TrustTBClient.lookupBalance}
+ * and {@link TrustTBClient.lookupBalances} so the overflow guards live in exactly ONE
+ * place. Module-private: nothing outside this file computes a balance from raw `Account`
+ * fields, which is the documented anti-pattern — the guards below are what stand between a
+ * corrupted TB response and a `NaN`/silently-wrapped balance reaching budget arithmetic.
+ */
+function accountBalance(acct: Account): {
+	available: number;
+	pending: number;
+	total: number;
+} {
+	const postedBig = acct.credits_posted - acct.debits_posted;
+	if (postedBig > BigInt(Number.MAX_SAFE_INTEGER) || postedBig < -BigInt(Number.MAX_SAFE_INTEGER)) {
+		throw new Error(
+			`[TB] Balance overflow: ${postedBig.toString()} exceeds Number.MAX_SAFE_INTEGER`,
+		);
+	}
+	const pendingBig = acct.debits_pending;
+	if (pendingBig > BigInt(Number.MAX_SAFE_INTEGER)) {
+		throw new Error(
+			`[TB] Pending overflow: ${pendingBig.toString()} exceeds Number.MAX_SAFE_INTEGER`,
+		);
+	}
+	const posted = Number(postedBig);
+	const pending = Number(acct.debits_pending);
+	return {
+		available: Math.max(0, posted - pending),
+		pending,
+		total: Math.max(0, posted),
+	};
+}
+
 export interface TrustTBClientOptions {
 	addresses: string[];
 	clusterId?: bigint;
@@ -750,29 +783,39 @@ export class TrustTBClient {
 	}> {
 		const accounts = await this.withReconnect(() => this.client.lookupAccounts([accountId]));
 		if (accounts.length === 0) throw new Error(`Account not found: ${accountId}`);
-		const acct = accounts[0] as Account;
-		const postedBig = acct.credits_posted - acct.debits_posted;
-		if (
-			postedBig > BigInt(Number.MAX_SAFE_INTEGER) ||
-			postedBig < -BigInt(Number.MAX_SAFE_INTEGER)
-		) {
-			throw new Error(
-				`[TB] Balance overflow: ${postedBig.toString()} exceeds Number.MAX_SAFE_INTEGER`,
-			);
+		return accountBalance(accounts[0] as Account);
+	}
+
+	/**
+	 * Batched {@link TrustTBClient.lookupBalance}: one `lookupAccounts` round trip for
+	 * every account in `accountIds`, sharing the exact same per-account computation (and
+	 * its overflow guards) via {@link accountBalance} — never a hand-rolled second copy.
+	 *
+	 * Two deliberate differences from the single-account method, both required by its
+	 * callers (budget/context.ts's envelope reads): a missing account is ABSENT from the
+	 * returned map rather than throwing — "never allocated" and "fully reclaimed" are the
+	 * same observable state with no registry, so the caller's implicit-zero reading is
+	 * `balances.get(id) ?? 0`, never a per-account try/catch; and only the `available`
+	 * figure is returned, since that is all any caller of the batch path needs.
+	 *
+	 * Results are matched to requests by `Account.id`, never by array position — TB is not
+	 * documented to preserve request order, and index-matching would silently mispair
+	 * balances the moment it didn't.
+	 *
+	 * Duplicate input ids are deduped before the round trip: TigerBeetle is queried once
+	 * per unique id, which is also what keeps this to exactly ONE `lookupAccounts` call
+	 * regardless of how many times a caller repeats an id. Empty input short-circuits
+	 * before any I/O — there is nothing to look up and no reason to open a round trip.
+	 */
+	async lookupBalances(accountIds: bigint[]): Promise<Map<bigint, number>> {
+		if (accountIds.length === 0) return new Map();
+		const uniqueIds = [...new Set(accountIds)];
+		const accounts = await this.withReconnect(() => this.client.lookupAccounts(uniqueIds));
+		const balances = new Map<bigint, number>();
+		for (const acct of accounts as Account[]) {
+			balances.set(acct.id, accountBalance(acct).available);
 		}
-		const pendingBig = acct.debits_pending;
-		if (pendingBig > BigInt(Number.MAX_SAFE_INTEGER)) {
-			throw new Error(
-				`[TB] Pending overflow: ${pendingBig.toString()} exceeds Number.MAX_SAFE_INTEGER`,
-			);
-		}
-		const posted = Number(postedBig);
-		const pending = Number(acct.debits_pending);
-		return {
-			available: Math.max(0, posted - pending),
-			pending,
-			total: Math.max(0, posted),
-		};
+		return balances;
 	}
 
 	async ping(): Promise<boolean> {

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -350,11 +350,15 @@ export interface PolicyContext extends Record<string, unknown> {
 	 * TRUSTED HOST INPUT ONLY. They are governance inputs, so only the host that
 	 * owns the allocation may write them — never a request body. `trust()` and
 	 * `createGovernor()` spread the caller's LLM params into the context and then
-	 * re-assert BOTH fields as `undefined`, so a client posting
+	 * re-assert BOTH fields, so a client posting
 	 * `{"budgetFractionRemaining": 0.95}` cannot make a budget tier look
-	 * satisfied; those SDK paths know no cost-center allocation, so the honest
-	 * value there is "absent". A host that does know the allocation reads it
-	 * itself and calls `evaluatePolicy` with a context it built:
+	 * satisfied. What they re-assert depends on the call: one made inside a
+	 * `withCostCenter(cc, fn, { allocated, periodStartMs })` scope carries the live
+	 * envelope numbers (see {@link PolicyContext.cost_center}); every other call
+	 * re-asserts explicit `undefined`, because without a scope the SDK genuinely
+	 * does not know which allocation funds the call and "absent" is the honest
+	 * answer. A host that owns the allocation itself can still read it and call
+	 * `evaluatePolicy` with a context it built:
 	 *
 	 * ```ts
 	 * const status = await getBudgetStatus(tb, {
@@ -398,15 +402,24 @@ export interface PolicyContext extends Record<string, unknown> {
 	 * can write the field explicitly as `undefined` to overwrite an untrusted
 	 * inbound value; `exists` reads the result as absent either way.
 	 *
-	 * ⚠️ WARNING — A TIER ON THIS FIELD CANNOT FIRE YET. Nothing in this
-	 * repository debits a cost-center wallet: the metering path spends from a
-	 * per-session funded holding account, not from the wallet `allocateBudget`
-	 * funds. `getBudgetStatus` therefore reports `fractionRemaining: 1` for a
-	 * cost center whose agent is genuinely burning budget, so a
-	 * `budgetFractionRemaining lt 0.3` rule never matches — a governance control
-	 * that fails open. These primitives ship AHEAD of their metering consumer;
-	 * do not rely on the tier until the spend path debits the cost-center wallet.
-	 * See the module doc comment in `budget/allocation.ts`.
+	 * WHERE THE NUMBER COMES FROM, and what it is worth. A governed call made
+	 * inside `withCostCenter(cc, fn, { allocated, periodStartMs })` populates this
+	 * from the envelope's LIVE ledger balance read at authorize, divided by the
+	 * `allocated` the scope declared and clamped to 0..1. That is what makes a
+	 * `budgetFractionRemaining lt 0.3` rule a real pre-spend control: the metering
+	 * path now debits the `(parent, costCenter)` wallet `allocateBudget` funds, so
+	 * the balance actually falls as the agent burns it.
+	 *
+	 * It is still ABSENT — explicitly `undefined` — for a call outside any scope,
+	 * for one whose scope declared no `allocated` (there is no cost-center
+	 * registry, so the SDK does not know the envelope's size and will not invent
+	 * one), and in dry-run. Absent is fail-closed for a hard rule, so lead a tier
+	 * that must apply only to attributed traffic with an `exists` guard, exactly as
+	 * the example above does.
+	 *
+	 * The one thing it is NOT is a number the caller chose: see the trust-boundary
+	 * paragraph above, and {@link PolicyContext.cost_center} for why the
+	 * attribution behind it cannot be forged either.
 	 */
 	budgetFractionRemaining?: number | undefined;
 	/**
@@ -424,10 +437,45 @@ export interface PolicyContext extends Record<string, unknown> {
 	 * a budget that is merely idle.
 	 *
 	 * `| undefined` for the same reason as
-	 * {@link PolicyContext.budgetFractionRemaining}, and the metering warning
-	 * there applies to this field too.
+	 * {@link PolicyContext.budgetFractionRemaining}, and populated from the same
+	 * place: `computeRunway` over the scope's declared allocation and period plus
+	 * the envelope's live balance, on an attributed call. `runwayHours` answers
+	 * `null` for "not projectable"; this field's convention for unknown is
+	 * explicit `undefined`, so the governor converts. The two conventions are
+	 * deliberate and per-surface — `budgetContext()`'s `EnvelopeStatus.runwayHours`
+	 * keeps `null`, matching `Runway` itself. Do not unify them.
 	 */
 	budgetRunwayHours?: number | undefined;
+
+	/**
+	 * The cost center funding this call — the `withCostCenter(cc, …)` scope the
+	 * governed call executed inside, or `undefined` when it ran inside none.
+	 *
+	 * snake_case is deliberate and matches this context's other governance fields
+	 * (`estimated_cost`, `budget_remaining`, `action_kind`) — a rule file reads
+	 * `cost_center`, while every TypeScript surface spells the same thing
+	 * `costCenter` (A11). Do not "unify" the two.
+	 *
+	 * TRUSTED HOST INPUT ONLY, and structurally so: its value comes from the
+	 * caller's own async execution context, never from the request body. All three
+	 * SDK call sites spread the caller's params first and then re-assert this field
+	 * — including asserting `undefined` when no scope is active — so a body carrying
+	 * `{"cost_center": "research"}` cannot make a rule believe a call it never
+	 * attributed is spending someone else's envelope.
+	 *
+	 * ENVELOPE-SCOPED SIBLINGS: when this field is set on a call that will actually
+	 * place a ledger hold, `budget_remaining` / `budget_remaining_after` above
+	 * describe THAT ENVELOPE rather than the session budget, and
+	 * {@link PolicyContext.budgetFractionRemaining} /
+	 * {@link PolicyContext.budgetRunwayHours} are populated from it whenever the
+	 * scope supplied allocation metadata. The gate and the hold therefore always
+	 * name the same wallet: an attributed call whose envelope balance cannot be
+	 * read is refused with a ledger-unavailable error BEFORE this context is ever
+	 * built, rather than being cleared against a session wallet its money would not
+	 * have come from. A rule that must apply only to attributed traffic should lead
+	 * with `{ field: "cost_center", operator: "exists" }`.
+	 */
+	cost_center?: string | undefined;
 }
 
 /**

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -8,8 +8,18 @@ export class InsufficientBalanceError extends Error {
 	public readonly hint: string;
 	public readonly docsUrl: string;
 
-	constructor(userId: string, required: number, available: number) {
-		const hint = "Increase the budget in trust() options or add funds via the ledger.";
+	/**
+	 * `hint` is overridable because the default advice is WRONG for a cost-center
+	 * envelope: raising `trust({ budget })` funds the session holding wallet, which
+	 * an attributed call never debits, so an operator who follows it watches the
+	 * same call fail again with a bigger number in the config. The governor passes
+	 * the envelope remedy (`allocateBudget`) when it re-wraps a rejected attributed
+	 * hold; every other caller omits the argument and gets today's string
+	 * byte-for-byte.
+	 */
+	constructor(userId: string, required: number, available: number, hintOverride?: string) {
+		const hint =
+			hintOverride ?? "Increase the budget in trust() options or add funds via the ledger.";
 		const docsUrl = "https://usertrust.ai/docs/errors/insufficient-balance";
 		super(
 			`Insufficient balance for user ${userId}: need ${required}, have ${available}\n\n  Hint: ${hint}\n  Docs: ${docsUrl}`,

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -49,6 +49,30 @@ export interface TrustReceipt {
 	endpoint?: { class: EndpointClass; runtime: LocalRuntime };
 	/** Metering provenance: denomination and rate origin of the settled cost. */
 	meter?: { costBasis: CostBasis; rateSource: RateSource; computeMs?: number };
+	/**
+	 * Cost-center envelope snapshot — the PUSH half of visibility (the pull half is
+	 * `budgetContext()`). Present only when the call ran inside a `withCostCenter`
+	 * scope AND settled AND the post-settle ledger read answered.
+	 *
+	 * OBSERVATIONAL, NEVER AUTHORITATIVE (A8), and the same contract
+	 * `budget/context.ts` documents: `remaining` is the envelope's ledger
+	 * `available` READ AFTER this call settled, so it races every concurrent
+	 * settlement against the same envelope by design. It is "what the envelope
+	 * holds now", never "what this call cost" (that is `cost`) and never anything a
+	 * verifier can recompute — it is not part of the hash chain and `packages/verify`
+	 * never sees this shape.
+	 *
+	 * ABSENT is not an error signal: an unattributed call, an unsettled (estimated)
+	 * stream handle, and a snapshot read that failed all omit it. The read is
+	 * deliberately allowed to fail silently — a receipt is a report, and degrading a
+	 * report must never unwind or re-decide money that already committed.
+	 */
+	budget?: {
+		costCenter: string;
+		remaining: number;
+		/** Omitted when the scope carried no `allocated` metadata (D4). */
+		fraction?: number;
+	};
 }
 
 // ── TrustedResponse — returned by every governed LLM call ──

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 Usertools, Inc.
 
 import { z } from "zod";
+import { parentUserIdRefusal } from "./ids.js";
 
 // ── Endpoint classification (M2 local-model governance) ──
 
@@ -69,6 +70,36 @@ export const TrustConfigSchema = z.object({
 	tier: z.enum(["free", "mini", "pro", "mega", "ultra"]).default("mini"),
 	proxy: z.string().url().optional(),
 	key: z.string().optional(),
+	/**
+	 * The parent half of the `(parentUserId, costCenter)` tuple every cost-center
+	 * envelope account is derived from — this governor's ledger identity.
+	 *
+	 * OPTIONAL, and it must stay optional: a governor that never spends from an
+	 * envelope needs no identity, and every config written before envelopes
+	 * existed keeps parsing to exactly the same object it did before (no key
+	 * materialises, no default is invented).
+	 *
+	 * Validated HERE, by the one authoritative rule `parentUserIdRefusal` — the
+	 * same charset-plus-`::`-quarantine that `createCostCenterWallet` and
+	 * `costCenterUserId` enforce at the ledger doors. Refusing at parse time is
+	 * what keeps the refusal off the money path: a malformed identity surfaces
+	 * when the operator writes it, not at the first attributed hold with a call
+	 * already in flight and the caller believing governance came up clean.
+	 *
+	 * TRUSTED-OPERATOR input, on the same boundary as budget/customRates —
+	 * whoever constructs a governor already holds the TigerBeetle client. Never
+	 * derive it from end-user or request data: attribution that request content
+	 * can steer is an agent relabelling its calls onto the fattest envelope.
+	 */
+	parentUserId: z
+		.string()
+		.superRefine((value, ctx) => {
+			const refusal = parentUserIdRefusal(value);
+			if (refusal !== null) {
+				ctx.addIssue(`parentUserId ${refusal}`);
+			}
+		})
+		.optional(),
 	policies: z.string().default("./policies/default.yml"),
 	pii: z.enum(["redact", "warn", "block", "off"]).default("warn"),
 	injection: z.enum(["block", "warn", "off"]).default("warn"),

--- a/packages/core/tests/budget/attribution.test.ts
+++ b/packages/core/tests/budget/attribution.test.ts
@@ -3,7 +3,12 @@
 
 import { EventEmitter } from "node:events";
 import { describe, expect, it } from "vitest";
-import { getCurrentCostCenter, withCostCenter } from "../../src/budget/attribution.js";
+import {
+	type CostCenterScopeOpts,
+	getCurrentCostCenter,
+	withCostCenter,
+} from "../../src/budget/attribution.js";
+import type { EnvelopeDescriptor } from "../../src/budget/context.js";
 
 // The two existing costCenter charset-door messages this scope's own message must
 // stay textually distinct from — ledger/client.ts:340 and budget/allocation.ts:114.
@@ -326,5 +331,87 @@ describe("withCostCenter — opts (D4) are carried onto the store", () => {
 			expect(store?.periodStartMs).toBeUndefined();
 			expect(store?.periodEndMs).toBeUndefined();
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The store is built field-by-field, never by spreading `opts`
+// ---------------------------------------------------------------------------
+//
+// Whole-branch review, finding 1. `opts` is METADATA about the envelope; the
+// costCenter that decides WHICH envelope is debited is the positional argument,
+// and it is the only one validated against COST_CENTER_PATTERN above. A blanket
+// `{ costCenter, ...opts }` puts the spread AFTER the validated field, so any
+// `costCenter` key riding along on `opts` silently wins — and TypeScript's
+// excess-property check does not fire for a non-literal argument, so the compiler
+// never sees it either. `EnvelopeDescriptor` (the shape `budgetContext()` takes,
+// `{ costCenter, allocated, periodStartMs, periodEndMs? }`) is structurally
+// assignable to `CostCenterScopeOpts`, so the natural mistake —
+// `withCostCenter("research", fn, oneOfMyDescriptors)` — type-checks and reroutes
+// the whole spend: wrong envelope debited, wrong audit label, wrong policy gate.
+// Attribution must come from CODE STRUCTURE, and the positional argument is that
+// structure.
+
+describe("withCostCenter — opts can never decide the attribution", () => {
+	it("IGNORES a costCenter key riding on opts and keeps the validated positional", () => {
+		const opts = {
+			allocated: 500,
+			periodStartMs: 1_700_000_000_000,
+			costCenter: "hijacked",
+		} as CostCenterScopeOpts;
+
+		withCostCenter(
+			"research",
+			() => {
+				const store = getCurrentCostCenter();
+				expect(store?.costCenter).toBe("research");
+				expect(store?.allocated).toBe(500);
+			},
+			opts,
+		);
+	});
+
+	it("keeps a stray key on opts out of the store entirely", () => {
+		const opts = {
+			allocated: 500,
+			periodStartMs: 1_700_000_000_000,
+			parentUserId: "someone-elses-parent",
+			accountId: 42,
+		} as CostCenterScopeOpts;
+
+		withCostCenter(
+			"research",
+			() => {
+				const store = getCurrentCostCenter();
+				// Only the three known metadata fields, plus the positional costCenter.
+				expect(Object.keys(store ?? {}).sort()).toEqual([
+					"allocated",
+					"costCenter",
+					"periodStartMs",
+				]);
+				expect(store).not.toHaveProperty("parentUserId");
+				expect(store).not.toHaveProperty("accountId");
+			},
+			opts,
+		);
+	});
+
+	it("attributes an EnvelopeDescriptor passed as opts to the POSITIONAL cost center", () => {
+		// No cast and no `@ts-expect-error`: this is the mistake as a caller makes
+		// it. `EnvelopeDescriptor` carries its own `costCenter`, and passing one as
+		// the scope's metadata must not re-route the spend to it.
+		const descriptor: EnvelopeDescriptor = {
+			costCenter: "marketing",
+			allocated: 9_000,
+			periodStartMs: 1_700_000_000_000,
+		};
+
+		withCostCenter(
+			"research",
+			() => {
+				expect(getCurrentCostCenter()?.costCenter).toBe("research");
+			},
+			descriptor,
+		);
 	});
 });

--- a/packages/core/tests/budget/attribution.test.ts
+++ b/packages/core/tests/budget/attribution.test.ts
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { getCurrentCostCenter, withCostCenter } from "../../src/budget/attribution.js";
+
+// The two existing costCenter charset-door messages this scope's own message must
+// stay textually distinct from — ledger/client.ts:340 and budget/allocation.ts:114.
+// Copied as literals (not imported) so this suite still catches a regression if
+// either door's wording ever collapses onto the scope-entry message by accident.
+const LEDGER_DOOR_MESSAGE = "Invalid costCenter: must match /^[a-zA-Z0-9._-]{1,64}$/";
+const ALLOCATION_DOOR_MESSAGE = "budget: costCenter must match /^[a-zA-Z0-9._-]{1,64}$/";
+
+describe("withCostCenter — validation is fail-fast and pre-I/O", () => {
+	it("rejects a costCenter outside COST_CENTER_PATTERN before running fn", () => {
+		let ran = false;
+		expect(() =>
+			withCostCenter("has a space", () => {
+				ran = true;
+			}),
+		).toThrow(/costCenter/);
+		expect(ran).toBe(false);
+	});
+
+	it("rejects an empty costCenter", () => {
+		let ran = false;
+		expect(() =>
+			withCostCenter("", () => {
+				ran = true;
+			}),
+		).toThrow(/costCenter/);
+		expect(ran).toBe(false);
+	});
+
+	it("rejects a non-string costCenter", () => {
+		let ran = false;
+		expect(() =>
+			// @ts-expect-error — exercising the runtime guard against a caller ignoring the type
+			withCostCenter(42, () => {
+				ran = true;
+			}),
+		).toThrow(/costCenter/);
+		expect(ran).toBe(false);
+	});
+
+	it("throws a message distinct from both existing costCenter charset-door messages", () => {
+		let message = "";
+		try {
+			withCostCenter("bad cc", () => "unreached");
+		} catch (err) {
+			message = err instanceof Error ? err.message : String(err);
+		}
+		expect(message).not.toBe(LEDGER_DOOR_MESSAGE);
+		expect(message).not.toBe(ALLOCATION_DOOR_MESSAGE);
+	});
+
+	it("rejects a non-finite opts.allocated before running fn", () => {
+		let ran = false;
+		expect(() =>
+			withCostCenter(
+				"cc",
+				() => {
+					ran = true;
+				},
+				{ allocated: Number.NaN, periodStartMs: 1000 },
+			),
+		).toThrow(/allocated/);
+		expect(ran).toBe(false);
+	});
+
+	it("rejects a negative opts.allocated before running fn", () => {
+		let ran = false;
+		expect(() =>
+			withCostCenter(
+				"cc",
+				() => {
+					ran = true;
+				},
+				{ allocated: -1, periodStartMs: 1000 },
+			),
+		).toThrow(/allocated/);
+		expect(ran).toBe(false);
+	});
+
+	it("rejects a non-finite opts.periodStartMs before running fn", () => {
+		let ran = false;
+		expect(() =>
+			withCostCenter(
+				"cc",
+				() => {
+					ran = true;
+				},
+				{ allocated: 100, periodStartMs: Number.POSITIVE_INFINITY },
+			),
+		).toThrow(/periodStartMs/);
+		expect(ran).toBe(false);
+	});
+
+	it("rejects a non-finite opts.periodEndMs when present, before running fn", () => {
+		let ran = false;
+		expect(() =>
+			withCostCenter(
+				"cc",
+				() => {
+					ran = true;
+				},
+				{ allocated: 100, periodStartMs: 1000, periodEndMs: Number.NaN },
+			),
+		).toThrow(/periodEndMs/);
+		expect(ran).toBe(false);
+	});
+
+	it("accepts allocated === 0 (no headroom is a legal envelope, not an invalid one)", () => {
+		const result = withCostCenter("cc", () => "ok", { allocated: 0, periodStartMs: 1000 });
+		expect(result).toBe("ok");
+	});
+});
+
+describe("withCostCenter — sync and async return values", () => {
+	it("returns fn()'s synchronous return value", () => {
+		const result = withCostCenter("cc", () => 42);
+		expect(result).toBe(42);
+	});
+
+	it("returns fn()'s resolved value when fn is async", async () => {
+		const result = await withCostCenter("cc", async () => {
+			await Promise.resolve();
+			return "done";
+		});
+		expect(result).toBe("done");
+	});
+
+	it("getCurrentCostCenter sees the active scope synchronously, and undefined outside it", () => {
+		expect(getCurrentCostCenter()).toBeUndefined();
+		withCostCenter("sync-cc", () => {
+			expect(getCurrentCostCenter()?.costCenter).toBe("sync-cc");
+		});
+		expect(getCurrentCostCenter()).toBeUndefined();
+	});
+
+	it("getCurrentCostCenter sees the active scope across an await", async () => {
+		await withCostCenter("async-cc", async () => {
+			expect(getCurrentCostCenter()?.costCenter).toBe("async-cc");
+			await new Promise((r) => setTimeout(r, 0));
+			expect(getCurrentCostCenter()?.costCenter).toBe("async-cc");
+		});
+		expect(getCurrentCostCenter()).toBeUndefined();
+	});
+});
+
+describe("withCostCenter — nesting and concurrent isolation", () => {
+	it("innermost scope wins; the outer scope is restored when the inner one exits", () => {
+		withCostCenter("outer", () => {
+			expect(getCurrentCostCenter()?.costCenter).toBe("outer");
+			withCostCenter("inner", () => {
+				expect(getCurrentCostCenter()?.costCenter).toBe("inner");
+			});
+			expect(getCurrentCostCenter()?.costCenter).toBe("outer");
+		});
+	});
+
+	it("Promise.all — two interleaved scopes never observe each other's costCenter", async () => {
+		const seenA: Array<string | undefined> = [];
+		const seenB: Array<string | undefined> = [];
+
+		const taskA = withCostCenter("scope-a", async () => {
+			seenA.push(getCurrentCostCenter()?.costCenter);
+			await new Promise((r) => setTimeout(r, 10));
+			seenA.push(getCurrentCostCenter()?.costCenter);
+			await new Promise((r) => setTimeout(r, 0));
+			seenA.push(getCurrentCostCenter()?.costCenter);
+		});
+		const taskB = withCostCenter("scope-b", async () => {
+			seenB.push(getCurrentCostCenter()?.costCenter);
+			await new Promise((r) => setTimeout(r, 0));
+			seenB.push(getCurrentCostCenter()?.costCenter);
+			await new Promise((r) => setTimeout(r, 10));
+			seenB.push(getCurrentCostCenter()?.costCenter);
+		});
+
+		await Promise.all([taskA, taskB]);
+
+		expect(seenA).toEqual(["scope-a", "scope-a", "scope-a"]);
+		expect(seenB).toEqual(["scope-b", "scope-b", "scope-b"]);
+	});
+});
+
+describe("withCostCenter — the emitter-tick hazard (pins WHY governors must capture at authorize)", () => {
+	it("a listener registered inside a scope sees undefined when emitted after the scope exits", () => {
+		const emitter = new EventEmitter();
+		let seen: string | undefined = "sentinel-never-overwritten";
+
+		withCostCenter("emitter-cc", () => {
+			emitter.on("tick", () => {
+				seen = getCurrentCostCenter()?.costCenter;
+			});
+		});
+
+		// The scope has already exited by the time emit() runs — emit() executes
+		// listeners synchronously in ITS OWN context, not the on()-registration
+		// context, so the listener must not see "emitter-cc" here.
+		expect(getCurrentCostCenter()).toBeUndefined();
+		emitter.emit("tick");
+		expect(seen).toBeUndefined();
+	});
+});
+
+describe("withCostCenter — timers/microtasks scheduled INSIDE the scope still propagate", () => {
+	it("queueMicrotask scheduled inside the scope sees the store when it runs", async () => {
+		let seen: string | undefined;
+		let resolveDone: () => void = () => {};
+		const done = new Promise<void>((r) => {
+			resolveDone = r;
+		});
+
+		withCostCenter("microtask-cc", () => {
+			queueMicrotask(() => {
+				seen = getCurrentCostCenter()?.costCenter;
+				resolveDone();
+			});
+		});
+
+		await done;
+		expect(seen).toBe("microtask-cc");
+	});
+
+	it("setTimeout scheduled inside the scope sees the store when it fires", async () => {
+		let seen: string | undefined;
+		let resolveDone: () => void = () => {};
+		const done = new Promise<void>((r) => {
+			resolveDone = r;
+		});
+
+		withCostCenter("timer-cc", () => {
+			setTimeout(() => {
+				seen = getCurrentCostCenter()?.costCenter;
+				resolveDone();
+			}, 0);
+		});
+
+		await done;
+		expect(seen).toBe("timer-cc");
+	});
+});
+
+describe("withCostCenter — store restoration on failure (A4)", () => {
+	it("restores the outer store after fn throws synchronously", () => {
+		withCostCenter("outer", () => {
+			expect(() =>
+				withCostCenter("inner", () => {
+					throw new Error("boom-sync");
+				}),
+			).toThrow("boom-sync");
+			expect(getCurrentCostCenter()?.costCenter).toBe("outer");
+		});
+		expect(getCurrentCostCenter()).toBeUndefined();
+	});
+
+	it("restores the outer store after fn's returned promise rejects", async () => {
+		await withCostCenter("outer", async () => {
+			expect(getCurrentCostCenter()?.costCenter).toBe("outer");
+			await expect(
+				withCostCenter("inner", async () => {
+					throw new Error("boom-async");
+				}),
+			).rejects.toThrow("boom-async");
+			expect(getCurrentCostCenter()?.costCenter).toBe("outer");
+		});
+		expect(getCurrentCostCenter()).toBeUndefined();
+	});
+});
+
+describe("withCostCenter — the store is frozen", () => {
+	it("a mutation attempt on the returned store throws and does not leak across reads", () => {
+		withCostCenter("frozen-cc", () => {
+			const store = getCurrentCostCenter();
+			expect(store).toBeDefined();
+			expect(Object.isFrozen(store)).toBe(true);
+			expect(() => {
+				// @ts-expect-error — exercising the runtime freeze against a caller ignoring `readonly`
+				store.costCenter = "hijacked";
+			}).toThrow(TypeError);
+
+			const reread = getCurrentCostCenter();
+			expect(reread?.costCenter).toBe("frozen-cc");
+		});
+	});
+});
+
+describe("withCostCenter — opts (D4) are carried onto the store", () => {
+	it("carries allocated/periodStartMs/periodEndMs when opts is present", () => {
+		withCostCenter(
+			"cc-with-opts",
+			() => {
+				const store = getCurrentCostCenter();
+				expect(store).toEqual({
+					costCenter: "cc-with-opts",
+					allocated: 500,
+					periodStartMs: 1_700_000_000_000,
+					periodEndMs: 1_700_003_600_000,
+				});
+			},
+			{ allocated: 500, periodStartMs: 1_700_000_000_000, periodEndMs: 1_700_003_600_000 },
+		);
+	});
+
+	it("carries opts without a periodEndMs (open-ended period)", () => {
+		withCostCenter(
+			"cc-open-ended",
+			() => {
+				const store = getCurrentCostCenter();
+				expect(store?.allocated).toBe(10);
+				expect(store?.periodStartMs).toBe(5000);
+				expect(store?.periodEndMs).toBeUndefined();
+			},
+			{ allocated: 10, periodStartMs: 5000 },
+		);
+	});
+
+	it("omits allocated/periodStartMs/periodEndMs from the store when opts is absent", () => {
+		withCostCenter("cc-no-opts", () => {
+			const store = getCurrentCostCenter();
+			expect(store?.costCenter).toBe("cc-no-opts");
+			expect(store?.allocated).toBeUndefined();
+			expect(store?.periodStartMs).toBeUndefined();
+			expect(store?.periodEndMs).toBeUndefined();
+		});
+	});
+});

--- a/packages/core/tests/budget/context.test.ts
+++ b/packages/core/tests/budget/context.test.ts
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock tigerbeetle-node — context.ts reaches TrustTBClient's static derivation methods
+// through ledger/client.js, which is a real (unmocked) module in this test. Mirrors
+// allocation.test.ts's minimal mock: context.ts never creates accounts or transfers, so
+// only the shapes ledger/client.ts's module scope touches at import time are needed.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(),
+	AccountFlags: { debits_must_not_exceed_credits: 1 << 2, history: 1 << 5 },
+	TransferFlags: { pending: 1, post_pending_transfer: 2, void_pending_transfer: 4 },
+	CreateAccountStatus: { created: 4294967295, exists: 1, exists_with_different_flags: 2 },
+	CreateTransferStatus: {
+		created: 4294967295,
+		exceeds_credits: 22,
+		overflows_debits: 30,
+		overflows_debits_pending: 31,
+	},
+	amount_max: (1n << 128n) - 1n,
+}));
+
+import { budgetContext, type EnvelopeDescriptor, MAX_ENVELOPES } from "../../src/budget/context.js";
+import { computeRunway, runwayHours } from "../../src/budget/runway.js";
+import { TrustTBClient } from "../../src/ledger/client.js";
+
+const PARENT = "acme";
+/**
+ * Known answers computed OUTSIDE the implementation, to the same spec as
+ * `tests/ledger/client.test.ts` and `tests/budget/allocation.test.ts`
+ * (sha256("usertrust:cost-center:v1" ‖ u32be(|p|) ‖ p ‖ u32be(|c|) ‖ c), first 16
+ * bytes; wallet ids are sha256("wallet:" + id), first 16 bytes). Spelled out rather
+ * than recomputed from the static, so this suite polices the wiring — that
+ * `budgetContext` calls `deriveAccountId`/`deriveCostCenterAccountId` with the exact
+ * (parent, costCenter) pairs it was given — not the hash function itself.
+ */
+const PARENT_ACCOUNT = 33860297148723319913169339150546196888n;
+const BILLING_ACCOUNT = 153698412649693138325753473963527840061n;
+const OPS_ACCOUNT = 21803936250278089508924990127628972679n;
+const ENG_ACCOUNT = 34097928597517032341262417297270767793n;
+
+const HOUR = 3_600_000;
+const T0 = 1_800_000_000_000;
+
+/**
+ * `getAccountId` THROWS, exactly as a real client does in a process that never called
+ * `createUserWallet` — its `accountMap` is per-process and nothing in src populates it
+ * for a parent id. Asserting it is never called is what proves `budgetContext` derives
+ * both the parent and every envelope account rather than looking either up.
+ */
+function createMockTBClient() {
+	return {
+		getAccountId: vi.fn((userId: string): bigint => {
+			throw new Error(`No TigerBeetle account for user: ${userId}`);
+		}),
+		lookupBalance: vi.fn(),
+		lookupAccounts: vi.fn(),
+		lookupBalances: vi.fn(async () => new Map<bigint, number>()),
+	};
+}
+
+type MockTB = ReturnType<typeof createMockTBClient>;
+
+/** Cast helper — the mock implements only the slice of the client this module uses. */
+function asClient(mock: MockTB): TrustTBClient {
+	return mock as unknown as TrustTBClient;
+}
+
+function envelope(
+	costCenter: string,
+	allocated: number,
+	periodStartMs = T0,
+	periodEndMs?: number,
+): EnvelopeDescriptor {
+	return periodEndMs === undefined
+		? { costCenter, allocated, periodStartMs }
+		: { costCenter, allocated, periodStartMs, periodEndMs };
+}
+
+describe("budgetContext — derives accounts, never looks them up", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("derives the parent and every envelope account through the one static, spelled-out KATs", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[PARENT_ACCOUNT, 900],
+				[BILLING_ACCOUNT, 400],
+				[OPS_ACCOUNT, 100],
+			]),
+		);
+
+		await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", 1000), envelope("ops", 200)],
+			T0 + HOUR,
+		);
+
+		expect(TrustTBClient.deriveAccountId(PARENT)).toBe(PARENT_ACCOUNT);
+		expect(TrustTBClient.deriveCostCenterAccountId(PARENT, "billing")).toBe(BILLING_ACCOUNT);
+		expect(TrustTBClient.deriveCostCenterAccountId(PARENT, "ops")).toBe(OPS_ACCOUNT);
+		expect(mockTB.lookupBalances).toHaveBeenCalledWith([
+			PARENT_ACCOUNT,
+			BILLING_ACCOUNT,
+			OPS_ACCOUNT,
+		]);
+	});
+
+	it("never calls getAccountId", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map());
+
+		await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 1000)], T0);
+
+		expect(mockTB.getAccountId).not.toHaveBeenCalled();
+	});
+
+	it("never calls lookupAccounts or the single-account lookupBalance", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map());
+
+		await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 1000)], T0);
+
+		expect(mockTB.lookupAccounts).not.toHaveBeenCalled();
+		expect(mockTB.lookupBalance).not.toHaveBeenCalled();
+	});
+
+	it("makes exactly ONE lookupBalances round trip regardless of envelope count", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map());
+
+		await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", 1000), envelope("ops", 200), envelope("eng", 300)],
+			T0,
+		);
+
+		expect(mockTB.lookupBalances).toHaveBeenCalledOnce();
+		expect(mockTB.lookupBalances).toHaveBeenCalledWith([
+			PARENT_ACCOUNT,
+			BILLING_ACCOUNT,
+			OPS_ACCOUNT,
+			ENG_ACCOUNT,
+		]);
+	});
+
+	it("makes exactly ONE lookupBalances round trip for zero envelopes (parent only)", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map());
+
+		await budgetContext(asClient(mockTB), PARENT, [], T0);
+
+		expect(mockTB.lookupBalances).toHaveBeenCalledOnce();
+		expect(mockTB.lookupBalances).toHaveBeenCalledWith([PARENT_ACCOUNT]);
+	});
+});
+
+describe("budgetContext — implicit zero for missing accounts, parent included", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("reads a never-allocated envelope as remaining: 0, not an error", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map([[PARENT_ACCOUNT, 500]]));
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, [envelope("never-used", 1000)], T0);
+
+		expect(ctx.envelopes).toHaveLength(1);
+		expect(ctx.envelopes[0]?.remaining).toBe(0);
+		expect(ctx.envelopes[0]?.spent).toBe(1000);
+		expect(ctx.envelopes[0]?.fraction).toBe(0);
+	});
+
+	it("reads a missing parent account as remaining: 0 too — symmetric with envelopes", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map([[BILLING_ACCOUNT, 400]]));
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 1000)], T0);
+
+		expect(ctx.parent.remaining).toBe(0);
+	});
+
+	it("reads everything as zero when lookupBalances returns an empty map", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map());
+
+		const ctx = await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", 1000), envelope("ops", 500)],
+			T0,
+		);
+
+		expect(ctx.parent.remaining).toBe(0);
+		expect(ctx.envelopes.map((e) => e.remaining)).toEqual([0, 0]);
+	});
+});
+
+describe("budgetContext — A5 clamp semantics", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("spent = max(0, allocated - remaining) in the ordinary case", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[PARENT_ACCOUNT, 0],
+				[BILLING_ACCOUNT, 400],
+			]),
+		);
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 1000)], T0);
+
+		expect(ctx.envelopes[0]?.remaining).toBe(400);
+		expect(ctx.envelopes[0]?.spent).toBe(600);
+		expect(ctx.envelopes[0]?.fraction).toBe(0.4);
+	});
+
+	it("clamps spent to 0 and fraction to 1 when the envelope holds more than it was allocated", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[PARENT_ACCOUNT, 0],
+				[BILLING_ACCOUNT, 1500],
+			]),
+		);
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 1000)], T0);
+
+		expect(ctx.envelopes[0]?.remaining).toBe(1500);
+		expect(ctx.envelopes[0]?.spent).toBe(0);
+		expect(ctx.envelopes[0]?.fraction).toBe(1);
+	});
+
+	it("reads fraction: 0 when allocated <= 0 — no headroom, not a division by zero", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[PARENT_ACCOUNT, 0],
+				[BILLING_ACCOUNT, 50],
+			]),
+		);
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 0)], T0);
+
+		expect(ctx.envelopes[0]?.allocated).toBe(0);
+		expect(ctx.envelopes[0]?.fraction).toBe(0);
+		expect(ctx.envelopes[0]?.spent).toBe(0);
+	});
+
+	it("normalizes a non-finite or negative allocated to 0 rather than propagating it", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map([[PARENT_ACCOUNT, 0]]));
+
+		const ctx = await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", Number.NaN)],
+			T0,
+		);
+
+		expect(ctx.envelopes[0]?.allocated).toBe(0);
+		expect(Number.isFinite(ctx.envelopes[0]?.spent)).toBe(true);
+		expect(Number.isFinite(ctx.envelopes[0]?.fraction)).toBe(true);
+	});
+
+	it("never reports a negative remaining — lookupBalances already floors available at 0", async () => {
+		// available is floored upstream in ledger/client.ts's accountBalance; a mock
+		// that somehow returned a negative number would still be clamped by the same
+		// `?? 0` implicit-zero reading only for MISSING accounts, not a present
+		// negative one — so this pins that the map value flows straight through
+		// (proving there is no separate, divergent clamp in this file).
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[PARENT_ACCOUNT, 0],
+				[BILLING_ACCOUNT, 0],
+			]),
+		);
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 1000)], T0);
+
+		expect(ctx.envelopes[0]?.remaining).toBeGreaterThanOrEqual(0);
+	});
+});
+
+describe("budgetContext — runway reuse (A6) and the single clock", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("runwayHours matches an independent computeRunway + runwayHours call for the same inputs", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[PARENT_ACCOUNT, 0],
+				[BILLING_ACCOUNT, 400],
+			]),
+		);
+
+		const ctx = await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", 1000, T0)],
+			T0 + 5 * HOUR,
+		);
+
+		const expected = runwayHours(
+			computeRunway({ allocated: 1000, spent: 600, periodStartMs: T0, nowMs: T0 + 5 * HOUR }),
+			T0 + 5 * HOUR,
+		);
+		expect(ctx.envelopes[0]?.runwayHours).toBe(expected);
+	});
+
+	it("null runwayHours (nothing spent yet) is preserved, not coerced to a number", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[PARENT_ACCOUNT, 0],
+				[BILLING_ACCOUNT, 1000],
+			]),
+		);
+
+		const ctx = await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", 1000, T0)],
+			T0 + HOUR,
+		);
+
+		expect(ctx.envelopes[0]?.runwayHours).toBeNull();
+	});
+
+	it("reads the wall clock exactly ONCE for a multi-envelope batch when nowMs is omitted", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map());
+		const nowSpy = vi.spyOn(Date, "now").mockReturnValue(T0 + 2 * HOUR);
+
+		await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", 1000), envelope("ops", 500), envelope("eng", 200)],
+			undefined,
+		);
+
+		expect(nowSpy).toHaveBeenCalledTimes(1);
+		nowSpy.mockRestore();
+	});
+
+	it("applies the SAME clock to every envelope in the batch", async () => {
+		mockTB.lookupBalances.mockResolvedValueOnce(
+			new Map([
+				[BILLING_ACCOUNT, 500],
+				[OPS_ACCOUNT, 500],
+			]),
+		);
+
+		const ctx = await budgetContext(
+			asClient(mockTB),
+			PARENT,
+			[envelope("billing", 1000, T0), envelope("ops", 1000, T0)],
+			T0 + 2 * HOUR,
+		);
+
+		// Same allocated/spent/period across both envelopes + same clock => same burn
+		// rate and the same runwayHours, which would drift apart if either envelope
+		// used a different `now`.
+		expect(ctx.envelopes[0]?.runwayHours).toBe(ctx.envelopes[1]?.runwayHours);
+	});
+});
+
+describe("budgetContext — validation doors, all pre-I/O", () => {
+	let mockTB: MockTB;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockTB = createMockTBClient();
+	});
+
+	it("rejects an invalid costCenter before any ledger I/O", async () => {
+		await expect(
+			budgetContext(asClient(mockTB), PARENT, [envelope("bad::cc", 1000)], T0),
+		).rejects.toThrow(/costCenter/);
+		expect(mockTB.lookupBalances).not.toHaveBeenCalled();
+	});
+
+	it("rejects an invalid parentUserId before any ledger I/O, even with zero envelopes", async () => {
+		await expect(budgetContext(asClient(mockTB), "acme::billing", [], T0)).rejects.toThrow(
+			/parentUserId must not contain "::"/,
+		);
+		expect(mockTB.lookupBalances).not.toHaveBeenCalled();
+	});
+
+	it("rejects an invalid parentUserId before any ledger I/O when envelopes are present", async () => {
+		await expect(
+			budgetContext(asClient(mockTB), "bad parent", [envelope("billing", 1000)], T0),
+		).rejects.toThrow(/parentUserId must match/);
+		expect(mockTB.lookupBalances).not.toHaveBeenCalled();
+	});
+
+	it("rejects duplicate costCenter descriptors before any ledger I/O (A3)", async () => {
+		await expect(
+			budgetContext(
+				asClient(mockTB),
+				PARENT,
+				[envelope("billing", 1000), envelope("billing", 500)],
+				T0,
+			),
+		).rejects.toThrow(/duplicate costCenter/);
+		expect(mockTB.lookupBalances).not.toHaveBeenCalled();
+	});
+
+	it(`rejects envelopes.length over the ${MAX_ENVELOPES} cap before any ledger I/O (A3)`, async () => {
+		const tooMany = Array.from({ length: MAX_ENVELOPES + 1 }, (_, i) => envelope(`cc-${i}`, 10));
+
+		await expect(budgetContext(asClient(mockTB), PARENT, tooMany, T0)).rejects.toThrow(
+			new RegExp(`exceeds the ${MAX_ENVELOPES} cap`),
+		);
+		expect(mockTB.lookupBalances).not.toHaveBeenCalled();
+	});
+
+	it(`accepts exactly ${MAX_ENVELOPES} envelopes — the cap is inclusive`, async () => {
+		const exactlyMax = Array.from({ length: MAX_ENVELOPES }, (_, i) => envelope(`cc-${i}`, 10));
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map());
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, exactlyMax, T0);
+
+		expect(ctx.envelopes).toHaveLength(MAX_ENVELOPES);
+		expect(mockTB.lookupBalances).toHaveBeenCalledOnce();
+	});
+});
+
+describe("budgetContext — does not require the parent to be in the client account map", () => {
+	it("reads without consulting getAccountId, the same guarantee getBudgetStatus gives", async () => {
+		const mockTB = createMockTBClient();
+		mockTB.lookupBalances.mockResolvedValueOnce(new Map([[PARENT_ACCOUNT, 750]]));
+
+		const ctx = await budgetContext(asClient(mockTB), PARENT, [envelope("billing", 1000)], T0);
+
+		expect(ctx.parent.remaining).toBe(750);
+		expect(mockTB.getAccountId).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/tests/budget/public-budget-api.test-d.ts
+++ b/packages/core/tests/budget/public-budget-api.test-d.ts
@@ -19,11 +19,21 @@
 import type {
 	AllocateResult,
 	BudgetAuditWriter,
+	BudgetContext,
 	BudgetStatus,
+	EnvelopeDescriptor,
+	EnvelopeStatus,
 	ReclaimResult,
 	Runway,
 } from "usertrust";
-import { allocateBudget, getBudgetStatus, reclaimBudget, TrustTBClient } from "usertrust";
+import {
+	allocateBudget,
+	budgetContext,
+	getBudgetStatus,
+	reclaimBudget,
+	TrustTBClient,
+	withCostCenter,
+} from "usertrust";
 
 type Assert<T extends true> = T;
 type Extends<A, B> = A extends B ? true : false;
@@ -57,3 +67,21 @@ export const _status: Promise<BudgetStatus> = getBudgetStatus(tb, {
 });
 
 export type _StatusCarriesRunway = Assert<Extends<Awaited<typeof _status>, { runway: Runway }>>;
+
+// The scarcity read API: EnvelopeDescriptor is constructible by a consumer without
+// importing anything else — the whole point of the F1 guard extended to this surface.
+declare const envelopes: EnvelopeDescriptor[];
+
+export const _context: Promise<BudgetContext> = budgetContext(tb, "acme", envelopes, Date.now());
+
+export type _ContextCarriesEnvelopes = Assert<
+	Extends<Awaited<typeof _context>, { parent: { remaining: number }; envelopes: EnvelopeStatus[] }>
+>;
+
+// withCostCenter closes over the same TrustTBClient-holding governor a caller already
+// constructed above; its own signature takes no TrustTBClient, so this asserts only
+// that the scope runs `fn` and returns its value, sync and with options both accepted.
+export const _withCostCenter: number = withCostCenter("billing", () => 42, {
+	allocated: 1_000,
+	periodStartMs: 0,
+});

--- a/packages/core/tests/budget/public-budget-api.test.ts
+++ b/packages/core/tests/budget/public-budget-api.test.ts
@@ -26,4 +26,13 @@ describe("public budget API surface", () => {
 		expect(typeof usertrust.TrustTBClient).toBe("function");
 		expect(typeof usertrust.TrustTBClient?.prototype).toBe("object");
 	});
+
+	// Same guard, extended to the scarcity surface this PR adds: withCostCenter is the
+	// attribution scope a caller wraps a governed call in, and budgetContext is the
+	// pull-side read across every envelope it holds. Both take (or, for withCostCenter,
+	// close over) the same `TrustTBClient` already asserted constructible above.
+	it("exports withCostCenter and budgetContext from the package root", () => {
+		expect(typeof usertrust.withCostCenter).toBe("function");
+		expect(typeof usertrust.budgetContext).toBe("function");
+	});
 });

--- a/packages/core/tests/govern/config.test.ts
+++ b/packages/core/tests/govern/config.test.ts
@@ -202,6 +202,30 @@ describe("loadConfig()", () => {
 		expect(config.audit.indexLimit).toBe(50_000);
 	});
 
+	it("refuses a malformed parentUserId written into the config file", async () => {
+		const vaultDir = join(tmpDir, VAULT_DIR);
+		mkdirSync(vaultDir, { recursive: true });
+		writeFileSync(
+			join(vaultDir, "usertrust.config.json"),
+			JSON.stringify({ budget: 1000, parentUserId: "acme::billing" }),
+		);
+
+		await expect(loadConfig()).rejects.toThrow();
+	});
+
+	it("loads a valid parentUserId from the config file", async () => {
+		const vaultDir = join(tmpDir, VAULT_DIR);
+		mkdirSync(vaultDir, { recursive: true });
+		writeFileSync(
+			join(vaultDir, "usertrust.config.json"),
+			JSON.stringify({ budget: 1000, parentUserId: "acme-team" }),
+		);
+
+		const config = await loadConfig();
+
+		expect(config.parentUserId).toBe("acme-team");
+	});
+
 	it("handles malformed JSON gracefully (throws)", async () => {
 		const vaultDir = join(tmpDir, VAULT_DIR);
 		mkdirSync(vaultDir, { recursive: true });
@@ -312,5 +336,48 @@ describe("defineConfig()", () => {
 				budget: -1,
 			} as never),
 		).toThrow();
+	});
+});
+
+// ── parentUserId: the governor's envelope identity ──
+//
+// Cost-center envelope accounts hash the (parentUserId, costCenter) tuple, so a
+// governor that spends from an envelope needs a parent id. The field is OPTIONAL
+// and validated by the one authoritative rule (`parentUserIdRefusal`): a config
+// that never mentions it must keep parsing exactly as before, and a malformed one
+// must be refused where it is written — not later, at the first hold, with money
+// already in flight.
+
+describe("TrustConfigSchema — parentUserId", () => {
+	it("accepts a single-colon parent id (issue #64)", () => {
+		const config = defineConfig({ budget: 1000, parentUserId: "acme:eu:prod" } as never);
+		expect(config.parentUserId).toBe("acme:eu:prod");
+	});
+
+	it("leaves configs that never mention it byte-identical", () => {
+		const before = defineConfig({ budget: 1000, tier: "pro" } as never);
+		expect(before.parentUserId).toBeUndefined();
+		// The optional field must not materialise a key — a config round-tripped
+		// through the schema is what an operator diffs against their file.
+		expect(Object.hasOwn(before, "parentUserId")).toBe(false);
+	});
+
+	it("refuses the quarantined `::` separator, and says so", () => {
+		let caught: unknown;
+		try {
+			defineConfig({ budget: 1000, parentUserId: "acme::billing" } as never);
+		} catch (e) {
+			caught = e;
+		}
+		expect(caught).toBeInstanceOf(Error);
+		// The refusal must name the quarantine — quoting the charset at an operator
+		// who passed `acme::billing` describes a rule that plainly admits their id.
+		expect((caught as Error).message).toContain("::");
+		expect((caught as Error).message).toContain("parentUserId");
+	});
+
+	it("refuses an id outside the parent charset", () => {
+		expect(() => defineConfig({ budget: 1000, parentUserId: "acme billing" } as never)).toThrow();
+		expect(() => defineConfig({ budget: 1000, parentUserId: "" } as never)).toThrow();
 	});
 });

--- a/packages/core/tests/govern/envelope-concurrency.test.ts
+++ b/packages/core/tests/govern/envelope-concurrency.test.ts
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * The envelope preflight read is serialised under the budget mutex, so a hard
+ * scarcity tier holds under SINGLE-GOVERNOR concurrency.
+ *
+ * The bug (Codex P1, found at MAX effort): the attributed-call envelope preflight
+ * balance read (`preflightEnvelopeRemaining`) used to run OUTSIDE `budgetMutex`. Two
+ * concurrent attributed calls to the SAME envelope therefore both read the
+ * pre-first-hold balance, and the envelope-scoped hard tiers
+ * (`budgetFractionRemaining` / `budgetRunwayHours`) were evaluated against that stale
+ * read. The ledger's atomic `debits_must_not_exceed_credits` rejects an OVERSHOOT but
+ * never a fractional/runway tier, so the second call slipped past a hard scarcity
+ * tier that should have denied it — defeating the feature's ledger-ENFORCED (not
+ * advisory) behaviour-shaping claim under concurrency. The session path is immune
+ * because its budget check reads IN-PROCESS counters mutated under the mutex; the
+ * envelope path reads the LEDGER and did it before locking.
+ *
+ * The fix moves the read INSIDE the mutex, before the gate and the hold, on all three
+ * attributed entry points (`trust()` LLM, `governAction`, headless `authorize`).
+ *
+ * WHY THIS IS DETERMINISTIC (no sleeps, no fake timers):
+ *  - `AsyncMutex.acquire()` mutates its queue tail SYNCHRONOUSLY before its first
+ *    `await`, so the acquisition order equals the call order. With `Promise.all[...]`
+ *    the array's first element runs its synchronous prefix — and, on the FIXED code,
+ *    calls `acquire()` — before the second element begins, so element 0 always wins
+ *    the lock.
+ *  - The mock engine is STATEFUL: `spendPending` decrements the envelope's `available`
+ *    by a fixed hold (a PENDING TigerBeetle transfer debits the wallet immediately),
+ *    and `lookupBalances` reports the CURRENT `available`.
+ *
+ * The two code paths then diverge with certainty:
+ *  - OLD (read outside the lock): both calls issue their preflight read as their
+ *    FIRST await, before either acquires the mutex, so both read the pre-hold 35% and
+ *    BOTH pass the < 30% tier. Zero denials.
+ *  - FIXED (read inside the lock): element 0 acquires, reads 35%, holds (→25%),
+ *    releases; element 1 then acquires, reads 25%, and the tier DENIES it. Exactly one
+ *    denial.
+ *
+ * So `expect(rejected).toHaveLength(1)` FAILS on HEAD (0 rejections) and passes after
+ * the fix — the failing-first pin this whole change exists for.
+ *
+ * SECURITY (mirrors the sibling suites): never log or snapshot a whole PolicyContext —
+ * it carries request-shaped data. Assert on outcomes and individual fields.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import { withCostCenter } from "../../src/budget/attribution.js";
+import { type TrustEngine, trust } from "../../src/govern.js";
+import { createGovernor } from "../../src/headless.js";
+import { TrustTBClient } from "../../src/ledger/client.js";
+import { PolicyDeniedError } from "../../src/shared/errors.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Fixtures ──
+
+const PARENT = "acme";
+const COST_CENTER = "research";
+const ENVELOPE_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, COST_CENTER);
+
+/** 1_000_000 allocated: `remaining / allocated` is the tier's `budgetFractionRemaining`. */
+const ALLOCATED = 1_000_000;
+const SCOPE_OPTS = { allocated: ALLOCATED, periodStartMs: Date.UTC(2026, 7, 3, 0, 0, 0) };
+/** Start at 35% and hold 10% at a time: the first hold drops the fraction to 25%. */
+const START_AVAILABLE = 350_000;
+const HOLD = 100_000;
+
+/**
+ * A hard tier keyed ONLY on the envelope fraction — no model condition, so it applies
+ * to LLM calls, actions, and headless authorizations alike. The `exists` guard keeps
+ * it off unattributed traffic (that field is `undefined` there). This is the rule the
+ * ledger cannot enforce: TigerBeetle rejects overshoot, never a fraction below 0.3.
+ */
+const TIER_RULE = {
+	id: "concurrency-envelope-tier",
+	name: "deny-below-30pct",
+	description: "attributed spend blocked below 30% of the envelope",
+	effect: "deny",
+	enforcement: "hard",
+	severity: "high",
+	conditions: [
+		{ field: "budgetFractionRemaining", operator: "exists" },
+		{ field: "budgetFractionRemaining", operator: "lt", value: 0.3 },
+	],
+};
+
+const CALL = {
+	model: "claude-sonnet-4-6",
+	max_tokens: 64,
+	messages: [{ role: "user", content: "hello" }],
+};
+
+interface EngineHandle extends TrustEngine {
+	spendPending: ReturnType<typeof vi.fn>;
+	postPendingSpend: ReturnType<typeof vi.fn>;
+	voidPendingSpend: ReturnType<typeof vi.fn>;
+	lookupBalances: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * The whole point of the harness: a ledger whose read reflects prior holds. A PENDING
+ * hold debits the envelope immediately, so a later `lookupBalances` must see it. The
+ * decrement is a FIXED `HOLD` (not the tiny per-call estimate) purely so the fraction
+ * crosses the tier boundary cleanly — the SIZE of the drop is not what is under test,
+ * only whether the second preflight observes it.
+ */
+function makeStatefulEnvelopeEngine(): EngineHandle {
+	let available = START_AVAILABLE;
+	const engine: EngineHandle = {
+		spendPending: vi.fn(async (p: { transferId: string; debitAccountId?: bigint }) => {
+			// Only an attributed hold moves the envelope; every call here is attributed.
+			if (p.debitAccountId === ENVELOPE_ID) available -= HOLD;
+			return { transferId: p.transferId };
+		}),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		voidAllPending: vi.fn(async () => {}),
+		lookupBalances: vi.fn(async (ids: bigint[]) => {
+			const map = new Map<bigint, number>();
+			for (const id of ids) map.set(id, available);
+			return map;
+		}),
+		destroy: vi.fn(),
+	};
+	return engine;
+}
+
+function makeMockAudit(): AuditWriter {
+	return {
+		appendEvent: vi.fn(
+			async (input: AppendEventInput): Promise<AuditEvent> => ({
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			}),
+		),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+function makeAnthropicMock() {
+	return {
+		messages: {
+			create: vi.fn(async () => ({
+				id: "msg_1",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			})),
+		},
+	};
+}
+
+function makeTierVault(): string {
+	const base = join(tmpdir(), `envelope-concurrency-${randomUUID()}`);
+	const usertrustDir = join(base, ".usertrust");
+	mkdirSync(join(usertrustDir, "policies"), { recursive: true });
+	writeFileSync(
+		join(usertrustDir, "policies", "tier.json"),
+		JSON.stringify({ rules: [TIER_RULE] }),
+	);
+	writeFileSync(
+		join(usertrustDir, "usertrust.config.json"),
+		JSON.stringify({ budget: 100_000_000, policies: "./policies/tier.json" }),
+	);
+	return base;
+}
+
+/** Exactly the calls that were REJECTED, for the "how many denials?" assertions. */
+function rejections(results: PromiseSettledResult<unknown>[]): PromiseRejectedResult[] {
+	return results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+}
+
+describe("the envelope tier holds under single-governor concurrency", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = makeTierVault();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("DENIES the second of two concurrent attributed LLM calls (trust) once the first hold drops the fraction below the tier", async () => {
+		const engine = makeStatefulEnvelopeEngine();
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		// Two attributed calls to the SAME envelope, launched together. On HEAD both
+		// read 35% before either hold lands and both pass; after the fix the second
+		// reads 25% under the lock and is denied.
+		const results = await Promise.allSettled([
+			withCostCenter(COST_CENTER, () => governed.messages.create(CALL), SCOPE_OPTS),
+			withCostCenter(COST_CENTER, () => governed.messages.create(CALL), SCOPE_OPTS),
+		]);
+
+		const denied = rejections(results);
+		expect(denied).toHaveLength(1);
+		const reason = denied[0]?.reason;
+		expect(reason).toBeInstanceOf(PolicyDeniedError);
+		expect(String((reason as PolicyDeniedError).message)).toContain("concurrency-envelope-tier");
+
+		// The tier is a PRE-spend deny: exactly one hold reached the ledger, and the
+		// blocked call never forwarded to the provider.
+		expect(engine.spendPending).toHaveBeenCalledTimes(1);
+		expect(client.messages.create).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
+	});
+
+	it("DENIES the second of two concurrent attributed ACTIONS (governAction)", async () => {
+		const engine = makeStatefulEnvelopeEngine();
+		const execute = vi.fn(async () => "ok");
+		const governed = await trust(makeAnthropicMock(), {
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const action = { kind: "tool_use", name: "search", cost: 100 };
+		const results = await Promise.allSettled([
+			withCostCenter(COST_CENTER, () => governed.governAction(action, execute), SCOPE_OPTS),
+			withCostCenter(COST_CENTER, () => governed.governAction(action, execute), SCOPE_OPTS),
+		]);
+
+		const denied = rejections(results);
+		expect(denied).toHaveLength(1);
+		const reason = denied[0]?.reason;
+		expect(reason).toBeInstanceOf(PolicyDeniedError);
+		expect(String((reason as PolicyDeniedError).message)).toContain("concurrency-envelope-tier");
+		// One hold, and the blocked action's body never executed.
+		expect(engine.spendPending).toHaveBeenCalledTimes(1);
+		expect(execute).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
+	});
+
+	it("DENIES the second of two concurrent attributed AUTHORIZATIONS (headless authorize)", async () => {
+		const engine = makeStatefulEnvelopeEngine();
+		const gov = await createGovernor({
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const authorizeParams = {
+			model: "claude-sonnet-4-6",
+			estimatedInputTokens: 10,
+			maxOutputTokens: 64,
+		};
+		const results = await Promise.allSettled([
+			withCostCenter(COST_CENTER, () => gov.authorize(authorizeParams), SCOPE_OPTS),
+			withCostCenter(COST_CENTER, () => gov.authorize(authorizeParams), SCOPE_OPTS),
+		]);
+
+		const denied = rejections(results);
+		expect(denied).toHaveLength(1);
+		const reason = denied[0]?.reason;
+		expect(reason).toBeInstanceOf(PolicyDeniedError);
+		expect(String((reason as PolicyDeniedError).message)).toContain("concurrency-envelope-tier");
+		// One hold placed; the blocked authorization returned no handle.
+		expect(engine.spendPending).toHaveBeenCalledTimes(1);
+
+		await gov.destroy();
+	});
+
+	it("lets BOTH concurrent calls through when neither hold crosses the tier (no false denials)", async () => {
+		// Same race, but the tier boundary is never crossed: with 35% start and a 10%
+		// hold, 25% is still ABOVE a 0.2 threshold, so the fix must not over-deny. This
+		// guards against a fix that simply serialised-and-denied everything.
+		const usertrustDir = join(vaultBase, ".usertrust");
+		writeFileSync(
+			join(usertrustDir, "policies", "tier.json"),
+			JSON.stringify({
+				rules: [
+					{
+						...TIER_RULE,
+						conditions: [
+							{ field: "budgetFractionRemaining", operator: "exists" },
+							{ field: "budgetFractionRemaining", operator: "lt", value: 0.2 },
+						],
+					},
+				],
+			}),
+		);
+
+		const engine = makeStatefulEnvelopeEngine();
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const results = await Promise.allSettled([
+			withCostCenter(COST_CENTER, () => governed.messages.create(CALL), SCOPE_OPTS),
+			withCostCenter(COST_CENTER, () => governed.messages.create(CALL), SCOPE_OPTS),
+		]);
+
+		expect(rejections(results)).toHaveLength(0);
+		expect(engine.spendPending).toHaveBeenCalledTimes(2);
+		expect(client.messages.create).toHaveBeenCalledTimes(2);
+
+		await governed.destroy();
+	});
+});

--- a/packages/core/tests/govern/envelope-threading.test.ts
+++ b/packages/core/tests/govern/envelope-threading.test.ts
@@ -40,6 +40,7 @@
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { mkdirSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -48,6 +49,7 @@ import { getCurrentCostCenter, withCostCenter } from "../../src/budget/attributi
 import { type TrustEngine, trust } from "../../src/govern.js";
 import { TrustTBClient } from "../../src/ledger/client.js";
 import { evaluatePolicy, type PolicyContext } from "../../src/policy/gate.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
 import { InsufficientBalanceError, LedgerUnavailableError } from "../../src/shared/errors.js";
 import type { AuditEvent, TrustReceipt } from "../../src/shared/types.js";
 
@@ -185,6 +187,20 @@ function auditData(audit: AuditHandle, kind: string): Record<string, unknown> {
 		);
 	}
 	return event.data as Record<string, unknown>;
+}
+
+/**
+ * The cumulative session spend persisted to disk, or `undefined` when no ledger
+ * was ever written. That file is what seeds the next run's holding wallet with
+ * `max(0, budget - budgetSpent)`, which is why envelope money must never reach it.
+ */
+async function readPersistedSpend(vaultBase: string): Promise<number | undefined> {
+	try {
+		const raw = await readFile(join(vaultBase, VAULT_DIR, "spend-ledger.json"), "utf-8");
+		return (JSON.parse(raw) as { budgetSpent: number }).budgetSpent;
+	} catch {
+		return undefined;
+	}
 }
 
 /** The context the (real) evaluator saw for the most recent gate call. */
@@ -760,6 +776,36 @@ describe("governAction attribution", () => {
 		await governed.destroy();
 	});
 
+	it("keeps an attributed ACTION out of the session budget (mixed traffic)", async () => {
+		const engine = makeMockEngine({ balance: 50_000 });
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const attributed = await withCostCenter(
+			COST_CENTER,
+			() =>
+				governed.governAction({ kind: "tool_use", name: "search", cost: 250 }, async () => "ok"),
+			SCOPE_OPTS,
+		);
+		expect(attributed.receipt.budgetRemaining).toBe(100_000);
+
+		const unattributed = await governed.governAction(
+			{ kind: "tool_use", name: "search", cost: 250 },
+			async () => "ok",
+		);
+		// The unattributed action was gated on a session remaining the envelope
+		// spend never moved, and only its own cost came off it.
+		expect(lastPolicyContext().budget_remaining).toBe(100_000);
+		expect(unattributed.receipt.budgetRemaining).toBe(100_000 - 250);
+
+		await governed.destroy();
+	});
+
 	it("leaves an unattributed action exactly as it was", async () => {
 		const engine = makeMockEngine({ balance: 3_000 });
 		const audit = makeMockAudit();
@@ -783,6 +829,154 @@ describe("governAction attribution", () => {
 		expect(ctx.budget_remaining).toBe(100_000);
 		expect(auditData(audit, "tool_use").costCenter).toBeUndefined();
 		expect(receipt.budget).toBeUndefined();
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Session accounting tracks SESSION-WALLET money only
+// ---------------------------------------------------------------------------
+//
+// Whole-branch review, finding 3. `budgetSpent` and `inFlightHoldTotal` describe
+// the per-session HOLDING wallet: they gate every unattributed call, they are what
+// `receipt.budgetRemaining` reports, and `persistSpendLedger` carries `budgetSpent`
+// across restarts as the `max(0, budget - budgetSpent)` seed of that wallet. An
+// attributed hold debits the `(parent, costCenter)` ENVELOPE and never touches the
+// holding wallet, so moving those counters for it charges the session for money it
+// did not pay. The drift is fail-closed — over-deny, never loss — but silent: the
+// session eventually hard-denies unattributed calls against a wallet TigerBeetle
+// would still have held against, and it survives a restart, and nothing reports it.
+
+describe("session accounting excludes envelope spend", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `envelope-session-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("keeps an attributed LLM call out of the session budget, and gates the next unattributed call on it", async () => {
+		const engine = makeMockEngine({ balance: 50_000 });
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const attributed = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		)) as { receipt: TrustReceipt };
+
+		expect(attributed.receipt.cost).toBeGreaterThan(0);
+		// A settled attributed receipt still reports SESSION headroom — the envelope's
+		// own number is `receipt.budget` — and this spend did not consume any of it.
+		expect(attributed.receipt.budgetRemaining).toBe(100_000);
+		expect(attributed.receipt.budget?.remaining).toBe(50_000);
+
+		const unattributed = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+
+		// THE PIN: the unattributed call is gated on a session remaining the
+		// attributed spend never moved.
+		expect(lastPolicyContext().budget_remaining).toBe(100_000);
+		expect(unattributed.receipt.budgetRemaining).toBe(100_000 - unattributed.receipt.cost);
+		// Only session-wallet spend is persisted, because only it belongs in the next
+		// run's `max(0, budget - budgetSpent)` holding-wallet seed.
+		expect(await readPersistedSpend(vaultBase)).toBe(unattributed.receipt.cost);
+
+		await governed.destroy();
+	});
+
+	it("keeps an attributed STREAM settle out of the session budget", async () => {
+		const engine = makeMockEngine({ balance: 6_000 });
+		const stream = new ManualMessageStream();
+		const client = {
+			messages: { create: vi.fn(), stream: vi.fn(() => stream) },
+		};
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const handle = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.stream(PARAMS),
+			SCOPE_OPTS,
+		)) as ManualMessageStream & { receipt: Promise<TrustReceipt> };
+
+		stream.emit("finalMessage", { usage: { input_tokens: 10, output_tokens: 5 } });
+		stream.emit("end");
+		const receipt = await handle.receipt;
+
+		// The stream terminal commits the spend on its own path (finalizeStreamSettle);
+		// it must skip the session commit for the same reason the non-stream settle does.
+		expect(receipt.settled).toBe(true);
+		expect(receipt.budgetRemaining).toBe(100_000);
+		expect(await readPersistedSpend(vaultBase)).toBeUndefined();
+
+		await governed.destroy();
+	});
+
+	it("never persists a spend ledger for an attributed-only session", async () => {
+		const engine = makeMockEngine({ balance: 50_000 });
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		await withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS);
+
+		// Nothing to record: the session wallet paid nothing. A ledger written here
+		// would shrink the next run's holding-wallet seed by envelope money — and
+		// `loadSpendLedger` has no way to tell the two apart.
+		expect(await readPersistedSpend(vaultBase)).toBeUndefined();
+
+		await governed.destroy();
+	});
+
+	it("restores nothing to the session on an attributed VOID terminal", async () => {
+		const engine = makeMockEngine({ balance: 50_000 });
+		const client = makeAnthropicMock();
+		// Only the FIRST (attributed) call fails; the unattributed readout below has
+		// to reach its own settle.
+		client.messages.create.mockRejectedValueOnce(new Error("provider exploded"));
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		await expect(
+			withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		).rejects.toThrow(/provider exploded/);
+
+		// The increment was skipped, so the matching decrement must be too: an
+		// asymmetric release drives `inFlightHoldTotal` negative and hands the session
+		// MORE headroom than its budget. An unattributed call is the readout.
+		const { receipt } = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+		expect(lastPolicyContext().budget_remaining).toBe(100_000);
+		expect(receipt.budgetRemaining).toBe(100_000 - receipt.cost);
 
 		await governed.destroy();
 	});

--- a/packages/core/tests/govern/envelope-threading.test.ts
+++ b/packages/core/tests/govern/envelope-threading.test.ts
@@ -519,6 +519,38 @@ describe("attributed calls spend from the cost-center envelope", () => {
 		await governed.destroy();
 	});
 
+	it("OMITS the budget block on an AMBIGUOUS settlement (settled:false), without a post-settle read", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		// The POST after the audit fails: the transfer may still be pending and be
+		// posted or voided later, so the envelope balance is transient. `receipt.budget`
+		// is a POST-SETTLEMENT observation (D7/A8) — a receipt marked settled:false must
+		// not carry it, and the ambiguous path must not even read the ledger for it.
+		engine.postPendingSpend.mockRejectedValueOnce(new Error("tb: postTransfer socket reset"));
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		)) as { receipt: TrustReceipt };
+
+		expect(receipt.settled).toBe(false);
+		expect(receipt.budget).toBeUndefined();
+		// The ambiguous settlement is still an attributed forensic record.
+		expect(auditData(audit, "settlement_ambiguous").costCenter).toBe(COST_CENTER);
+		// Only the authorize-time preflight ran — no pointless post-settle snapshot.
+		expect(engine.lookupBalances).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
+	});
+
 	it("carries the attribution into the VOID terminal's audit record (A1)", async () => {
 		const engine = makeMockEngine({ balance: 4_000 });
 		const audit = makeMockAudit();
@@ -669,6 +701,45 @@ describe("stream settlement survives the scope exit", () => {
 
 		await governed.destroy();
 	});
+
+	it("OMITS the budget block on an AMBIGUOUS stream settlement (settled:false)", async () => {
+		const engine = makeMockEngine({ balance: 6_000 });
+		engine.postPendingSpend.mockRejectedValueOnce(new Error("tb: postTransfer socket reset"));
+		const audit = makeMockAudit();
+		const stream = new ManualMessageStream();
+		const client = {
+			messages: {
+				create: vi.fn(),
+				stream: vi.fn(() => stream),
+			},
+		};
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const handle = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.stream(PARAMS),
+			SCOPE_OPTS,
+		)) as ManualMessageStream & { receipt: Promise<TrustReceipt> };
+
+		stream.emit("streamEvent", { type: "message_start", message: { usage: { input_tokens: 10 } } });
+		stream.emit("finalMessage", { usage: { input_tokens: 10, output_tokens: 5 } });
+		stream.emit("end");
+
+		const receipt = await handle.receipt;
+
+		expect(receipt.settled).toBe(false);
+		expect(receipt.budget).toBeUndefined();
+		expect(auditData(audit, "settlement_ambiguous").costCenter).toBe(COST_CENTER);
+		expect(engine.lookupBalances).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -719,6 +790,32 @@ describe("governAction attribution", () => {
 
 		expect(auditData(audit, "tool_use").costCenter).toBe(COST_CENTER);
 		expect(receipt.budget).toMatchObject({ costCenter: COST_CENTER, remaining: 3_000 });
+
+		await governed.destroy();
+	});
+
+	it("OMITS the budget block on an AMBIGUOUS action settlement (settled:false)", async () => {
+		const engine = makeMockEngine({ balance: 3_000 });
+		engine.postPendingSpend.mockRejectedValueOnce(new Error("tb: postTransfer socket reset"));
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = await withCostCenter(
+			COST_CENTER,
+			() => governed.governAction({ kind: "tool_use", name: "search", cost: 25 }, async () => "ok"),
+			SCOPE_OPTS,
+		);
+
+		expect(receipt.settled).toBe(false);
+		expect(receipt.budget).toBeUndefined();
+		expect(auditData(audit, "settlement_ambiguous").costCenter).toBe(COST_CENTER);
+		expect(engine.lookupBalances).toHaveBeenCalledTimes(1);
 
 		await governed.destroy();
 	});

--- a/packages/core/tests/govern/envelope-threading.test.ts
+++ b/packages/core/tests/govern/envelope-threading.test.ts
@@ -1,0 +1,789 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Task 5 — `trust()` threads cost-center attribution through the whole call.
+ *
+ * What is pinned here, and why each pin exists:
+ *
+ *  - ONE `getCurrentCostCenter()` read, at `interceptCall`'s top, captured into the
+ *    closure. The decisive case is the stream test: the `withCostCenter` scope has
+ *    already EXITED (asserted, not assumed) by the time the emitter's terminal fires
+ *    from the test body, so a governor that re-read the store in its terminal would
+ *    attribute the settle to nothing. Both the hold and the settle-time records are
+ *    checked on that path.
+ *  - D1: an active scope with no `parentUserId` throws BEFORE any I/O. Silently
+ *    falling back to the session wallet would un-enforce the envelope the caller
+ *    asked for, and it would do it invisibly.
+ *  - The attributed hold names the ENVELOPE account — `deriveCostCenterAccountId`,
+ *    never a lookup, never a joined string.
+ *  - The policy context is envelope-scoped whenever the hold will debit an envelope,
+ *    and the UNATTRIBUTED construction is byte-identical to what it was before
+ *    envelopes existed (regression pin: this file is the only place that comparison
+ *    lives). `budget_remaining_after` is UNFLOORED on both paths (A7) — it has to be
+ *    able to go negative or `block-budget-overshoot`, the one non-disableable
+ *    pre-spend deny, can never fire on attributed traffic.
+ *  - A2: an attributed call whose envelope cannot be read is REFUSED before the
+ *    policy gate with the ledger-unavailable classification — never gated on the
+ *    session wallet its hold would not have touched, and never continued with the
+ *    field absent (which the hard overshoot rule would turn into a deny that names
+ *    the wrong cause).
+ *  - Attributed audit records carry `costCenter` (A1) — settle AND void terminals.
+ *  - Settled receipts carry the D7 post-settle `budget` snapshot, and a failed
+ *    snapshot read OMITS the block rather than failing a settlement that already
+ *    committed.
+ *
+ * SECURITY (mirrors budget-tier.test.ts): never log or snapshot a whole
+ * PolicyContext — it carries request-shaped data. Assert on individual fields.
+ */
+
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import { getCurrentCostCenter, withCostCenter } from "../../src/budget/attribution.js";
+import { type TrustEngine, trust } from "../../src/govern.js";
+import { TrustTBClient } from "../../src/ledger/client.js";
+import { evaluatePolicy, type PolicyContext } from "../../src/policy/gate.js";
+import { InsufficientBalanceError, LedgerUnavailableError } from "../../src/shared/errors.js";
+import type { AuditEvent, TrustReceipt } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// The evaluator itself stays REAL — this only records the context each call site
+// hands it, so the assertions are about what the gate actually saw.
+vi.mock("../../src/policy/gate.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/policy/gate.js")>();
+	return { ...actual, evaluatePolicy: vi.fn(actual.evaluatePolicy) };
+});
+
+// ── Fixtures ──
+
+const PARENT = "acme";
+const COST_CENTER = "research";
+const ENVELOPE_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, COST_CENTER);
+const ENVELOPE_LABEL = `${PARENT}::${COST_CENTER}`;
+const SCOPE_OPTS = { allocated: 10_000, periodStartMs: Date.UTC(2026, 7, 3, 0, 0, 0) };
+
+const PARAMS = {
+	model: "claude-sonnet-4-6",
+	max_tokens: 64,
+	messages: [{ role: "user", content: "hello" }],
+};
+
+interface EngineHandle extends TrustEngine {
+	spendPending: ReturnType<typeof vi.fn>;
+	postPendingSpend: ReturnType<typeof vi.fn>;
+	voidPendingSpend: ReturnType<typeof vi.fn>;
+	lookupBalances?: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * `balance` shapes the seam the governor reads envelope numbers through:
+ *   number   → the envelope's live `available`
+ *   "missing"→ the account is absent from the map (never allocated / fully reclaimed)
+ *   "throw"  → the read fails (A2 transport failure)
+ *   undefined→ the engine has NO `lookupBalances` at all (the optional-capability case)
+ */
+function makeMockEngine(opts: { balance?: number | "throw" | "missing" } = {}): EngineHandle {
+	const engine: EngineHandle = {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		destroy: vi.fn(),
+	};
+	if (opts.balance !== undefined) {
+		engine.lookupBalances = vi.fn(async (ids: bigint[]) => {
+			if (opts.balance === "throw") throw new Error("tb: lookupAccounts timed out");
+			const map = new Map<bigint, number>();
+			if (opts.balance !== "missing") {
+				for (const id of ids) map.set(id, opts.balance as number);
+			}
+			return map;
+		});
+	}
+	return engine;
+}
+
+interface AuditHandle extends AuditWriter {
+	events: AppendEventInput[];
+}
+
+function makeMockAudit(): AuditHandle {
+	const events: AppendEventInput[] = [];
+	return {
+		events,
+		appendEvent: vi.fn(async (input: AppendEventInput): Promise<AuditEvent> => {
+			events.push(input);
+			return {
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			};
+		}),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+function makeAnthropicMock() {
+	return {
+		messages: {
+			create: vi.fn(async () => ({
+				id: "msg_1",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			})),
+		},
+	};
+}
+
+/** A MessageStream-shaped emitter that emits NOTHING until the test says so. */
+class ManualMessageStream extends EventEmitter {
+	abort(): void {
+		this.emit("abort", new Error("aborted"));
+	}
+	finalMessage(): Promise<unknown> {
+		return Promise.resolve({ usage: { input_tokens: 10, output_tokens: 5 } });
+	}
+	async *[Symbol.asyncIterator](): AsyncIterator<unknown> {
+		// The caller owns the iterator; governance never touches it.
+	}
+}
+
+function auditData(audit: AuditHandle, kind: string): Record<string, unknown> {
+	const event = audit.events.find((e) => e.kind === kind);
+	if (event === undefined) {
+		throw new Error(
+			`no ${kind} audit event was appended (saw: ${audit.events.map((e) => e.kind).join(", ")})`,
+		);
+	}
+	return event.data as Record<string, unknown>;
+}
+
+/** The context the (real) evaluator saw for the most recent gate call. */
+function lastPolicyContext(): PolicyContext {
+	const calls = vi.mocked(evaluatePolicy).mock.calls;
+	const last = calls[calls.length - 1];
+	if (last === undefined) throw new Error("the policy evaluator was never called");
+	return last[1];
+}
+
+// ── Tests ──
+
+describe("attributed calls spend from the cost-center envelope", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `envelope-threading-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("routes the PENDING hold to the derived envelope account", async () => {
+		const engine = makeMockEngine({ balance: 5_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		)) as { receipt: TrustReceipt };
+
+		expect(engine.spendPending).toHaveBeenCalledOnce();
+		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+		expect(receipt.settled).toBe(true);
+
+		await governed.destroy();
+	});
+
+	it("leaves an UNATTRIBUTED hold and its policy numbers exactly as they were", async () => {
+		const engine = makeMockEngine({ balance: 5_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+
+		// No debit account: the session holding wallet, exactly as before envelopes.
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).toBeUndefined();
+		// No envelope read is even attempted for an unattributed call.
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBeUndefined();
+		expect(ctx.budget_remaining).toBe(100_000);
+		expect(ctx.budget_remaining_after).toBe(100_000 - (ctx.estimated_cost as number));
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+
+		// Nothing envelope-shaped reaches the audit chain or the receipt either.
+		expect(auditData(audit, "llm_call").costCenter).toBeUndefined();
+		expect(receipt.budget).toBeUndefined();
+
+		await governed.destroy();
+	});
+
+	it("throws BEFORE any I/O when a scope is active and the governor has no parentUserId (D1)", async () => {
+		const engine = makeMockEngine({ balance: 5_000 });
+		const audit = makeMockAudit();
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		await expect(
+			withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		).rejects.toThrow(/parentUserId/);
+
+		// Pre-I/O means pre-EVERYTHING: no hold, no provider call, no audit record,
+		// and not even a policy evaluation.
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect(client.messages.create).not.toHaveBeenCalled();
+		expect(audit.events).toHaveLength(0);
+		expect(vi.mocked(evaluatePolicy)).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("gives the policy gate ENVELOPE-scoped numbers, from the live ledger read", async () => {
+		const engine = makeMockEngine({ balance: 2_500 });
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		await withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS);
+
+		// Exactly one preflight read, of exactly the envelope account.
+		expect(engine.lookupBalances).toHaveBeenCalledTimes(2); // preflight + post-settle (D7)
+		expect(engine.lookupBalances?.mock.calls[0]?.[0]).toEqual([ENVELOPE_ID]);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBe(COST_CENTER);
+		expect(ctx.budget_remaining).toBe(2_500);
+		expect(ctx.budget_remaining_after).toBe(2_500 - (ctx.estimated_cost as number));
+		// 2500 / 10000 allocated.
+		expect(ctx.budgetFractionRemaining).toBeCloseTo(0.25);
+		expect(ctx.budgetRunwayHours).toBeTypeOf("number");
+
+		await governed.destroy();
+	});
+
+	it("reads a never-allocated envelope as zero and denies the spend at the gate", async () => {
+		const engine = makeMockEngine({ balance: "missing" });
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		await expect(
+			withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		).rejects.toThrow(/Policy denied/);
+
+		// The default hard rules now guard the ENVELOPE: an empty envelope is a
+		// pre-spend deny, before the hold and before the provider call.
+		expect(lastPolicyContext().budget_remaining).toBe(0);
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(client.messages.create).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("denies an over-envelope call at the gate, BEFORE any hold, on an UNFLOORED remaining_after (A7)", async () => {
+		// Five usertokens left, an estimate far above it: the envelope has funds, so
+		// `block-budget-exhausted` does not apply and `block-budget-overshoot` is the
+		// only rule that can fire — which it can only do if the governor let
+		// `budget_remaining_after` go NEGATIVE. Flooring it at 0 would leave this
+		// call authorised and structurally disable the one non-disableable pre-spend
+		// deny on every attributed call.
+		const engine = makeMockEngine({ balance: 5 });
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		await expect(
+			withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		).rejects.toThrow(/Policy denied/);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.budget_remaining).toBe(5);
+		expect(ctx.budget_remaining_after).toBe(5 - (ctx.estimated_cost as number));
+		expect(ctx.budget_remaining_after as number).toBeLessThan(0);
+		// Pre-spend means pre-everything downstream of the gate.
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(client.messages.create).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("REFUSES an attributed call whose envelope read fails, before the gate (A2)", async () => {
+		const engine = makeMockEngine({ balance: "throw" });
+		const client = makeAnthropicMock();
+		const audit = makeMockAudit();
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const err = await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		).catch((e: unknown) => e);
+
+		// The existing ledger-unavailable classification, naming the envelope that
+		// could not be read. NOT a policy denial: the policy gate never ran.
+		expect(err).toBeInstanceOf(LedgerUnavailableError);
+		expect((err as LedgerUnavailableError).message).toContain(ENVELOPE_LABEL);
+
+		// Why refusal rather than the session numbers: the preflight and the hold
+		// share one TigerBeetle transport, so a read that genuinely failed means the
+		// hold was doomed anyway — and gating the call on the SESSION wallet while
+		// the hold debits the ENVELOPE would clear it against a wallet the money
+		// never came from, in the one record an auditor reads.
+		expect(vi.mocked(evaluatePolicy)).not.toHaveBeenCalled();
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(client.messages.create).not.toHaveBeenCalled();
+		expect(audit.events).toHaveLength(0);
+
+		await governed.destroy();
+	});
+
+	it("REFUSES an attributed call when the engine cannot read balances at all (A2)", async () => {
+		// Same refusal, different cause: an engine with no `lookupBalances` would
+		// place the envelope hold and be unable to report on it. Both `createTBEngine`
+		// factories implement the method, so this is the injected-engine case — and
+		// it must not degrade into session-scoped policy numbers either.
+		const engine = makeMockEngine();
+		expect(engine.lookupBalances).toBeUndefined();
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		await expect(
+			withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		).rejects.toThrow(LedgerUnavailableError);
+
+		expect(vi.mocked(evaluatePolicy)).not.toHaveBeenCalled();
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(client.messages.create).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("stamps costCenter on the llm_call record and the settled receipt", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		)) as { receipt: TrustReceipt };
+
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+		expect(receipt.budget).toEqual({
+			costCenter: COST_CENTER,
+			remaining: 4_000,
+			fraction: 0.4,
+		});
+
+		await governed.destroy();
+	});
+
+	it("OMITS the receipt budget block when the post-settle read fails, without touching the settlement", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		// Preflight succeeds; the post-settle snapshot read fails.
+		engine.lookupBalances?.mockImplementationOnce(async (ids: bigint[]) => {
+			const map = new Map<bigint, number>();
+			for (const id of ids) map.set(id, 4_000);
+			return map;
+		});
+		engine.lookupBalances?.mockImplementationOnce(async () => {
+			throw new Error("tb: lookupAccounts timed out");
+		});
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const { receipt } = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		)) as { receipt: TrustReceipt };
+
+		expect(receipt.budget).toBeUndefined();
+		// Receipt degradation NEVER unwinds committed money.
+		expect(receipt.settled).toBe(true);
+		expect(engine.postPendingSpend).toHaveBeenCalledOnce();
+		expect(engine.voidPendingSpend).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("carries the attribution into the VOID terminal's audit record (A1)", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const client = {
+			messages: { create: vi.fn(async () => Promise.reject(new Error("provider exploded"))) },
+		};
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		await expect(
+			withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		).rejects.toThrow(/provider exploded/);
+
+		expect(engine.voidPendingSpend).toHaveBeenCalledOnce();
+		// Attributed hold ⇒ attributed terminal record: forensic continuity.
+		expect(auditData(audit, "llm_call_failed").costCenter).toBe(COST_CENTER);
+
+		await governed.destroy();
+	});
+
+	it("names the envelope LABEL and the right remedy when the ledger rejects the hold", async () => {
+		const engine = makeMockEngine({ balance: 10 });
+		// What the T4 engine seam throws for an exhausted envelope: the derived
+		// ACCOUNT id, because the label lives in the governor.
+		engine.spendPending.mockRejectedValueOnce(
+			new InsufficientBalanceError(`envelope:${ENVELOPE_ID}`, 999, 10),
+		);
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const err = await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		).catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		const balanceErr = err as InsufficientBalanceError;
+		// The operator reads `acme::research`, not a 39-digit account id.
+		expect(balanceErr.userId).toBe(ENVELOPE_LABEL);
+		expect(balanceErr.message).toContain(ENVELOPE_LABEL);
+		// And is told the remedy that actually funds an envelope.
+		expect(balanceErr.hint).toMatch(/allocateBudget/);
+		expect(balanceErr.hint).not.toMatch(/Increase the budget in trust\(\) options/);
+		// The ledger's own numbers survive the re-wrap.
+		expect(balanceErr.required).toBe(999);
+		expect(balanceErr.available).toBe(10);
+
+		await governed.destroy();
+	});
+
+	it("leaves an UNATTRIBUTED ledger rejection byte-identical", async () => {
+		const engine = makeMockEngine({ balance: 10 });
+		const thrown = new InsufficientBalanceError("trust:hold", 999, 10);
+		engine.spendPending.mockRejectedValueOnce(thrown);
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const err = await governed.messages.create(PARAMS).catch((e: unknown) => e);
+
+		// The SAME error object, not a re-wrap: nothing on this path changed.
+		expect(err).toBe(thrown);
+		expect((err as InsufficientBalanceError).hint).toBe(
+			"Increase the budget in trust() options or add funds via the ledger.",
+		);
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The decisive one: the settle happens on an emitter tick, OUTSIDE the scope
+// ---------------------------------------------------------------------------
+
+describe("stream settlement survives the scope exit", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `envelope-stream-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("attributes a MessageStream settle fired after withCostCenter returned", async () => {
+		const engine = makeMockEngine({ balance: 6_000 });
+		const audit = makeMockAudit();
+		const stream = new ManualMessageStream();
+		const client = {
+			messages: {
+				create: vi.fn(),
+				stream: vi.fn(() => stream),
+			},
+		};
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const handle = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.stream(PARAMS),
+			SCOPE_OPTS,
+		)) as ManualMessageStream & { receipt: Promise<TrustReceipt> };
+
+		// The hold was placed while the scope was live.
+		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+
+		// THE PIN: we are outside every scope now. An `AsyncLocalStorage` read from
+		// inside the terminal below would see exactly this — nothing.
+		expect(getCurrentCostCenter()).toBeUndefined();
+
+		stream.emit("streamEvent", { type: "message_start", message: { usage: { input_tokens: 10 } } });
+		stream.emit("finalMessage", { usage: { input_tokens: 10, output_tokens: 5 } });
+		stream.emit("end");
+
+		const receipt = await handle.receipt;
+
+		expect(receipt.settled).toBe(true);
+		// The capture, not the store, is what the terminal read.
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+		expect(receipt.budget).toMatchObject({ costCenter: COST_CENTER, remaining: 6_000 });
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// governAction — its own governor entry point, its own single ALS read
+// ---------------------------------------------------------------------------
+
+describe("governAction attribution", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `envelope-action-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("debits the envelope, stamps the record, and snapshots the receipt", async () => {
+		const engine = makeMockEngine({ balance: 3_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = await withCostCenter(
+			COST_CENTER,
+			() => governed.governAction({ kind: "tool_use", name: "search", cost: 25 }, async () => "ok"),
+			SCOPE_OPTS,
+		);
+
+		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBe(COST_CENTER);
+		expect(ctx.budget_remaining).toBe(3_000);
+		expect(ctx.budget_remaining_after).toBe(3_000 - 25);
+		expect(ctx.budgetFractionRemaining).toBeCloseTo(0.3);
+
+		expect(auditData(audit, "tool_use").costCenter).toBe(COST_CENTER);
+		expect(receipt.budget).toMatchObject({ costCenter: COST_CENTER, remaining: 3_000 });
+
+		await governed.destroy();
+	});
+
+	it("throws pre-I/O on an attributed action with no parentUserId (D1)", async () => {
+		const engine = makeMockEngine({ balance: 3_000 });
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+		const execute = vi.fn(async () => "ok");
+
+		await expect(
+			withCostCenter(
+				COST_CENTER,
+				() => governed.governAction({ kind: "tool_use", name: "search", cost: 25 }, execute),
+				SCOPE_OPTS,
+			),
+		).rejects.toThrow(/parentUserId/);
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(engine.spendPending).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("carries the attribution into the action's VOID terminal record (A1)", async () => {
+		const engine = makeMockEngine({ balance: 3_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		await expect(
+			withCostCenter(
+				COST_CENTER,
+				() =>
+					governed.governAction({ kind: "tool_use", name: "search", cost: 25 }, async () => {
+						throw new Error("tool exploded");
+					}),
+				SCOPE_OPTS,
+			),
+		).rejects.toThrow(/tool exploded/);
+
+		expect(engine.voidPendingSpend).toHaveBeenCalledOnce();
+		// Attributed hold ⇒ attributed terminal record, on the void side too.
+		expect(auditData(audit, "tool_use_failed").costCenter).toBe(COST_CENTER);
+
+		await governed.destroy();
+	});
+
+	it("leaves an unattributed action exactly as it was", async () => {
+		const engine = makeMockEngine({ balance: 3_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = await governed.governAction(
+			{ kind: "tool_use", name: "search", cost: 25 },
+			async () => "ok",
+		);
+
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).toBeUndefined();
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBeUndefined();
+		expect(ctx.budget_remaining).toBe(100_000);
+		expect(auditData(audit, "tool_use").costCenter).toBeUndefined();
+		expect(receipt.budget).toBeUndefined();
+
+		await governed.destroy();
+	});
+});

--- a/packages/core/tests/govern/tb-engine-seam.test.ts
+++ b/packages/core/tests/govern/tb-engine-seam.test.ts
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * The `createTBEngine` seam, driven against a stateful TigerBeetle fake that does
+ * real double-entry math and enforces `debits_must_not_exceed_credits`.
+ *
+ * What it pins:
+ *  - the debit account defaults to the session holding wallet (unattributed
+ *    behaviour, unchanged from pre-envelope);
+ *  - an explicit `debitAccountId` debits THAT account and leaves the session
+ *    wallet untouched, through hold, settle AND void;
+ *  - D5: on an ATTRIBUTED hold, TigerBeetle's `debit_account_not_found` means a
+ *    never-allocated envelope (≡ zero balance), so it surfaces as an
+ *    InsufficientBalanceError naming the envelope — not as a ledger outage;
+ *  - an ATTRIBUTED hold rejected by the envelope's own
+ *    `debits_must_not_exceed_credits` names THAT envelope and its real balance,
+ *    never the session holding wallet and its seed;
+ *  - on an UNATTRIBUTED hold both statuses keep today's classification exactly
+ *    (raw TBTransferError → the governor's LedgerUnavailableError for a missing
+ *    account; `trust:hold` + the session seed for an over-budget one), down to
+ *    adding no ledger round trip — the session wallet is one this factory just
+ *    created, so its absence really is an outage and its seed is already known.
+ *
+ * The factory is duplicated between `govern.ts` and `headless.ts` and must change
+ * in lockstep (AGENTS.md, Known drift). Only `govern.ts`'s copy is reachable by
+ * name — `headless.ts` is a package entry point, so exporting its copy would put
+ * an engine factory in the published API for the sake of a test. The two copies
+ * are held identical by the source-parity suite in
+ * `tests/harden/engine-factory-parity.test.ts`, and the headless copy is driven
+ * end-to-end through `createGovernor().authorize()` at the bottom of this file.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+const DMNEC = 1 << 2; // AccountFlags.debits_must_not_exceed_credits
+const DEBIT_ACCOUNT_NOT_FOUND = 21; // CreateTransferStatus.debit_account_not_found
+
+const { store, created, pendings, holds, mockClient } = vi.hoisted(() => {
+	interface Acct {
+		flags: number;
+		credits_posted: bigint;
+		debits_posted: bigint;
+		debits_pending: bigint;
+	}
+	interface Pend {
+		debit: bigint;
+		credit: bigint;
+		amount: bigint;
+	}
+	const S = {
+		exceeds_credits: 22,
+		debit_account_not_found: 21,
+		credit_account_not_found: 23,
+		pending_transfer_not_found: 40,
+	};
+	const DMNEC_FLAG = 1 << 2;
+	const PENDING_FLAG = 1;
+	const POST_FLAG = 2;
+	const VOID_FLAG = 4;
+
+	const store = new Map<bigint, Acct>();
+	/** Account ids in creation order: [treasury, holding wallet, …]. */
+	const created: bigint[] = [];
+	/** Live pending transfers by id, so post/void can resolve their accounts. */
+	const pendings = new Map<bigint, Pend>();
+	/** Every accepted PENDING transfer, in order — the debit-account assertions. */
+	const holds: Pend[] = [];
+
+	const mockClient = {
+		createAccounts: vi.fn(async (accts: { id: bigint; flags: number }[]) => {
+			for (const a of accts) {
+				if (store.has(a.id)) return [{ status: 1 /* exists */ }];
+				store.set(a.id, {
+					flags: a.flags,
+					credits_posted: 0n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+				});
+				created.push(a.id);
+			}
+			return [];
+		}),
+		createTransfers: vi.fn(
+			async (
+				xs: {
+					id: bigint;
+					debit_account_id: bigint;
+					credit_account_id: bigint;
+					pending_id: bigint;
+					amount: bigint;
+					flags: number;
+				}[],
+			) => {
+				for (const t of xs) {
+					// Post/void resolve their accounts from the original pending transfer
+					// (the client sends 0n for both account ids on those).
+					if (t.flags & (POST_FLAG | VOID_FLAG)) {
+						const orig = pendings.get(t.pending_id);
+						if (!orig) return [{ status: S.pending_transfer_not_found }];
+						const debit = store.get(orig.debit);
+						const credit = store.get(orig.credit);
+						if (!debit || !credit) return [{ status: S.debit_account_not_found }];
+						debit.debits_pending -= orig.amount;
+						if (t.flags & POST_FLAG) {
+							const posted = t.amount < orig.amount ? t.amount : orig.amount;
+							debit.debits_posted += posted;
+							credit.credits_posted += posted;
+						}
+						pendings.delete(t.pending_id);
+						continue;
+					}
+					const debit = store.get(t.debit_account_id);
+					const credit = store.get(t.credit_account_id);
+					if (!debit) return [{ status: S.debit_account_not_found }];
+					if (!credit) return [{ status: S.credit_account_not_found }];
+					if (t.flags & PENDING_FLAG) {
+						if (
+							(debit.flags & DMNEC_FLAG) !== 0 &&
+							debit.debits_pending + debit.debits_posted + t.amount > debit.credits_posted
+						) {
+							return [{ status: S.exceeds_credits }];
+						}
+						debit.debits_pending += t.amount;
+						const rec = {
+							debit: t.debit_account_id,
+							credit: t.credit_account_id,
+							amount: t.amount,
+						};
+						pendings.set(t.id, rec);
+						holds.push(rec);
+					} else {
+						// Immediate transfer (treasury mint → wallet): the treasury carries no
+						// balance constraint.
+						debit.debits_posted += t.amount;
+						credit.credits_posted += t.amount;
+					}
+				}
+				return [];
+			},
+		),
+		lookupAccounts: vi.fn(async (ids: bigint[]) =>
+			ids
+				.map((id) => {
+					const a = store.get(id);
+					return a
+						? {
+								id,
+								credits_posted: a.credits_posted,
+								debits_posted: a.debits_posted,
+								debits_pending: a.debits_pending,
+								credits_pending: 0n,
+							}
+						: undefined;
+				})
+				.filter(Boolean),
+		),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	};
+	return { store, created, pendings, holds, mockClient };
+});
+
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => mockClient),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 1 << 2, history: 1 << 5 },
+	TransferFlags: {
+		pending: 1,
+		post_pending_transfer: 2,
+		void_pending_transfer: 4,
+		linked: 8,
+	},
+	CreateAccountStatus: { created: 4294967295, exists: 1 },
+	CreateTransferStatus: {
+		created: 4294967295,
+		exists: 1,
+		exceeds_credits: 22,
+		overflows_debits: 30,
+		overflows_debits_pending: 31,
+		debit_account_not_found: 21,
+	},
+	amount_max: (1n << 128n) - 1n,
+}));
+
+import { createTBEngine, trust } from "../../src/govern.js";
+import { createGovernor } from "../../src/headless.js";
+import { TBTransferError } from "../../src/ledger/client.js";
+import { InsufficientBalanceError } from "../../src/shared/errors.js";
+import { TrustConfigSchema } from "../../src/shared/types.js";
+
+const CONFIG = TrustConfigSchema.parse({ budget: 100_000 });
+
+function reset(): void {
+	store.clear();
+	created.length = 0;
+	pendings.clear();
+	holds.length = 0;
+}
+
+/** The session holding wallet: created right after the treasury. */
+function holdingWallet(): bigint {
+	const id = created[1];
+	if (id === undefined) throw new Error("holding wallet was never created");
+	return id;
+}
+
+describe("createTBEngine — caller-selected debit account", () => {
+	it("defaults the debit to the funded session holding wallet", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 500);
+
+		await engine.spendPending({ transferId: "call-1", amount: 40 });
+
+		expect(holds).toHaveLength(1);
+		expect(holds[0]?.debit).toBe(holdingWallet());
+		expect(store.get(holdingWallet())?.debits_pending).toBe(40n);
+		engine.destroy?.();
+	});
+
+	it("debits the caller-supplied account and leaves the session wallet untouched", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 500);
+		const envelope = 777_000_111n;
+		store.set(envelope, {
+			flags: DMNEC,
+			credits_posted: 200n,
+			debits_posted: 0n,
+			debits_pending: 0n,
+		});
+
+		await engine.spendPending({ transferId: "call-2", amount: 40, debitAccountId: envelope });
+
+		expect(holds).toHaveLength(1);
+		expect(holds[0]?.debit).toBe(envelope);
+		expect(store.get(envelope)?.debits_pending).toBe(40n);
+		// The seam must not double-reserve: the session wallet sees nothing.
+		expect(store.get(holdingWallet())?.debits_pending).toBe(0n);
+		engine.destroy?.();
+	});
+
+	it("settles an attributed hold against the same envelope account", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 500);
+		const envelope = 777_000_222n;
+		store.set(envelope, {
+			flags: DMNEC,
+			credits_posted: 200n,
+			debits_posted: 0n,
+			debits_pending: 0n,
+		});
+
+		await engine.spendPending({ transferId: "call-3", amount: 40, debitAccountId: envelope });
+		await engine.postPendingSpend("call-3", 12);
+
+		expect(store.get(envelope)?.debits_posted).toBe(12n);
+		expect(store.get(envelope)?.debits_pending).toBe(0n);
+		expect(store.get(holdingWallet())?.debits_posted).toBe(0n);
+		engine.destroy?.();
+	});
+
+	it("voids an attributed hold against the same envelope account", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 500);
+		const envelope = 777_000_333n;
+		store.set(envelope, {
+			flags: DMNEC,
+			credits_posted: 200n,
+			debits_posted: 0n,
+			debits_pending: 0n,
+		});
+
+		await engine.spendPending({ transferId: "call-4", amount: 40, debitAccountId: envelope });
+		await engine.voidPendingSpend("call-4");
+
+		expect(store.get(envelope)?.debits_pending).toBe(0n);
+		expect(store.get(envelope)?.debits_posted).toBe(0n);
+		engine.destroy?.();
+	});
+});
+
+describe("createTBEngine — rejection classification (D5)", () => {
+	it("maps a missing ENVELOPE account to InsufficientBalanceError naming the envelope", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 500);
+		const envelope = 909_090_909n;
+
+		const err = await engine
+			.spendPending({ transferId: "call-5", amount: 42, debitAccountId: envelope })
+			.catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		const balanceErr = err as InsufficientBalanceError;
+		// Never-allocated ≡ zero balance: the envelope is named, and `available`
+		// is the truthful 0 rather than the session wallet's seed.
+		expect(balanceErr.userId).toBe(`envelope:${envelope}`);
+		expect(balanceErr.required).toBe(42);
+		expect(balanceErr.available).toBe(0);
+		expect(balanceErr.message).toContain(`envelope:${envelope}`);
+		engine.destroy?.();
+	});
+
+	it("keeps today's classification when the SESSION wallet is missing (unattributed)", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 500);
+		// Simulate the outage this status really means for a session wallet the
+		// factory itself just created.
+		store.delete(holdingWallet());
+
+		const err = await engine
+			.spendPending({ transferId: "call-6", amount: 42 })
+			.catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(TBTransferError);
+		expect(err).not.toBeInstanceOf(InsufficientBalanceError);
+		expect((err as TBTransferError).code).toBe(DEBIT_ACCOUNT_NOT_FOUND);
+		engine.destroy?.();
+	});
+
+	it("keeps the over-budget mapping byte-identical on an unattributed hold", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 50);
+		const readsBefore = mockClient.lookupAccounts.mock.calls.length;
+
+		const err = await engine
+			.spendPending({ transferId: "call-7", amount: 120 })
+			.catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		const balanceErr = err as InsufficientBalanceError;
+		expect(balanceErr.userId).toBe("trust:hold");
+		expect(balanceErr.required).toBe(120);
+		expect(balanceErr.available).toBe(50);
+		// Byte-identical includes the I/O: the session seed is a number this factory
+		// already holds, so an unattributed rejection adds no ledger round trip.
+		expect(mockClient.lookupAccounts.mock.calls.length).toBe(readsBefore);
+		engine.destroy?.();
+	});
+
+	it("names the exhausted ENVELOPE and its real balance, not the session wallet", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 5_000);
+		const envelope = 777_000_444n;
+		store.set(envelope, {
+			flags: DMNEC,
+			credits_posted: 10n,
+			debits_posted: 0n,
+			debits_pending: 0n,
+		});
+
+		const err = await engine
+			.spendPending({ transferId: "call-8", amount: 999, debitAccountId: envelope })
+			.catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		const balanceErr = err as InsufficientBalanceError;
+		// The account that REJECTED is the account that gets named. Reporting
+		// `trust:hold` + the 5000 session seed would name an account the hold never
+		// touched and print `available` (5000) GREATER than `required` (999) — an
+		// exhausted cost center rendered as an SDK bug, with nothing in the message
+		// identifying which envelope to top up.
+		expect(balanceErr.userId).toBe(`envelope:${envelope}`);
+		expect(balanceErr.required).toBe(999);
+		expect(balanceErr.available).toBe(10);
+		expect(balanceErr.available).toBeLessThan(balanceErr.required);
+		expect(balanceErr.message).toContain(`envelope:${envelope}`);
+		expect(balanceErr.message).not.toContain("5000");
+		// The read reports; it never decides. TigerBeetle's atomic rejection already
+		// did that, and the hold reserved nothing.
+		expect(store.get(envelope)?.debits_pending).toBe(0n);
+		engine.destroy?.();
+	});
+
+	it("reports 0 rather than fabricating headroom when the reporting read fails", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 5_000);
+		const envelope = 777_000_555n;
+		store.set(envelope, {
+			flags: DMNEC,
+			credits_posted: 10n,
+			debits_posted: 0n,
+			debits_pending: 0n,
+		});
+		// The reporting read is the first lookup after the rejection.
+		mockClient.lookupAccounts.mockImplementationOnce(async () => {
+			throw new Error("tb: connection reset");
+		});
+
+		const err = await engine
+			.spendPending({ transferId: "call-9", amount: 999, debitAccountId: envelope })
+			.catch((e: unknown) => e);
+
+		// A failed reporting read must not change the classification, and must not
+		// invent an `available` the ledger never answered.
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		const balanceErr = err as InsufficientBalanceError;
+		expect(balanceErr.userId).toBe(`envelope:${envelope}`);
+		expect(balanceErr.required).toBe(999);
+		expect(balanceErr.available).toBe(0);
+		expect(mockClient.lookupAccounts).toHaveBeenCalledWith([envelope]);
+		engine.destroy?.();
+	});
+});
+
+function makeMockAudit(): AuditWriter {
+	return {
+		appendEvent: vi.fn(
+			async (input: AppendEventInput): Promise<AuditEvent> => ({
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			}),
+		),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+/**
+ * `headless.ts` carries its own copy of the factory and is the engine
+ * `createGovernor()` actually runs on. Its copy is not exported, so it is driven
+ * here the way production drives it: a real governor over the same stateful fake,
+ * authorizing one unattributed call. That pins the copy's default — the hold lands
+ * on the funded session wallet — end to end; the parity suite covers the rest.
+ */
+describe("createGovernor — the headless copy of the factory", () => {
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = join(tmpdir(), `tb-engine-seam-${randomUUID()}`);
+		mkdirSync(tmpVault, { recursive: true });
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("holds an unattributed call against the funded session wallet", async () => {
+		reset();
+		const governor = await createGovernor({
+			budget: 100_000,
+			vaultBase: tmpVault,
+			_audit: makeMockAudit(),
+		});
+
+		const auth = await governor.authorize({
+			model: "claude-sonnet-4-6",
+			estimatedInputTokens: 100,
+			maxOutputTokens: 50,
+		});
+		expect(holds).toHaveLength(1);
+		expect(holds[0]?.debit).toBe(holdingWallet());
+
+		await governor.settle(auth, { inputTokens: 100, outputTokens: 20 });
+		expect(store.get(holdingWallet())?.debits_pending).toBe(0n);
+		expect(store.get(holdingWallet())?.debits_posted).toBeGreaterThan(0n);
+
+		await governor.destroy();
+	});
+});
+
+// ── Governor identity ──
+//
+// `parentUserId` is the parent half of the (parent, costCenter) tuple every
+// envelope account is derived from. It is OPERATOR-trusted config, so it is
+// validated by the one authoritative rule at CONSTRUCTION — before a governor
+// exists, let alone a hold. Deferring it to the first attributed call would put
+// the refusal on the money path, after the caller believed governance was up.
+
+describe("governor identity — parentUserId is validated at construction", () => {
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = join(tmpdir(), `tb-engine-seam-${randomUUID()}`);
+		mkdirSync(tmpVault, { recursive: true });
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("trust() refuses a quarantined parent id before building anything", async () => {
+		await expect(
+			trust(
+				{ messages: { create: vi.fn(async () => ({})) } },
+				{
+					parentUserId: "acme::billing",
+					dryRun: true,
+					vaultBase: tmpVault,
+					_audit: makeMockAudit(),
+				},
+			),
+		).rejects.toThrow(/parentUserId/);
+	});
+
+	it("createGovernor() refuses a parent id outside the charset", async () => {
+		await expect(
+			createGovernor({
+				parentUserId: "acme billing",
+				dryRun: true,
+				vaultBase: tmpVault,
+				_audit: makeMockAudit(),
+			}),
+		).rejects.toThrow(/parentUserId/);
+	});
+
+	it("accepts a legal parent id on both governors", async () => {
+		const governed = await trust(
+			{ messages: { create: vi.fn(async () => ({})) } },
+			{
+				parentUserId: "acct:123",
+				dryRun: true,
+				vaultBase: tmpVault,
+				_audit: makeMockAudit(),
+			},
+		);
+		await governed.destroy();
+
+		const governor = await createGovernor({
+			parentUserId: "acct:123",
+			dryRun: true,
+			vaultBase: tmpVault,
+			_audit: makeMockAudit(),
+		});
+		await governor.destroy();
+	});
+});

--- a/packages/core/tests/govern/tb-engine-seam.test.ts
+++ b/packages/core/tests/govern/tb-engine-seam.test.ts
@@ -188,11 +188,12 @@ vi.mock("tigerbeetle-node", () => ({
 	amount_max: (1n << 128n) - 1n,
 }));
 
+import { withCostCenter } from "../../src/budget/attribution.js";
 import { createTBEngine, trust } from "../../src/govern.js";
 import { createGovernor } from "../../src/headless.js";
-import { TBTransferError } from "../../src/ledger/client.js";
-import { InsufficientBalanceError } from "../../src/shared/errors.js";
-import { TrustConfigSchema } from "../../src/shared/types.js";
+import { TBTransferError, TrustTBClient } from "../../src/ledger/client.js";
+import { InsufficientBalanceError, PolicyDeniedError } from "../../src/shared/errors.js";
+import { TrustConfigSchema, type TrustReceipt } from "../../src/shared/types.js";
 
 const CONFIG = TrustConfigSchema.parse({ budget: 100_000 });
 
@@ -471,6 +472,133 @@ describe("createGovernor — the headless copy of the factory", () => {
 		expect(store.get(holdingWallet())?.debits_posted).toBeGreaterThan(0n);
 
 		await governor.destroy();
+	});
+});
+
+// ── The envelope preflight, through the REAL factory ──
+//
+// MF1. The governor reads an envelope's balance through `TrustEngine.lookupBalances`,
+// and the first cut of the threading implemented that method on TEST MOCKS ONLY. Every
+// unit suite stayed green while production shipped attributed calls with no
+// envelope-scoped policy numbers, no `budgetFractionRemaining`/`budgetRunwayHours`,
+// and no `receipt.budget` — the visibility half of this feature dead on arrival, and
+// the same mock-shadows-production shape AGENTS.md records for the budget API that
+// once shipped fully exported with an unconstructable argument.
+//
+// So these two drive the preflight through `createTBEngine` itself — no `_engine`
+// injection anywhere — against the stateful TigerBeetle fake above. A factory that
+// stops delegating `lookupBalances` fails HERE, not silently in production.
+
+describe("envelope preflight through the real createTBEngine (MF1)", () => {
+	const PARENT = "acme";
+	const COST_CENTER = "research";
+	const ENVELOPE = TrustTBClient.deriveCostCenterAccountId(PARENT, COST_CENTER);
+	const SCOPE_OPTS = { allocated: 10_000, periodStartMs: Date.UTC(2026, 7, 3, 0, 0, 0) };
+	const PARAMS = {
+		model: "claude-sonnet-4-6",
+		max_tokens: 64,
+		messages: [{ role: "user", content: "hello" }],
+	};
+
+	let tmpVault: string;
+
+	beforeEach(() => {
+		tmpVault = join(tmpdir(), `tb-engine-seam-${randomUUID()}`);
+		mkdirSync(tmpVault, { recursive: true });
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	/** A funded envelope wallet, as `allocateBudget` would have left it. */
+	function fundEnvelope(credits: bigint): void {
+		store.set(ENVELOPE, {
+			flags: DMNEC,
+			credits_posted: credits,
+			debits_posted: 0n,
+			debits_pending: 0n,
+		});
+	}
+
+	function anthropicMock() {
+		return {
+			messages: {
+				create: vi.fn(async () => ({
+					id: "msg_1",
+					type: "message",
+					role: "assistant",
+					content: [{ type: "text", text: "ok" }],
+					model: "claude-sonnet-4-6",
+					usage: { input_tokens: 10, output_tokens: 5 },
+				})),
+			},
+		};
+	}
+
+	it("holds against the envelope and reports its post-settle balance on the receipt", async () => {
+		reset();
+		fundEnvelope(10_000n);
+		const governed = await trust(anthropicMock(), {
+			budget: 100_000,
+			vaultBase: tmpVault,
+			parentUserId: PARENT,
+			_audit: makeMockAudit(),
+		});
+
+		const { receipt } = (await withCostCenter(
+			COST_CENTER,
+			() => governed.messages.create(PARAMS),
+			SCOPE_OPTS,
+		)) as { receipt: TrustReceipt };
+
+		// The money went where the scope said it should.
+		expect(holds).toHaveLength(1);
+		expect(holds[0]?.debit).toBe(ENVELOPE);
+		expect(store.get(holdingWallet())?.debits_pending).toBe(0n);
+		expect(store.get(holdingWallet())?.debits_posted).toBe(0n);
+
+		// And the receipt saw it, which is only possible if the factory delegated
+		// lookupBalances to the real client.
+		const env = store.get(ENVELOPE);
+		if (env === undefined) throw new Error("the envelope account vanished");
+		const remaining = Number(env.credits_posted - env.debits_posted - env.debits_pending);
+		expect(env.debits_posted).toBeGreaterThan(0n);
+		expect(receipt.budget).toEqual({
+			costCenter: COST_CENTER,
+			remaining,
+			fraction: remaining / SCOPE_OPTS.allocated,
+		});
+
+		await governed.destroy();
+	});
+
+	it("gates the call on the envelope's real balance, denying pre-hold when it is short", async () => {
+		reset();
+		fundEnvelope(3n);
+		const client = anthropicMock();
+		const governed = await trust(client, {
+			budget: 100_000,
+			vaultBase: tmpVault,
+			parentUserId: PARENT,
+			_audit: makeMockAudit(),
+		});
+
+		// Three usertokens in the envelope against a much larger estimate. The
+		// SESSION wallet holds 100_000, so a governor that fell back to session
+		// numbers — or never read the envelope at all — would authorise this.
+		await expect(
+			withCostCenter(COST_CENTER, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		).rejects.toBeInstanceOf(PolicyDeniedError);
+
+		expect(holds).toHaveLength(0);
+		expect(client.messages.create).not.toHaveBeenCalled();
+
+		await governed.destroy();
 	});
 });
 

--- a/packages/core/tests/harden/cost-center-spoof.test.ts
+++ b/packages/core/tests/harden/cost-center-spoof.test.ts
@@ -486,11 +486,13 @@ describe("headless authorize — request-body cost-center forgery", () => {
 			SCOPE_OPTS,
 		);
 
-		// The handle carries the SCOPE's truth, never the body's claim.
+		// The handle carries the SCOPE's truth, never the body's claim. The account id
+		// itself no longer rides the public handle (it is a bigint, kept on the
+		// governor's internal capture) — the debit account is asserted on the engine.
 		expect(auth.costCenter).toBe(COST_CENTER);
-		expect(auth.envelope?.accountId).toBe(ENVELOPE_ID);
-		expect(auth.envelope?.accountId).not.toBe(ATTACKER_ENVELOPE_ID);
+		expect(auth.costCenter).not.toBe(ATTACKER_COST_CENTER);
 		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).not.toBe(ATTACKER_ENVELOPE_ID);
 
 		const ctx = lastPolicyContext();
 		expect(ctx.cost_center).toBe(COST_CENTER);

--- a/packages/core/tests/harden/cost-center-spoof.test.ts
+++ b/packages/core/tests/harden/cost-center-spoof.test.ts
@@ -1,0 +1,706 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * P1-PARAM-SHADOW, extended to cost-center attribution — the request body must
+ * never be able to forge, override, or bootstrap envelope attribution.
+ *
+ * `param-shadow.test.ts` pins that `tier`/`estimated_cost`/`budget_remaining`
+ * survive a request-body shadowing attempt on the primary LLM path. This file
+ * pins the SAME property for the fields envelopes added — `cost_center` and the
+ * envelope-scoped `budget_remaining` / `budget_remaining_after` /
+ * `budgetFractionRemaining` / `budgetRunwayHours` — at ALL THREE re-assertion
+ * sites the AGENTS.md table now lists (govern.ts's LLM path, govern.ts's
+ * `governAction`, headless.ts's `authorize`), plus two properties specific to
+ * attribution that param-shadow has no analogue for:
+ *
+ *  - **No attribution without a scope.** Attribution is "structurally
+ *    un-forgeable" per the source comments at every site — it comes from
+ *    `getCurrentCostCenter()`, an AsyncLocalStorage read of the CALLER's own
+ *    execution context, never from anything the request body carries. A body
+ *    that names a costCenter which genuinely has a funded envelope must still
+ *    produce an UNATTRIBUTED call when no `withCostCenter` scope is active: the
+ *    hold debits the session wallet, no envelope preflight read is even
+ *    attempted, and the policy context's `cost_center` is `undefined` — not the
+ *    body's value. Both spellings are tried (`cost_center`, the policy-context
+ *    key, and `costCenter`, the TS-surface spelling per A11) because neither
+ *    name is ever read back out of a request body at any site.
+ *  - **Concurrent isolation holds under the full stack, not just at the ALS
+ *    primitive.** `budget/attribution.test.ts` already pins `Promise.all`
+ *    isolation at the ALS layer directly; this file re-proves it through the
+ *    whole governed call — hold, policy context, audit, and receipt — because a
+ *    bug in `resolveEnvelope`/`interceptCall`'s single-read discipline could
+ *    still leak across concurrent calls even with a perfectly isolated ALS.
+ *  - **A10**: the same costCenter STRING under two different `parentUserId`s
+ *    must derive and debit two different accounts — the tuple hash, not the
+ *    bare label, is what money is keyed on (AGENTS.md, "Cost-center account ids
+ *    hash the (parent, costCenter) TUPLE").
+ *
+ * SECURITY (mirrors budget-tier.test.ts / envelope-threading.test.ts): never
+ * log or snapshot a whole PolicyContext — it carries request-shaped data.
+ * Assert on individual fields.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import { withCostCenter } from "../../src/budget/attribution.js";
+import { type TrustEngine, trust } from "../../src/govern.js";
+import { createGovernor } from "../../src/headless.js";
+import { TrustTBClient } from "../../src/ledger/client.js";
+import { evaluatePolicy, type PolicyContext } from "../../src/policy/gate.js";
+import type { AuditEvent, TrustReceipt } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// The evaluator itself stays REAL — this only records the context each call
+// site hands it, so the assertions are about what the gate actually saw, not
+// about a stub's opinion of what it should have seen.
+vi.mock("../../src/policy/gate.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/policy/gate.js")>();
+	return { ...actual, evaluatePolicy: vi.fn(actual.evaluatePolicy) };
+});
+
+// ── Fixtures ──
+
+const PARENT = "acme";
+// The scope's REAL cost center — has a real, derivable envelope.
+const COST_CENTER = "research";
+// What the request body claims instead — a syntactically valid costCenter that
+// names a DIFFERENT (also derivable) envelope, so a naive implementation that
+// read it would silently debit the wrong wallet rather than fail loudly.
+const ATTACKER_COST_CENTER = "attacker-picked";
+
+const ENVELOPE_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, COST_CENTER);
+const ATTACKER_ENVELOPE_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, ATTACKER_COST_CENTER);
+const SCOPE_OPTS = { allocated: 10_000, periodStartMs: Date.UTC(2026, 7, 3, 0, 0, 0) };
+
+// Fabricated, deliberately implausible numbers a forged body would supply to
+// try to manufacture headroom or dodge a scarcity-keyed tier. None of these
+// may ever reach a policy context, an audit record, or a receipt.
+const SPOOFED_BUDGET_REMAINING = 987_654_321;
+const SPOOFED_BUDGET_REMAINING_AFTER = 987_654_321;
+const SPOOFED_FRACTION = 1;
+const SPOOFED_RUNWAY = 999_999;
+
+/** What a forged request body looks like, for a given claimed costCenter. */
+function spoofedBody(claimedCostCenter: string): Record<string, unknown> {
+	return {
+		cost_center: claimedCostCenter, // the policy-context spelling
+		costCenter: claimedCostCenter, // the TS-surface spelling (A11) — also tried
+		budget_remaining: SPOOFED_BUDGET_REMAINING,
+		budget_remaining_after: SPOOFED_BUDGET_REMAINING_AFTER,
+		budgetFractionRemaining: SPOOFED_FRACTION,
+		budgetRunwayHours: SPOOFED_RUNWAY,
+	};
+}
+
+const PARAMS = {
+	model: "claude-sonnet-4-6",
+	max_tokens: 64,
+	messages: [{ role: "user", content: "hello" }],
+};
+
+interface EngineHandle extends TrustEngine {
+	spendPending: ReturnType<typeof vi.fn>;
+	postPendingSpend: ReturnType<typeof vi.fn>;
+	voidPendingSpend: ReturnType<typeof vi.fn>;
+	lookupBalances?: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * `balance` shapes the seam the governor reads envelope numbers through: a flat
+ * number answers `available` for WHATEVER account ids are requested — enough to
+ * prove a spoofed body cannot change which account gets debited or read,
+ * without needing per-account bookkeeping in every test.
+ */
+function makeMockEngine(opts: { balance?: number } = {}): EngineHandle {
+	const engine: EngineHandle = {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		destroy: vi.fn(),
+	};
+	if (opts.balance !== undefined) {
+		engine.lookupBalances = vi.fn(async (ids: bigint[]) => {
+			const map = new Map<bigint, number>();
+			for (const id of ids) map.set(id, opts.balance as number);
+			return map;
+		});
+	}
+	return engine;
+}
+
+interface AuditHandle extends AuditWriter {
+	events: AppendEventInput[];
+}
+
+function makeMockAudit(): AuditHandle {
+	const events: AppendEventInput[] = [];
+	return {
+		events,
+		appendEvent: vi.fn(async (input: AppendEventInput): Promise<AuditEvent> => {
+			events.push(input);
+			return {
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			};
+		}),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+function makeAnthropicMock() {
+	return {
+		messages: {
+			create: vi.fn(async () => ({
+				id: "msg_1",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			})),
+		},
+	};
+}
+
+function auditData(audit: AuditHandle, kind: string): Record<string, unknown> {
+	const event = audit.events.find((e) => e.kind === kind);
+	if (event === undefined) {
+		throw new Error(
+			`no ${kind} audit event was appended (saw: ${audit.events.map((e) => e.kind).join(", ")})`,
+		);
+	}
+	return event.data as Record<string, unknown>;
+}
+
+/** The context the (real) evaluator saw for the most recent gate call. */
+function lastPolicyContext(): PolicyContext {
+	const calls = vi.mocked(evaluatePolicy).mock.calls;
+	const last = calls[calls.length - 1];
+	if (last === undefined) throw new Error("the policy evaluator was never called");
+	return last[1];
+}
+
+// ---------------------------------------------------------------------------
+// Site 1 — govern.ts's LLM path (interceptCall)
+// ---------------------------------------------------------------------------
+
+describe("LLM path (trust()) — request-body cost-center forgery", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `spoof-llm-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("an unattributed call ignores a body claiming a REAL envelope — no attribution without a scope", async () => {
+		const engine = makeMockEngine({ balance: 5_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		// The body's cost_center names COST_CENTER — a genuinely fundable
+		// envelope — but no withCostCenter scope wraps this call. Naming a real
+		// envelope from the body must not be enough to attribute to it.
+		const { receipt } = (await governed.messages.create({
+			...PARAMS,
+			...spoofedBody(COST_CENTER),
+		} as Record<string, unknown>)) as { receipt: TrustReceipt };
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBeUndefined();
+		// Session numbers, not the body's fabricated 987,654,321.
+		expect(ctx.budget_remaining).toBe(100_000);
+		expect(ctx.budget_remaining_after).toBe(100_000 - (ctx.estimated_cost as number));
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+
+		// No envelope preflight is even attempted for an unattributed call — the
+		// body's cost_center never got far enough to trigger a ledger read.
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).toBeUndefined();
+		expect(auditData(audit, "llm_call").costCenter).toBeUndefined();
+		expect(receipt.budget).toBeUndefined();
+
+		await governed.destroy();
+	});
+
+	it("an attributed call ignores a forged body cost_center and forged envelope numbers — scope truth wins everywhere", async () => {
+		const engine = makeMockEngine({ balance: 2_500 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await withCostCenter(
+			COST_CENTER,
+			() =>
+				governed.messages.create({
+					...PARAMS,
+					...spoofedBody(ATTACKER_COST_CENTER),
+				} as Record<string, unknown>),
+			SCOPE_OPTS,
+		)) as { receipt: TrustReceipt };
+
+		// The hold debited the SCOPE's envelope, never the attacker's.
+		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).not.toBe(ATTACKER_ENVELOPE_ID);
+		// Only the SCOPE's envelope was ever read — the attacker's account was
+		// never even looked up.
+		expect(engine.lookupBalances?.mock.calls.every((c) => c[0][0] === ENVELOPE_ID)).toBe(true);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBe(COST_CENTER);
+		expect(ctx.cost_center).not.toBe(ATTACKER_COST_CENTER);
+		// The live ledger read (2,500 / 10,000 allocated), not the body's forged
+		// 987,654,321 / fraction 1 / runway 999,999.
+		expect(ctx.budget_remaining).toBe(2_500);
+		expect(ctx.budget_remaining_after).toBe(2_500 - (ctx.estimated_cost as number));
+		expect(ctx.budgetFractionRemaining).toBeCloseTo(0.25);
+		expect(ctx.budgetRunwayHours).not.toBe(SPOOFED_RUNWAY);
+
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+		expect(receipt.budget).toEqual({ costCenter: COST_CENTER, remaining: 2_500, fraction: 0.25 });
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Site 2 — govern.ts's governAction (its own governor entry point)
+// ---------------------------------------------------------------------------
+
+describe("governAction — request-body cost-center forgery", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `spoof-action-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("an unattributed action ignores action.params claiming a REAL envelope — no attribution without a scope", async () => {
+		const engine = makeMockEngine({ balance: 3_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = await governed.governAction(
+			{ kind: "tool_use", name: "search", cost: 25, params: spoofedBody(COST_CENTER) },
+			async () => "ok",
+		);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBeUndefined();
+		expect(ctx.budget_remaining).toBe(100_000);
+		expect(ctx.budget_remaining_after).toBe(100_000 - 25);
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).toBeUndefined();
+		expect(auditData(audit, "tool_use").costCenter).toBeUndefined();
+		expect(receipt.budget).toBeUndefined();
+
+		await governed.destroy();
+	});
+
+	it("an attributed action ignores a forged action.params cost_center and forged envelope numbers", async () => {
+		const engine = makeMockEngine({ balance: 3_000 });
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = await withCostCenter(
+			COST_CENTER,
+			() =>
+				governed.governAction(
+					{
+						kind: "tool_use",
+						name: "search",
+						cost: 25,
+						params: spoofedBody(ATTACKER_COST_CENTER),
+					},
+					async () => "ok",
+				),
+			SCOPE_OPTS,
+		);
+
+		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).not.toBe(ATTACKER_ENVELOPE_ID);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBe(COST_CENTER);
+		expect(ctx.cost_center).not.toBe(ATTACKER_COST_CENTER);
+		expect(ctx.budget_remaining).toBe(3_000);
+		expect(ctx.budget_remaining_after).toBe(3_000 - 25);
+		expect(ctx.budgetFractionRemaining).toBeCloseTo(0.3);
+		expect(ctx.budgetRunwayHours).not.toBe(SPOOFED_RUNWAY);
+
+		expect(auditData(audit, "tool_use").costCenter).toBe(COST_CENTER);
+		expect(receipt.budget).toMatchObject({ costCenter: COST_CENTER, remaining: 3_000 });
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Site 3 — headless.ts's authorize
+// ---------------------------------------------------------------------------
+
+describe("headless authorize — request-body cost-center forgery", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `spoof-headless-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	const AUTHORIZE = {
+		model: "claude-sonnet-4-6",
+		estimatedInputTokens: 100,
+		maxOutputTokens: 500,
+	};
+
+	it("an unattributed authorize ignores params.params claiming a REAL envelope — no attribution without a scope", async () => {
+		const engine = makeMockEngine({ balance: 2_500 });
+		const audit = makeMockAudit();
+		const gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const auth = await gov.authorize({ ...AUTHORIZE, params: spoofedBody(COST_CENTER) });
+
+		expect("costCenter" in auth).toBe(false);
+		expect("envelope" in auth).toBe(false);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBeUndefined();
+		expect(ctx.budget_remaining).toBe(100_000);
+		expect(ctx.budget_remaining_after).toBe(100_000 - (ctx.estimated_cost as number));
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).toBeUndefined();
+
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+		expect(receipt.budget).toBeUndefined();
+		expect(auditData(audit, "llm_call").costCenter).toBeUndefined();
+
+		await gov.destroy();
+	});
+
+	it("an attributed authorize ignores a forged params.params cost_center and forged envelope numbers", async () => {
+		const engine = makeMockEngine({ balance: 2_500 });
+		const audit = makeMockAudit();
+		const gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const auth = await withCostCenter(
+			COST_CENTER,
+			() => gov.authorize({ ...AUTHORIZE, params: spoofedBody(ATTACKER_COST_CENTER) }),
+			SCOPE_OPTS,
+		);
+
+		// The handle carries the SCOPE's truth, never the body's claim.
+		expect(auth.costCenter).toBe(COST_CENTER);
+		expect(auth.envelope?.accountId).toBe(ENVELOPE_ID);
+		expect(auth.envelope?.accountId).not.toBe(ATTACKER_ENVELOPE_ID);
+		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBe(COST_CENTER);
+		expect(ctx.cost_center).not.toBe(ATTACKER_COST_CENTER);
+		expect(ctx.budget_remaining).toBe(2_500);
+		expect(ctx.budget_remaining_after).toBe(2_500 - (ctx.estimated_cost as number));
+		expect(ctx.budgetFractionRemaining).toBeCloseTo(0.25);
+		expect(ctx.budgetRunwayHours).not.toBe(SPOOFED_RUNWAY);
+
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+		expect(receipt.budget).toMatchObject({ costCenter: COST_CENTER, remaining: 2_500 });
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+
+		await gov.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent isolation, re-proved through the FULL governed call
+// ---------------------------------------------------------------------------
+
+describe("concurrent calls under different scopes never bleed into each other", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `spoof-concurrent-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("Promise.all across two scopes on one governor: each call's hold, policy context, audit, and receipt show ONLY its own scope", async () => {
+		const ALPHA = "alpha-scope";
+		const BETA = "beta-scope";
+		const ALPHA_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, ALPHA);
+		const BETA_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, BETA);
+
+		const engine = makeMockEngine({ balance: 50_000 });
+		const audit = makeMockAudit();
+		// Invert the resolution order — the SECOND call (beta) finishes before
+		// the FIRST (alpha) — so a store read from the wrong tick would show up
+		// as a swapped or blended attribution rather than passing by accident.
+		let callIndex = 0;
+		const delays = [20, 0];
+		const client = {
+			messages: {
+				create: vi.fn(async () => {
+					const delay = delays[callIndex] ?? 0;
+					callIndex++;
+					await new Promise((r) => setTimeout(r, delay));
+					return {
+						id: "msg",
+						type: "message",
+						role: "assistant",
+						content: [{ type: "text", text: "ok" }],
+						model: "claude-sonnet-4-6",
+						usage: { input_tokens: 10, output_tokens: 5 },
+					};
+				}),
+			},
+		};
+		const governed = await trust(client, {
+			budget: 200_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const [alphaResult, betaResult] = (await Promise.all([
+			withCostCenter(ALPHA, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+			withCostCenter(BETA, () => governed.messages.create(PARAMS), SCOPE_OPTS),
+		])) as [{ receipt: TrustReceipt }, { receipt: TrustReceipt }];
+
+		// Two holds, each on its OWN envelope — never the other's, never a third.
+		const debitIds = engine.spendPending.mock.calls.map((c) => c[0].debitAccountId);
+		expect(debitIds).toHaveLength(2);
+		expect(new Set(debitIds)).toEqual(new Set([ALPHA_ID, BETA_ID]));
+
+		// Every policy evaluation saw exactly ONE of the two scopes — never both
+		// (a merge bug), never neither (a drop bug).
+		const seenCostCenters = vi.mocked(evaluatePolicy).mock.calls.map((c) => c[1].cost_center);
+		expect(seenCostCenters.sort()).toEqual([ALPHA, BETA].sort());
+
+		// Receipts and audit records: attribution followed its OWN call all the
+		// way to settlement, regardless of resolution order.
+		const receiptCostCenters = [
+			alphaResult.receipt.budget?.costCenter,
+			betaResult.receipt.budget?.costCenter,
+		];
+		expect(receiptCostCenters.sort()).toEqual([ALPHA, BETA].sort());
+
+		const llmCostCenters = audit.events
+			.filter((e) => e.kind === "llm_call")
+			.map((e) => (e.data as Record<string, unknown>).costCenter);
+		expect(llmCostCenters.sort()).toEqual([ALPHA, BETA].sort());
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// A10 — same costCenter string, different parentUserId → isolated accounts
+// ---------------------------------------------------------------------------
+
+describe("A10 — same costCenter, different parentUserId → isolated envelope accounts", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `spoof-a10-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("two governors sharing one ledger engine derive and debit DISTINCT accounts for the same costCenter label, run concurrently, with zero cross-talk", async () => {
+		const PARENT_A = "acme";
+		const PARENT_B = "globex";
+		const SHARED_CC = "research"; // identical costCenter STRING for both parents
+
+		const ACCOUNT_A = TrustTBClient.deriveCostCenterAccountId(PARENT_A, SHARED_CC);
+		const ACCOUNT_B = TrustTBClient.deriveCostCenterAccountId(PARENT_B, SHARED_CC);
+		// Sanity: the tuple hash, not the bare costCenter string, is what money
+		// is keyed on (AGENTS.md — "Cost-center account ids hash the (parent,
+		// costCenter) TUPLE"). If this ever failed, every assertion below would
+		// be vacuous.
+		expect(ACCOUNT_A).not.toBe(ACCOUNT_B);
+
+		// ONE physical engine behind both governors, as if they shared a single
+		// TigerBeetle cluster — balances keyed strictly per ACCOUNT id, never
+		// per costCenter string, so a wrong-parent bug would read or debit the
+		// OTHER company's envelope and this test would catch it directly.
+		const balances = new Map<bigint, number>([
+			[ACCOUNT_A, 4_000],
+			[ACCOUNT_B, 9_000],
+		]);
+		const spendPending = vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId }));
+		const postPendingSpend = vi.fn(async () => {});
+		const voidPendingSpend = vi.fn(async () => {});
+		const lookupBalances = vi.fn(async (ids: bigint[]) => {
+			const map = new Map<bigint, number>();
+			for (const id of ids) {
+				const bal = balances.get(id);
+				if (bal !== undefined) map.set(id, bal);
+			}
+			return map;
+		});
+		const sharedEngine: TrustEngine = {
+			spendPending,
+			postPendingSpend,
+			voidPendingSpend,
+			lookupBalances,
+			destroy: vi.fn(),
+		};
+
+		const auditA = makeMockAudit();
+		const auditB = makeMockAudit();
+		mkdirSync(join(vaultBase, "a"), { recursive: true });
+		mkdirSync(join(vaultBase, "b"), { recursive: true });
+
+		const governedA = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase: join(vaultBase, "a"),
+			parentUserId: PARENT_A,
+			_engine: sharedEngine,
+			_audit: auditA,
+		});
+		const governedB = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase: join(vaultBase, "b"),
+			parentUserId: PARENT_B,
+			_engine: sharedEngine,
+			_audit: auditB,
+		});
+
+		const [resultA, resultB] = (await Promise.all([
+			withCostCenter(SHARED_CC, () => governedA.messages.create(PARAMS), SCOPE_OPTS),
+			withCostCenter(SHARED_CC, () => governedB.messages.create(PARAMS), SCOPE_OPTS),
+		])) as [{ receipt: TrustReceipt }, { receipt: TrustReceipt }];
+
+		// Each hold debited ITS OWN company's account — never the other's.
+		const debitIds = spendPending.mock.calls.map((c) => c[0].debitAccountId);
+		expect(new Set(debitIds)).toEqual(new Set([ACCOUNT_A, ACCOUNT_B]));
+
+		// Each governor's receipt shows ITS OWN envelope's true balance — a swap
+		// would show 9,000 on A's receipt or 4,000 on B's.
+		expect(resultA.receipt.budget?.remaining).toBe(4_000);
+		expect(resultB.receipt.budget?.remaining).toBe(9_000);
+
+		// The SAME identifying label appears in both audit chains — that part is
+		// deliberately not secret — but it is backed by genuinely different
+		// money, which is the property that matters.
+		expect(auditData(auditA, "llm_call").costCenter).toBe(SHARED_CC);
+		expect(auditData(auditB, "llm_call").costCenter).toBe(SHARED_CC);
+
+		await governedA.destroy();
+		await governedB.destroy();
+	});
+});

--- a/packages/core/tests/harden/engine-factory-parity.test.ts
+++ b/packages/core/tests/harden/engine-factory-parity.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * `createTBEngine` — and the two TigerBeetle status predicates it classifies
+ * rejections with — are DUPLICATED between `govern.ts` and `headless.ts`. AGENTS.md
+ * (Known drift) records the rule: change both in lockstep. Nothing mechanical
+ * enforced it until this suite.
+ *
+ * The failure it exists to catch: a change landed in one governor's copy and not
+ * the other's. Both copies build the funded, balance-enforcing holding wallet that
+ * IS the budget enforcement, so a one-sided edit does not fail a build or a type
+ * check — `trust()` and `createGovernor()` simply stop agreeing about where money
+ * is held or how a ledger rejection is classified, and only whichever governor the
+ * deployment happens to use is right. Envelope routing made that concrete: the
+ * debit account and the D5 `debit_account_not_found` mapping have to be identical
+ * on both, or an attributed hold spends from the session wallet on one of them.
+ *
+ * Comments and blank lines are stripped before comparison — the two copies carry
+ * deliberately different prose (each names its own file) — so what is pinned is the
+ * CODE. Do not "fix" a failure here by editing this test: copy the change across.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const governSourcePath = fileURLToPath(new URL("../../src/govern.ts", import.meta.url));
+const headlessSourcePath = fileURLToPath(new URL("../../src/headless.ts", import.meta.url));
+
+/**
+ * Pull one top-level function out of a source file as text, minus comments and
+ * blank lines. Relies on the house formatting: a declaration line starting at
+ * column 0 and a closing `}` at column 0.
+ */
+function extractFunction(sourcePath: string, name: string): string {
+	const lines = readFileSync(sourcePath, "utf-8").split("\n");
+	const start = lines.findIndex((line) => {
+		const bare = line.startsWith("export ") ? line.slice("export ".length) : line;
+		return bare.startsWith(`function ${name}(`) || bare.startsWith(`async function ${name}(`);
+	});
+	if (start === -1) {
+		throw new Error(
+			`${sourcePath}: no top-level declaration of ${name} — was it renamed, moved, or indented?`,
+		);
+	}
+	const end = lines.indexOf("}", start);
+	if (end === -1) {
+		throw new Error(`${sourcePath}: ${name} has no closing brace at column 0`);
+	}
+	return lines
+		.slice(start, end + 1)
+		.map((line) => (line.startsWith("export ") ? line.slice("export ".length) : line))
+		.filter((line) => line.trim() !== "" && !line.trim().startsWith("//"))
+		.join("\n");
+}
+
+const DRIFT_HINT =
+	"govern.ts and headless.ts carry duplicate copies of this function and must change " +
+	"in lockstep (AGENTS.md, Known drift). Copy the edit into the other file verbatim — " +
+	"do not relax this test.";
+
+describe("engine factory parity — govern.ts and headless.ts stay in lockstep", () => {
+	it.each(["createTBEngine", "isTBInsufficientBalance", "isTBDebitAccountNotFound"])(
+		"keeps %s identical in both governors",
+		(name) => {
+			expect(extractFunction(headlessSourcePath, name), DRIFT_HINT).toBe(
+				extractFunction(governSourcePath, name),
+			);
+		},
+	);
+
+	it("still finds a real function body to compare (guards the extractor itself)", () => {
+		const body = extractFunction(governSourcePath, "createTBEngine");
+		// A silently-empty extraction would make every assertion above vacuous.
+		expect(body).toContain("createFundedBudgetWallet");
+		expect(body).toContain("spendPending");
+		expect(body.split("\n").length).toBeGreaterThan(20);
+	});
+});

--- a/packages/core/tests/headless/envelope-handle.test.ts
+++ b/packages/core/tests/headless/envelope-handle.test.ts
@@ -1,0 +1,605 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Task 6 — `createGovernor()` threads cost-center attribution through the
+ * AUTHORIZATION HANDLE.
+ *
+ * The structural difference from `trust()`, and the reason this file exists at
+ * all: the headless governor has NO closure spanning authorize→settle. `settle()`
+ * and `abort()` are separate public calls that a caller makes later, from wherever
+ * their own control flow happens to be — routinely a `finally`, a `catch`, or an
+ * entirely different task, long after the `withCostCenter` scope exited. So the
+ * `Authorization` handle is what a closure is on the SDK path, and the decisive
+ * test below asserts `getCurrentCostCenter()` is `undefined` at the moment settle
+ * is called and then asserts the settle was STILL attributed: the handle, not the
+ * store, is the truth. A governor that re-read the store in `settle()` would
+ * attribute the settle to nothing here — and, worse, to a LATER unrelated call's
+ * scope in a server that multiplexes callers.
+ *
+ * Also pinned: D1's pre-I/O throw, the envelope-scoped policy site (the third of
+ * the three re-assertion sites AGENTS.md tabulates, now carrying `cost_center`),
+ * A7's unfloored `budget_remaining_after`, A2's pre-gate refusal, A1's attributed
+ * records on the settle AND abort terminals, D5's label/hint re-wrap, and D7's
+ * post-settle receipt snapshot — each with its unattributed counterpart asserted
+ * byte-identical to the pre-envelope behaviour.
+ *
+ * SECURITY: never log or snapshot a whole PolicyContext — it carries
+ * request-shaped data. Assert on individual fields.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import { getCurrentCostCenter, withCostCenter } from "../../src/budget/attribution.js";
+import type { TrustEngine } from "../../src/govern.js";
+import { createGovernor, type Governor } from "../../src/headless.js";
+import { TrustTBClient } from "../../src/ledger/client.js";
+import { evaluatePolicy, type PolicyContext } from "../../src/policy/gate.js";
+import { InsufficientBalanceError, LedgerUnavailableError } from "../../src/shared/errors.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// The evaluator itself stays REAL — this only records the context the call site
+// hands it, so the assertions are about what the gate actually saw.
+vi.mock("../../src/policy/gate.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/policy/gate.js")>();
+	return { ...actual, evaluatePolicy: vi.fn(actual.evaluatePolicy) };
+});
+
+// ── Fixtures ──
+
+const PARENT = "acme";
+const COST_CENTER = "research";
+const ENVELOPE_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, COST_CENTER);
+const ENVELOPE_LABEL = `${PARENT}::${COST_CENTER}`;
+const SCOPE_OPTS = { allocated: 10_000, periodStartMs: Date.UTC(2026, 7, 3, 0, 0, 0) };
+
+const AUTHORIZE = {
+	model: "claude-sonnet-4-6",
+	estimatedInputTokens: 100,
+	maxOutputTokens: 500,
+};
+
+interface EngineHandle extends TrustEngine {
+	spendPending: ReturnType<typeof vi.fn>;
+	postPendingSpend: ReturnType<typeof vi.fn>;
+	voidPendingSpend: ReturnType<typeof vi.fn>;
+	lookupBalances?: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * `balance` shapes the seam the governor reads envelope numbers through:
+ *   number    → the envelope's live `available`
+ *   "missing" → the account is absent from the map (never allocated / fully reclaimed)
+ *   "throw"   → the read fails (A2 transport failure)
+ *   undefined → the engine has NO `lookupBalances` at all (optional-capability case)
+ */
+function makeMockEngine(opts: { balance?: number | "throw" | "missing" } = {}): EngineHandle {
+	const engine: EngineHandle = {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		voidAllPending: vi.fn(async () => {}),
+		destroy: vi.fn(),
+	};
+	if (opts.balance !== undefined) {
+		engine.lookupBalances = vi.fn(async (ids: bigint[]) => {
+			if (opts.balance === "throw") throw new Error("tb: lookupAccounts timed out");
+			const map = new Map<bigint, number>();
+			if (opts.balance !== "missing") {
+				for (const id of ids) map.set(id, opts.balance as number);
+			}
+			return map;
+		});
+	}
+	return engine;
+}
+
+interface AuditHandle extends AuditWriter {
+	events: AppendEventInput[];
+}
+
+function makeMockAudit(): AuditHandle {
+	const events: AppendEventInput[] = [];
+	return {
+		events,
+		appendEvent: vi.fn(async (input: AppendEventInput): Promise<AuditEvent> => {
+			events.push(input);
+			return {
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			};
+		}),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+function auditData(audit: AuditHandle, kind: string): Record<string, unknown> {
+	const event = audit.events.find((e) => e.kind === kind);
+	if (event === undefined) {
+		throw new Error(
+			`no ${kind} audit event was appended (saw: ${audit.events.map((e) => e.kind).join(", ")})`,
+		);
+	}
+	return event.data as Record<string, unknown>;
+}
+
+/** The context the (real) evaluator saw for the most recent gate call. */
+function lastPolicyContext(): PolicyContext {
+	const calls = vi.mocked(evaluatePolicy).mock.calls;
+	const last = calls[calls.length - 1];
+	if (last === undefined) throw new Error("the policy evaluator was never called");
+	return last[1];
+}
+
+// ── Tests ──
+
+describe("headless authorize routes attributed holds to the envelope", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `headless-envelope-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	// `parentUserId: null` means "construct this governor with NO ledger identity"
+	// — a default parameter could not express that, because passing `undefined`
+	// explicitly is what selects a default.
+	async function governorWith(
+		engine: EngineHandle,
+		audit: AuditHandle,
+		parentUserId: string | null = PARENT,
+	): Promise<Governor> {
+		return await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			...(parentUserId !== null ? { parentUserId } : {}),
+			_engine: engine,
+			_audit: audit,
+		});
+	}
+
+	it("places the PENDING hold against the derived envelope account", async () => {
+		const engine = makeMockEngine({ balance: 5_000 });
+		const gov = await governorWith(engine, makeMockAudit());
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+
+		expect(engine.spendPending).toHaveBeenCalledOnce();
+		expect(engine.spendPending.mock.calls[0]?.[0]).toMatchObject({ debitAccountId: ENVELOPE_ID });
+		// The handle carries the capture forward — this is the ONLY thing settle and
+		// abort will have to go on.
+		expect(auth.costCenter).toBe(COST_CENTER);
+		expect(auth.envelope?.accountId).toBe(ENVELOPE_ID);
+		expect(auth.envelope?.label).toBe(ENVELOPE_LABEL);
+
+		await gov.destroy();
+	});
+
+	it("leaves an UNATTRIBUTED authorize exactly as it was", async () => {
+		const engine = makeMockEngine({ balance: 5_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await gov.authorize(AUTHORIZE);
+
+		// No debit account: the session holding wallet, exactly as before envelopes.
+		expect(engine.spendPending.mock.calls[0]?.[0].debitAccountId).toBeUndefined();
+		// No envelope read is even attempted for an unattributed call.
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		// Spread-omission, not `undefined`: the handle keeps its pre-envelope shape.
+		expect("costCenter" in auth).toBe(false);
+		expect("envelope" in auth).toBe(false);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBeUndefined();
+		expect(ctx.budget_remaining).toBe(100_000);
+		expect(ctx.budget_remaining_after).toBe(100_000 - (ctx.estimated_cost as number));
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+		expect(receipt.budget).toBeUndefined();
+		expect(auditData(audit, "llm_call").costCenter).toBeUndefined();
+
+		await gov.destroy();
+	});
+
+	it("throws BEFORE any I/O when a scope is active and the governor has no parentUserId (D1)", async () => {
+		const engine = makeMockEngine({ balance: 5_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit, null);
+
+		await expect(
+			withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS),
+		).rejects.toThrow(/parentUserId/);
+
+		// Pre-I/O means pre-EVERYTHING: no envelope read, no policy evaluation, no
+		// hold, no audit record. Silently spending from the session wallet instead is
+		// the exact failure the throw exists to prevent — it would leave the envelope
+		// reporting a full balance while the agent burned the session budget.
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect(vi.mocked(evaluatePolicy)).not.toHaveBeenCalled();
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(audit.events).toHaveLength(0);
+
+		await gov.destroy();
+	});
+
+	it("gives the policy gate ENVELOPE-scoped numbers, from the live ledger read", async () => {
+		const engine = makeMockEngine({ balance: 2_500 });
+		const gov = await governorWith(engine, makeMockAudit());
+
+		await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+
+		// Exactly one preflight read, of exactly the envelope account.
+		expect(engine.lookupBalances).toHaveBeenCalledOnce();
+		expect(engine.lookupBalances?.mock.calls[0]?.[0]).toEqual([ENVELOPE_ID]);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBe(COST_CENTER);
+		expect(ctx.budget_remaining).toBe(2_500);
+		expect(ctx.budget_remaining_after).toBe(2_500 - (ctx.estimated_cost as number));
+		// 2500 / 10000 allocated.
+		expect(ctx.budgetFractionRemaining).toBeCloseTo(0.25);
+		expect(ctx.budgetRunwayHours).toBeTypeOf("number");
+
+		await gov.destroy();
+	});
+
+	it("asserts the tier fields UNDEFINED when the scope carried no allocation metadata (D4)", async () => {
+		const engine = makeMockEngine({ balance: 2_500 });
+		const gov = await governorWith(engine, makeMockAudit());
+
+		// No opts: attribution without an allocation. There is no cost-center
+		// registry, so the governor genuinely does not know the envelope's size — and
+		// a fabricated number is worse than an absent one. A hard tier on these
+		// fields then fires (indeterminate ⇒ fail closed); a soft one stays lenient.
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE));
+
+		const ctx = lastPolicyContext();
+		expect(ctx.cost_center).toBe(COST_CENTER);
+		// The envelope-scoped ledger numbers are still real — they need no metadata.
+		expect(ctx.budget_remaining).toBe(2_500);
+		expect(ctx.budgetFractionRemaining).toBeUndefined();
+		expect(ctx.budgetRunwayHours).toBeUndefined();
+
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+		// `remaining` is knowable, `fraction` is not — omitted rather than guessed.
+		expect(receipt.budget).toEqual({ costCenter: COST_CENTER, remaining: 2_500 });
+
+		await gov.destroy();
+	});
+
+	it("reads a never-allocated envelope as zero and denies the spend at the gate", async () => {
+		const engine = makeMockEngine({ balance: "missing" });
+		const gov = await governorWith(engine, makeMockAudit());
+
+		await expect(
+			withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS),
+		).rejects.toThrow(/Policy denied/);
+
+		// Never-allocated and fully-reclaimed are the same observable state, so the
+		// default hard rules now guard the ENVELOPE: an empty one is a pre-spend deny.
+		expect(lastPolicyContext().budget_remaining).toBe(0);
+		expect(engine.spendPending).not.toHaveBeenCalled();
+
+		await gov.destroy();
+	});
+
+	it("denies an over-envelope call at the gate on an UNFLOORED remaining_after (A7)", async () => {
+		// Five usertokens left against a much larger estimate: the envelope has funds,
+		// so `block-budget-exhausted` cannot apply and `block-budget-overshoot` is the
+		// only rule that can fire — which it can only do if the governor let
+		// `budget_remaining_after` go NEGATIVE. Flooring it at 0 would leave this call
+		// authorised and structurally disarm the one non-disableable pre-spend deny on
+		// every attributed call, forking the field's semantics across the two paths.
+		const engine = makeMockEngine({ balance: 5 });
+		const gov = await governorWith(engine, makeMockAudit());
+
+		await expect(
+			withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS),
+		).rejects.toThrow(/Policy denied/);
+
+		const ctx = lastPolicyContext();
+		expect(ctx.budget_remaining).toBe(5);
+		expect(ctx.budget_remaining_after).toBe(5 - (ctx.estimated_cost as number));
+		expect(ctx.budget_remaining_after as number).toBeLessThan(0);
+		expect(engine.spendPending).not.toHaveBeenCalled();
+
+		await gov.destroy();
+	});
+
+	it("REFUSES an attributed authorize whose envelope read fails, before the gate (A2)", async () => {
+		const engine = makeMockEngine({ balance: "throw" });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const err = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS).catch(
+			(e: unknown) => e,
+		);
+
+		// The existing ledger-unavailable classification, naming the envelope that
+		// could not be read. NOT a policy denial: the policy gate never ran.
+		expect(err).toBeInstanceOf(LedgerUnavailableError);
+		expect((err as LedgerUnavailableError).message).toContain(ENVELOPE_LABEL);
+
+		// Why refusal rather than the session numbers: the preflight and the hold
+		// share one TigerBeetle transport, so a read that genuinely failed means the
+		// hold was doomed anyway — and gating on the SESSION wallet while the hold
+		// debits the ENVELOPE would clear the call against a wallet the money never
+		// came from, in the one record an auditor reads.
+		expect(vi.mocked(evaluatePolicy)).not.toHaveBeenCalled();
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(audit.events).toHaveLength(0);
+
+		await gov.destroy();
+	});
+
+	it("REFUSES an attributed authorize when the engine cannot read balances at all (A2)", async () => {
+		// Same refusal, different cause: an engine with no `lookupBalances` would
+		// place the envelope hold and be unable to report on it. Both `createTBEngine`
+		// factories implement the method, so this is the injected-engine case — and it
+		// must not degrade into session-scoped policy numbers either.
+		const engine = makeMockEngine();
+		expect(engine.lookupBalances).toBeUndefined();
+		const gov = await governorWith(engine, makeMockAudit());
+
+		await expect(
+			withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS),
+		).rejects.toThrow(LedgerUnavailableError);
+
+		expect(vi.mocked(evaluatePolicy)).not.toHaveBeenCalled();
+		expect(engine.spendPending).not.toHaveBeenCalled();
+
+		await gov.destroy();
+	});
+
+	it("names the envelope LABEL and the right remedy when the ledger rejects the hold (D5)", async () => {
+		const engine = makeMockEngine({ balance: 10 });
+		// What the engine seam throws for an exhausted envelope: the derived ACCOUNT
+		// id, because the `parent::costCenter` label lives in the governor.
+		engine.spendPending.mockRejectedValueOnce(
+			new InsufficientBalanceError(`envelope:${ENVELOPE_ID}`, 999, 10),
+		);
+		const gov = await governorWith(engine, makeMockAudit());
+
+		const err = await withCostCenter(
+			COST_CENTER,
+			() => gov.authorize({ ...AUTHORIZE, maxOutputTokens: 1 }),
+			SCOPE_OPTS,
+		).catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(InsufficientBalanceError);
+		const balanceErr = err as InsufficientBalanceError;
+		// The operator reads `acme::research`, not a 39-digit account id.
+		expect(balanceErr.userId).toBe(ENVELOPE_LABEL);
+		expect(balanceErr.message).toContain(ENVELOPE_LABEL);
+		// And is told the remedy that actually funds an envelope — raising the
+		// createGovernor() budget funds the session wallet this hold never debits.
+		expect(balanceErr.hint).toMatch(/allocateBudget/);
+		expect(balanceErr.hint).not.toMatch(/Increase the budget in trust\(\) options/);
+		// The ledger's own numbers survive the re-wrap.
+		expect(balanceErr.required).toBe(999);
+		expect(balanceErr.available).toBe(10);
+
+		await gov.destroy();
+	});
+
+	it("leaves an UNATTRIBUTED ledger rejection byte-identical", async () => {
+		const engine = makeMockEngine({ balance: 10 });
+		const thrown = new InsufficientBalanceError("trust:hold", 999, 10);
+		engine.spendPending.mockRejectedValueOnce(thrown);
+		const gov = await governorWith(engine, makeMockAudit());
+
+		const err = await gov.authorize(AUTHORIZE).catch((e: unknown) => e);
+
+		// The SAME error object, not a re-wrap: nothing on this path changed.
+		expect(err).toBe(thrown);
+		expect((err as InsufficientBalanceError).hint).toBe(
+			"Increase the budget in trust() options or add funds via the ledger.",
+		);
+
+		await gov.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The decisive one: settle/abort run OUTSIDE every scope, on the handle alone
+// ---------------------------------------------------------------------------
+
+describe("headless settle and abort attribute from the handle, not the store", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `headless-envelope-settle-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	async function governorWith(engine: EngineHandle, audit: AuditHandle): Promise<Governor> {
+		return await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+	}
+
+	it("attributes a settle called outside any withCostCenter scope", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+
+		// THE PIN: we are outside every scope now. An `AsyncLocalStorage` read from
+		// inside settle() would see exactly this — nothing. Unlike `trust()`, this
+		// governor has no closure to fall back on, so the handle is the only carrier.
+		expect(getCurrentCostCenter()).toBeUndefined();
+
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.settled).toBe(true);
+		// The handle, not the store, is what the settle read.
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+		expect(receipt.budget).toEqual({
+			costCenter: COST_CENTER,
+			remaining: 4_000,
+			fraction: 0.4,
+		});
+		// One read at authorize (preflight), one after the POST (D7 snapshot).
+		expect(engine.lookupBalances).toHaveBeenCalledTimes(2);
+
+		await gov.destroy();
+	});
+
+	it("does NOT pick up a DIFFERENT scope that happens to be active at settle time", async () => {
+		// The failure a store read in settle() would produce in a server that
+		// multiplexes callers: the settle lands on whichever scope the settling task
+		// is standing in, which is not the scope that placed the hold. Here the hold
+		// is `research` and the settle runs inside `marketing`; the record must still
+		// say `research`, because that is the envelope the money actually came from.
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+
+		const receipt = await withCostCenter("marketing", () =>
+			gov.settle(auth, { inputTokens: 80, outputTokens: 200 }),
+		);
+
+		expect(receipt.budget?.costCenter).toBe(COST_CENTER);
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+		// And the money followed the same handle: the D7 snapshot read the envelope
+		// the hold debited, not the one the settling task was standing in.
+		expect(engine.lookupBalances?.mock.calls.at(-1)?.[0]).toEqual([ENVELOPE_ID]);
+
+		await gov.destroy();
+	});
+
+	it("OMITS the receipt budget block when the post-settle read fails, without touching the settlement (D7)", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		// Preflight succeeds; the post-settle snapshot read fails.
+		engine.lookupBalances?.mockImplementationOnce(async (ids: bigint[]) => {
+			const map = new Map<bigint, number>();
+			for (const id of ids) map.set(id, 4_000);
+			return map;
+		});
+		engine.lookupBalances?.mockImplementationOnce(async () => {
+			throw new Error("tb: lookupAccounts timed out");
+		});
+		const gov = await governorWith(engine, makeMockAudit());
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.budget).toBeUndefined();
+		// Receipt degradation NEVER unwinds committed money.
+		expect(receipt.settled).toBe(true);
+		expect(engine.postPendingSpend).toHaveBeenCalledOnce();
+		expect(engine.voidPendingSpend).not.toHaveBeenCalled();
+
+		await gov.destroy();
+	});
+
+	it("stamps the attribution on a settlement_ambiguous record (A1)", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		engine.postPendingSpend.mockRejectedValueOnce(new Error("tb: postTransfer socket reset"));
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.settled).toBe(false);
+		// An ambiguous settlement is precisely the record an auditor reconstructs a
+		// cost center's history from — it must name the envelope.
+		expect(auditData(audit, "settlement_ambiguous").costCenter).toBe(COST_CENTER);
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+
+		await gov.destroy();
+	});
+
+	it("carries the attribution into the abort terminal's record (A1)", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+
+		// abort() is normally called from a `catch` outside the scope, exactly here.
+		expect(getCurrentCostCenter()).toBeUndefined();
+		await gov.abort(auth, new Error("provider exploded"));
+
+		expect(engine.voidPendingSpend).toHaveBeenCalledOnce();
+		// Attributed hold ⇒ attributed terminal record: forensic continuity.
+		expect(auditData(audit, "llm_call_failed").costCenter).toBe(COST_CENTER);
+
+		await gov.destroy();
+	});
+
+	it("leaves an unattributed abort record byte-identical", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await gov.authorize(AUTHORIZE);
+		await gov.abort(auth, new Error("provider exploded"));
+
+		const data = auditData(audit, "llm_call_failed");
+		expect("costCenter" in data).toBe(false);
+
+		await gov.destroy();
+	});
+});

--- a/packages/core/tests/headless/envelope-handle.test.ts
+++ b/packages/core/tests/headless/envelope-handle.test.ts
@@ -30,15 +30,17 @@
 
 import { randomUUID } from "node:crypto";
 import { mkdirSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
 import { getCurrentCostCenter, withCostCenter } from "../../src/budget/attribution.js";
-import type { TrustEngine } from "../../src/govern.js";
-import { createGovernor, type Governor } from "../../src/headless.js";
+import type { ResolvedEnvelope, TrustEngine } from "../../src/govern.js";
+import { type Authorization, createGovernor, type Governor } from "../../src/headless.js";
 import { TrustTBClient } from "../../src/ledger/client.js";
 import { evaluatePolicy, type PolicyContext } from "../../src/policy/gate.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
 import { InsufficientBalanceError, LedgerUnavailableError } from "../../src/shared/errors.js";
 import type { AuditEvent } from "../../src/shared/types.js";
 
@@ -149,6 +151,20 @@ function auditData(audit: AuditHandle, kind: string): Record<string, unknown> {
 		);
 	}
 	return event.data as Record<string, unknown>;
+}
+
+/**
+ * The cumulative session spend persisted to disk, or `undefined` when no ledger
+ * was ever written. That file is what seeds the next run's holding wallet with
+ * `max(0, budget - budgetSpent)`, which is why envelope money must never reach it.
+ */
+async function readPersistedSpend(vaultBase: string): Promise<number | undefined> {
+	try {
+		const raw = await readFile(join(vaultBase, VAULT_DIR, "spend-ledger.json"), "utf-8");
+		return (JSON.parse(raw) as { budgetSpent: number }).budgetSpent;
+	} catch {
+		return undefined;
+	}
 }
 
 /** The context the (real) evaluator saw for the most recent gate call. */
@@ -599,6 +615,275 @@ describe("headless settle and abort attribute from the handle, not the store", (
 
 		const data = auditData(audit, "llm_call_failed");
 		expect("costCenter" in data).toBe(false);
+
+		await gov.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The handle is CALLER-OWNED; the attribution the governor reads is not
+// ---------------------------------------------------------------------------
+//
+// Whole-branch review, finding 2. `activeAuths.set(transferId, auth)` stores the
+// caller's own object, and `settle()`/`abort()` established liveness with
+// `has(transferId)` and then read `auth.costCenter` / `auth.envelope` off that same
+// caller-mutable object. Money never moved wrong — `postPendingSpend` is
+// transferId-bound and the hold was placed at authorize — but AGENTS.md's rule is
+// that EVERY audit record comes from the authorize-time capture and never from
+// caller input, and a relabelled `llm_call` / `llm_call_failed` is exactly the
+// record an auditor reconstructs a cost center's history from. The second-order
+// effect is worse than the label: `snapshotEnvelopeRemaining` reads whatever
+// account the envelope names, so a forged `auth.envelope` turns the receipt's
+// budget block into an arbitrary account's balance.
+//
+// `trust()` was already immune — its attribution is a closure `const`. This pins
+// the same immutability for the handle-based governor.
+
+describe("headless settle and abort read an INTERNAL capture, not the caller's handle", () => {
+	let vaultBase: string;
+
+	const FORGED_COST_CENTER = "marketing";
+	const FORGED_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, FORGED_COST_CENTER);
+	const FORGED_LABEL = `${PARENT}::${FORGED_COST_CENTER}`;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `headless-envelope-forge-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	async function governorWith(engine: EngineHandle, audit: AuditHandle): Promise<Governor> {
+		return await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit,
+		});
+	}
+
+	/** The relabelling a caller can attempt between authorize and settle/abort. */
+	function forge(auth: Authorization): void {
+		auth.costCenter = FORGED_COST_CENTER;
+		auth.envelope = {
+			attribution: {
+				costCenter: FORGED_COST_CENTER,
+				allocated: 1_000_000,
+				periodStartMs: SCOPE_OPTS.periodStartMs,
+			},
+			accountId: FORGED_ID,
+			label: FORGED_LABEL,
+		};
+	}
+
+	it("IGNORES a handle relabelled between authorize and settle", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		forge(auth);
+
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		// The record still names the envelope the hold actually debited.
+		expect(auditData(audit, "llm_call").costCenter).toBe(COST_CENTER);
+		expect(receipt.budget?.costCenter).toBe(COST_CENTER);
+		// And the D7 snapshot read THAT envelope's account — not the arbitrary
+		// account the forged handle named.
+		expect(engine.lookupBalances?.mock.calls.at(-1)?.[0]).toEqual([ENVELOPE_ID]);
+		expect(receipt.budget?.remaining).toBe(4_000);
+
+		await gov.destroy();
+	});
+
+	it("IGNORES a handle relabelled between authorize and abort", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		forge(auth);
+
+		await gov.abort(auth, new Error("provider exploded"));
+
+		expect(engine.voidPendingSpend).toHaveBeenCalledOnce();
+		expect(auditData(audit, "llm_call_failed").costCenter).toBe(COST_CENTER);
+
+		await gov.destroy();
+	});
+
+	it("cannot be relabelled by mutating the envelope object the handle exposes", async () => {
+		// The narrower attack: not replacing `auth.envelope`, but editing the object
+		// in place — which would reach the governor too if the handle and the
+		// governor's capture were the same mutable object.
+		const engine = makeMockEngine({ balance: 4_000 });
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+
+		expect(Object.isFrozen(auth.envelope)).toBe(true);
+		expect(Object.isFrozen(auth.envelope?.attribution)).toBe(true);
+		expect(() => {
+			(auth.envelope as ResolvedEnvelope).accountId = FORGED_ID;
+		}).toThrow(TypeError);
+
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.budget?.costCenter).toBe(COST_CENTER);
+		expect(engine.lookupBalances?.mock.calls.at(-1)?.[0]).toEqual([ENVELOPE_ID]);
+
+		await gov.destroy();
+	});
+
+	it("still refuses a settle for an authorization that is no longer active", async () => {
+		// The liveness/one-shot semantics are unchanged by the capture lookup: the
+		// first terminal claims the entry, the second is refused.
+		const engine = makeMockEngine({ balance: 4_000 });
+		const gov = await governorWith(engine, makeMockAudit());
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		await expect(gov.settle(auth, { inputTokens: 80, outputTokens: 200 })).rejects.toThrow(
+			/is not active/,
+		);
+		// abort stays idempotent-silent rather than throwing.
+		await expect(gov.abort(auth)).resolves.toBeUndefined();
+		expect(engine.postPendingSpend).toHaveBeenCalledOnce();
+		expect(engine.voidPendingSpend).not.toHaveBeenCalled();
+
+		await gov.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Session accounting tracks SESSION-WALLET money only
+// ---------------------------------------------------------------------------
+//
+// Whole-branch review, finding 3. `inFlightHoldTotal` and `budgetSpent` are the
+// SESSION holding wallet's accounting — the numbers `budgetRemaining()`, the
+// receipt, the unattributed policy gate and the restart seed
+// (`max(0, budget - budgetSpent)`) are all computed from. An ATTRIBUTED hold
+// debits the ENVELOPE wallet and never touches the session wallet, so moving those
+// counters for it charges the session for money it did not pay: unattributed calls
+// eventually hard-deny against a wallet TigerBeetle would still have held against,
+// and every attributed receipt reports a session `budgetRemaining` decremented by
+// envelope money. Fail-closed, but unrecorded and wrong.
+
+describe("headless session accounting excludes envelope spend", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `headless-envelope-session-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("leaves the session budget untouched by an attributed call, and gates the next unattributed call on it", async () => {
+		const engine = makeMockEngine({ balance: 50_000 });
+		const gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const attributed = await withCostCenter(
+			COST_CENTER,
+			() => gov.authorize(AUTHORIZE),
+			SCOPE_OPTS,
+		);
+		// The hold went to the envelope, so the session wallet has no in-flight
+		// exposure to report.
+		expect(gov.budgetRemaining()).toBe(100_000);
+
+		const attributedReceipt = await gov.settle(attributed, {
+			inputTokens: 80,
+			outputTokens: 200,
+		});
+		expect(attributedReceipt.cost).toBeGreaterThan(0);
+		// A settled attributed receipt reports SESSION headroom, which this spend did
+		// not consume — the envelope's own number is `receipt.budget`.
+		expect(attributedReceipt.budgetRemaining).toBe(100_000);
+		expect(attributedReceipt.budget?.remaining).toBe(50_000);
+
+		// Mixed traffic: the unattributed call that follows is gated on a session
+		// remaining the envelope spend never moved.
+		const unattributed = await gov.authorize(AUTHORIZE);
+		expect(lastPolicyContext().budget_remaining).toBe(100_000);
+
+		const unattributedReceipt = await gov.settle(unattributed, {
+			inputTokens: 80,
+			outputTokens: 200,
+		});
+		expect(unattributedReceipt.budgetRemaining).toBe(100_000 - unattributedReceipt.cost);
+		// Only the session-wallet spend is persisted, because only it survives a
+		// restart as `max(0, budget - budgetSpent)` seeding of the holding wallet.
+		expect(await readPersistedSpend(vaultBase)).toBe(unattributedReceipt.cost);
+
+		await gov.destroy();
+	});
+
+	it("never persists a spend ledger for an attributed-only session", async () => {
+		const engine = makeMockEngine({ balance: 50_000 });
+		const gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		// Nothing to record: the session wallet paid nothing. A ledger written here
+		// would shrink the next run's holding-wallet seed by envelope money.
+		expect(await readPersistedSpend(vaultBase)).toBeUndefined();
+
+		await gov.destroy();
+	});
+
+	it("restores the in-flight hold on an attributed abort without moving session numbers", async () => {
+		const engine = makeMockEngine({ balance: 50_000 });
+		const gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit(),
+		});
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		await gov.abort(auth, new Error("provider exploded"));
+
+		// The increment was skipped, so the matching decrement must be too — an
+		// asymmetric release would drive `inFlightHoldTotal` negative and hand the
+		// session MORE headroom than its budget.
+		expect(gov.budgetRemaining()).toBe(100_000);
 
 		await gov.destroy();
 	});

--- a/packages/core/tests/headless/envelope-handle.test.ts
+++ b/packages/core/tests/headless/envelope-handle.test.ts
@@ -587,6 +587,26 @@ describe("headless settle and abort attribute from the handle, not the store", (
 		await gov.destroy();
 	});
 
+	it("OMITS the budget block on an AMBIGUOUS settlement (settled:false), without a post-settle read", async () => {
+		const engine = makeMockEngine({ balance: 4_000 });
+		// The POST after the audit fails: the transfer may still be pending and be
+		// posted or voided later, so the envelope balance is transient. `receipt.budget`
+		// is a POST-SETTLEMENT observation (D7/A8) — a receipt marked settled:false must
+		// not carry it, and the ambiguous path must not even read the ledger for it.
+		engine.postPendingSpend.mockRejectedValueOnce(new Error("tb: postTransfer socket reset"));
+		const gov = await governorWith(engine, makeMockAudit());
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.settled).toBe(false);
+		expect(receipt.budget).toBeUndefined();
+		// Only the authorize-time preflight ran — no pointless post-settle snapshot.
+		expect(engine.lookupBalances).toHaveBeenCalledTimes(1);
+
+		await gov.destroy();
+	});
+
 	it("carries the attribution into the abort terminal's record (A1)", async () => {
 		const engine = makeMockEngine({ balance: 4_000 });
 		const audit = makeMockAudit();

--- a/packages/core/tests/headless/envelope-handle.test.ts
+++ b/packages/core/tests/headless/envelope-handle.test.ts
@@ -36,7 +36,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
 import { getCurrentCostCenter, withCostCenter } from "../../src/budget/attribution.js";
-import type { ResolvedEnvelope, TrustEngine } from "../../src/govern.js";
+import type { TrustEngine } from "../../src/govern.js";
 import { type Authorization, createGovernor, type Governor } from "../../src/headless.js";
 import { TrustTBClient } from "../../src/ledger/client.js";
 import { evaluatePolicy, type PolicyContext } from "../../src/policy/gate.js";
@@ -224,8 +224,28 @@ describe("headless authorize routes attributed holds to the envelope", () => {
 		// The handle carries the capture forward — this is the ONLY thing settle and
 		// abort will have to go on.
 		expect(auth.costCenter).toBe(COST_CENTER);
-		expect(auth.envelope?.accountId).toBe(ENVELOPE_ID);
-		expect(auth.envelope?.label).toBe(ENVELOPE_LABEL);
+
+		await gov.destroy();
+	});
+
+	it("returns a JSON-serializable handle for an ATTRIBUTED authorization", async () => {
+		// Regression pin (Codex P2). An attributed handle used to carry the resolved
+		// envelope, whose `accountId` is a bigint — so `JSON.stringify(auth)` threw
+		// "Do not know how to serialize a BigInt" for exactly the attributed case,
+		// while an unattributed handle serialized fine. Integrations that log or
+		// transport the handle broke the moment a call was attributed. The envelope now
+		// lives only on the governor's internal capture; the handle keeps the string.
+		const engine = makeMockEngine({ balance: 5_000 });
+		const gov = await governorWith(engine, makeMockAudit());
+
+		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
+
+		expect(() => JSON.stringify(auth)).not.toThrow();
+		const roundTripped = JSON.parse(JSON.stringify(auth)) as { costCenter?: string };
+		expect(roundTripped.costCenter).toBe(COST_CENTER);
+		// costCenter survives as reporting; the bigint account id is NOT on the handle.
+		expect(auth.costCenter).toBe(COST_CENTER);
+		expect("envelope" in auth).toBe(false);
 
 		await gov.destroy();
 	});
@@ -644,17 +664,22 @@ describe("headless settle and abort attribute from the handle, not the store", (
 // The handle is CALLER-OWNED; the attribution the governor reads is not
 // ---------------------------------------------------------------------------
 //
-// Whole-branch review, finding 2. `activeAuths.set(transferId, auth)` stores the
-// caller's own object, and `settle()`/`abort()` established liveness with
-// `has(transferId)` and then read `auth.costCenter` / `auth.envelope` off that same
-// caller-mutable object. Money never moved wrong — `postPendingSpend` is
-// transferId-bound and the hold was placed at authorize — but AGENTS.md's rule is
-// that EVERY audit record comes from the authorize-time capture and never from
-// caller input, and a relabelled `llm_call` / `llm_call_failed` is exactly the
-// record an auditor reconstructs a cost center's history from. The second-order
-// effect is worse than the label: `snapshotEnvelopeRemaining` reads whatever
-// account the envelope names, so a forged `auth.envelope` turns the receipt's
-// budget block into an arbitrary account's balance.
+// Whole-branch review, finding 2. `activeAuths` once stored the caller's own
+// object, and `settle()`/`abort()` established liveness with `has(transferId)` and
+// then read attribution off that same caller-mutable handle. Money never moved
+// wrong — `postPendingSpend` is transferId-bound and the hold was placed at
+// authorize — but AGENTS.md's rule is that EVERY audit record comes from the
+// authorize-time capture and never from caller input, and a relabelled `llm_call` /
+// `llm_call_failed` is exactly the record an auditor reconstructs a cost center's
+// history from. The governor now keeps its OWN immutable capture keyed by
+// `transferId` and reads attribution from THAT, so mutating the handle's
+// `costCenter` between the two phases changes nothing below.
+//
+// The resolved envelope is no longer even exposed on the handle: its `accountId` is
+// a bigint (kept on the internal capture, which is also what keeps the handle
+// JSON-serializable), so the second-order attack the original finding named — a
+// forged `auth.envelope` pointing `snapshotEnvelopeRemaining` at an arbitrary
+// account's balance — has no surface left at all.
 //
 // `trust()` was already immune — its attribution is a closure `const`. This pins
 // the same immutability for the handle-based governor.
@@ -663,8 +688,6 @@ describe("headless settle and abort read an INTERNAL capture, not the caller's h
 	let vaultBase: string;
 
 	const FORGED_COST_CENTER = "marketing";
-	const FORGED_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, FORGED_COST_CENTER);
-	const FORGED_LABEL = `${PARENT}::${FORGED_COST_CENTER}`;
 
 	beforeEach(() => {
 		vaultBase = join(tmpdir(), `headless-envelope-forge-${randomUUID()}`);
@@ -692,18 +715,13 @@ describe("headless settle and abort read an INTERNAL capture, not the caller's h
 		});
 	}
 
-	/** The relabelling a caller can attempt between authorize and settle/abort. */
+	/**
+	 * The relabelling a caller can attempt between authorize and settle/abort. The
+	 * resolved envelope is no longer on the handle, so `costCenter` — a plain,
+	 * reporting-only string — is the entire remaining relabel surface.
+	 */
 	function forge(auth: Authorization): void {
 		auth.costCenter = FORGED_COST_CENTER;
-		auth.envelope = {
-			attribution: {
-				costCenter: FORGED_COST_CENTER,
-				allocated: 1_000_000,
-				periodStartMs: SCOPE_OPTS.periodStartMs,
-			},
-			accountId: FORGED_ID,
-			label: FORGED_LABEL,
-		};
 	}
 
 	it("IGNORES a handle relabelled between authorize and settle", async () => {
@@ -743,21 +761,19 @@ describe("headless settle and abort read an INTERNAL capture, not the caller's h
 		await gov.destroy();
 	});
 
-	it("cannot be relabelled by mutating the envelope object the handle exposes", async () => {
-		// The narrower attack: not replacing `auth.envelope`, but editing the object
-		// in place — which would reach the governor too if the handle and the
-		// governor's capture were the same mutable object.
+	it("exposes no resolved envelope on the handle to mutate in the first place", async () => {
+		// The narrower attack the original finding named — editing the exposed envelope
+		// object in place so a forged account reaches the governor — has no surface now:
+		// the resolved envelope (a bigint account id) is never put on the caller-owned
+		// handle at all. The settle below still reads the D7 snapshot from the internal
+		// capture's envelope, naming the account the hold actually debited.
 		const engine = makeMockEngine({ balance: 4_000 });
 		const audit = makeMockAudit();
 		const gov = await governorWith(engine, audit);
 
 		const auth = await withCostCenter(COST_CENTER, () => gov.authorize(AUTHORIZE), SCOPE_OPTS);
 
-		expect(Object.isFrozen(auth.envelope)).toBe(true);
-		expect(Object.isFrozen(auth.envelope?.attribution)).toBe(true);
-		expect(() => {
-			(auth.envelope as ResolvedEnvelope).accountId = FORGED_ID;
-		}).toThrow(TypeError);
+		expect("envelope" in auth).toBe(false);
 
 		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
 

--- a/packages/core/tests/integration/budget-envelope.tb.test.ts
+++ b/packages/core/tests/integration/budget-envelope.tb.test.ts
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Real-TigerBeetle cost-center envelope spend cycle.
+ *
+ * `tigerbeetle.tb.test.ts` proves the session-wallet two-phase hold against a real
+ * cluster; this file proves the SAME invariant for an attributed spend — a governed
+ * call made inside a `withCostCenter(cc, fn)` scope debits the `(parent, costCenter)`
+ * envelope wallet, not the session holding wallet, and every read surface
+ * (`getBudgetStatus`, `budgetContext`, `receipt.budget`) reports the real ledger
+ * balance rather than the `spent: 0` gap `budget/allocation.ts`'s module doc names.
+ *
+ * Like its sibling, this does NOT mock `tigerbeetle-node` and does NOT use dryRun —
+ * `trust()` builds a real `createTBEngine` against a live cluster, and the setup
+ * steps (fund the parent, `allocateBudget`) run through a second, directly
+ * constructed `TrustTBClient` pointed at the same cluster, exactly as an operator's
+ * own allocation tooling would.
+ *
+ * The suite self-skips (via `describe.skipIf`) whenever `USERTRUST_TB_ADDRESS` is
+ * absent, so it auto-collects into the normal `test` job without failing it, and is
+ * proven green against a real cluster only by the dedicated `tb-integration` CI job.
+ *
+ * NOTE: because this file loads the real native `tigerbeetle-node` binding at import
+ * time, all cluster-touching code lives INSIDE the `it` body — which never runs when
+ * the suite is skipped. Only pure pricing math executes at collection.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { allocateBudget, getBudgetStatus, reclaimBudget } from "../../src/budget/allocation.js";
+import { withCostCenter } from "../../src/budget/attribution.js";
+import { budgetContext } from "../../src/budget/context.js";
+import { trust } from "../../src/govern.js";
+import { TrustTBClient, XFER_PURCHASE } from "../../src/ledger/client.js";
+import { estimateCost, estimateInputTokens } from "../../src/ledger/pricing.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
+import { InsufficientBalanceError, PolicyDeniedError } from "../../src/shared/errors.js";
+
+const TB_ADDRESS = process.env.USERTRUST_TB_ADDRESS;
+
+/**
+ * A correct hard envelope stop — pre-spend policy denial or the ledger's atomic
+ * rejection. Per A7, a SEQUENTIAL over-envelope call is denied at the policy gate
+ * (`block-budget-overshoot`, the non-disableable pre-spend hard rule, firing on an
+ * unfloored negative `budget_remaining_after`) before any hold reaches the engine —
+ * the ledger's own `InsufficientBalanceError` is the backstop for what per-call
+ * policy cannot catch (concurrent/cross-process holds), the same division of labor
+ * `tigerbeetle.tb.test.ts` documents for the session wallet. This predicate — copied
+ * from that file's own `isHardDenial` — accepts either, which is the conservative
+ * reading of this task's literal "rejected by the ledger (`InsufficientBalanceError`)"
+ * wording: the actual denial for a sequential call is `PolicyDeniedError`, pinned by
+ * `tests/govern/envelope-threading.test.ts`'s "denies an over-envelope call at the
+ * gate, BEFORE any hold" test (A7's correction post-dates this task's original
+ * description). Recorded here rather than narrowed to one class, so this test keeps
+ * proving the money invariant that matters — nothing moved — instead of an
+ * implementation detail of which layer caught it.
+ */
+const isHardDenial = (err: unknown): boolean =>
+	err instanceof InsufficientBalanceError || err instanceof PolicyDeniedError;
+
+// ── Fixtures ──
+// A single, fixed call shape so the envelope can be sized to the exact PENDING hold —
+// same technique and same rates as tigerbeetle.tb.test.ts.
+const MODEL = "claude-sonnet-4-6";
+const MAX_TOKENS = 1024;
+const MESSAGES = [{ role: "user", content: "Summarize two-phase commit in one line." }];
+
+// The EXACT hold the governor reserves for this call against the envelope.
+const HOLD = estimateCost(MODEL, estimateInputTokens(MESSAGES), MAX_TOKENS);
+
+// Provider-reported usage → a SETTLED cost strictly below the reserved hold, so the
+// envelope has real, nonzero headroom left after one settle and the second identical
+// call's fresh HOLD-sized reservation no longer fits.
+const USAGE = { input_tokens: 100, output_tokens: 50 };
+const ACTUAL_COST = estimateCost(MODEL, USAGE.input_tokens, USAGE.output_tokens);
+
+// The envelope is funded with exactly one hold's worth — the same boundary
+// tigerbeetle.tb.test.ts's sequential-over-budget test uses, applied to the
+// cost-center wallet instead of the session wallet.
+const ENVELOPE_ALLOCATED = HOLD;
+// The parent wallet is funded with exactly what it delegates — nothing left over
+// after allocateBudget, which doubles as the budgetContext parent-balance check.
+const PARENT_FUND = ENVELOPE_ALLOCATED;
+// The session holding wallet an attributed call never debits — present only because
+// TrustConfigSchema.budget is required. Its size is irrelevant to every assertion.
+const SESSION_BUDGET = 1_000_000;
+
+const COST_CENTER = "research";
+
+// ── Helpers ──
+
+const vaults: string[] = [];
+
+/** Write a tmp vault whose config points the engine at the live cluster. */
+function makeVault(budget: number): string {
+	const dir = join(tmpdir(), `tb-envelope-${randomUUID()}`);
+	mkdirSync(join(dir, VAULT_DIR), { recursive: true });
+	writeFileSync(
+		join(dir, VAULT_DIR, "usertrust.config.json"),
+		JSON.stringify({
+			budget,
+			// `addresses`/`clusterId` are the exact TrustTBClient config keys (ledger/client.ts).
+			tigerbeetle: { addresses: [TB_ADDRESS], clusterId: 0 },
+		}),
+	);
+	vaults.push(dir);
+	return dir;
+}
+
+/** An Anthropic-shaped client whose `messages.create` is the given spy. */
+function anthropicClient(create: (...args: unknown[]) => unknown): Record<string, unknown> {
+	return { messages: { create } };
+}
+
+/** A successful non-stream Anthropic response carrying provider usage. */
+function okResponse(): Record<string, unknown> {
+	return {
+		id: `msg_${randomUUID()}`,
+		type: "message",
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		model: MODEL,
+		usage: { ...USAGE },
+	};
+}
+
+const CALL = { model: MODEL, max_tokens: MAX_TOKENS, messages: MESSAGES } as const;
+
+afterEach(() => {
+	for (const dir of vaults.splice(0)) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* best-effort cleanup */
+		}
+	}
+});
+
+// ── Suite (self-skips with no live cluster) ──
+
+describe.skipIf(!TB_ADDRESS)("real TigerBeetle — cost-center envelope spend cycle", () => {
+	it(
+		"funds a parent, allocates an envelope, spends it via withCostCenter, reports " +
+			"real spend on both getBudgetStatus and budgetContext, hard-refuses an " +
+			"over-envelope hold, and reclaims the remainder",
+		async () => {
+			// A fresh parent id per test run — this file's own setup client, not the
+			// governed one, funds and allocates through it, exactly as an operator's
+			// allocation tooling would against the live cluster.
+			const PARENT = `envelope-tb-${randomUUID()}`;
+
+			const tb = new TrustTBClient({ addresses: [TB_ADDRESS as string], clusterId: 0n });
+			try {
+				// ── Fund parent ──
+				const treasury = await tb.createTreasury();
+				const parentAccountId = await tb.createUserWallet(PARENT);
+				await tb.immediateTransfer({
+					debitAccountId: treasury,
+					creditAccountId: parentAccountId,
+					amount: PARENT_FUND,
+					code: XFER_PURCHASE,
+				});
+
+				// ── allocateBudget ──
+				const allocation = await allocateBudget(tb, {
+					parentUserId: PARENT,
+					costCenter: COST_CENTER,
+					amount: ENVELOPE_ALLOCATED,
+				});
+				expect(allocation.allocated).toBe(ENVELOPE_ALLOCATED);
+
+				const create = vi.fn(async () => okResponse());
+				const governed = await trust(anthropicClient(create), {
+					vaultBase: makeVault(SESSION_BUDGET),
+					parentUserId: PARENT,
+				});
+				try {
+					const periodStartMs = Date.now();
+					const scopeOpts = { allocated: ENVELOPE_ALLOCATED, periodStartMs };
+
+					// ── withCostCenter authorize+settle against the real envelope ──
+					const r1 = (await withCostCenter(
+						COST_CENTER,
+						() => governed.messages.create({ ...CALL }),
+						scopeOpts,
+					)) as { receipt: { settled: boolean; cost: number; budget?: unknown } };
+
+					expect(r1.receipt.settled).toBe(true);
+					expect(r1.receipt.cost).toBe(ACTUAL_COST);
+					// D7: the post-settle envelope snapshot on the settled receipt — this IS
+					// the real ledger's own read, not an in-process estimate.
+					expect(r1.receipt.budget).toEqual({
+						costCenter: COST_CENTER,
+						remaining: ENVELOPE_ALLOCATED - ACTUAL_COST,
+						fraction: (ENVELOPE_ALLOCATED - ACTUAL_COST) / ENVELOPE_ALLOCATED,
+					});
+					expect(create).toHaveBeenCalledTimes(1);
+
+					// ── getBudgetStatus shows real spent ──
+					// The exact gap AGENTS.md's "Known drift" section names as closed by this
+					// feature: an agent that spends inside a scope no longer reports spent: 0.
+					const status = await getBudgetStatus(tb, {
+						parentUserId: PARENT,
+						costCenter: COST_CENTER,
+						allocated: ENVELOPE_ALLOCATED,
+						periodStartMs,
+					});
+					expect(status.balance).toBe(ENVELOPE_ALLOCATED - ACTUAL_COST);
+					expect(status.runway.remaining).toBe(ENVELOPE_ALLOCATED - ACTUAL_COST);
+
+					// ── budgetContext shows the same real spent, one round trip ──
+					const ctx = await budgetContext(tb, PARENT, [
+						{ costCenter: COST_CENTER, allocated: ENVELOPE_ALLOCATED, periodStartMs },
+					]);
+					expect(ctx.envelopes).toHaveLength(1);
+					expect(ctx.envelopes[0]?.spent).toBe(ACTUAL_COST);
+					expect(ctx.envelopes[0]?.remaining).toBe(ENVELOPE_ALLOCATED - ACTUAL_COST);
+					// The parent gave away its entire balance in one allocateBudget call, so
+					// its own remaining reads 0 — the same round trip proves the parent side
+					// of `budgetContext` too.
+					expect(ctx.parent.remaining).toBe(0);
+
+					// ── Over-envelope hold rejected ──
+					// A second identical call needs a fresh HOLD-sized reservation; the
+					// envelope holds only (HOLD - ACTUAL_COST), strictly less. Hard-refused
+					// pre-spend — see isHardDenial's doc comment for which layer denies it.
+					const denied = await withCostCenter(
+						COST_CENTER,
+						() => governed.messages.create({ ...CALL }),
+						scopeOpts,
+					).then(
+						() => null,
+						(e: unknown) => e,
+					);
+					expect(denied).not.toBeNull();
+					expect(isHardDenial(denied)).toBe(true);
+					// The provider was never reached for the denied call — still exactly 1.
+					expect(create).toHaveBeenCalledTimes(1);
+
+					// The denial moved nothing: the real ledger balance is unchanged.
+					const statusAfterDenial = await getBudgetStatus(tb, {
+						parentUserId: PARENT,
+						costCenter: COST_CENTER,
+						allocated: ENVELOPE_ALLOCATED,
+						periodStartMs,
+					});
+					expect(statusAfterDenial.balance).toBe(ENVELOPE_ALLOCATED - ACTUAL_COST);
+
+					// ── reclaim remainder ──
+					const reclaim = await reclaimBudget(tb, {
+						parentUserId: PARENT,
+						costCenter: COST_CENTER,
+					});
+					expect(reclaim.reclaimed).toBe(ENVELOPE_ALLOCATED - ACTUAL_COST);
+
+					const statusAfterReclaim = await getBudgetStatus(tb, {
+						parentUserId: PARENT,
+						costCenter: COST_CENTER,
+						allocated: ENVELOPE_ALLOCATED,
+						periodStartMs,
+					});
+					expect(statusAfterReclaim.balance).toBe(0);
+				} finally {
+					await governed.destroy();
+				}
+			} finally {
+				tb.destroy();
+			}
+		},
+	);
+});

--- a/packages/core/tests/ledger/client.test.ts
+++ b/packages/core/tests/ledger/client.test.ts
@@ -923,6 +923,176 @@ describe("TrustTBClient", () => {
 		});
 	});
 
+	describe("lookupBalances", () => {
+		// Batch math must equal the single-account helper's answer for the SAME
+		// account data — both paths share one module-private computation, so this
+		// pins that they cannot silently diverge. Each account's reference answer
+		// is taken from a SEPARATE, isolated lookupBalance() call (its own mock
+		// queue entry) so this test does not depend on lookupBalances existing yet.
+		it("matches lookupBalance's answer for account 1, via the batch path", async () => {
+			const account = {
+				id: 1n,
+				credits_posted: 1000n,
+				debits_posted: 200n,
+				debits_pending: 50n,
+				credits_pending: 0n,
+			};
+			mockLookupAccounts.mockResolvedValueOnce([account]);
+			const single = await client.lookupBalance(1n);
+
+			mockLookupAccounts.mockResolvedValueOnce([account]);
+			const batch = await client.lookupBalances([1n]);
+			expect(batch.get(1n)).toBe(single.available);
+		});
+
+		it("matches lookupBalance's answer for account 2 (pending exceeds posted), via the batch path", async () => {
+			const account = {
+				id: 2n,
+				credits_posted: 100n,
+				debits_posted: 0n,
+				debits_pending: 200n,
+				credits_pending: 0n,
+			};
+			mockLookupAccounts.mockResolvedValueOnce([account]);
+			const single = await client.lookupBalance(2n);
+
+			mockLookupAccounts.mockResolvedValueOnce([account]);
+			const batch = await client.lookupBalances([2n]);
+			expect(batch.get(2n)).toBe(single.available);
+		});
+
+		it("omits accounts TigerBeetle does not return, rather than throwing", async () => {
+			mockLookupAccounts.mockResolvedValueOnce([
+				{
+					id: 1n,
+					credits_posted: 500n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+			]);
+			const balances = await client.lookupBalances([1n, 999n]);
+			expect(balances.has(1n)).toBe(true);
+			expect(balances.has(999n)).toBe(false);
+			expect(balances.size).toBe(1);
+		});
+
+		it("matches results by Account.id, never by array index", async () => {
+			// TB returns accounts in a DIFFERENT order than requested.
+			mockLookupAccounts.mockResolvedValueOnce([
+				{
+					id: 2n,
+					credits_posted: 300n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+				{
+					id: 1n,
+					credits_posted: 700n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+			]);
+			const balances = await client.lookupBalances([1n, 2n]);
+			expect(balances.get(1n)).toBe(700);
+			expect(balances.get(2n)).toBe(300);
+		});
+
+		it("returns an empty map with zero I/O for empty input", async () => {
+			const balances = await client.lookupBalances([]);
+			expect(balances.size).toBe(0);
+			expect(mockLookupAccounts).not.toHaveBeenCalled();
+		});
+
+		it("dedupes duplicate input ids into a single round trip", async () => {
+			mockLookupAccounts.mockResolvedValueOnce([
+				{
+					id: 1n,
+					credits_posted: 500n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+			]);
+			const balances = await client.lookupBalances([1n, 1n, 1n]);
+			expect(mockLookupAccounts).toHaveBeenCalledOnce();
+			expect(mockLookupAccounts).toHaveBeenCalledWith([1n]);
+			expect(balances.get(1n)).toBe(500);
+		});
+
+		it("makes exactly one lookupAccounts round trip regardless of input size", async () => {
+			mockLookupAccounts.mockResolvedValueOnce([
+				{
+					id: 1n,
+					credits_posted: 100n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+				{
+					id: 2n,
+					credits_posted: 200n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+				{
+					id: 3n,
+					credits_posted: 300n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+			]);
+			await client.lookupBalances([1n, 2n, 3n]);
+			expect(mockLookupAccounts).toHaveBeenCalledTimes(1);
+		});
+
+		// The overflow guards live in the shared helper — exercised here through the
+		// batch path to prove they are not duplicated-and-diverged, not skipped.
+		it("throws on balance overflow exceeding MAX_SAFE_INTEGER through the batch path", async () => {
+			mockLookupAccounts.mockResolvedValueOnce([
+				{
+					id: 1n,
+					credits_posted: BigInt(Number.MAX_SAFE_INTEGER) + 100n,
+					debits_posted: 0n,
+					debits_pending: 0n,
+					credits_pending: 0n,
+				},
+			]);
+			await expect(client.lookupBalances([1n])).rejects.toThrow("Balance overflow");
+		});
+
+		it("throws on pending overflow exceeding MAX_SAFE_INTEGER through the batch path", async () => {
+			mockLookupAccounts.mockResolvedValueOnce([
+				{
+					id: 1n,
+					credits_posted: 1000n,
+					debits_posted: 0n,
+					debits_pending: BigInt(Number.MAX_SAFE_INTEGER) + 100n,
+					credits_pending: 0n,
+				},
+			]);
+			await expect(client.lookupBalances([1n])).rejects.toThrow("Pending overflow");
+		});
+
+		it("clamps available to 0 when pending exceeds posted, through the batch path", async () => {
+			mockLookupAccounts.mockResolvedValueOnce([
+				{
+					id: 1n,
+					credits_posted: 100n,
+					debits_posted: 0n,
+					debits_pending: 200n,
+					credits_pending: 0n,
+				},
+			]);
+			const balances = await client.lookupBalances([1n]);
+			expect(balances.get(1n)).toBe(0);
+		});
+	});
+
 	describe("lookupTransfer", () => {
 		it("returns transfer when found", async () => {
 			const mockTransfer = { id: 100n, amount: 500n };

--- a/packages/core/tests/policy/budget-tier.test.ts
+++ b/packages/core/tests/policy/budget-tier.test.ts
@@ -40,6 +40,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withCostCenter } from "../../src/budget/attribution.js";
 import { trust } from "../../src/govern.js";
 import { createGovernor } from "../../src/headless.js";
 import { evaluatePolicy, type GateRule, type PolicyContext } from "../../src/policy/gate.js";
@@ -494,5 +495,162 @@ describe("budget fields are trusted-host input at every call site", () => {
 		expect(auth.transferId).toMatch(/^tx_/);
 
 		await gov.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The tier stops shadow-boxing: an ATTRIBUTED call actually fires it
+// ---------------------------------------------------------------------------
+
+/**
+ * Until envelopes, `budgetFractionRemaining` could not fire on ANY SDK-governed
+ * call. Both `trust()` call sites and headless `authorize` asserted it explicitly
+ * `undefined` — honestly, because nothing in the repo debited a cost-center wallet
+ * — so the `exists` guard the gate's own doc comment recommends never matched, and
+ * a tier written exactly as documented was a rule that could only ever be dead
+ * code. (Worse for a host that built the context itself: `getBudgetStatus`
+ * reported `fractionRemaining: 1` for a genuinely burning agent, so the tier
+ * failed OPEN.)
+ *
+ * A call inside `withCostCenter(cc, fn, { allocated, periodStartMs })` now carries
+ * the envelope's LIVE ledger balance into the field. These three pin the whole
+ * behaviour change: the tier fires on an attributed call below the threshold,
+ * stays quiet on one above it, and — because the `exists` guard is still doing its
+ * job — leaves unattributed traffic exactly as it was.
+ */
+const ENVELOPE_TIER_RULE = {
+	id: "envelope-tier-frontier",
+	name: "frontier-model-below-30pct",
+	effect: "deny",
+	enforcement: "hard",
+	severity: "high",
+	conditions: [
+		{ field: "budgetFractionRemaining", operator: "exists" },
+		{ field: "budgetFractionRemaining", operator: "lt", value: 0.3 },
+		{ field: "model", operator: "in", value: ["claude-opus-4-6"] },
+	],
+};
+
+const ENVELOPE_PARENT = "acme";
+const ENVELOPE_COST_CENTER = "research";
+/** 10_000 allocated: `remaining` below 3_000 is what has to trip the rule. */
+const ENVELOPE_SCOPE = { allocated: 10_000, periodStartMs: Date.UTC(2026, 7, 3, 0, 0, 0) };
+
+function makeTierVault(): string {
+	const base = join(tmpdir(), `budget-tier-envelope-${randomUUID()}`);
+	const usertrustDir = join(base, ".usertrust");
+	mkdirSync(join(usertrustDir, "policies"), { recursive: true });
+	writeFileSync(
+		join(usertrustDir, "policies", "tier.json"),
+		JSON.stringify({ rules: [ENVELOPE_TIER_RULE] }),
+	);
+	writeFileSync(
+		join(usertrustDir, "usertrust.config.json"),
+		JSON.stringify({ budget: 1_000_000, policies: "./policies/tier.json" }),
+	);
+	return base;
+}
+
+/** An engine whose envelope read answers `remaining` for every account asked for. */
+function makeEnvelopeEngine(remaining: number) {
+	return {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		lookupBalances: vi.fn(async (ids: bigint[]) => new Map(ids.map((id) => [id, remaining]))),
+		destroy: vi.fn(),
+	};
+}
+
+const FRONTIER_CALL = {
+	model: "claude-opus-4-6",
+	max_tokens: 64,
+	messages: [{ role: "user", content: "hello" }],
+};
+
+describe("an envelope-scoped tier fires on an attributed call", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = makeTierVault();
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+	});
+
+	it("DENIES a frontier call at 20% of the envelope — the case that could not fire before", async () => {
+		const engine = makeEnvelopeEngine(2_000);
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			vaultBase,
+			parentUserId: ENVELOPE_PARENT,
+			_engine: engine,
+		});
+
+		await expect(
+			withCostCenter(
+				ENVELOPE_COST_CENTER,
+				() => governed.messages.create(FRONTIER_CALL),
+				ENVELOPE_SCOPE,
+			),
+		).rejects.toThrow(/Policy denied/);
+
+		// The number came off the ledger, not off the request body.
+		const ctx = vi.mocked(evaluatePolicy).mock.calls.at(-1)?.[1];
+		expect(ctx?.budgetFractionRemaining).toBeCloseTo(0.2);
+		// A hard deny is a PRE-spend deny: no hold, no provider call.
+		expect(engine.spendPending).not.toHaveBeenCalled();
+		expect(client.messages.create).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("stays quiet on the same call when the envelope is at 90%", async () => {
+		const engine = makeEnvelopeEngine(9_000);
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			vaultBase,
+			parentUserId: ENVELOPE_PARENT,
+			_engine: engine,
+		});
+
+		await withCostCenter(
+			ENVELOPE_COST_CENTER,
+			() => governed.messages.create(FRONTIER_CALL),
+			ENVELOPE_SCOPE,
+		);
+
+		const ctx = vi.mocked(evaluatePolicy).mock.calls.at(-1)?.[1];
+		expect(ctx?.budgetFractionRemaining).toBeCloseTo(0.9);
+		expect(client.messages.create).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
+	});
+
+	it("leaves UNATTRIBUTED traffic untouched — the `exists` guard still holds it back", async () => {
+		const engine = makeEnvelopeEngine(2_000);
+		const client = makeAnthropicMock();
+		const governed = await trust(client, {
+			vaultBase,
+			parentUserId: ENVELOPE_PARENT,
+			_engine: engine,
+		});
+
+		await governed.messages.create(FRONTIER_CALL);
+
+		const ctx = vi.mocked(evaluatePolicy).mock.calls.at(-1)?.[1];
+		// No scope, no envelope, no number to gate on — asserted absent, never
+		// guessed, and never taken from the request body.
+		expect(ctx?.budgetFractionRemaining).toBeUndefined();
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect(client.messages.create).toHaveBeenCalledTimes(1);
+
+		await governed.destroy();
 	});
 });


### PR DESCRIPTION
## Summary

Closes the three budget-as-personality gaps from the design (`docs/superpowers/specs/2026-08-03-budget-envelopes-design.md`). **Additive, v3.1.0 — no migration.**

- **Spend routing.** Governed calls inside a `withCostCenter(cc, fn)` scope debit the `(parent, cc)` envelope wallet through the existing two-phase machinery — the PENDING hold's `debits_must_not_exceed_credits` enforces the per-envelope budget atomically in the ledger, exactly like the holding wallet. Unattributed calls are byte-identical to today (parent holding wallet). `getBudgetStatus` now reports real spend for attributed traffic — the gap that made a burning agent read `spent: 0`.
- **Attribution.** `withCostCenter(costCenter, fn, opts?)` — an AsyncLocalStorage scope, the repo's first. The binding is code-structure only (tool dispatch is code, not model output); `cost_center` joins the trusted policy-context fields re-asserted after the spread at all three call sites, so a request body cannot forge attribution. New AGENTS.md Money invariant records this.
- **Visibility.** `budgetContext(tb, parent, envelopes)` pull API + `receipt.budget` post-settle push snapshot — numbers and operator labels only, nothing prompt-derived. Envelope-scoped policy numbers make per-envelope depletion tiers fire, which is the personality mechanism.

## Deviations from the spec's literal shapes (flagged for your record)
- **D3:** `budgetContext` takes `EnvelopeDescriptor[]` (`{costCenter, allocated, periodStartMs, periodEndMs?}`), not `string[]` — `allocated`/period are caller state with no registry, mirroring `getBudgetStatus`.
- **D4:** `withCostCenter` gains an optional `{allocated, periodStartMs, periodEndMs?}` so envelope-scoped `budgetFractionRemaining`/`budgetRunwayHours` have a denominator; absent → those fields assert explicit `undefined` (hard tiers fire closed, soft lenient).
- **A7 (corrected mid-implementation):** `budget_remaining_after` is **unfloored** — flooring at 0 would have structurally disabled the non-disableable `block-budget-overshoot` rule on every attributed call and forked the field's meaning across paths. Caught by the implementer; the pre-spend hard deny now fires identically on both paths.
- **A2 (corrected):** on an attributed call whose preflight balance read fails, the call is **refused pre-gate** with the ledger-unavailable classification (the preflight and hold share the TB transport — a failed read means the hold was doomed). Not session-fallback (mixed-semantics records), not continue-with-undefined (self-contradictory).

## Review trail (all on the branch history)
- 6-agent surface map → dual external plan review (GPT-5.4 + Grok-4, 11 amendments) → subagent-driven implementation, 10 tasks, per-task adversarial review.
- Whole-branch review (MERGEABLE-after-fixes) + in-house security (2 P1 + 1 P2) + Trail of Bits (no findings) surfaced **three real must-fix findings** — attribution override via `opts`, headless handle-relabel, session-budget double-count — all fixed TDD-first in `f396042` with an adversarial re-review reproducing each attack against the fixed code.

## Test plan
- 2616 tests green; coverage over CI gate (statements 93.29 / branches 86.03 / functions 95.40 / lines 94.78; both sides of every new fork verified against the coverage JSON).
- New: attribution scope suite (ALS isolation, emitter-tick pin), `budgetContext` math, request-body spoof harden suite, real-TigerBeetle envelope spend cycle (tb-integration), mixed-traffic session-accounting pin.
- Belt-greps: 3 ALS reader sites only, `packages/verify` untouched, no `costCenter` in anomaly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)