### PR TITLE
fix(budget): settle-shortfall hardening — cap at the hold, audit the truncation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -349,9 +349,9 @@ accounting, matching the numbers its policy gate saw.
 *Every audit record an attributed call emits carries `costCenter`, from that same capture* — not
 from params, and on the failure terminals as well as the settle ones (`llm_call`, `<action.kind>`,
 `llm_call_failed`, `<action.kind>_failed`, `stream_partial_delivery`, `settlement_ambiguous`,
-`injection_detected`, `anomaly_detected`). An attributed hold must leave an attributed forensic
-trail whichever way it ends. Unattributed calls spread an empty object, so their records stay
-byte-identical to what they were before envelopes existed.
+`settlement_shortfall`, `injection_detected`, `anomaly_detected`). An attributed hold must leave an
+attributed forensic trail whichever way it ends. Unattributed calls spread an empty object, so their
+records stay byte-identical to what they were before envelopes existed.
 
 *One field, two spellings, deliberately.* The policy context spells it `cost_center` — snake_case,
 beside `estimated_cost`, `budget_remaining` and `action_kind`, because a rule file is what reads it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,10 @@ are not.
 8. **Audit first.** The `llm_call` event is appended to the hash chain **before** the budget commit
    and before the ledger POST, so a `failClosed` deployment never settles an unaudited spend.
 9. **Settle.** `finalizeOnce("settle")` claims the single terminal outcome, then the budget commits
-   and `engine.postPendingSpend(transferId, actualCost)` posts the actual (≤ reserved) amount.
+   and `engine.postPendingSpend(transferId, actualCost)` posts `min(actual, reserved)` — TigerBeetle
+   REJECTS (never caps) a post above the pending amount, so the factories cap it and return the
+   truncation, which the governor audits as `settlement_shortfall` and reports as
+   `receipt.postedCost`. `receipt.cost` stays the true metered cost.
 10. **Or void.** Any failure path routes to `finalizeOnce("void")` → `voidPendingSpend`.
 
 `destroy()` waits up to 5s for in-flight work, voids all remaining pending transfers, flushes and
@@ -131,6 +134,16 @@ settle-then-void leaving the ledger holding a debit its accounting does not.
   circuit-breaker failure.
 - A governance anomaly cutoff voids.
 - A post-commit `failClosed` throw must **not** void an already-posted transfer.
+
+**Settle never exceeds the hold — and never silently fails because of it.** The hold's input side
+is a chars/4 × 1.5 heuristic (`pricing.ts`), so real usage CAN price above the reserve. Both
+`createTBEngine` factories cap the post at the reserved amount (`pendingMap` carries
+`heldAmount`) and return `{ posted, shortfall }`; `ledger/engine.ts` reaches the same semantics
+reactively (status-31 → re-post via `amount_max`). A shortfall is recorded as a
+`settlement_shortfall` audit event and `receipt.postedCost`; `settled` stays true.
+*Prevents:* the pre-hardening behavior — TigerBeetle rejecting the post, the call reporting
+`settled:false` with the hold stranded PENDING until destroy/300s timeout, and the wallet
+ultimately charged ZERO for a successful call while receipt and chain recorded the full cost.
 
 **TigerBeetle `exists` IS SUCCESS.**
 On `createTransfers`/`createAccounts`, `CreateTransferStatus.exists` / `CreateAccountStatus.exists`
@@ -576,6 +589,15 @@ rejection of the hold — an OVERSHOOT, never a fractional/runway tier — the s
 session path has, and a stale cross-process read can still only under-deny. Moving the read under the
 lock is not check-then-act: the money decision stays the hold's atomic rejection; the read only makes
 the policy record consistent with the wallet the hold will debit.
+
+**`budgetFractionRemaining` is computed before the call's own hold, and excludes its estimated
+cost** — only `budget_remaining_after` is estimate-inclusive, so the fraction/runway tiers gate on
+the balance as it stood before this call, never on where this call's own spend would leave it.
+`receipt.budget` and `budgetContext()` are likewise POST-SETTLE snapshots, so any monitoring surface
+built on either one reads one call behind the gate. The practical consequence: an `lt` tier denies
+starting with the call *after* the one whose settle actually crossed the threshold, not the crossing
+call itself — a fraction that lands exactly on the boundary is read by `lt` as still inside it. Use
+`lte` where the tier must also catch that edge call.
 
 **Policy regexes are structurally ReDoS-guarded.** Patterns over 200 characters, with adjacent
 nested quantifiers (`a+*`), or with a quantified group whose body contains a quantifier or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Budget envelopes: spend routing, per-envelope caps, and scarcity visibility
+  (#79, previously unlisted).** `withCostCenter(costCenter, fn, opts?)`
+  (`budget/attribution.ts`) attributes a governed call's spend to a
+  `(parentUserId, costCenter)` envelope by CODE STRUCTURE — an
+  `AsyncLocalStorage` scope, never anything a request body can carry. An
+  attributed hold debits the envelope's own ledger-derived account
+  (`allocateBudget` / `reclaimBudget`), so TigerBeetle's atomic
+  `debits_must_not_exceed_credits` enforces the per-envelope cap the same way
+  it already enforced the session wallet's. `getBudgetStatus` and the batched
+  `budgetContext()` read the envelope's live balance; the gate's
+  `budgetFractionRemaining` / `budgetRunwayHours` turn that into pre-spend
+  policy tiers, and settled receipts carry the same numbers under
+  `receipt.budget` as a post-settle snapshot. Both surfaces are OBSERVATIONS,
+  never authority — see the Money invariants in `AGENTS.md`.
+- **Settle-shortfall hardening.** The PENDING hold's size is a heuristic
+  estimate (chars/4 tokens × a 1.5x safety margin), so real usage can price
+  above the reserve. TigerBeetle rejects — never caps — a settle POST above
+  its pending transfer's amount, which previously left the call reporting
+  `settled: false` with the hold stranded PENDING until `destroy()` or the
+  300s TigerBeetle timeout, and the wallet ultimately charged nothing for a
+  call that succeeded. Both `createTBEngine` factories (`govern.ts`,
+  `headless.ts`) now cap the post at the reserved amount themselves and audit
+  the truncation as a `settlement_shortfall` event; `ledger/engine.ts` reaches
+  the same outcome reactively (catches `exceeds_pending_transfer_amount`,
+  re-posts with the amount omitted so TigerBeetle posts the full hold).
+  `TrustReceipt.postedCost` is now populated whenever the post was capped
+  (`receipt.cost − receipt.postedCost` is the shortfall); `receipt.cost` stays
+  the true metered cost, and `settled` stays `true`.
+- **Class-aware denial hints.** A hard policy denial whose triggering rule
+  conditions any budget-scoped field (`budget_remaining`,
+  `budget_remaining_after`, `budgetFractionRemaining`, `budgetRunwayHours`,
+  `estimated_cost`) now surfaces a budget-specific remedy pointing at
+  `allocateBudget` and the fraction/runway tiers (`derivePolicyHint`), instead
+  of the rule's generic description.
+
+### Fixed
+
+- A policy rule with no `description` no longer renders its identifier twice
+  in the denial reason (`[scarcity-brake] scarcity-brake` is now
+  `[scarcity-brake]`).
+
+## [3.0.0] - 2026-08-03
+
 **Loopback/local endpoints now settle at nominal local rates instead of silently
 billing frontier fallback.** Before, a free `llama3.3:70b` call against
 `http://localhost:11434/v1` was priced like an unknown cloud model at

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -1143,6 +1143,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			// e. Forward to original SDK. P3-PII-REDACT-EGRESS: forwardArgs is the
 			// redacted clone in redact mode, or the original args otherwise.
 			let settled = true;
+			// D4: set only when the engine capped the post at the reserved hold. The
+			// stream and non-stream terminals are mutually exclusive for one hold, so
+			// they share this the same way they share `settled`.
+			let postedCost: number | undefined;
 
 			// A2: one idempotent finalize gate per hold. The FIRST terminal signal for
 			// this authorization wins and claims the single ledger outcome (settle XOR
@@ -1265,8 +1269,28 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					}
 				} else if (engine != null && !isDryRun) {
 					try {
-						// Post the ACTUAL consumed cost (RECON #3).
-						await engine.postPendingSpend(transferId, streamCost);
+						// Post the ACTUAL consumed cost (RECON #3), capped by the engine
+						// at the reserved hold; a truncation comes back as `shortfall`.
+						const postResult = await engine.postPendingSpend(transferId, streamCost);
+						if (postResult != null && postResult.shortfall > 0) {
+							postedCost = postResult.posted;
+							await audit
+								.appendEvent({
+									kind: "settlement_shortfall",
+									actor: "local",
+									data: {
+										model,
+										actual: streamCost,
+										posted: postResult.posted,
+										shortfall: postResult.shortfall,
+										transferId,
+										...costCenterAudit,
+									},
+								})
+								.catch(() => {
+									callAuditDegraded = true;
+								});
+						}
 					} catch (postErr) {
 						settled = false;
 						await audit
@@ -1367,6 +1391,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						costBasis: rateResolution.costBasis,
 						rateSource: rateResolution.rateSource,
 					},
+					...(postedCost !== undefined ? { postedCost } : {}),
 					...(streamBudget !== undefined ? { budget: streamBudget } : {}),
 					...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 					// AUD-456: Flag proxy stub receipts
@@ -1886,8 +1911,28 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				// g2. Failure mode 15.1: POST fails after LLM success
 				if (engine != null && !isDryRun) {
 					try {
-						// Post the ACTUAL consumed cost (RECON #3).
-						await engine.postPendingSpend(transferId, actualCost);
+						// Post the ACTUAL consumed cost (RECON #3), capped by the engine
+						// at the reserved hold; a truncation comes back as `shortfall`.
+						const postResult = await engine.postPendingSpend(transferId, actualCost);
+						if (postResult != null && postResult.shortfall > 0) {
+							postedCost = postResult.posted;
+							await audit
+								.appendEvent({
+									kind: "settlement_shortfall",
+									actor: "local",
+									data: {
+										model,
+										actual: actualCost,
+										posted: postResult.posted,
+										shortfall: postResult.shortfall,
+										transferId,
+										...costCenterAudit,
+									},
+								})
+								.catch(() => {
+									callAuditDegraded = true;
+								});
+						}
 					} catch (postErr) {
 						// POST failed — LLM call succeeded but settlement is ambiguous
 						settled = false;
@@ -2002,6 +2047,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						costBasis: rateResolution.costBasis,
 						rateSource: rateResolution.rateSource,
 					},
+					...(postedCost !== undefined ? { postedCost } : {}),
 					...(settledBudget !== undefined ? { budget: settledBudget } : {}),
 					...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 					// AUD-456: Flag proxy stub receipts

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -1154,6 +1154,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 			// stream and non-stream terminals are mutually exclusive for one hold, so
 			// they share this the same way they share `settled`.
 			let postedCost: number | undefined;
+			// D4 event-order buffer for the STREAM terminal: the truncation is learned at
+			// POST time but the `settlement_shortfall` event may only be appended AFTER
+			// this call's `llm_call`, so it is parked here and drained below.
+			let streamShortfall: { posted: number; shortfall: number } | undefined;
 
 			// A2: one idempotent finalize gate per hold. The FIRST terminal signal for
 			// this authorization wins and claims the single ledger outcome (settle XOR
@@ -1281,22 +1285,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						const postResult = await engine.postPendingSpend(transferId, streamCost);
 						if (postResult != null && postResult.shortfall > 0) {
 							postedCost = postResult.posted;
-							await audit
-								.appendEvent({
-									kind: "settlement_shortfall",
-									actor: "local",
-									data: {
-										model,
-										actual: streamCost,
-										posted: postResult.posted,
-										shortfall: postResult.shortfall,
-										transferId,
-										...costCenterAudit,
-									},
-								})
-								.catch(() => {
-									callAuditDegraded = true;
-								});
+							// EVENT ORDER: captured here, APPENDED after `llm_call` below.
+							// `verifyTransaction` resolves a transfer by the FIRST chain event
+							// whose `data.transferId` matches, so a shortfall written ahead of
+							// its `llm_call` would render this settled call as PENDING with no
+							// cost. The correction must annotate the settlement, never precede it.
+							streamShortfall = { posted: postResult.posted, shortfall: postResult.shortfall };
 						}
 					} catch (postErr) {
 						settled = false;
@@ -1352,6 +1346,29 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					auditHash = auditEvent.hash;
 				} catch {
 					callAuditDegraded = true;
+				}
+
+				// D4: the truncation correction, appended AFTER the `llm_call` it
+				// annotates (see the capture at the POST above). Still advisory — a chain
+				// that cannot take it degrades the receipt and NEVER unwinds a settlement
+				// that already committed.
+				if (streamShortfall !== undefined) {
+					await audit
+						.appendEvent({
+							kind: "settlement_shortfall",
+							actor: "local",
+							data: {
+								model,
+								actual: streamCost,
+								posted: streamShortfall.posted,
+								shortfall: streamShortfall.shortfall,
+								transferId,
+								...costCenterAudit,
+							},
+						})
+						.catch(() => {
+							callAuditDegraded = true;
+						});
 				}
 
 				// P3-AUDIT-FAILCLOSED (streaming): chunks were already delivered, so the

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -49,7 +49,7 @@ import {
 } from "./ledger/pricing.js";
 import { recordPattern } from "./memory/patterns.js";
 import { DEFAULT_RULES, mergePolicies } from "./policy/default-rules.js";
-import { evaluatePolicy, type GateRule, loadPolicies } from "./policy/gate.js";
+import { derivePolicyHint, evaluatePolicy, type GateRule, loadPolicies } from "./policy/gate.js";
 import { detectInjection } from "./policy/injection.js";
 import { detectPII, redactPII } from "./policy/pii.js";
 import type { ProxyConnection } from "./proxy.js";
@@ -284,7 +284,10 @@ function enforceUnknownModelPolicy(
 ): void {
 	if (!resolution.unknown) return;
 	if (config.unknownModelPolicy === "deny") {
-		throw new PolicyDeniedError(`unknown_model: ${model} not in pricing table`);
+		throw new PolicyDeniedError(
+			`unknown_model: ${model} not in pricing table`,
+			"Add the model to customRates in trust() options, or use a model from the built-in pricing table.",
+		);
 	}
 	if (config.unknownModelPolicy === "warn") {
 		warnUnknownModel(model);
@@ -1008,7 +1011,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (policyResult.decision === "deny") {
 					const reason =
 						policyResult.reasons.length > 0 ? policyResult.reasons.join("; ") : "Policy denied";
-					throw new PolicyDeniedError(reason);
+					throw new PolicyDeniedError(reason, derivePolicyHint(policyResult));
 				}
 
 				// d. PII check + redact-egress
@@ -1016,7 +1019,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					const piiResult = detectPII(promptParts);
 					if (piiResult.found && config.pii === "block") {
 						// block mode: throw BEFORE any egress.
-						throw new PolicyDeniedError(`PII detected: ${piiResult.types.join(", ")}`);
+						throw new PolicyDeniedError(
+							`PII detected: ${piiResult.types.join(", ")}`,
+							'PII enforcement blocked this call. Use { pii: "warn" } to log instead, or { pii: "redact" } to strip PII before egress.',
+						);
 					}
 					if (config.pii === "redact" && piiResult.found) {
 						// redact mode: forward a redacted DEEP CLONE so PII never egresses.
@@ -1034,6 +1040,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						if (config.injection === "block") {
 							throw new PolicyDeniedError(
 								`Prompt injection detected: ${injectionResult.patterns.join(", ")}`,
+								'Injection enforcement blocked this call. Use { injection: "warn" } to log instead of block.',
 							);
 						}
 						// warn: log to audit trail (non-fatal)
@@ -2236,7 +2243,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (policyResult.decision === "deny") {
 					const reason =
 						policyResult.reasons.length > 0 ? policyResult.reasons.join("; ") : "Policy denied";
-					throw new PolicyDeniedError(reason);
+					throw new PolicyDeniedError(reason, derivePolicyHint(policyResult));
 				}
 
 				// d. PII check on action params
@@ -2245,6 +2252,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					if (piiResult.found && config.pii === "block") {
 						throw new PolicyDeniedError(
 							`PII detected in action params: ${piiResult.types.join(", ")}`,
+							'PII enforcement blocked this call. Use { pii: "warn" } to log instead, or { pii: "redact" } to strip PII before egress.',
 						);
 					}
 				}
@@ -2256,6 +2264,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						if (config.injection === "block") {
 							throw new PolicyDeniedError(
 								`Injection detected in action params: ${injectionResult.patterns.join(", ")}`,
+								'Injection enforcement blocked this call. Use { injection: "warn" } to log instead of block.',
 							);
 						}
 						// warn: log to audit trail (non-fatal)

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -154,10 +154,18 @@ export interface TrustEngine {
 		debitAccountId?: bigint | undefined;
 	}): Promise<{ transferId: string }>;
 	/**
-	 * Settle a PENDING hold. `actualAmount` posts the true consumed cost (which may
-	 * be less than the reserved estimate); omitting it posts the full pending amount.
+	 * Settle a PENDING hold. `actualAmount` is CAPPED at the reserved amount —
+	 * TigerBeetle rejects (never caps) a post above the pending transfer — and the
+	 * truncation is reported back as `shortfall` for the governor to audit as
+	 * `settlement_shortfall`. Omitting `actualAmount` posts the full pending
+	 * amount. An engine that returns `void` (injected test engines) is treated as
+	 * posted-in-full with zero shortfall.
 	 */
-	postPendingSpend(transferId: string, actualAmount?: number): Promise<void>;
+	postPendingSpend(
+		transferId: string,
+		actualAmount?: number,
+		// biome-ignore lint/suspicious/noConfusingVoidType: load-bearing — an injected engine declaring `Promise<void>` must stay assignable, and `void` is the only member type that accepts it; `undefined` would reject every one.
+	): Promise<{ posted: number; shortfall: number } | void>;
 	voidPendingSpend(transferId: string): Promise<void>;
 	/** AUD-461: Void all remaining pending transfers on destroy. */
 	voidAllPending?(): Promise<void>;
@@ -2776,8 +2784,11 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 	// account across restarts (which would inflate the TB-enforced budget).
 	const holdingId = await tbClient.createFundedBudgetWallet(seedBudget);
 
-	// Pending transfer ID mapping (trustId string -> TB bigint)
-	const pendingMap = new Map<string, bigint>();
+	// Pending transfer mapping (trustId string -> TB id + the reserved amount).
+	// heldAmount is what postPendingSpend caps against: TigerBeetle REJECTS a post
+	// above the pending amount (exceeds_pending_transfer_amount) — it never caps —
+	// so the truncation must happen here, where the reserve is known (spec D1).
+	const pendingMap = new Map<string, { tbId: bigint; heldAmount: number }>();
 
 	return {
 		async spendPending(params: {
@@ -2796,7 +2807,7 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 					amount: params.amount,
 					code: XFER_SPEND,
 				});
-				pendingMap.set(params.transferId, tbTransferId);
+				pendingMap.set(params.transferId, { tbId: tbTransferId, heldAmount: params.amount });
 				return { transferId: params.transferId };
 			} catch (err) {
 				// Over-budget reservation → TB rejects the pending debit. Surface as a
@@ -2865,23 +2876,31 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 			return await tbClient.lookupBalances(accountIds);
 		},
 
-		async postPendingSpend(transferId: string, actualAmount?: number): Promise<void> {
-			const tbId = pendingMap.get(transferId);
-			if (tbId === undefined) {
+		async postPendingSpend(
+			transferId: string,
+			actualAmount?: number,
+			// biome-ignore lint/suspicious/noConfusingVoidType: matches the TrustEngine interface, where `void` is load-bearing (see the declaration in govern.ts).
+		): Promise<{ posted: number; shortfall: number } | void> {
+			const entry = pendingMap.get(transferId);
+			if (entry === undefined) {
 				throw new Error(`No pending transfer found for ${transferId}`);
 			}
-			// Post the ACTUAL consumed amount (≤ the reserved estimate); omitting it
-			// posts the full pending amount.
-			await tbClient.postTransfer(tbId, actualAmount);
+			// Post at most the RESERVED amount; the truncation (shortfall) is
+			// returned for the governor to audit. Omitting actualAmount still posts
+			// the full pending amount (amount_max), unchanged.
+			const posted =
+				actualAmount != null ? Math.min(actualAmount, entry.heldAmount) : entry.heldAmount;
+			await tbClient.postTransfer(entry.tbId, actualAmount != null ? posted : undefined);
 			pendingMap.delete(transferId);
+			return { posted, shortfall: actualAmount != null ? actualAmount - posted : 0 };
 		},
 
 		async voidPendingSpend(transferId: string): Promise<void> {
-			const tbId = pendingMap.get(transferId);
-			if (tbId === undefined) {
+			const entry = pendingMap.get(transferId);
+			if (entry === undefined) {
 				throw new Error(`No pending transfer found for ${transferId}`);
 			}
-			await tbClient.voidTransfer(tbId);
+			await tbClient.voidTransfer(entry.tbId);
 			pendingMap.delete(transferId);
 		},
 
@@ -2889,9 +2908,9 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 		// Best-effort — TigerBeetle auto-voids after 300s regardless.
 		async voidAllPending(): Promise<void> {
 			const entries = [...pendingMap.entries()];
-			for (const [trustIdKey, tbTransferId] of entries) {
+			for (const [trustIdKey, entry] of entries) {
 				try {
-					await tbClient.voidTransfer(tbTransferId);
+					await tbClient.voidTransfer(entry.tbId);
 				} catch {
 					// Best-effort — ignore individual void failures
 				}

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -286,7 +286,7 @@ function enforceUnknownModelPolicy(
 	if (config.unknownModelPolicy === "deny") {
 		throw new PolicyDeniedError(
 			`unknown_model: ${model} not in pricing table`,
-			"Add the model to customRates in trust() options, or use a model from the built-in pricing table.",
+			'Set pricing: "custom" with a customRates entry for this model in usertrust.config.json, or use a model from the built-in pricing table.',
 		);
 	}
 	if (config.unknownModelPolicy === "warn") {
@@ -1011,7 +1011,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (policyResult.decision === "deny") {
 					const reason =
 						policyResult.reasons.length > 0 ? policyResult.reasons.join("; ") : "Policy denied";
-					throw new PolicyDeniedError(reason, derivePolicyHint(policyResult));
+					throw new PolicyDeniedError(
+						reason,
+						derivePolicyHint(policyResult, envelope !== undefined),
+					);
 				}
 
 				// d. PII check + redact-egress
@@ -2260,7 +2263,10 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 				if (policyResult.decision === "deny") {
 					const reason =
 						policyResult.reasons.length > 0 ? policyResult.reasons.join("; ") : "Policy denied";
-					throw new PolicyDeniedError(reason, derivePolicyHint(policyResult));
+					throw new PolicyDeniedError(
+						reason,
+						derivePolicyHint(policyResult, envelope !== undefined),
+					);
 				}
 
 				// d. PII check on action params
@@ -2269,7 +2275,7 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 					if (piiResult.found && config.pii === "block") {
 						throw new PolicyDeniedError(
 							`PII detected in action params: ${piiResult.types.join(", ")}`,
-							'PII enforcement blocked this call. Use { pii: "warn" } to log instead, or { pii: "redact" } to strip PII before egress.',
+							'PII enforcement blocked this action. Use { pii: "warn" } to log instead of block; on governed actions { pii: "redact" } redacts only the audit copy — the action itself runs on the original input.',
 						);
 					}
 				}

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -450,7 +450,11 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 	// account across restarts (which would inflate the TB-enforced budget).
 	const holdingId = await tbClient.createFundedBudgetWallet(seedBudget);
 
-	const pendingMap = new Map<string, bigint>();
+	// Pending transfer mapping (trustId string -> TB id + the reserved amount).
+	// heldAmount is what postPendingSpend caps against: TigerBeetle REJECTS a post
+	// above the pending amount (exceeds_pending_transfer_amount) — it never caps —
+	// so the truncation must happen here, where the reserve is known (spec D1).
+	const pendingMap = new Map<string, { tbId: bigint; heldAmount: number }>();
 
 	return {
 		async spendPending(params: {
@@ -469,7 +473,7 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 					amount: params.amount,
 					code: XFER_SPEND,
 				});
-				pendingMap.set(params.transferId, tbTransferId);
+				pendingMap.set(params.transferId, { tbId: tbTransferId, heldAmount: params.amount });
 				return { transferId: params.transferId };
 			} catch (err) {
 				// Over-budget reservation → TB rejects the pending debit. Surface as a
@@ -538,31 +542,39 @@ async function createTBEngine(config: TrustConfig, seedBudget: number): Promise<
 			return await tbClient.lookupBalances(accountIds);
 		},
 
-		async postPendingSpend(transferId: string, actualAmount?: number): Promise<void> {
-			const tbId = pendingMap.get(transferId);
-			if (tbId === undefined) {
+		async postPendingSpend(
+			transferId: string,
+			actualAmount?: number,
+			// biome-ignore lint/suspicious/noConfusingVoidType: matches the TrustEngine interface, where `void` is load-bearing (see the declaration in govern.ts).
+		): Promise<{ posted: number; shortfall: number } | void> {
+			const entry = pendingMap.get(transferId);
+			if (entry === undefined) {
 				throw new Error(`No pending transfer found for ${transferId}`);
 			}
-			// Post the ACTUAL consumed amount (≤ the reserved estimate); omitting it
-			// posts the full pending amount.
-			await tbClient.postTransfer(tbId, actualAmount);
+			// Post at most the RESERVED amount; the truncation (shortfall) is
+			// returned for the governor to audit. Omitting actualAmount still posts
+			// the full pending amount (amount_max), unchanged.
+			const posted =
+				actualAmount != null ? Math.min(actualAmount, entry.heldAmount) : entry.heldAmount;
+			await tbClient.postTransfer(entry.tbId, actualAmount != null ? posted : undefined);
 			pendingMap.delete(transferId);
+			return { posted, shortfall: actualAmount != null ? actualAmount - posted : 0 };
 		},
 
 		async voidPendingSpend(transferId: string): Promise<void> {
-			const tbId = pendingMap.get(transferId);
-			if (tbId === undefined) {
+			const entry = pendingMap.get(transferId);
+			if (entry === undefined) {
 				throw new Error(`No pending transfer found for ${transferId}`);
 			}
-			await tbClient.voidTransfer(tbId);
+			await tbClient.voidTransfer(entry.tbId);
 			pendingMap.delete(transferId);
 		},
 
 		async voidAllPending(): Promise<void> {
 			const entries = [...pendingMap.entries()];
-			for (const [trustIdKey, tbTransferId] of entries) {
+			for (const [trustIdKey, entry] of entries) {
 				try {
-					await tbClient.voidTransfer(tbTransferId);
+					await tbClient.voidTransfer(entry.tbId);
 				} catch {
 					// Best-effort
 				}

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -1056,6 +1056,8 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 
 			// POST settlement
 			let settled = true;
+			// D4: set only when the engine capped the post at the reserved hold.
+			let postedCost: number | undefined;
 			if (proxyConn != null && !isDryRun) {
 				try {
 					await proxyConn.settle(auth.proxyTransferId ?? auth.transferId, actualCost);
@@ -1082,9 +1084,28 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				}
 			} else if (engine != null && !isDryRun) {
 				try {
-					// Post the ACTUAL consumed cost (RECON #3) — which may be less than
-					// the reserved estimate.
-					await engine.postPendingSpend(auth.transferId, actualCost);
+					// Post the ACTUAL consumed cost (RECON #3), capped by the engine at
+					// the reserved hold; a truncation comes back as `shortfall`.
+					const postResult = await engine.postPendingSpend(auth.transferId, actualCost);
+					if (postResult != null && postResult.shortfall > 0) {
+						postedCost = postResult.posted;
+						await audit
+							.appendEvent({
+								kind: "settlement_shortfall",
+								actor: "local",
+								data: {
+									model,
+									actual: actualCost,
+									posted: postResult.posted,
+									shortfall: postResult.shortfall,
+									transferId: auth.transferId,
+									...costCenterAudit,
+								},
+							})
+							.catch(() => {
+								callAuditDegraded = true;
+							});
+					}
 				} catch (postErr) {
 					settled = false;
 					await audit
@@ -1206,6 +1227,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 						: {}),
 				},
 				...(params?.chunksDelivered != null ? { chunksDelivered: params.chunksDelivered } : {}),
+				...(postedCost !== undefined ? { postedCost } : {}),
 				...(settledBudget !== undefined ? { budget: settledBudget } : {}),
 				...(callAuditDegraded ? { auditDegraded: true as const } : {}),
 				...(proxyConn != null ? { proxyStub: true as const } : {}),

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -73,7 +73,7 @@ import {
 } from "./ledger/pricing.js";
 import { recordPattern } from "./memory/patterns.js";
 import { DEFAULT_RULES, mergePolicies } from "./policy/default-rules.js";
-import { evaluatePolicy, type GateRule, loadPolicies } from "./policy/gate.js";
+import { derivePolicyHint, evaluatePolicy, type GateRule, loadPolicies } from "./policy/gate.js";
 import { detectPII } from "./policy/pii.js";
 import type { ProxyConnection } from "./proxy.js";
 import { CircuitBreakerRegistry } from "./resilience/circuit.js";
@@ -755,7 +755,10 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			const rateInfo = resolveRates(model, endpoint.class, config);
 			if (rateInfo.unknown) {
 				if (config.unknownModelPolicy === "deny") {
-					throw new PolicyDeniedError(`unknown_model: ${model} not in pricing table`);
+					throw new PolicyDeniedError(
+						`unknown_model: ${model} not in pricing table`,
+						"Add the model to customRates in trust() options, or use a model from the built-in pricing table.",
+					);
 				}
 				if (config.unknownModelPolicy === "warn") {
 					// Shared once-per-process helper — identical wording to trust() (F5).
@@ -860,14 +863,17 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				if (policyResult.decision === "deny") {
 					const reason =
 						policyResult.reasons.length > 0 ? policyResult.reasons.join("; ") : "Policy denied";
-					throw new PolicyDeniedError(reason);
+					throw new PolicyDeniedError(reason, derivePolicyHint(policyResult));
 				}
 
 				// PII check
 				if (config.pii !== "off" && messages.length > 0) {
 					const piiResult = detectPII(messages);
 					if (piiResult.found && config.pii === "block") {
-						throw new PolicyDeniedError(`PII detected: ${piiResult.types.join(", ")}`);
+						throw new PolicyDeniedError(
+							`PII detected: ${piiResult.types.join(", ")}`,
+							'PII enforcement blocked this call. Use { pii: "warn" } to log instead, or { pii: "redact" } to strip PII before egress.',
+						);
 					}
 				}
 

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -757,7 +757,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				if (config.unknownModelPolicy === "deny") {
 					throw new PolicyDeniedError(
 						`unknown_model: ${model} not in pricing table`,
-						"Add the model to customRates in trust() options, or use a model from the built-in pricing table.",
+						'Set pricing: "custom" with a customRates entry for this model in usertrust.config.json, or use a model from the built-in pricing table.',
 					);
 				}
 				if (config.unknownModelPolicy === "warn") {
@@ -863,7 +863,10 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				if (policyResult.decision === "deny") {
 					const reason =
 						policyResult.reasons.length > 0 ? policyResult.reasons.join("; ") : "Policy denied";
-					throw new PolicyDeniedError(reason, derivePolicyHint(policyResult));
+					throw new PolicyDeniedError(
+						reason,
+						derivePolicyHint(policyResult, envelope !== undefined),
+					);
 				}
 
 				// PII check
@@ -872,7 +875,7 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 					if (piiResult.found && config.pii === "block") {
 						throw new PolicyDeniedError(
 							`PII detected: ${piiResult.types.join(", ")}`,
-							'PII enforcement blocked this call. Use { pii: "warn" } to log instead, or { pii: "redact" } to strip PII before egress.',
+							'PII enforcement blocked this call. Use { pii: "warn" } to log instead of block; the headless governor does not redact egress — redaction is the integrating host\'s responsibility.',
 						);
 					}
 				}

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -1064,6 +1064,10 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			let settled = true;
 			// D4: set only when the engine capped the post at the reserved hold.
 			let postedCost: number | undefined;
+			// D4 event-order buffer: the truncation is learned at POST time but the
+			// `settlement_shortfall` event may only be appended AFTER this call's
+			// `llm_call`, so it is parked here and drained below.
+			let shortfallRecord: { posted: number; shortfall: number } | undefined;
 			if (proxyConn != null && !isDryRun) {
 				try {
 					await proxyConn.settle(auth.proxyTransferId ?? auth.transferId, actualCost);
@@ -1095,22 +1099,12 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 					const postResult = await engine.postPendingSpend(auth.transferId, actualCost);
 					if (postResult != null && postResult.shortfall > 0) {
 						postedCost = postResult.posted;
-						await audit
-							.appendEvent({
-								kind: "settlement_shortfall",
-								actor: "local",
-								data: {
-									model,
-									actual: actualCost,
-									posted: postResult.posted,
-									shortfall: postResult.shortfall,
-									transferId: auth.transferId,
-									...costCenterAudit,
-								},
-							})
-							.catch(() => {
-								callAuditDegraded = true;
-							});
+						// EVENT ORDER: captured here, APPENDED after `llm_call` below.
+						// `verifyTransaction` resolves a transfer by the FIRST chain event whose
+						// `data.transferId` matches, so a shortfall written ahead of its
+						// `llm_call` would render this settled call as PENDING with no cost. The
+						// correction must annotate the settlement, never precede it.
+						shortfallRecord = { posted: postResult.posted, shortfall: postResult.shortfall };
 					}
 				} catch (postErr) {
 					settled = false;
@@ -1156,6 +1150,29 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 				auditHash = auditEvent.hash;
 			} catch {
 				callAuditDegraded = true;
+			}
+
+			// D4: the truncation correction, appended AFTER the `llm_call` it annotates
+			// (see the capture at the POST above). Still advisory — a chain that cannot
+			// take it degrades the receipt and NEVER unwinds a settlement that already
+			// committed.
+			if (shortfallRecord !== undefined) {
+				await audit
+					.appendEvent({
+						kind: "settlement_shortfall",
+						actor: "local",
+						data: {
+							model,
+							actual: actualCost,
+							posted: shortfallRecord.posted,
+							shortfall: shortfallRecord.shortfall,
+							transferId: auth.transferId,
+							...costCenterAudit,
+						},
+					})
+					.catch(() => {
+						callAuditDegraded = true;
+					});
 			}
 
 			// Daily-rotated receipt

--- a/packages/core/src/ledger/client.ts
+++ b/packages/core/src/ledger/client.ts
@@ -669,7 +669,10 @@ export class TrustTBClient {
 				res.status !== CreateTransferStatus.created &&
 				res.status !== CreateTransferStatus.exists
 			) {
-				throw new Error(`Post transfer failed: ${CreateTransferStatus[res.status] ?? res.status}`);
+				throw new TBTransferError(
+					res.status,
+					`Post transfer failed: ${CreateTransferStatus[res.status] ?? res.status}`,
+				);
 			}
 		}
 		return postId;

--- a/packages/core/src/ledger/engine.ts
+++ b/packages/core/src/ledger/engine.ts
@@ -202,8 +202,10 @@ export class TrustEngine {
 	 * Optionally pass actual amount if less than the hold.
 	 */
 	async postPendingSpend(transferId: string, actualAmount?: number): Promise<void> {
+		let posted = false;
 		try {
 			await this.tb.postTransfer(BigInt(transferId), actualAmount);
+			posted = true;
 		} catch (err) {
 			// Actual cost priced above the reserved hold: TigerBeetle rejects the
 			// post outright (it never caps). The call itself succeeded, so voiding
@@ -212,31 +214,41 @@ export class TrustEngine {
 			// stateless (no held-amount tracking survives it), so the cap is
 			// reactive here; the governor-side factories precompute it (spec D1).
 			if (isExceedsPendingAmount(err)) {
-				await this.tb.postTransfer(BigInt(transferId), undefined);
-				return;
+				try {
+					await this.tb.postTransfer(BigInt(transferId), undefined);
+					posted = true;
+				} catch {
+					// The RECOVERY post failed too. Leaving this error to escape would
+					// skip the void attempt and the dead letter below while the transfer
+					// is still pending — the hold outlives the call with no record. Its
+					// state is exactly as ambiguous as a first-post failure, so it falls
+					// through into the SAME handling rather than getting its own.
+				}
 			}
-			// Post may have succeeded on TB but timed out — try to void
-			let voidSucceeded = false;
-			try {
-				await this.tb.voidTransfer(BigInt(transferId));
-				voidSucceeded = true;
-			} catch {
-				// Both post and void failed — transfer state is ambiguous
-				writeDeadLetter(
-					{
-						timestamp: new Date().toISOString(),
-						source: "engine.postPendingSpend.ambiguous",
-						transferId,
-						payload: { actualAmount },
-						error: "Both post and void failed — transfer state ambiguous",
-					},
-					this.dlqPath,
-				);
-				throw new Error(`Spend settlement ambiguous for transfer ${transferId}`);
-			}
-			if (voidSucceeded) {
-				throw new Error("Spend failed: pending transfer voided after post failure");
-			}
+		}
+		if (posted) return;
+
+		// Post may have succeeded on TB but timed out — try to void
+		let voidSucceeded = false;
+		try {
+			await this.tb.voidTransfer(BigInt(transferId));
+			voidSucceeded = true;
+		} catch {
+			// Both post and void failed — transfer state is ambiguous
+			writeDeadLetter(
+				{
+					timestamp: new Date().toISOString(),
+					source: "engine.postPendingSpend.ambiguous",
+					transferId,
+					payload: { actualAmount },
+					error: "Both post and void failed — transfer state ambiguous",
+				},
+				this.dlqPath,
+			);
+			throw new Error(`Spend settlement ambiguous for transfer ${transferId}`);
+		}
+		if (voidSucceeded) {
+			throw new Error("Spend failed: pending transfer voided after post failure");
 		}
 	}
 

--- a/packages/core/src/ledger/engine.ts
+++ b/packages/core/src/ledger/engine.ts
@@ -120,6 +120,16 @@ function isInsufficientBalanceError(err: unknown): err is TBTransferError {
 	);
 }
 
+/** TigerBeetle's rejection of a post whose amount exceeds the pending transfer's. */
+function isExceedsPendingAmount(err: unknown): err is TBTransferError {
+	if (err == null || typeof err !== "object") return false;
+	if (!("code" in err) || !("name" in err)) return false;
+	const e = err as { code: number; name: string };
+	return (
+		e.name === "TBTransferError" && e.code === CreateTransferStatus.exceeds_pending_transfer_amount
+	);
+}
+
 // ── Engine ──
 
 export class TrustEngine {
@@ -195,6 +205,16 @@ export class TrustEngine {
 		try {
 			await this.tb.postTransfer(BigInt(transferId), actualAmount);
 		} catch (err) {
+			// Actual cost priced above the reserved hold: TigerBeetle rejects the
+			// post outright (it never caps). The call itself succeeded, so voiding
+			// would settle ZERO for real spend — instead re-post with the amount
+			// omitted, which posts the full pending (= held) amount. This engine is
+			// stateless (no held-amount tracking survives it), so the cap is
+			// reactive here; the governor-side factories precompute it (spec D1).
+			if (isExceedsPendingAmount(err)) {
+				await this.tb.postTransfer(BigInt(transferId), undefined);
+				return;
+			}
 			// Post may have succeeded on TB but timed out — try to void
 			let voidSucceeded = false;
 			try {

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -447,6 +447,16 @@ export interface PolicyContext extends Record<string, unknown> {
 	 * The one thing it is NOT is a number the caller chose: see the trust-boundary
 	 * paragraph above, and {@link PolicyContext.cost_center} for why the
 	 * attribution behind it cannot be forged either.
+	 *
+	 * OPERATOR NOTE — this is a lagging number, twice over. It is computed before
+	 * the call's own hold and excludes its estimated cost (only
+	 * `budget_remaining_after` is estimate-inclusive), and `receipt.budget` /
+	 * `budgetContext()` are post-settle snapshots, so any dashboard built on
+	 * either one reads one call behind the gate. In practice: an `lt` tier
+	 * starts denying with the call *after* the one whose settle crossed the
+	 * threshold, not the crossing call itself — a fraction sitting exactly on
+	 * the boundary still reads as inside it under `lt`. Write `lte` where the
+	 * tier must also catch that edge call.
 	 */
 	budgetFractionRemaining?: number | undefined;
 	/**

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -75,15 +75,23 @@ const BUDGET_HINT_FIELDS = new Set([
  * hard violation is budget-classed — the error's default hint then applies. PII
  * and injection denials never reach here: they throw from their own detector
  * sites, which pass their own class hints.
+ *
+ * `attributed` is the caller's own truth about whether an ENVELOPE is in scope for
+ * the denied call, and it selects between two remedies that are not
+ * interchangeable. An attributed call's hold debits the cost center's wallet, so
+ * `allocateBudget` can move it. An UNATTRIBUTED call's hold debits the session
+ * holding wallet, which no envelope funds — prescribing `allocateBudget` there
+ * sends an operator to a lever that provably cannot lift this denial. Pass
+ * `envelope !== undefined` from the gate call site; never guess it from the rule.
  */
-export function derivePolicyHint(result: PolicyResult): string | undefined {
+export function derivePolicyHint(result: PolicyResult, attributed: boolean): string | undefined {
 	const budgetHit = result.hardViolations.some((v) =>
 		v.fields.some((f) => BUDGET_HINT_FIELDS.has(f)),
 	);
-	if (budgetHit) {
-		return "A budget rule denied this call: check the envelope's allocation (allocateBudget) and your budgetFractionRemaining / budgetRunwayHours tiers.";
-	}
-	return undefined;
+	if (!budgetHit) return undefined;
+	return attributed
+		? "A budget rule denied this call: check the envelope's allocation (allocateBudget) and your budgetFractionRemaining / budgetRunwayHours tiers."
+		: "A budget rule denied this call: increase the budget in trust() options or reduce the call's max_tokens, and review your budget_remaining / budget_remaining_after tiers.";
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -40,6 +40,8 @@ export interface RuleMatch {
 	enforcement: PolicyEnforcement;
 	/** Severity if set */
 	severity: PolicySeverity | undefined;
+	/** Field names of the rule's conditions — lets a throw site classify the denial. */
+	fields: string[];
 }
 
 export interface PolicyResult {
@@ -57,6 +59,31 @@ export interface PolicyResult {
 	reasons: string[];
 	/** Evaluation timestamp */
 	evaluatedAt: string;
+}
+
+/** Policy-context fields whose rules deny for BUDGET reasons, not content reasons. */
+const BUDGET_HINT_FIELDS = new Set([
+	"budget_remaining",
+	"budget_remaining_after",
+	"budgetFractionRemaining",
+	"budgetRunwayHours",
+	"estimated_cost",
+]);
+
+/**
+ * Class-aware operator remedy for a gate denial (D6). Returns `undefined` when no
+ * hard violation is budget-classed — the error's default hint then applies. PII
+ * and injection denials never reach here: they throw from their own detector
+ * sites, which pass their own class hints.
+ */
+export function derivePolicyHint(result: PolicyResult): string | undefined {
+	const budgetHit = result.hardViolations.some((v) =>
+		v.fields.some((f) => BUDGET_HINT_FIELDS.has(f)),
+	);
+	if (budgetHit) {
+		return "A budget rule denied this call: check the envelope's allocation (allocateBudget) and your budgetFractionRemaining / budgetRunwayHours tiers.";
+	}
+	return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -571,6 +598,7 @@ export function evaluatePolicy(rules: GateRule[], context: PolicyContext): Polic
 			effect: rule.effect,
 			enforcement: rule.enforcement,
 			severity: rule.severity,
+			fields: rule.conditions.map((fc) => fc.field),
 		};
 
 		matched.push(match);

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -607,9 +607,12 @@ export function evaluatePolicy(rules: GateRule[], context: PolicyContext): Polic
 		const isViolation = rule.effect === "deny" || rule.effect === "warn";
 		if (isViolation) {
 			const label = rule.id ? `[${rule.id}]` : `[${rule.name}]`;
-			const rationale = rule.description ?? rule.name;
-			const reason =
-				rule.enforcement === "hard" ? `${label} ${rationale}` : `[WARN] ${label} ${rationale}`;
+			// A description-less rule would render its identifier twice
+			// ("[scarcity-brake] scarcity-brake"): the rationale falls back to
+			// rule.name, which the label already shows unless a distinct id exists.
+			const rationale = rule.description ?? ((rule.id ?? rule.name) === rule.name ? "" : rule.name);
+			const body = rationale === "" ? label : `${label} ${rationale}`;
+			const reason = rule.enforcement === "hard" ? body : `[WARN] ${body}`;
 
 			reasons.push(reason);
 

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -38,9 +38,16 @@ export class PolicyDeniedError extends Error {
 	public readonly hint: string;
 	public readonly docsUrl: string;
 
-	constructor(reason: string) {
+	/**
+	 * `hint` is overridable because the default advice is WRONG for a budget or
+	 * scarcity denial: it names a PII downgrade that has nothing to do with the
+	 * rule that fired. The governor derives a class-aware remedy at the throw
+	 * site; every caller that omits the argument gets the default string.
+	 */
+	constructor(reason: string, hintOverride?: string) {
 		const hint =
-			'Check your policy rules in .usertrust/policies/ or use { pii: "warn" } to downgrade PII enforcement.';
+			hintOverride ??
+			'Check your policy rules in .usertrust/policies/default.yml or use { pii: "warn" } to downgrade PII enforcement.';
 		const docsUrl = "https://usertrust.ai/docs/errors/policy-denied";
 		super(`Policy denied: ${reason}\n\n  Hint: ${hint}\n  Docs: ${docsUrl}`);
 		this.name = "PolicyDeniedError";

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -29,6 +29,14 @@ export type RateSource = "table" | "custom" | "local-model" | "local-default" | 
 export interface TrustReceipt {
 	transferId: string;
 	cost: number;
+	/**
+	 * Ledger amount actually POSTED when it differs from `cost`: the settle was
+	 * capped at the reserved hold (`cost - postedCost` = the shortfall, audited as
+	 * `settlement_shortfall`). Absent when the post matched `cost`. `cost` stays
+	 * the true metered cost — the receipt, hash chain, and ledger reconcile
+	 * through this field rather than by overwriting any of them.
+	 */
+	postedCost?: number;
 	budgetRemaining: number;
 	auditHash: string;
 	chainPath: string;

--- a/packages/core/tests/govern/settle-shortfall.test.ts
+++ b/packages/core/tests/govern/settle-shortfall.test.ts
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Spec D4 — `trust()` reports a TRUNCATED settlement instead of hiding it.
+ *
+ * TigerBeetle rejects (never caps) a post above the pending transfer, so the
+ * engine caps the settle at the reserved hold and hands the truncation back as
+ * `{ posted, shortfall }`. What that costs the caller is visibility: the ledger
+ * moved less money than the call actually consumed. This file pins where that
+ * gap surfaces.
+ *
+ *  - `receipt.cost` stays the TRUE metered cost. Overwriting it with the posted
+ *    amount would make the receipt agree with the ledger by forgetting the
+ *    overspend, which is the one number an auditor is here for.
+ *  - `receipt.postedCost` carries the ledger side, and ONLY when the two differ —
+ *    an absent key is the assertion that nothing was truncated, so a zero
+ *    shortfall must not leave the field behind.
+ *  - One `settlement_shortfall` event per truncated settle, carrying both numbers
+ *    and the transfer they belong to.
+ *  - The event is advisory: an audit chain that cannot take it degrades the
+ *    receipt (`AUDIT_DEGRADED`) and NEVER unwinds a settlement that committed —
+ *    the same contract its sibling `settlement_ambiguous` holds.
+ *  - An injected engine whose `postPendingSpend` resolves `void` is posted-in-full.
+ */
+
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import { type TrustEngine, trust } from "../../src/govern.js";
+import type { AuditEvent, TrustReceipt } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Fixtures ──
+
+const PARAMS = {
+	model: "claude-sonnet-4-6",
+	max_tokens: 64,
+	messages: [{ role: "user", content: "hello" }],
+};
+
+/** What the capped engine claims to have posted; deliberately not the metered cost. */
+const POSTED = 78;
+const SHORTFALL = 6;
+
+interface EngineHandle extends TrustEngine {
+	spendPending: ReturnType<typeof vi.fn>;
+	postPendingSpend: ReturnType<typeof vi.fn>;
+	voidPendingSpend: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * `post` is the whole point of this harness: it is the Task 3 return shape the
+ * governor has to read. `undefined` (the default) models the injected engine that
+ * predates the shape and resolves `void`.
+ */
+function makeMockEngine(post?: TrustEngine["postPendingSpend"]): EngineHandle {
+	return {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(post ?? (async () => {})),
+		voidPendingSpend: vi.fn(async () => {}),
+		destroy: vi.fn(),
+	};
+}
+
+interface AuditHandle extends AuditWriter {
+	events: AppendEventInput[];
+}
+
+/** `failOnCall` is 1-based: the Nth append throws, every other one succeeds. */
+function makeMockAudit(opts: { failOnCall?: number } = {}): AuditHandle {
+	const events: AppendEventInput[] = [];
+	let calls = 0;
+	return {
+		events,
+		appendEvent: vi.fn(async (input: AppendEventInput): Promise<AuditEvent> => {
+			calls++;
+			if (calls === opts.failOnCall) throw new Error("audit disk full");
+			events.push(input);
+			return {
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			};
+		}),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+function makeAnthropicMock() {
+	return {
+		messages: {
+			create: vi.fn(async () => ({
+				id: "msg_1",
+				type: "message",
+				role: "assistant",
+				content: [{ type: "text", text: "ok" }],
+				model: "claude-sonnet-4-6",
+				usage: { input_tokens: 10, output_tokens: 5 },
+			})),
+		},
+	};
+}
+
+/** A MessageStream-shaped emitter that emits NOTHING until the test says so. */
+class ManualMessageStream extends EventEmitter {
+	finalMessage(): Promise<unknown> {
+		return Promise.resolve({ usage: { input_tokens: 10, output_tokens: 5 } });
+	}
+	async *[Symbol.asyncIterator](): AsyncIterator<unknown> {
+		// The caller owns the iterator; governance never touches it.
+	}
+}
+
+function shortfallEvents(audit: AuditHandle): AppendEventInput[] {
+	return audit.events.filter((e) => e.kind === "settlement_shortfall");
+}
+
+// ── Tests ──
+
+describe("settlement_shortfall — non-streaming settle", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `settle-shortfall-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("audits settlement_shortfall and sets receipt.postedCost when the engine reports truncation", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+
+		expect(receipt.settled).toBe(true);
+		expect(receipt.postedCost).toBe(POSTED);
+		// The receipt keeps the METERED cost — the ledger's number lives beside it.
+		expect(receipt.cost).not.toBe(POSTED);
+		expect(receipt.cost).toBeGreaterThan(0);
+
+		const events = shortfallEvents(audit);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.data).toMatchObject({
+			model: PARAMS.model,
+			actual: receipt.cost,
+			posted: POSTED,
+			shortfall: SHORTFALL,
+			transferId: receipt.transferId,
+		});
+
+		await governed.destroy();
+	});
+
+	it("omits postedCost and the event when shortfall is zero", async () => {
+		const engine = makeMockEngine(async (_transferId, actualAmount) => ({
+			posted: actualAmount ?? 0,
+			shortfall: 0,
+		}));
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+
+		expect(receipt.settled).toBe(true);
+		// An ABSENT key, not an undefined one: consumers read the presence.
+		expect(Object.hasOwn(receipt, "postedCost")).toBe(false);
+		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await governed.destroy();
+	});
+
+	it("treats a void-returning engine as posted-in-full (injected-engine compatibility)", async () => {
+		const engine = makeMockEngine();
+		const audit = makeMockAudit();
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+
+		expect(receipt.settled).toBe(true);
+		expect(Object.hasOwn(receipt, "postedCost")).toBe(false);
+		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await governed.destroy();
+	});
+
+	it("audit-append failure on the shortfall event degrades without unsettling", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		// llm_call is append #1 and the shortfall event is #2 on this path.
+		const audit = makeMockAudit({ failOnCall: 2 });
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+			_audit: audit,
+		});
+
+		const { receipt } = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+
+		// The money committed; only the record of the gap was lost.
+		expect(receipt.settled).toBe(true);
+		expect(receipt.auditHash).toBe("AUDIT_DEGRADED");
+		expect(receipt.postedCost).toBe(POSTED);
+		expect(engine.voidPendingSpend).not.toHaveBeenCalled();
+		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await governed.destroy();
+	});
+});
+
+describe("settlement_shortfall — streaming settle", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `settle-shortfall-stream-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("audits the shortfall and stamps postedCost on the stream receipt", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		const audit = makeMockAudit();
+		const stream = new ManualMessageStream();
+		const governed = await trust(
+			{ messages: { create: vi.fn(), stream: vi.fn(() => stream) } },
+			{ budget: 100_000, vaultBase, _engine: engine, _audit: audit },
+		);
+
+		const handle = (await governed.messages.stream(PARAMS)) as ManualMessageStream & {
+			receipt: Promise<TrustReceipt>;
+		};
+		stream.emit("finalMessage", { usage: { input_tokens: 10, output_tokens: 5 } });
+		stream.emit("end");
+		const receipt = await handle.receipt;
+
+		expect(receipt.settled).toBe(true);
+		expect(receipt.postedCost).toBe(POSTED);
+		expect(receipt.cost).not.toBe(POSTED);
+
+		const events = shortfallEvents(audit);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.data).toMatchObject({
+			actual: receipt.cost,
+			posted: POSTED,
+			shortfall: SHORTFALL,
+			transferId: receipt.transferId,
+		});
+
+		await governed.destroy();
+	});
+
+	it("omits postedCost and the event on a full stream post", async () => {
+		const engine = makeMockEngine();
+		const audit = makeMockAudit();
+		const stream = new ManualMessageStream();
+		const governed = await trust(
+			{ messages: { create: vi.fn(), stream: vi.fn(() => stream) } },
+			{ budget: 100_000, vaultBase, _engine: engine, _audit: audit },
+		);
+
+		const handle = (await governed.messages.stream(PARAMS)) as ManualMessageStream & {
+			receipt: Promise<TrustReceipt>;
+		};
+		stream.emit("finalMessage", { usage: { input_tokens: 10, output_tokens: 5 } });
+		stream.emit("end");
+		const receipt = await handle.receipt;
+
+		expect(receipt.settled).toBe(true);
+		expect(Object.hasOwn(receipt, "postedCost")).toBe(false);
+		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await governed.destroy();
+	});
+});

--- a/packages/core/tests/govern/settle-shortfall.test.ts
+++ b/packages/core/tests/govern/settle-shortfall.test.ts
@@ -26,12 +26,13 @@
 
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
 import { type TrustEngine, trust } from "../../src/govern.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
 import type { AuditEvent, TrustReceipt } from "../../src/shared/types.js";
 
 // tigerbeetle-node is a native module and is never loaded in unit tests.
@@ -140,6 +141,39 @@ class ManualMessageStream extends EventEmitter {
 
 function shortfallEvents(audit: AuditHandle): AppendEventInput[] {
 	return audit.events.filter((e) => e.kind === "settlement_shortfall");
+}
+
+/**
+ * Read the REAL hash-linked chain — not a mock's call log. `verifyTransaction`
+ * resolves a transfer by the FIRST event whose `data.transferId` matches
+ * (packages/verify/src/index.ts), so the on-disk ORDER is the contract: a
+ * `settlement_shortfall` written ahead of its `llm_call` renders a settled call
+ * as PENDING with no cost. These helpers pin the order at the byte level.
+ */
+function readChain(vaultBase: string): AuditEvent[] {
+	const chainPath = join(vaultBase, VAULT_DIR, "audit", "events.jsonl");
+	return readFileSync(chainPath, "utf-8")
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line) as AuditEvent);
+}
+
+/** Index of the first chain event of `kind` carrying `transferId`, or -1. */
+function chainIndexOf(events: AuditEvent[], kind: string, transferId: string): number {
+	return events.findIndex((e) => e.kind === kind && e.data?.transferId === transferId);
+}
+
+/**
+ * The one assertion this file exists to protect: `llm_call` FIRST, then the
+ * shortfall correction that annotates it.
+ */
+function expectLlmCallBeforeShortfall(vaultBase: string, transferId: string): void {
+	const events = readChain(vaultBase);
+	const llmCallIdx = chainIndexOf(events, "llm_call", transferId);
+	const shortfallIdx = chainIndexOf(events, "settlement_shortfall", transferId);
+	expect(llmCallIdx).toBeGreaterThanOrEqual(0);
+	expect(shortfallIdx).toBeGreaterThanOrEqual(0);
+	expect(llmCallIdx).toBeLessThan(shortfallIdx);
 }
 
 // ── Tests ──
@@ -255,6 +289,24 @@ describe("settlement_shortfall — non-streaming settle", () => {
 
 		await governed.destroy();
 	});
+
+	it("writes llm_call BEFORE settlement_shortfall on the real chain", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		// No `_audit`: this test needs the REAL writer so the on-disk order is what
+		// is asserted, exactly as `verifyTransaction` will read it.
+		const governed = await trust(makeAnthropicMock(), {
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+		});
+
+		const { receipt } = (await governed.messages.create(PARAMS)) as { receipt: TrustReceipt };
+
+		expect(receipt.postedCost).toBe(POSTED);
+		expectLlmCallBeforeShortfall(vaultBase, receipt.transferId);
+
+		await governed.destroy();
+	});
 });
 
 describe("settlement_shortfall — streaming settle", () => {
@@ -324,6 +376,28 @@ describe("settlement_shortfall — streaming settle", () => {
 		expect(receipt.settled).toBe(true);
 		expect(Object.hasOwn(receipt, "postedCost")).toBe(false);
 		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await governed.destroy();
+	});
+
+	it("writes llm_call BEFORE settlement_shortfall on the real chain", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		const stream = new ManualMessageStream();
+		// No `_audit`: the REAL writer, so the assertion is about bytes on disk.
+		const governed = await trust(
+			{ messages: { create: vi.fn(), stream: vi.fn(() => stream) } },
+			{ budget: 100_000, vaultBase, _engine: engine },
+		);
+
+		const handle = (await governed.messages.stream(PARAMS)) as ManualMessageStream & {
+			receipt: Promise<TrustReceipt>;
+		};
+		stream.emit("finalMessage", { usage: { input_tokens: 10, output_tokens: 5 } });
+		stream.emit("end");
+		const receipt = await handle.receipt;
+
+		expect(receipt.postedCost).toBe(POSTED);
+		expectLlmCallBeforeShortfall(vaultBase, receipt.transferId);
 
 		await governed.destroy();
 	});

--- a/packages/core/tests/govern/tb-engine-seam.test.ts
+++ b/packages/core/tests/govern/tb-engine-seam.test.ts
@@ -35,14 +35,15 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { AccountFlags, CreateTransferStatus } from "tigerbeetle-node";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
 import type { AuditEvent } from "../../src/shared/types.js";
 
-const DMNEC = 1 << 2; // AccountFlags.debits_must_not_exceed_credits
-const DEBIT_ACCOUNT_NOT_FOUND = 21; // CreateTransferStatus.debit_account_not_found
+const DMNEC = AccountFlags.debits_must_not_exceed_credits;
+const DEBIT_ACCOUNT_NOT_FOUND = CreateTransferStatus.debit_account_not_found;
 
-const { store, created, pendings, holds, mockClient } = vi.hoisted(() => {
+const { store, created, pendings, holds, mockClient, tb } = vi.hoisted(() => {
 	interface Acct {
 		flags: number;
 		credits_posted: bigint;
@@ -54,16 +55,24 @@ const { store, created, pendings, holds, mockClient } = vi.hoisted(() => {
 		credit: bigint;
 		amount: bigint;
 	}
-	const S = {
-		exceeds_credits: 22,
-		debit_account_not_found: 21,
-		credit_account_not_found: 23,
-		pending_transfer_not_found: 40,
+	/**
+	 * The INSTALLED tigerbeetle-node enums, filled in by the module mock below —
+	 * a `vi.hoisted` block cannot await the import itself, and the fake's handlers
+	 * only read these at call time, long after the mock factory has run.
+	 *
+	 * Hand-copied constants are what let the previous fake answer 22 for
+	 * `exceeds_credits`, the code the real database uses for
+	 * `credit_account_not_found`. Production branches on specific numbers
+	 * (`isTBInsufficientBalance`, `isTBDebitAccountNotFound`), so a mis-copied
+	 * status makes the seam agree with itself and disagree with TigerBeetle.
+	 */
+	const tb = {} as {
+		AccountFlags: typeof AccountFlags;
+		TransferFlags: typeof import("tigerbeetle-node").TransferFlags;
+		CreateAccountStatus: typeof import("tigerbeetle-node").CreateAccountStatus;
+		CreateTransferStatus: typeof CreateTransferStatus;
+		amount_max: bigint;
 	};
-	const DMNEC_FLAG = 1 << 2;
-	const PENDING_FLAG = 1;
-	const POST_FLAG = 2;
-	const VOID_FLAG = 4;
 
 	const store = new Map<bigint, Acct>();
 	/** Account ids in creation order: [treasury, holding wallet, …]. */
@@ -76,7 +85,7 @@ const { store, created, pendings, holds, mockClient } = vi.hoisted(() => {
 	const mockClient = {
 		createAccounts: vi.fn(async (accts: { id: bigint; flags: number }[]) => {
 			for (const a of accts) {
-				if (store.has(a.id)) return [{ status: 1 /* exists */ }];
+				if (store.has(a.id)) return [{ status: tb.CreateAccountStatus.exists }];
 				store.set(a.id, {
 					flags: a.flags,
 					credits_posted: 0n,
@@ -98,6 +107,13 @@ const { store, created, pendings, holds, mockClient } = vi.hoisted(() => {
 					flags: number;
 				}[],
 			) => {
+				const S = tb.CreateTransferStatus;
+				const {
+					pending: PENDING_FLAG,
+					post_pending_transfer: POST_FLAG,
+					void_pending_transfer: VOID_FLAG,
+				} = tb.TransferFlags;
+				const DMNEC_FLAG = tb.AccountFlags.debits_must_not_exceed_credits;
 				for (const t of xs) {
 					// Post/void resolve their accounts from the original pending transfer
 					// (the client sends 0n for both account ids on those).
@@ -107,11 +123,21 @@ const { store, created, pendings, holds, mockClient } = vi.hoisted(() => {
 						const debit = store.get(orig.debit);
 						const credit = store.get(orig.credit);
 						if (!debit || !credit) return [{ status: S.debit_account_not_found }];
+						// `amount_max` is TigerBeetle's "post the whole pending amount"
+						// sentinel, and is what the client sends when no actual amount is
+						// given. Everything else is a literal request.
+						const requested = t.amount === tb.amount_max ? orig.amount : t.amount;
+						// Real TigerBeetle REJECTS a post above the pending amount — it does
+						// not cap. (The previous fake capped, modelling semantics the
+						// database does not have.) The rejection lands BEFORE the pending
+						// debit is released, so a rejected post leaves the hold untouched.
+						if ((t.flags & POST_FLAG) !== 0 && requested > orig.amount) {
+							return [{ status: S.exceeds_pending_transfer_amount }];
+						}
 						debit.debits_pending -= orig.amount;
 						if (t.flags & POST_FLAG) {
-							const posted = t.amount < orig.amount ? t.amount : orig.amount;
-							debit.debits_posted += posted;
-							credit.credits_posted += posted;
+							debit.debits_posted += requested;
+							credit.credits_posted += requested;
 						}
 						pendings.delete(t.pending_id);
 						continue;
@@ -164,29 +190,21 @@ const { store, created, pendings, holds, mockClient } = vi.hoisted(() => {
 		lookupTransfers: vi.fn(async () => []),
 		destroy: vi.fn(),
 	};
-	return { store, created, pendings, holds, mockClient };
+	return { store, created, pendings, holds, mockClient, tb };
 });
 
-vi.mock("tigerbeetle-node", () => ({
-	createClient: vi.fn(() => mockClient),
-	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 1 << 2, history: 1 << 5 },
-	TransferFlags: {
-		pending: 1,
-		post_pending_transfer: 2,
-		void_pending_transfer: 4,
-		linked: 8,
-	},
-	CreateAccountStatus: { created: 4294967295, exists: 1 },
-	CreateTransferStatus: {
-		created: 4294967295,
-		exists: 1,
-		exceeds_credits: 22,
-		overflows_debits: 30,
-		overflows_debits_pending: 31,
-		debit_account_not_found: 21,
-	},
-	amount_max: (1n << 128n) - 1n,
-}));
+// Only `createClient` is faked. Every enum and sentinel comes from the INSTALLED
+// package, so the fake's status codes, account flags and transfer flags are the
+// ones production compares against rather than a self-consistent fiction.
+vi.mock("tigerbeetle-node", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("tigerbeetle-node")>();
+	tb.AccountFlags = actual.AccountFlags;
+	tb.TransferFlags = actual.TransferFlags;
+	tb.CreateAccountStatus = actual.CreateAccountStatus;
+	tb.CreateTransferStatus = actual.CreateTransferStatus;
+	tb.amount_max = actual.amount_max;
+	return { ...actual, createClient: vi.fn(() => mockClient) };
+});
 
 import { withCostCenter } from "../../src/budget/attribution.js";
 import { createTBEngine, trust } from "../../src/govern.js";
@@ -404,6 +422,51 @@ describe("createTBEngine — rejection classification (D5)", () => {
 		expect(balanceErr.required).toBe(999);
 		expect(balanceErr.available).toBe(0);
 		expect(mockClient.lookupAccounts).toHaveBeenCalledWith([envelope]);
+		engine.destroy?.();
+	});
+});
+
+describe("createTBEngine — settle is capped at the reserved hold (D1)", () => {
+	it("caps an above-hold settle at the reserved amount and reports the shortfall", async () => {
+		reset();
+		// Hold 78, actual 84. TigerBeetle REJECTS a post above the pending amount
+		// (`exceeds_pending_transfer_amount`) rather than capping, so the factory has
+		// to truncate before it asks — and hand the governor the 6-usertoken
+		// shortfall to audit.
+		const engine = await createTBEngine(CONFIG, 10_000);
+
+		await engine.spendPending({ transferId: "t-over", amount: 78 });
+		const result = await engine.postPendingSpend("t-over", 84);
+
+		expect(result).toEqual({ posted: 78, shortfall: 6 });
+		expect(store.get(holdingWallet())?.debits_posted).toBe(78n);
+		expect(store.get(holdingWallet())?.debits_pending).toBe(0n);
+		engine.destroy?.();
+	});
+
+	it("below-hold settle still posts the actual amount with zero shortfall", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 10_000);
+
+		await engine.spendPending({ transferId: "t-under", amount: 78 });
+		const result = await engine.postPendingSpend("t-under", 30);
+
+		expect(result).toEqual({ posted: 30, shortfall: 0 });
+		expect(store.get(holdingWallet())?.debits_posted).toBe(30n);
+		expect(store.get(holdingWallet())?.debits_pending).toBe(0n);
+		engine.destroy?.();
+	});
+
+	it("omitting the actual amount posts the whole hold, unchanged", async () => {
+		reset();
+		const engine = await createTBEngine(CONFIG, 10_000);
+
+		await engine.spendPending({ transferId: "t-full", amount: 78 });
+		const result = await engine.postPendingSpend("t-full");
+
+		expect(result).toEqual({ posted: 78, shortfall: 0 });
+		expect(store.get(holdingWallet())?.debits_posted).toBe(78n);
+		expect(store.get(holdingWallet())?.debits_pending).toBe(0n);
 		engine.destroy?.();
 	});
 });

--- a/packages/core/tests/harden/pii-redact-egress.test.ts
+++ b/packages/core/tests/harden/pii-redact-egress.test.ts
@@ -5,6 +5,12 @@
  * P3-PII-REDACT-EGRESS (HIGH) — in `pii:"redact"` mode the OUTBOUND request to
  * the provider must be redacted (not just the local audit copy), and the caller's
  * original object must never be mutated. `pii:"block"` must prevent egress.
+ *
+ * The second half of this file pins the DENIAL HINTS, because the remedy a hint
+ * prescribes is only honest on the path that can actually perform it. Exactly one
+ * of the three PII block sites forwards a redacted clone to the provider; the
+ * other two do not, and must not tell an operator that `pii:"redact"` will strip
+ * PII before egress for them.
  */
 
 import { randomUUID } from "node:crypto";
@@ -13,6 +19,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { trust } from "../../src/govern.js";
+import { createGovernor } from "../../src/headless.js";
+import type { PolicyDeniedError } from "../../src/shared/errors.js";
 
 vi.mock("tigerbeetle-node", () => ({
 	createClient: vi.fn(() => ({
@@ -133,5 +141,164 @@ describe("P3-PII-REDACT-EGRESS", () => {
 		expect(forwarded).not.toContain("REDACTED");
 
 		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Denial-hint truth: a hint may only prescribe a remedy its own path performs
+// ---------------------------------------------------------------------------
+
+/** Run `fn`, require it to reject, and hand back the thrown PolicyDeniedError. */
+async function denialFrom(fn: () => Promise<unknown>): Promise<PolicyDeniedError> {
+	try {
+		await fn();
+	} catch (err) {
+		return err as PolicyDeniedError;
+	}
+	throw new Error("expected the call to be denied, but it resolved");
+}
+
+describe("PII denial hints name only the remedy their own path can perform", () => {
+	let tmpVault: string;
+	beforeEach(() => {
+		tmpVault = makeTmpVault();
+	});
+	afterEach(() => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("trust() LLM path offers redact — it is the ONE site that redacts egress", async () => {
+		writeConfig(tmpVault, { budget: 1_000_000, pii: "block" });
+		const governed = await trust(
+			{ messages: { create: vi.fn() } },
+			{ dryRun: true, vaultBase: tmpVault },
+		);
+
+		const err = await denialFrom(() =>
+			governed.messages.create({
+				model: "claude-sonnet-4-6",
+				max_tokens: 64,
+				messages: [{ role: "user", content: "ssn 123-45-6789" }],
+			}),
+		);
+
+		// The interceptCall redact branch really does forward a redacted DEEP CLONE
+		// (pinned by the first test in this file), so this remedy is TRUE here.
+		expect(err.hint).toBe(
+			'PII enforcement blocked this call. Use { pii: "warn" } to log instead, or { pii: "redact" } to strip PII before egress.',
+		);
+
+		await governed.destroy();
+	});
+
+	it("headless authorize does NOT promise redaction — the host owns egress", async () => {
+		writeConfig(tmpVault, { budget: 1_000_000, pii: "block" });
+		const gov = await createGovernor({ dryRun: true, vaultBase: tmpVault });
+
+		const err = await denialFrom(() =>
+			gov.authorize({
+				model: "claude-sonnet-4-6",
+				messages: [{ role: "user", content: "ssn 123-45-6789" }],
+			}),
+		);
+
+		// The headless governor never sees the outbound request — it authorizes and
+		// settles around a call the integrating host makes itself. `pii: "redact"`
+		// cannot strip anything here, so the hint must not claim it will.
+		expect(err.hint).toBe(
+			'PII enforcement blocked this call. Use { pii: "warn" } to log instead of block; the headless governor does not redact egress — redaction is the integrating host\'s responsibility.',
+		);
+		expect(err.hint).not.toContain("strip PII before egress");
+
+		await gov.destroy();
+	});
+
+	it("governAction says redact touches the AUDIT copy only — execute sees the original", async () => {
+		writeConfig(tmpVault, { budget: 1_000_000, pii: "block" });
+		const governed = await trust(
+			{ messages: { create: vi.fn() } },
+			{ dryRun: true, vaultBase: tmpVault },
+		);
+		const executeFn = vi.fn(async () => "done");
+
+		const err = await denialFrom(() =>
+			governed.governAction(
+				{ kind: "tool_use", name: "send_data", cost: 10, params: { ssn: "123-45-6789" } },
+				executeFn,
+			),
+		);
+
+		// On a governed action, redaction applies to the audited copy of the params.
+		// The execute closure is the caller's own and runs on the ORIGINAL input, so
+		// "strip PII before egress" would be a false promise.
+		expect(err.hint).toBe(
+			'PII enforcement blocked this action. Use { pii: "warn" } to log instead of block; on governed actions { pii: "redact" } redacts only the audit copy — the action itself runs on the original input.',
+		);
+		expect(err.hint).not.toContain("strip PII before egress");
+		expect(executeFn).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+});
+
+describe("unknown-model denial hint names the real configuration surface", () => {
+	let tmpVault: string;
+	beforeEach(() => {
+		tmpVault = makeTmpVault();
+	});
+	afterEach(() => {
+		try {
+			rmSync(tmpVault, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	// `customRates` is NOT a trust()/GovernorOpts option. It is a
+	// usertrust.config.json field, honored only when `pricing` is "custom"
+	// (ledger/pricing.ts resolveRates) — so the old hint sent operators to an
+	// option that does not exist.
+	const EXPECTED_HINT =
+		'Set pricing: "custom" with a customRates entry for this model in usertrust.config.json, or use a model from the built-in pricing table.';
+
+	it("trust() names usertrust.config.json + pricing: custom", async () => {
+		writeConfig(tmpVault, { budget: 1_000_000, unknownModelPolicy: "deny" });
+		const governed = await trust(
+			{ messages: { create: vi.fn() } },
+			{ dryRun: true, vaultBase: tmpVault },
+		);
+
+		const err = await denialFrom(() =>
+			governed.messages.create({
+				model: "not-a-real-model-abc",
+				max_tokens: 64,
+				messages: [{ role: "user", content: "hello" }],
+			}),
+		);
+
+		expect(err.message).toContain("unknown_model");
+		expect(err.hint).toBe(EXPECTED_HINT);
+		expect(err.hint).not.toContain("trust() options");
+
+		await governed.destroy();
+	});
+
+	it("createGovernor() names the same surface (F5: identical wording)", async () => {
+		writeConfig(tmpVault, { budget: 1_000_000, unknownModelPolicy: "deny" });
+		const gov = await createGovernor({ dryRun: true, vaultBase: tmpVault });
+
+		const err = await denialFrom(() =>
+			gov.authorize({ model: "not-a-real-model-abc", maxOutputTokens: 64 }),
+		);
+
+		expect(err.message).toContain("unknown_model");
+		expect(err.hint).toBe(EXPECTED_HINT);
+		expect(err.hint).not.toContain("trust() options");
+
+		await gov.destroy();
 	});
 });

--- a/packages/core/tests/headless/settle-shortfall.test.ts
+++ b/packages/core/tests/headless/settle-shortfall.test.ts
@@ -23,13 +23,14 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
 import type { TrustEngine } from "../../src/govern.js";
 import { createGovernor, type Governor } from "../../src/headless.js";
+import { VAULT_DIR } from "../../src/shared/constants.js";
 import type { AuditEvent } from "../../src/shared/types.js";
 
 // tigerbeetle-node is a native module and is never loaded in unit tests.
@@ -114,6 +115,26 @@ function makeMockAudit(opts: { failOnCall?: number } = {}): AuditHandle {
 
 function shortfallEvents(audit: AuditHandle): AppendEventInput[] {
 	return audit.events.filter((e) => e.kind === "settlement_shortfall");
+}
+
+/**
+ * Read the REAL hash-linked chain — not a mock's call log. `verifyTransaction`
+ * resolves a transfer by the FIRST event whose `data.transferId` matches
+ * (packages/verify/src/index.ts), so the on-disk ORDER is the contract: a
+ * `settlement_shortfall` written ahead of its `llm_call` renders a settled call
+ * as PENDING with no cost.
+ */
+function readChain(vaultBase: string): AuditEvent[] {
+	const chainPath = join(vaultBase, VAULT_DIR, "audit", "events.jsonl");
+	return readFileSync(chainPath, "utf-8")
+		.trim()
+		.split("\n")
+		.map((line) => JSON.parse(line) as AuditEvent);
+}
+
+/** Index of the first chain event of `kind` carrying `transferId`, or -1. */
+function chainIndexOf(events: AuditEvent[], kind: string, transferId: string): number {
+	return events.findIndex((e) => e.kind === kind && e.data?.transferId === transferId);
 }
 
 // ── Tests ──
@@ -206,12 +227,33 @@ describe("headless settlement_shortfall threading", () => {
 		await gov.destroy();
 	});
 
+	it("writes llm_call BEFORE settlement_shortfall on the real chain", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		// No `_audit`: this test needs the REAL writer so the on-disk order is what
+		// is asserted, exactly as `verifyTransaction` will read it.
+		const gov = await createGovernor({ budget: 100_000, vaultBase, _engine: engine });
+
+		const auth = await gov.authorize(AUTHORIZE);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.postedCost).toBe(POSTED);
+		const events = readChain(vaultBase);
+		const llmCallIdx = chainIndexOf(events, "llm_call", auth.transferId);
+		const shortfallIdx = chainIndexOf(events, "settlement_shortfall", auth.transferId);
+		expect(llmCallIdx).toBeGreaterThanOrEqual(0);
+		expect(shortfallIdx).toBeGreaterThanOrEqual(0);
+		expect(llmCallIdx).toBeLessThan(shortfallIdx);
+
+		await gov.destroy();
+	});
+
 	it("audit-append failure on the shortfall event degrades without unsettling", async () => {
 		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
-		// Headless settle POSTs (and appends settlement_shortfall) BEFORE it appends
-		// llm_call — the reverse order from trust()'s non-stream path — so the
-		// shortfall append is call #1 here, and llm_call is call #2.
-		const audit = makeMockAudit({ failOnCall: 1 });
+		// Headless settle appends llm_call FIRST and the settlement_shortfall
+		// correction AFTER it — the same order as trust()'s non-stream path, and the
+		// order `verifyTransaction` depends on — so llm_call is call #1 here and the
+		// shortfall append is call #2.
+		const audit = makeMockAudit({ failOnCall: 2 });
 		const gov = await governorWith(engine, audit);
 
 		const auth = await gov.authorize(AUTHORIZE);

--- a/packages/core/tests/headless/settle-shortfall.test.ts
+++ b/packages/core/tests/headless/settle-shortfall.test.ts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Spec D4, headless mirror of `tests/govern/settle-shortfall.test.ts` — the
+ * headless governor reports a TRUNCATED settlement instead of hiding it.
+ *
+ * TigerBeetle rejects (never caps) a post above the pending transfer, so the
+ * engine caps the settle at the reserved hold and hands the truncation back as
+ * `{ posted, shortfall }`. What that costs the caller is visibility: the
+ * ledger moved less money than the call actually consumed. This file pins
+ * where that gap surfaces on `createGovernor()`'s explicit authorize/settle
+ * lifecycle — same event/receipt names as `trust()` (Task 4), same contract.
+ *
+ *  - `receipt.cost` stays the TRUE metered cost. `receipt.postedCost` carries
+ *    the ledger side, and ONLY when the two differ.
+ *  - One `settlement_shortfall` event per truncated settle.
+ *  - The event is advisory: an audit chain that cannot take it degrades the
+ *    receipt (`auditDegraded: true`) and NEVER unwinds a settlement that
+ *    committed.
+ *  - An injected engine whose `postPendingSpend` resolves `void` is
+ *    posted-in-full.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import type { TrustEngine } from "../../src/govern.js";
+import { createGovernor, type Governor } from "../../src/headless.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Fixtures ──
+
+const AUTHORIZE = {
+	model: "claude-sonnet-4-6",
+	estimatedInputTokens: 100,
+	maxOutputTokens: 500,
+};
+
+/** What the capped engine claims to have posted; deliberately not the metered cost. */
+const POSTED = 78;
+const SHORTFALL = 6;
+
+interface EngineHandle extends TrustEngine {
+	spendPending: ReturnType<typeof vi.fn>;
+	postPendingSpend: ReturnType<typeof vi.fn>;
+	voidPendingSpend: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * `post` is the whole point of this harness: it is the Task 3 return shape the
+ * governor has to read. `undefined` (the default) models the injected engine
+ * that predates the shape and resolves `void`.
+ */
+function makeMockEngine(post?: TrustEngine["postPendingSpend"]): EngineHandle {
+	return {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(post ?? (async () => {})),
+		voidPendingSpend: vi.fn(async () => {}),
+		voidAllPending: vi.fn(async () => {}),
+		destroy: vi.fn(),
+	};
+}
+
+interface AuditHandle extends AuditWriter {
+	events: AppendEventInput[];
+}
+
+/** `failOnCall` is 1-based: the Nth append throws, every other one succeeds. */
+function makeMockAudit(opts: { failOnCall?: number } = {}): AuditHandle {
+	const events: AppendEventInput[] = [];
+	let calls = 0;
+	return {
+		events,
+		appendEvent: vi.fn(async (input: AppendEventInput): Promise<AuditEvent> => {
+			calls++;
+			if (calls === opts.failOnCall) throw new Error("audit disk full");
+			events.push(input);
+			return {
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			};
+		}),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+function shortfallEvents(audit: AuditHandle): AppendEventInput[] {
+	return audit.events.filter((e) => e.kind === "settlement_shortfall");
+}
+
+// ── Tests ──
+
+describe("headless settlement_shortfall threading", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `headless-settle-shortfall-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	async function governorWith(engine: EngineHandle, audit: AuditHandle): Promise<Governor> {
+		return await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			_engine: engine,
+			_audit: audit,
+		});
+	}
+
+	it("audits settlement_shortfall and sets receipt.postedCost when the engine reports truncation", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await gov.authorize(AUTHORIZE);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.settled).toBe(true);
+		expect(receipt.postedCost).toBe(POSTED);
+		// The receipt keeps the METERED cost — the ledger's number lives beside it.
+		expect(receipt.cost).not.toBe(POSTED);
+		expect(receipt.cost).toBeGreaterThan(0);
+
+		const events = shortfallEvents(audit);
+		expect(events).toHaveLength(1);
+		expect(events[0]?.data).toMatchObject({
+			model: AUTHORIZE.model,
+			actual: receipt.cost,
+			posted: POSTED,
+			shortfall: SHORTFALL,
+			transferId: auth.transferId,
+		});
+
+		await gov.destroy();
+	});
+
+	it("omits postedCost and the event when shortfall is zero", async () => {
+		const engine = makeMockEngine(async (_transferId, actualAmount) => ({
+			posted: actualAmount ?? 0,
+			shortfall: 0,
+		}));
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await gov.authorize(AUTHORIZE);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.settled).toBe(true);
+		// An ABSENT key, not an undefined one: consumers read the presence.
+		expect(Object.hasOwn(receipt, "postedCost")).toBe(false);
+		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await gov.destroy();
+	});
+
+	it("treats a void-returning engine as posted-in-full (injected-engine compatibility)", async () => {
+		const engine = makeMockEngine();
+		const audit = makeMockAudit();
+		const gov = await governorWith(engine, audit);
+
+		const auth = await gov.authorize(AUTHORIZE);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		expect(receipt.settled).toBe(true);
+		expect(Object.hasOwn(receipt, "postedCost")).toBe(false);
+		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await gov.destroy();
+	});
+
+	it("audit-append failure on the shortfall event degrades without unsettling", async () => {
+		const engine = makeMockEngine(async () => ({ posted: POSTED, shortfall: SHORTFALL }));
+		// Headless settle POSTs (and appends settlement_shortfall) BEFORE it appends
+		// llm_call — the reverse order from trust()'s non-stream path — so the
+		// shortfall append is call #1 here, and llm_call is call #2.
+		const audit = makeMockAudit({ failOnCall: 1 });
+		const gov = await governorWith(engine, audit);
+
+		const auth = await gov.authorize(AUTHORIZE);
+		const receipt = await gov.settle(auth, { inputTokens: 80, outputTokens: 200 });
+
+		// The money committed; only the record of the gap was lost.
+		expect(receipt.settled).toBe(true);
+		expect(receipt.auditDegraded).toBe(true);
+		expect(receipt.postedCost).toBe(POSTED);
+		expect(engine.voidPendingSpend).not.toHaveBeenCalled();
+		expect(shortfallEvents(audit)).toHaveLength(0);
+
+		await gov.destroy();
+	});
+});

--- a/packages/core/tests/integration/budget-envelope.tb.test.ts
+++ b/packages/core/tests/integration/budget-envelope.tb.test.ts
@@ -31,6 +31,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLedgerEvents } from "../../src/audit/read.js";
 import { allocateBudget, getBudgetStatus, reclaimBudget } from "../../src/budget/allocation.js";
 import { withCostCenter } from "../../src/budget/attribution.js";
 import { budgetContext } from "../../src/budget/context.js";
@@ -39,6 +40,7 @@ import { TrustTBClient, XFER_PURCHASE } from "../../src/ledger/client.js";
 import { estimateCost, estimateInputTokens } from "../../src/ledger/pricing.js";
 import { VAULT_DIR } from "../../src/shared/constants.js";
 import { InsufficientBalanceError, PolicyDeniedError } from "../../src/shared/errors.js";
+import type { TrustReceipt } from "../../src/shared/types.js";
 
 const TB_ADDRESS = process.env.USERTRUST_TB_ADDRESS;
 
@@ -78,6 +80,13 @@ const HOLD = estimateCost(MODEL, estimateInputTokens(MESSAGES), MAX_TOKENS);
 const USAGE = { input_tokens: 100, output_tokens: 50 };
 const ACTUAL_COST = estimateCost(MODEL, USAGE.input_tokens, USAGE.output_tokens);
 
+// Provider-reported usage → a SETTLED cost strictly ABOVE the reserved hold: the
+// input side of the estimate is a chars/4×1.5 heuristic, so real usage can price
+// above it (spec: settle-shortfall hardening). The settle must cap at HOLD, keep
+// settled:true, and audit the shortfall — never strand the hold or void real spend.
+const USAGE_OVER = { input_tokens: 5000, output_tokens: 1024 };
+const ACTUAL_OVER = estimateCost(MODEL, USAGE_OVER.input_tokens, USAGE_OVER.output_tokens);
+
 // The envelope is funded with exactly one hold's worth — the same boundary
 // tigerbeetle.tb.test.ts's sequential-over-budget test uses, applied to the
 // cost-center wallet instead of the session wallet.
@@ -90,6 +99,9 @@ const PARENT_FUND = ENVELOPE_ALLOCATED;
 const SESSION_BUDGET = 1_000_000;
 
 const COST_CENTER = "research";
+// A cost center of its own for the overrun case: `(parent, costCenter)` IS the
+// envelope's account id, and both tests may run against one long-lived cluster.
+const COST_CENTER_OVER = "research-overrun";
 
 // ── Helpers ──
 
@@ -126,6 +138,11 @@ function okResponse(): Record<string, unknown> {
 		model: MODEL,
 		usage: { ...USAGE },
 	};
+}
+
+/** The same response, reporting the usage that prices ABOVE the reserved hold. */
+function overResponse(): Record<string, unknown> {
+	return { ...okResponse(), usage: { ...USAGE_OVER } };
 }
 
 const CALL = { model: MODEL, max_tokens: MAX_TOKENS, messages: MESSAGES } as const;
@@ -267,6 +284,120 @@ describe.skipIf(!TB_ADDRESS)("real TigerBeetle — cost-center envelope spend cy
 				} finally {
 					await governed.destroy();
 				}
+			} finally {
+				tb.destroy();
+			}
+		},
+	);
+
+	it(
+		"caps a settle ABOVE the reserved hold at the hold, audits the shortfall once, " +
+			"and leaves nothing pending on the real envelope",
+		async () => {
+			// The fixture's premise, asserted rather than assumed: a pricing-table
+			// change that made the estimate generous again would quietly turn this into
+			// a duplicate of the test above instead of failing.
+			expect(ACTUAL_OVER).toBeGreaterThan(HOLD);
+
+			// A fresh parent per run, as above — `(parent, costCenter)` IS the envelope
+			// account, and this file's two tests share one cluster.
+			const PARENT = `envelope-tb-over-${randomUUID()}`;
+
+			const tb = new TrustTBClient({ addresses: [TB_ADDRESS as string], clusterId: 0n });
+			try {
+				// ── Fund parent, allocate exactly one hold's worth ──
+				const treasury = await tb.createTreasury();
+				const parentAccountId = await tb.createUserWallet(PARENT);
+				await tb.immediateTransfer({
+					debitAccountId: treasury,
+					creditAccountId: parentAccountId,
+					amount: PARENT_FUND,
+					code: XFER_PURCHASE,
+				});
+				const allocation = await allocateBudget(tb, {
+					parentUserId: PARENT,
+					costCenter: COST_CENTER_OVER,
+					amount: ENVELOPE_ALLOCATED,
+				});
+				expect(allocation.allocated).toBe(ENVELOPE_ALLOCATED);
+
+				const vaultBase = makeVault(SESSION_BUDGET);
+				const periodStartMs = Date.now();
+				const create = vi.fn(async () => overResponse());
+				const governed = await trust(anthropicClient(create), { vaultBase, parentUserId: PARENT });
+				try {
+					const { receipt } = (await withCostCenter(
+						COST_CENTER_OVER,
+						() => governed.messages.create({ ...CALL }),
+						{ allocated: ENVELOPE_ALLOCATED, periodStartMs },
+					)) as { receipt: TrustReceipt };
+
+					// Against a REAL cluster this single assertion is the whole proof that
+					// the engine capped: TigerBeetle REJECTS (never caps) a post above its
+					// pending transfer, so an uncapped settle of ACTUAL_OVER would have come
+					// back settled:false with a `settlement_ambiguous` event instead.
+					expect(receipt.settled).toBe(true);
+					// The receipt keeps the TRUE metered cost — the ledger's number sits
+					// beside it in postedCost rather than overwriting it.
+					expect(receipt.cost).toBe(ACTUAL_OVER);
+					expect(receipt.postedCost).toBe(HOLD);
+					expect(create).toHaveBeenCalledTimes(1);
+					// D7 post-settle snapshot: one hold allocated, one hold consumed.
+					expect(receipt.budget).toEqual({
+						costCenter: COST_CENTER_OVER,
+						remaining: 0,
+						fraction: 0,
+					});
+
+					// ── Both read surfaces agree with the real ledger ──
+					const status = await getBudgetStatus(tb, {
+						parentUserId: PARENT,
+						costCenter: COST_CENTER_OVER,
+						allocated: ENVELOPE_ALLOCATED,
+						periodStartMs,
+					});
+					expect(status.balance).toBe(0);
+					expect(status.runway.remaining).toBe(0);
+
+					const ctx = await budgetContext(tb, PARENT, [
+						{ costCenter: COST_CENTER_OVER, allocated: ENVELOPE_ALLOCATED, periodStartMs },
+					]);
+					expect(ctx.envelopes[0]?.spent).toBe(HOLD);
+					expect(ctx.envelopes[0]?.remaining).toBe(0);
+				} finally {
+					await governed.destroy();
+				}
+
+				// ── The hold was POSTED, not stranded ──
+				// destroy() voids every hold still pending, so a hold left behind would
+				// come BACK here as a full refund (balance === HOLD) — the exact signature
+				// of the pre-capping behaviour this test exists to keep out. Read through a
+				// FRESH client — a connection that took no part in the session.
+				const verifier = new TrustTBClient({ addresses: [TB_ADDRESS as string], clusterId: 0n });
+				try {
+					const afterDestroy = await getBudgetStatus(verifier, {
+						parentUserId: PARENT,
+						costCenter: COST_CENTER_OVER,
+						allocated: ENVELOPE_ALLOCATED,
+						periodStartMs,
+					});
+					expect(afterDestroy.balance).toBe(0);
+				} finally {
+					verifier.destroy();
+				}
+
+				// ── The gap is on the REAL chain, exactly once ──
+				const events = readLedgerEvents(join(vaultBase, VAULT_DIR));
+				const shortfalls = events.filter((e) => e.kind === "settlement_shortfall");
+				expect(shortfalls).toHaveLength(1);
+				expect(shortfalls[0]?.data).toMatchObject({
+					costCenter: COST_CENTER_OVER,
+					actual: ACTUAL_OVER,
+					posted: HOLD,
+					shortfall: ACTUAL_OVER - HOLD,
+				});
+				// A capped settle is a SETTLED one — nothing about it is ambiguous.
+				expect(events.filter((e) => e.kind === "settlement_ambiguous")).toHaveLength(0);
 			} finally {
 				tb.destroy();
 			}

--- a/packages/core/tests/integration/tigerbeetle.tb.test.ts
+++ b/packages/core/tests/integration/tigerbeetle.tb.test.ts
@@ -28,10 +28,12 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { readLedgerEvents } from "../../src/audit/read.js";
 import { trust } from "../../src/govern.js";
 import { estimateCost, estimateInputTokens } from "../../src/ledger/pricing.js";
 import { VAULT_DIR } from "../../src/shared/constants.js";
 import { InsufficientBalanceError, PolicyDeniedError } from "../../src/shared/errors.js";
+import type { TrustReceipt } from "../../src/shared/types.js";
 
 const TB_ADDRESS = process.env.USERTRUST_TB_ADDRESS;
 
@@ -56,6 +58,13 @@ const HOLD = estimateCost(MODEL, estimateInputTokens(MESSAGES), MAX_TOKENS);
 // settle permanently frees less than a full hold on the real ledger.
 const USAGE = { input_tokens: 100, output_tokens: 50 };
 const ACTUAL_COST = estimateCost(MODEL, USAGE.input_tokens, USAGE.output_tokens);
+
+// The mirror image: provider-reported usage → a SETTLED cost strictly ABOVE the
+// reserved hold. The input side of the estimate is a chars/4×1.5 heuristic, so
+// real usage can price above what was reserved. TigerBeetle REJECTS (never caps)
+// a post above its pending transfer, so the settle must be capped at the hold.
+const USAGE_OVER = { input_tokens: 5000, output_tokens: 1024 };
+const ACTUAL_OVER = estimateCost(MODEL, USAGE_OVER.input_tokens, USAGE_OVER.output_tokens);
 
 // ── Helpers ──
 
@@ -92,6 +101,11 @@ function okResponse(): Record<string, unknown> {
 		model: MODEL,
 		usage: { ...USAGE },
 	};
+}
+
+/** The same response, reporting the usage that prices ABOVE the reserved hold. */
+function overResponse(): Record<string, unknown> {
+	return { ...okResponse(), usage: { ...USAGE_OVER } };
 }
 
 const CALL = { model: MODEL, max_tokens: MAX_TOKENS, messages: MESSAGES } as const;
@@ -131,6 +145,54 @@ describe.skipIf(!TB_ADDRESS)("real TigerBeetle — two-phase hard-budget invaria
 		} finally {
 			await governed.destroy();
 		}
+	});
+
+	it("caps a settle above the reserved hold at the hold and audits the shortfall", async () => {
+		// The fixture's premise, asserted rather than assumed.
+		expect(ACTUAL_OVER).toBeGreaterThan(HOLD);
+
+		// The wallet is funded with EXACTLY one hold, so the capped post consumes the
+		// session wallet down to zero and there is no headroom an uncapped post could
+		// have hidden in.
+		const vaultBase = makeVault(HOLD);
+		const create = vi.fn(async () => overResponse());
+		const governed = await trust(anthropicClient(create), { vaultBase });
+		try {
+			const { receipt } = (await governed.messages.create({ ...CALL })) as {
+				receipt: TrustReceipt;
+			};
+
+			// Against a REAL cluster, `settled: true` IS the ledger assertion: TB rejects
+			// a post above its pending transfer (exceeds_pending_transfer_amount), so an
+			// uncapped settle of ACTUAL_OVER could only have come back settled:false with
+			// a `settlement_ambiguous` event. It committed, at `postedCost` — the exact
+			// held amount, no more (which would be impossible) and no less (which is what
+			// a void would have made of it).
+			expect(receipt.settled).toBe(true);
+			expect(receipt.usageSource).toBe("provider");
+			// The receipt keeps the TRUE metered cost; the ledger's number sits beside it.
+			expect(receipt.cost).toBe(ACTUAL_OVER);
+			expect(receipt.postedCost).toBe(HOLD);
+			expect(create).toHaveBeenCalledTimes(1);
+		} finally {
+			await governed.destroy();
+		}
+
+		// The gap is on the REAL chain — the persisted events.jsonl, not an injected
+		// writer — exactly once, and carrying both sides of the truncation.
+		const events = readLedgerEvents(join(vaultBase, VAULT_DIR));
+		const shortfalls = events.filter((e) => e.kind === "settlement_shortfall");
+		expect(shortfalls).toHaveLength(1);
+		expect(shortfalls[0]?.data).toMatchObject({
+			model: MODEL,
+			actual: ACTUAL_OVER,
+			posted: HOLD,
+			shortfall: ACTUAL_OVER - HOLD,
+		});
+		// An unattributed hold debits the session wallet, so no cost center is named.
+		expect(shortfalls[0]?.data).not.toHaveProperty("costCenter");
+		// A capped settle is a SETTLED one — nothing about it is ambiguous.
+		expect(events.filter((e) => e.kind === "settlement_ambiguous")).toHaveLength(0);
 	});
 
 	it("hard-refuses a sequential over-budget call pre-spend and keeps the real ledger consistent", async () => {

--- a/packages/core/tests/ledger/client.test.ts
+++ b/packages/core/tests/ledger/client.test.ts
@@ -54,13 +54,20 @@ vi.mock("tigerbeetle-node", () => ({
 		exceeds_credits: 22,
 		overflows_debits: 30,
 		overflows_debits_pending: 31,
+		// The real binding's value (spec D2): a post above the pending transfer's
+		// amount, which real TigerBeetle rejects rather than caps. Real TS numeric
+		// enums generate a reverse (value -> name) mapping too, which client.ts's
+		// error messages rely on (`CreateTransferStatus[res.status]`) — mirror it
+		// here so this plain mock object behaves the same way.
+		exceeds_pending_transfer_amount: 31,
+		31: "exceeds_pending_transfer_amount",
 		// The real binding's value — a transfer with this id already committed.
 		exists: 46,
 	},
 	amount_max: (1n << 128n) - 1n,
 }));
 
-import { AccountFlags, CreateAccountStatus } from "tigerbeetle-node";
+import { AccountFlags, CreateAccountStatus, CreateTransferStatus } from "tigerbeetle-node";
 import {
 	CODE_ESCROW,
 	CODE_PLATFORM_TREASURY,
@@ -600,6 +607,22 @@ describe("TrustTBClient", () => {
 		it("throws on failure", async () => {
 			mockCreateTransfers.mockResolvedValueOnce([{ status: 5 }]);
 			await expect(client.postTransfer(123n)).rejects.toThrow("Post transfer failed");
+		});
+
+		it("rejects a post above the pending amount with a code-carrying TBTransferError", async () => {
+			// Real TigerBeetle REJECTS (never caps) a post above the pending transfer's
+			// amount. The code must be structurally matchable so the engine layer can
+			// recover (spec D2) — a plain Error string is not.
+			mockCreateTransfers.mockResolvedValueOnce([
+				{ status: CreateTransferStatus.exceeds_pending_transfer_amount },
+			]);
+			const err = await client.postTransfer(123n, 84).catch((e: unknown) => e);
+			expect(err).toBeInstanceOf(TBTransferError);
+			expect((err as TBTransferError).code).toBe(
+				CreateTransferStatus.exceeds_pending_transfer_amount,
+			);
+			expect((err as TBTransferError).message).toContain("Post transfer failed:");
+			expect((err as TBTransferError).message).toContain("exceeds_pending_transfer_amount");
 		});
 
 		it("throws when error array element is undefined", async () => {

--- a/packages/core/tests/ledger/client.test.ts
+++ b/packages/core/tests/ledger/client.test.ts
@@ -51,9 +51,9 @@ vi.mock("tigerbeetle-node", () => ({
 	},
 	CreateTransferStatus: {
 		created: 4294967295,
-		exceeds_credits: 22,
-		overflows_debits: 30,
-		overflows_debits_pending: 31,
+		exceeds_credits: 54,
+		overflows_debits: 51,
+		overflows_debits_pending: 47,
 		// The real binding's value (spec D2): a post above the pending transfer's
 		// amount, which real TigerBeetle rejects rather than caps. Real TS numeric
 		// enums generate a reverse (value -> name) mapping too, which client.ts's

--- a/packages/core/tests/ledger/engine.test.ts
+++ b/packages/core/tests/ledger/engine.test.ts
@@ -24,6 +24,7 @@ vi.mock("tigerbeetle-node", () => ({
 		exceeds_credits: 22,
 		overflows_debits: 30,
 		overflows_debits_pending: 31,
+		exceeds_pending_transfer_amount: 31,
 	},
 	amount_max: (1n << 128n) - 1n,
 }));
@@ -42,8 +43,9 @@ vi.mock("node:fs", async (importOriginal) => {
 	};
 });
 
+import { CreateTransferStatus } from "tigerbeetle-node";
 import type { TrustTBClient } from "../../src/ledger/client.js";
-import { XFER_SPEND } from "../../src/ledger/client.js";
+import { TBTransferError, XFER_SPEND } from "../../src/ledger/client.js";
 import type { SpendAction } from "../../src/ledger/engine.js";
 import { TrustEngine } from "../../src/ledger/engine.js";
 import { InsufficientBalanceError } from "../../src/shared/errors.js";
@@ -541,6 +543,27 @@ describe("TrustEngine", () => {
 			// Actual cost was less
 			await engine.postPendingSpend(result.transferId, 80);
 			expect(mockTB.postTransfer).toHaveBeenCalledWith(42n, 80);
+		});
+
+		it("recovers an above-hold settle by re-posting the full pending amount, never voiding", async () => {
+			mockTB.createPendingTransfer.mockResolvedValueOnce(42n);
+			// First post (actual 200 > hold 105) → TB rejects with status 31.
+			mockTB.postTransfer.mockRejectedValueOnce(
+				new TBTransferError(
+					CreateTransferStatus.exceeds_pending_transfer_amount,
+					"Post transfer failed: exceeds_pending_transfer_amount",
+				),
+			);
+			// Recovery re-post (amount omitted → amount_max → full pending amount).
+			mockTB.postTransfer.mockResolvedValueOnce(101n);
+
+			const result = await engine.spendPending({ userId: "user_1", action: DEFAULT_ACTION });
+			await engine.postPendingSpend(result.transferId, 200);
+
+			expect(mockTB.postTransfer).toHaveBeenNthCalledWith(1, 42n, 200);
+			expect(mockTB.postTransfer).toHaveBeenNthCalledWith(2, 42n, undefined);
+			// The old behavior voided the hold (settling ZERO for a successful call).
+			expect(mockTB.voidTransfer).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/core/tests/ledger/engine.test.ts
+++ b/packages/core/tests/ledger/engine.test.ts
@@ -319,6 +319,72 @@ describe("TrustEngine", () => {
 			expect(mockTB.voidTransfer).toHaveBeenCalledWith(42n);
 		});
 
+		// ── Status-31 recovery: re-post the FULL pending amount ──
+		//
+		// TigerBeetle REJECTS (never caps) a post above the pending transfer. The
+		// LLM call already happened, so voiding would settle ZERO for real spend —
+		// the engine re-posts with the amount omitted, which posts the held amount.
+		// That recovery post is a network call like any other and can fail; when it
+		// does, the transfer is in exactly the same ambiguous state as a first-post
+		// failure and MUST route into the same void → DLQ handling.
+
+		it("recovers a status-31 rejection by re-posting the full pending amount", async () => {
+			mockTB.postTransfer.mockRejectedValueOnce(
+				new TBTransferError(
+					CreateTransferStatus.exceeds_pending_transfer_amount,
+					"exceeds pending transfer amount",
+				),
+			);
+			mockTB.postTransfer.mockResolvedValueOnce(100n);
+
+			await expect(engine.postPendingSpend("42", 5000)).resolves.toBeUndefined();
+
+			expect(mockTB.postTransfer).toHaveBeenNthCalledWith(1, 42n, 5000);
+			expect(mockTB.postTransfer).toHaveBeenNthCalledWith(2, 42n, undefined);
+			expect(mockTB.voidTransfer).not.toHaveBeenCalled();
+		});
+
+		it("voids and throws when the status-31 recovery re-post itself fails", async () => {
+			mockTB.postTransfer.mockRejectedValueOnce(
+				new TBTransferError(
+					CreateTransferStatus.exceeds_pending_transfer_amount,
+					"exceeds pending transfer amount",
+				),
+			);
+			mockTB.postTransfer.mockRejectedValueOnce(new Error("recovery post failed"));
+			mockTB.voidTransfer.mockResolvedValueOnce(101n);
+
+			// The recovery failure must NOT escape as its own raw error: that would
+			// skip the void attempt and leave the hold outstanding.
+			await expect(engine.postPendingSpend("42", 5000)).rejects.toThrow(
+				"Spend failed: pending transfer voided after post failure",
+			);
+			expect(mockTB.voidTransfer).toHaveBeenCalledWith(42n);
+		});
+
+		it("dead-letters when the status-31 recovery re-post AND the void both fail", async () => {
+			mockTB.postTransfer.mockRejectedValueOnce(
+				new TBTransferError(
+					CreateTransferStatus.exceeds_pending_transfer_amount,
+					"exceeds pending transfer amount",
+				),
+			);
+			mockTB.postTransfer.mockRejectedValueOnce(new Error("recovery post failed"));
+			mockTB.voidTransfer.mockRejectedValueOnce(new Error("void failed"));
+
+			await expect(engine.postPendingSpend("42", 5000)).rejects.toThrow(
+				"Spend settlement ambiguous",
+			);
+
+			const writtenData = mockWriteSync.mock.calls[0]?.[1] as string;
+			const dlqEntry = JSON.parse(writtenData.trim());
+			expect(dlqEntry.source).toBe("engine.postPendingSpend.ambiguous");
+			expect(dlqEntry.transferId).toBe("42");
+			// The DLQ carries the ORIGINAL requested amount — the one an operator
+			// needs to reconcile against, not the omitted recovery argument.
+			expect(dlqEntry.payload.actualAmount).toBe(5000);
+		});
+
 		it("writes to DLQ when both post and void fail", async () => {
 			mockTB.postTransfer.mockRejectedValueOnce(new Error("post failed"));
 			mockTB.voidTransfer.mockRejectedValueOnce(new Error("void failed"));

--- a/packages/core/tests/ledger/engine.test.ts
+++ b/packages/core/tests/ledger/engine.test.ts
@@ -23,7 +23,7 @@ vi.mock("tigerbeetle-node", () => ({
 		created: 4294967295,
 		exceeds_credits: 22,
 		overflows_debits: 30,
-		overflows_debits_pending: 31,
+		overflows_debits_pending: 47,
 		exceeds_pending_transfer_amount: 31,
 	},
 	amount_max: (1n << 128n) - 1n,
@@ -181,7 +181,7 @@ describe("TrustEngine", () => {
 
 		it("catches TB overflows_debits_pending error and wraps it", async () => {
 			const tbErr = new Error("Pending transfer failed: overflows_debits_pending");
-			Object.assign(tbErr, { name: "TBTransferError", code: 31 });
+			Object.assign(tbErr, { name: "TBTransferError", code: 47 });
 			mockTB.createPendingTransfer.mockRejectedValueOnce(tbErr);
 			mockTB.lookupBalance.mockResolvedValueOnce({
 				available: 0,

--- a/packages/core/tests/policy/budget-tier.test.ts
+++ b/packages/core/tests/policy/budget-tier.test.ts
@@ -43,7 +43,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withCostCenter } from "../../src/budget/attribution.js";
 import { trust } from "../../src/govern.js";
 import { createGovernor } from "../../src/headless.js";
-import { evaluatePolicy, type GateRule, type PolicyContext } from "../../src/policy/gate.js";
+import {
+	derivePolicyHint,
+	evaluatePolicy,
+	type GateRule,
+	type PolicyContext,
+} from "../../src/policy/gate.js";
 import type { PolicyEnforcement } from "../../src/shared/types.js";
 
 // tigerbeetle-node is a native module and is never loaded in tests.
@@ -652,5 +657,44 @@ describe("an envelope-scoped tier fires on an attributed call", () => {
 		expect(client.messages.create).toHaveBeenCalledTimes(1);
 
 		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Class-aware denial hints (D6)
+// ---------------------------------------------------------------------------
+
+describe("class-aware denial hints (D6)", () => {
+	it("a budget-tier denial derives the budget remedy hint", () => {
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0.1,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.decision).toBe("deny");
+		expect(derivePolicyHint(result)).toContain("allocateBudget");
+	});
+
+	it("a non-budget denial derives no override (falls back to the default hint)", () => {
+		const rule: GateRule = {
+			id: "no-frontier",
+			name: "no-frontier",
+			effect: "deny",
+			enforcement: "hard",
+			conditions: [{ field: "model", operator: "eq", value: "claude-opus-4-6" }],
+		};
+		const result = evaluatePolicy([rule], { model: "claude-opus-4-6" });
+
+		expect(result.decision).toBe("deny");
+		expect(derivePolicyHint(result)).toBeUndefined();
+	});
+
+	it("RuleMatch carries the violated rule's condition fields", () => {
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0.1,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.hardViolations[0]?.fields).toContain("budgetFractionRemaining");
 	});
 });

--- a/packages/core/tests/policy/budget-tier.test.ts
+++ b/packages/core/tests/policy/budget-tier.test.ts
@@ -43,6 +43,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withCostCenter } from "../../src/budget/attribution.js";
 import { trust } from "../../src/govern.js";
 import { createGovernor } from "../../src/headless.js";
+import { DEFAULT_RULES } from "../../src/policy/default-rules.js";
 import {
 	derivePolicyHint,
 	evaluatePolicy,
@@ -696,5 +697,23 @@ describe("class-aware denial hints (D6)", () => {
 		});
 
 		expect(result.hardViolations[0]?.fields).toContain("budgetFractionRemaining");
+	});
+
+	it("a rule without a description renders its identifier once, not twice", () => {
+		const rule = {
+			id: "scarcity-brake",
+			name: "scarcity-brake",
+			effect: "deny",
+			enforcement: "hard",
+			conditions: [{ field: "budgetFractionRemaining", operator: "lt", value: 0.3 }],
+		} as const;
+		const result = evaluatePolicy([rule], { budgetFractionRemaining: 0.1 });
+		expect(result.reasons[0]).toBe("[scarcity-brake]"); // was "[scarcity-brake] scarcity-brake"
+	});
+
+	it("a rule with a description keeps the full label + rationale", () => {
+		// DEFAULT_RULES all carry descriptions — pin one stays unchanged.
+		const result = evaluatePolicy(DEFAULT_RULES, { budget_remaining_after: -1 });
+		expect(result.reasons[0]).toMatch(/^\[block-budget-overshoot\] Deny pre-spend/);
 	});
 });

--- a/packages/core/tests/policy/budget-tier.test.ts
+++ b/packages/core/tests/policy/budget-tier.test.ts
@@ -659,6 +659,126 @@ describe("an envelope-scoped tier fires on an attributed call", () => {
 
 		await governed.destroy();
 	});
+
+	it("an ATTRIBUTED denial's hint prescribes the envelope lever that can actually move it", async () => {
+		const engine = makeEnvelopeEngine(2_000);
+		const governed = await trust(makeAnthropicMock(), {
+			vaultBase,
+			parentUserId: ENVELOPE_PARENT,
+			_engine: engine,
+		});
+
+		const err = await budgetDenialFrom(() =>
+			withCostCenter(
+				ENVELOPE_COST_CENTER,
+				() => governed.messages.create(FRONTIER_CALL),
+				ENVELOPE_SCOPE,
+			),
+		);
+
+		// This hold WOULD have debited the envelope, so funding the envelope is a
+		// remedy that exists.
+		expect(err.hint).toContain("allocateBudget");
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Denial-hint ATTRIBUTION: the remedy must match the wallet that was gated
+// ---------------------------------------------------------------------------
+
+/**
+ * An UNATTRIBUTED call places its hold on the SESSION holding wallet — no
+ * envelope exists for `allocateBudget` to fund, so the envelope remedy is not
+ * merely unhelpful, it is unreachable. These pin that all three gate call sites
+ * pass their own local truth about whether an envelope is in scope.
+ *
+ * The rule under test here is the platform default `block-budget-overshoot`
+ * (`budget_remaining_after lt 0`), which is BUDGET-classed and, unlike the tier
+ * rules above, needs no envelope to fire — exactly the unattributed case.
+ */
+const SESSION_HINT =
+	"A budget rule denied this call: increase the budget in trust() options or reduce the call's max_tokens, and review your budget_remaining / budget_remaining_after tiers.";
+
+/** Run `fn`, require a PolicyDeniedError, and return it. */
+async function budgetDenialFrom(fn: () => Promise<unknown>): Promise<{ hint: string }> {
+	try {
+		await fn();
+	} catch (err) {
+		return err as { hint: string };
+	}
+	throw new Error("expected a budget denial, but the call resolved");
+}
+
+describe("budget denial hints follow the wallet that was gated", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `budget-hint-${randomUUID()}`);
+		mkdirSync(join(vaultBase, ".usertrust"), { recursive: true });
+		// No policies file: the platform DEFAULT_RULES always apply, and
+		// `block-budget-overshoot` is the one that fires on a starved session.
+		writeFileSync(
+			join(vaultBase, ".usertrust", "usertrust.config.json"),
+			JSON.stringify({ budget: 1 }),
+		);
+		vi.mocked(evaluatePolicy).mockClear();
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+	});
+
+	it("trust() LLM path: an unattributed overshoot names the session lever", async () => {
+		const governed = await trust(makeAnthropicMock(), { dryRun: true, vaultBase });
+
+		const err = await budgetDenialFrom(() => governed.messages.create(FRONTIER_CALL));
+
+		expect(err.hint).toBe(SESSION_HINT);
+		expect(err.hint).not.toContain("allocateBudget");
+
+		await governed.destroy();
+	});
+
+	it("governAction path: an unattributed overshoot names the session lever", async () => {
+		const governed = await trust(makeAnthropicMock(), { dryRun: true, vaultBase });
+		const execute = vi.fn(async () => "executed");
+
+		const err = await budgetDenialFrom(() =>
+			governed.governAction(
+				{ kind: "tool_use", name: "expensive_tool", cost: 5_000, params: {} },
+				execute,
+			),
+		);
+
+		expect(err.hint).toBe(SESSION_HINT);
+		expect(err.hint).not.toContain("allocateBudget");
+		expect(execute).not.toHaveBeenCalled();
+
+		await governed.destroy();
+	});
+
+	it("headless authorize: an unattributed overshoot names the session lever", async () => {
+		const gov = await createGovernor({ dryRun: true, vaultBase });
+
+		const err = await budgetDenialFrom(() =>
+			gov.authorize({
+				model: "claude-opus-4-6",
+				estimatedInputTokens: 5_000,
+				maxOutputTokens: 5_000,
+			}),
+		);
+
+		expect(err.hint).toBe(SESSION_HINT);
+		expect(err.hint).not.toContain("allocateBudget");
+
+		await gov.destroy();
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -666,17 +786,33 @@ describe("an envelope-scoped tier fires on an attributed call", () => {
 // ---------------------------------------------------------------------------
 
 describe("class-aware denial hints (D6)", () => {
-	it("a budget-tier denial derives the budget remedy hint", () => {
+	it("an ATTRIBUTED budget-tier denial derives the envelope remedy hint", () => {
 		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
 			budgetFractionRemaining: 0.1,
 			model: "claude-opus-4-6",
 		});
 
 		expect(result.decision).toBe("deny");
-		expect(derivePolicyHint(result)).toContain("allocateBudget");
+		expect(derivePolicyHint(result, true)).toContain("allocateBudget");
 	});
 
-	it("a non-budget denial derives no override (falls back to the default hint)", () => {
+	// An unattributed call has no envelope: its hold debits the SESSION holding
+	// wallet, which `allocateBudget` cannot fund. Prescribing envelope funding
+	// there sends the operator to a lever that provably cannot move this denial.
+	it("an UNATTRIBUTED budget denial prescribes the session lever, not allocateBudget", () => {
+		const result = evaluatePolicy([DENY_FRONTIER_BELOW_30], {
+			budgetFractionRemaining: 0.1,
+			model: "claude-opus-4-6",
+		});
+
+		expect(result.decision).toBe("deny");
+		expect(derivePolicyHint(result, false)).toBe(
+			"A budget rule denied this call: increase the budget in trust() options or reduce the call's max_tokens, and review your budget_remaining / budget_remaining_after tiers.",
+		);
+		expect(derivePolicyHint(result, false)).not.toContain("allocateBudget");
+	});
+
+	it("a non-budget denial derives no override on either branch", () => {
 		const rule: GateRule = {
 			id: "no-frontier",
 			name: "no-frontier",
@@ -687,7 +823,8 @@ describe("class-aware denial hints (D6)", () => {
 		const result = evaluatePolicy([rule], { model: "claude-opus-4-6" });
 
 		expect(result.decision).toBe("deny");
-		expect(derivePolicyHint(result)).toBeUndefined();
+		expect(derivePolicyHint(result, true)).toBeUndefined();
+		expect(derivePolicyHint(result, false)).toBeUndefined();
 	});
 
 	it("RuleMatch carries the violated rule's condition fields", () => {

--- a/packages/core/tests/shared/errors.test.ts
+++ b/packages/core/tests/shared/errors.test.ts
@@ -32,12 +32,21 @@ describe("domain errors", () => {
 		expect(err.name).toBe("PolicyDeniedError");
 		expect(err).toBeInstanceOf(Error);
 		expect(err.hint).toBe(
-			'Check your policy rules in .usertrust/policies/ or use { pii: "warn" } to downgrade PII enforcement.',
+			'Check your policy rules in .usertrust/policies/default.yml or use { pii: "warn" } to downgrade PII enforcement.',
 		);
 		expect(err.docsUrl).toBe("https://usertrust.ai/docs/errors/policy-denied");
 		expect(err.message).toContain("Policy denied: blocked by rule X");
 		expect(err.message).toContain("\n\n  Hint: ");
 		expect(err.message).toContain("\n  Docs: https://usertrust.ai/docs/errors/policy-denied");
+	});
+
+	it("PolicyDeniedError hint is overridable per denial class", () => {
+		// Mirrors InsufficientBalanceError's hintOverride (errors.ts): the static
+		// hint gives PII advice on budget denials, which is wrong for that class.
+		const err = new PolicyDeniedError("[budget-tier] low runway", "Fund it: allocateBudget(...)");
+		expect(err.hint).toBe("Fund it: allocateBudget(...)");
+		expect(err.message).toContain("\n\n  Hint: Fund it: allocateBudget(...)");
+		expect(err.reason).toBe("[budget-tier] low runway");
 	});
 
 	it("AccountNotFoundError has userId", () => {


### PR DESCRIPTION
## Summary
Closes the settle-above-hold defect gating v3.1.0: TigerBeetle rejects (never caps) a post above
the pending amount; the previous behavior stranded the hold and charged the wallet ZERO for a
successful call while receipt and chain recorded the full cost.

- Both parity-locked TB engine factories cap the post at the reserved amount and return
  `{posted, shortfall}`; `ledger/engine.ts` recovers reactively via `amount_max` re-post.
- New `settlement_shortfall` audit event + `receipt.postedCost`; `receipt.cost` stays true actual.
- Seam mock now models real TigerBeetle (status-31 rejection; corrected status codes).
- Real-TB integration tests settle ABOVE the hold for both envelope and session wallets.
- Class-aware `PolicyDeniedError` hints (budget remedy for budget rules; hintOverride mirrors
  InsufficientBalanceError); description-less rules no longer render their id twice.
- AGENTS.md Money invariant replaces the unenforced "(≤ reserved)" claim; CHANGELOG gains the
  v3.1.0 envelope surface.

## Test plan
TDD throughout (see branch history). Locally proven before this PR: full suite green, real-TB
integration 7/7 against a live TigerBeetle 0.17.9, coverage 93.36/86.15/95.34/94.85 over the
92/84/90/92 CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)