### PR TITLE
feat(openclaw): tool→envelope attribution + per-turn scarcity injection (Ship 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,13 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      # `npm run typecheck` = `tsc -b` + `tsc -p packages/core/tsconfig.type-tests.json`
-      # so the F5 TrustedClient type-surface guard (trusted-client-types.test-d.ts)
-      # actually gates CI — a bare `tsc -b` never compiles the .test-d.ts.
+      # `npm run typecheck` = `tsc -b` + the two type-test projects
+      # (packages/core, packages/openclaw), because a bare `tsc -b` never compiles
+      # a .test-d.ts. That is what makes the F5 TrustedClient type-surface guard
+      # (trusted-client-types.test-d.ts) and the pi-ai half of the openclaw host
+      # contract (packages/openclaw/tests/contract.test-d.ts) gate every push. The
+      # openclaw half of that contract needs a package `npm ci` does not install;
+      # it is proven in the `openclaw-contract` job instead.
       - run: npm run typecheck
 
   test:
@@ -73,6 +77,68 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 14
+
+  openclaw-contract:
+    name: openclaw-contract
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    # The proving ground for the openclaw half of the host contract.
+    #
+    # openclaw is NOT a dependency of this repo. It is declared as an OPTIONAL
+    # PEER of packages/openclaw (the plugin's real relationship to its host), and
+    # `npm ci` does not install optional peers — so no other job in this workflow
+    # has openclaw on disk, and none of them can prove anything about it. This
+    # job installs the pinned version out-of-tree and runs the two gates that
+    # need it. A failure here is a real contract drift, so it fails the workflow.
+    #
+    # The pin lives in exactly one file, sourced below. Never inline the version.
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Install the pinned openclaw host (out-of-tree)
+        # --no-save: this install is a test fixture, not a dependency. Verified
+        # locally from a clean `npm ci` tree: package.json, packages/*/package.json
+        # and package-lock.json all come out BYTE-IDENTICAL, which the next step
+        # re-checks rather than trusting.
+        # --ignore-scripts: openclaw's tree carries native postinstalls (node-pty
+        # and friends) that this job never executes; only its .d.ts files matter.
+        #
+        # NOT `--package-lock=false`. That flag makes arborist rebuild the ideal
+        # tree from scratch instead of the lockfile, and npm 10.9.2 then crashes
+        # resolving this repo's peer sets:
+        #   TypeError: Cannot read properties of null (reading 'edgesOut')
+        #     at #loadPeerSet (@npmcli/arborist/lib/arborist/build-ideal-tree.js)
+        # It is a deterministic arborist bug, not an environment quirk — it
+        # reproduces on a tree straight out of `npm ci`. `--no-save` alone achieves
+        # what the flag was there for.
+        run: |
+          source packages/openclaw/openclaw-contract.env
+          npm install --no-save --ignore-scripts openclaw@"$OPENCLAW_CONTRACT_VERSION"
+      - name: Assert the fixture install left no tracked file behind
+        # The whole point of an out-of-tree install: if this ever starts rewriting
+        # package-lock.json, the pin has silently become a dependency again and
+        # this job must say so instead of passing.
+        run: git diff --exit-code -- package.json package-lock.json 'packages/*/package.json'
+      - name: Type-level contract vs. the pinned host
+        # tsconfig.contract-openclaw.json, not tsconfig.type-tests.json: `tsc` has
+        # no way to skip a file whose import cannot resolve, so the openclaw
+        # assertions live in their own project and their own .test-d.ts. The pi-ai
+        # half stays in tsconfig.type-tests.json, which `npm run typecheck` runs on
+        # every push. Between the two, every assertion runs somewhere in CI.
+        env:
+          USERTRUST_OPENCLAW_CONTRACT: "1"
+        run: npx tsc -p packages/openclaw/tsconfig.contract-openclaw.json
+      - name: Host smoke test vs. the pinned host
+        # USERTRUST_OPENCLAW_CONTRACT=1 makes an absent or version-mismatched
+        # openclaw a HARD failure in contract.test.ts. Without it the suite skips
+        # itself, which is right everywhere else and worthless here.
+        env:
+          USERTRUST_OPENCLAW_CONTRACT: "1"
+        run: npx vitest run packages/openclaw/tests/contract.test.ts
 
   tb-integration:
     name: tb-integration
@@ -132,9 +198,20 @@ jobs:
           echo "::error::TigerBeetle did not start within 60s"
           cat tigerbeetle.log || true
           exit 1
-      - name: Run TigerBeetle integration test
+      - name: Run TigerBeetle integration tests
         env:
-          # The gated test writes this into tigerbeetle.addresses; "3000" resolves to
+          # The gated tests write this into tigerbeetle.addresses; "3000" resolves to
           # 127.0.0.1:3000, matching the server's --addresses=3000 bind above.
           USERTRUST_TB_ADDRESS: "3000"
-        run: npx vitest run packages/core/tests/integration/tigerbeetle.tb.test.ts
+        # Every real-cluster suite in the repo, named explicitly rather than by
+        # directory: `packages/openclaw/tests/envelope-integration.test.ts` does not
+        # live under any integration/ folder, and a glob over
+        # `packages/core/tests/integration/` would have silently kept missing it and
+        # `budget-envelope.tb.test.ts`. Each one self-skips when USERTRUST_TB_ADDRESS
+        # is unset, which is why the ordinary `test` job never runs them — this job
+        # is the only place a hard-budget or envelope-accounting failure can surface.
+        run: >-
+          npx vitest run
+          packages/core/tests/integration/tigerbeetle.tb.test.ts
+          packages/core/tests/integration/budget-envelope.tb.test.ts
+          packages/openclaw/tests/envelope-integration.test.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,22 @@ jobs:
         # package-lock.json, the pin has silently become a dependency again and
         # this job must say so instead of passing.
         run: git diff --exit-code -- package.json package-lock.json 'packages/*/package.json'
+      - name: Build packages/core declarations
+        # `usertrust` is a workspace symlink to packages/core, whose package.json
+        # points `types` at dist/index.d.ts — a file that does not exist on a fresh
+        # runner (dist/ is gitignored). The contract project imports `usertrust`
+        # through src/types.ts and src/index.ts, and `tsc -p` — unlike `tsc -b` —
+        # does NOT build referenced projects, so without this step the next step
+        # fails with `TS2307: Cannot find module 'usertrust'`. That is exactly how
+        # this job failed on its first real run (#82, job 93028801034).
+        #
+        # `tsc -b packages/core` is the same idiom the `typecheck` job gets for free
+        # (`npm run typecheck` = `tsc -b && …`, where the leading `tsc -b` is what
+        # makes tsconfig.type-tests.json resolve `usertrust` at all), scoped to the
+        # one project the contract needs. The `test` job needs no equivalent:
+        # vitest.config.ts aliases `usertrust` to packages/core/src, which is why
+        # the vitest step below is unaffected.
+        run: npx tsc -b packages/core
       - name: Type-level contract vs. the pinned host
         # tsconfig.contract-openclaw.json, not tsconfig.type-tests.json: `tsc` has
         # no way to skip a file whose import cannot resolve, so the openclaw

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,6 +375,20 @@ and `remaining` stays honest while `spent`, `fraction` and `runwayHours` silentl
 stream handle, or a post-settle read that did not answer. That read failing is deliberately silent:
 a receipt is a report, and degrading a report must never unwind or re-decide committed money.
 
+**The `withCostCenter` scope itself stays operator-authored even where the `cc` string is
+selected by agent activity.** `packages/openclaw`'s `deriveAttribution` (`src/attribution.ts`)
+picks *which* operator-declared cost center a call's `withCostCenter` scope opens by reading the
+trailing, correlated, non-error tool-result run out of the caller-supplied context — never from
+message text — but the only strings it can ever return are values already present in the
+plugin's frozen `tools`/`default` config, both validated at construction through this same
+`withCostCenter` door (§ above) before any call runs. The scope-opens-from-code-structure
+invariant is intact: what changed is that the code choosing the argument now reads agent
+activity instead of being hardcoded, and that choice is bounded to envelopes the operator
+explicitly delegated. Full security-model treatment — the bounded-delegation argument, the
+plugin-vs-programmatic evidence-trust boundary, and the documented residual — lives in
+`packages/openclaw/README.md`'s "Security model" section (verbatim from the ship's design spec),
+not duplicated here.
+
 **1 usertoken = $0.0001 USD, everywhere.** All pricing rates are usertokens per 1,000 LLM tokens.
 This constant is duplicated in `packages/verify` on purpose.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -978,9 +978,22 @@ Real, verified, and worth knowing before you touch the surrounding code.
   means an agent that never opens a scope still reads as `spent: 0` while it burns the session
   budget. That residue is an INSTRUMENTATION gap, not an enforcement one: the session wallet's own
   `debits_must_not_exceed_credits` bounds that spend either way.
-- **`packages/openclaw` is not typechecked by CI.** It is absent from the root `tsconfig.json`
-  references and is not `composite`, so neither `tsc -b` nor `npm run typecheck` covers it. Type
-  errors there surface only at release time.
+- **`packages/openclaw/src` is still not typechecked by CI.** The package is absent from the root
+  `tsconfig.json` references and is not `composite`, so `tsc -b` does not cover it. What *is*
+  covered: `npm run typecheck` now also runs `tsc -p packages/openclaw/tsconfig.type-tests.json`,
+  which compiles the host-contract type assertions and, through them, `src/types.ts`. Errors
+  anywhere else under `src/` still surface only at release time (`cd packages/openclaw && npx tsc`).
+- **The openclaw host contract is split across two CI jobs, because openclaw is not installed.**
+  `openclaw` is an OPTIONAL PEER of `packages/openclaw`, never a devDependency, and `npm ci` does
+  not install optional peers — so no ordinary job has it on disk. The pi-ai half of the contract
+  (`tests/contract.test-d.ts`) compiles in `typecheck` on every push. The openclaw half
+  (`tests/contract-openclaw.test-d.ts` + the `contract.test.ts` host smoke) runs only in the
+  required `openclaw-contract` job, which installs the pinned version out-of-tree and sets
+  `USERTRUST_OPENCLAW_CONTRACT=1` — the flag that turns an absent or mismatched openclaw from a
+  loud skip into a hard failure. **The pin lives in exactly one file,
+  `packages/openclaw/openclaw-contract.env`; never inline the version anywhere else.** The split is
+  two tsconfigs rather than one conditional include because `tsc` cannot skip a file whose import
+  does not resolve.
 - **`site/` is not typechecked or built by CI** — only linted. Its `tsconfig.json` is standalone and
   has neither `noUncheckedIndexedAccess` nor `exactOptionalPropertyTypes`.
   **A green CI run says nothing about whether the site builds.** `site/` is not a workspace and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `estimated_cost`) now surfaces a budget-specific remedy pointing at
   `allocateBudget` and the fraction/runway tiers (`derivePolicyHint`), instead
   of the rule's generic description.
+- **`usertrust-openclaw`: operator-declared tool→envelope attribution and
+  per-turn scarcity injection.** A new `costCenters` plugin config
+  (`parentUserId`, `tools`, `default`, `envelopes`, `scarcityContext`) routes
+  each governed call's spend to a named, operator-capped budget envelope,
+  selected STATELESSLY per call from the caller-supplied context's trailing,
+  correlated, non-error tool-result run (`deriveAttribution`,
+  `src/attribution.ts`) — structured-field matching only, never message text.
+  Validated once at plugin construction through core's own
+  `parentUserIdRefusal` and `withCostCenter` doors, normalized into a
+  deep-frozen config every wrapper reads. When enabled, a
+  `[usertrust scarcity] research: 34% left (~2.1h runway) · …` block is
+  appended to each call's system prompt from a live batched read of the
+  configured envelopes (`Governor.budgetContext`, core), on a copy of the
+  caller's context — never gating, delaying, or throwing into the money path
+  on a read failure. Fixes a pre-existing money bug in the same pass: the
+  stream wrapper now guarantees exactly one settle/abort on every terminal
+  mode (completion, thrown error, error event, consumer break/return,
+  close-without-`done`), where it previously leaked the PENDING hold on an
+  early consumer `break`. See `packages/openclaw/README.md` for the full
+  attribution rule and the security-model carve-out.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
 			"version": "3.977.6",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
 			"integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.974.2",
@@ -89,7 +89,7 @@
 			"version": "3.972.67",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
 			"integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -106,7 +106,7 @@
 			"version": "3.972.69",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
 			"integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -125,7 +125,7 @@
 			"version": "3.973.12",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
 			"integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -150,7 +150,7 @@
 			"version": "3.972.74",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
 			"integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -168,7 +168,7 @@
 			"version": "3.972.78",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
 			"integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "^3.972.67",
@@ -191,7 +191,7 @@
 			"version": "3.972.67",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
 			"integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -208,7 +208,7 @@
 			"version": "3.973.11",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
 			"integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -227,7 +227,7 @@
 			"version": "3.1103.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
 			"integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -245,7 +245,7 @@
 			"version": "3.972.73",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
 			"integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -314,7 +314,7 @@
 			"version": "3.997.41",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
 			"integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.977.6",
@@ -334,7 +334,7 @@
 			"version": "3.996.43",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
 			"integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.974.2",
@@ -368,7 +368,7 @@
 			"version": "3.974.2",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
 			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.16.1",
@@ -382,7 +382,7 @@
 			"version": "3.972.37",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
 			"integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.16.1",
@@ -396,7 +396,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
 			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=18.0.0"
@@ -1655,7 +1655,7 @@
 			"version": "3.31.1",
 			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
 			"integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.16.1",
@@ -1669,7 +1669,7 @@
 			"version": "4.4.16",
 			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
 			"integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.31.1",
@@ -1684,7 +1684,7 @@
 			"version": "5.6.13",
 			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
 			"integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.31.1",
@@ -1699,7 +1699,7 @@
 			"version": "4.9.13",
 			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
 			"integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.31.1",
@@ -1714,7 +1714,7 @@
 			"version": "5.6.12",
 			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
 			"integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.31.1",
@@ -1729,7 +1729,7 @@
 			"version": "4.16.1",
 			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
 			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -2712,7 +2712,7 @@
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
 			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
@@ -3977,10 +3977,11 @@
 			"version": "2026.7.1-2",
 			"resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1-2.tgz",
 			"integrity": "sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==",
-			"dev": true,
 			"hasInstallScript": true,
 			"hasShrinkwrap": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@agentclientprotocol/sdk": "1.1.0",
 				"@anthropic-ai/sdk": "0.109.1",
@@ -4053,8 +4054,9 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.1.0.tgz",
 			"integrity": "sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"peerDependencies": {
 				"zod": "^3.25.0 || ^4.0.0"
 			}
@@ -4063,8 +4065,9 @@
 			"version": "0.109.1",
 			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.1.tgz",
 			"integrity": "sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"json-schema-to-ts": "^3.1.1",
 				"standardwebhooks": "^1.0.0"
@@ -4085,8 +4088,9 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
 			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -4095,8 +4099,9 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
 			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Borewit"
@@ -4106,8 +4111,9 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
 			"integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fast-wrap-ansi": "^0.2.0",
 				"sisteransi": "^1.0.5"
@@ -4120,8 +4126,9 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
 			"integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@clack/core": "1.4.2",
 				"fast-string-width": "^3.0.2",
@@ -4136,8 +4143,9 @@
 			"version": "0.80.3",
 			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
 			"integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"get-east-asian-width": "1.6.0",
 				"marked": "18.0.5"
@@ -4150,9 +4158,10 @@
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.10.0.tgz",
 			"integrity": "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"google-auth-library": "^10.3.0",
 				"p-retry": "^4.6.2",
@@ -4175,8 +4184,9 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
 			"integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"abort-controller": "^3.0.0"
 			},
@@ -4191,8 +4201,9 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
 			"integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"bottleneck": "^2.0.0"
 			},
@@ -4207,15 +4218,17 @@
 			"version": "3.28.0",
 			"resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.28.0.tgz",
 			"integrity": "sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@homebridge/ciao": {
 			"version": "1.3.9",
 			"resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.9.tgz",
 			"integrity": "sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.3",
 				"fast-deep-equal": "^3.1.3",
@@ -4230,8 +4243,9 @@
 			"version": "1.19.14",
 			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
 			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18.14.1"
 			},
@@ -4243,8 +4257,9 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
 			"integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"minipass": "^7.0.4"
 			},
@@ -4256,8 +4271,9 @@
 			"version": "1.2.0-beta.12",
 			"resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.12.tgz",
 			"integrity": "sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"optionalDependencies": {
 				"@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
 				"@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
@@ -4274,12 +4290,12 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@lydell/node-pty-darwin-x64": {
 			"version": "1.2.0-beta.12",
@@ -4288,12 +4304,12 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@lydell/node-pty-linux-arm64": {
 			"version": "1.2.0-beta.12",
@@ -4302,12 +4318,12 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@lydell/node-pty-linux-x64": {
 			"version": "1.2.0-beta.12",
@@ -4316,12 +4332,12 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@lydell/node-pty-win32-arm64": {
 			"version": "1.2.0-beta.12",
@@ -4330,12 +4346,12 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@lydell/node-pty-win32-x64": {
 			"version": "1.2.0-beta.12",
@@ -4344,19 +4360,20 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@mistralai/mistralai": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.4.0.tgz",
 			"integrity": "sha512-t6hCx242MTGolB76CI+17jDtPIe/bzLsMdUTMMoMn9Qo1h02N2G5jQYHmKDGU3X//OgR2wvngTD7tO6tPp5poQ==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.40.0",
 				"ws": "^8.18.0",
@@ -4376,8 +4393,9 @@
 			"version": "1.29.0",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
 			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@hono/node-server": "^1.19.9",
 				"ajv": "^8.17.1",
@@ -4417,8 +4435,9 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
 			"integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=14.0.0"
 			}
@@ -4427,8 +4446,9 @@
 			"version": "2026.7.1-2",
 			"resolved": "https://registry.npmjs.org/@openclaw/ai/-/ai-2026.7.1-2.tgz",
 			"integrity": "sha512-st+NH0cxlQqdbEur//yYqM7WlYBjeEBnop3cztJTSCONKjv6LNoGguI9cH65asZG94FdM/39z857isRGPnZvEw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@anthropic-ai/sdk": "0.109.1",
 				"@google/genai": "2.10.0",
@@ -4445,8 +4465,9 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.4.1.tgz",
 			"integrity": "sha512-hQi+BxO10KdRFlYUot1syC+hTaUnGeQNdqX5kwkKJig8CFq1tKsYJLPm+zkiiGsSKOprPAquQl/txejEhpKPgg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=22"
 			},
@@ -4459,8 +4480,9 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@openclaw/proxyline/-/proxyline-0.3.3.tgz",
 			"integrity": "sha512-sftHnW69NHQqLjCxBTvQ8f/eQl+peZ5pHCBQtuTWBbeuYRHZ0/GXVTmw/O/YKsShMbqPWhJB0UYtPPdvCUSS8w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=22.19.0"
 			},
@@ -4472,8 +4494,9 @@
 			"version": "1.41.1",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
 			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -4482,36 +4505,41 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
 			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/base64": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
 			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/codegen": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
 			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/eventemitter": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
 			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/fetch": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
 			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
-			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.1"
 			}
@@ -4520,57 +4548,65 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
 			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/inquire": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
 			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/path": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
 			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/pool": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
 			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@protobufjs/utf8": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
 			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@silvia-odwyer/photon-node": {
 			"version": "0.3.4",
 			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
 			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
-			"dev": true,
-			"license": "Apache-2.0"
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@stablelib/base64": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
 			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
 			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.3",
 				"token-types": "^6.1.1"
@@ -4587,15 +4623,17 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/@types/node": {
 			"version": "26.1.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
 			"integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~8.3.0"
 			}
@@ -4604,15 +4642,17 @@
 			"version": "0.12.5",
 			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
 			"integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/abort-controller": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
 			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"event-target-shim": "^5.0.0"
 			},
@@ -4624,8 +4664,9 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
 			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
@@ -4638,8 +4679,9 @@
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
 			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 14"
 			}
@@ -4648,8 +4690,9 @@
 			"version": "8.20.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
 			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -4665,8 +4708,9 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
 			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -4683,8 +4727,9 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -4693,8 +4738,9 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1"
 			},
@@ -4709,8 +4755,9 @@
 			"version": "5.4.1",
 			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
 			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
@@ -4722,8 +4769,9 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "18 || 20 || >=22"
 			}
@@ -4732,7 +4780,6 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4747,14 +4794,17 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/bignumber.js": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
 			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "*"
 			}
@@ -4763,15 +4813,17 @@
 			"version": "4.12.4",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
 			"integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/body-parser": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
 			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"bytes": "^3.1.2",
 				"content-type": "^2.0.0",
@@ -4795,8 +4847,9 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
 			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -4809,22 +4862,25 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/bottleneck": {
 			"version": "2.19.5",
 			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
 			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/brace-expansion": {
 			"version": "5.0.7",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
 			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
@@ -4836,22 +4892,25 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/buffer-from": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -4860,8 +4919,9 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2"
@@ -4874,8 +4934,9 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -4891,8 +4952,9 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -4901,8 +4963,9 @@
 			"version": "5.6.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
 			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
 			},
@@ -4914,8 +4977,9 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
 			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"readdirp": "^5.0.0"
 			},
@@ -4930,8 +4994,9 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
 			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4940,8 +5005,9 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/clawpdf/-/clawpdf-0.3.0.tgz",
 			"integrity": "sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"clawpdf": "dist/cli.js"
 			},
@@ -4953,8 +5019,9 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -4968,8 +5035,9 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"color-name": "~1.1.4"
 			},
@@ -4981,15 +5049,17 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/commander": {
 			"version": "15.0.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
 			"integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=22.12.0"
 			}
@@ -4998,8 +5068,9 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
 			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -5012,8 +5083,9 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
 			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5022,8 +5094,9 @@
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
 			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5032,8 +5105,9 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
 			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.6.0"
 			}
@@ -5042,15 +5116,17 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/cors": {
 			"version": "2.8.6",
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
 			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"object-assign": "^4",
 				"vary": "^1"
@@ -5067,7 +5143,6 @@
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
 			"integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "other",
@@ -5079,6 +5154,8 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18.0"
 			}
@@ -5087,8 +5164,9 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
@@ -5102,8 +5180,9 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
 			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"boolbase": "^1.0.0",
 				"css-what": "^6.1.0",
@@ -5119,8 +5198,9 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
 			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 6"
 			},
@@ -5132,15 +5212,17 @@
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
 			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/data-uri-to-buffer": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
 			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 12"
 			}
@@ -5149,8 +5231,9 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -5167,8 +5250,9 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5177,8 +5261,9 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
 			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -5187,8 +5272,9 @@
 			"version": "9.0.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
 			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
-			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -5197,15 +5283,17 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
 			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/dom-serializer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
 			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.2",
@@ -5219,21 +5307,23 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
 			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/fb55"
 				}
 			],
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/domhandler": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
 			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"domelementtype": "^2.3.0"
 			},
@@ -5248,8 +5338,9 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
 			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"dom-serializer": "^2.0.0",
 				"domelementtype": "^2.3.0",
@@ -5263,8 +5354,9 @@
 			"version": "17.4.2",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
 			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5276,8 +5368,9 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -5291,8 +5384,9 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
 			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -5301,22 +5395,25 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/encodeurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
 			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -5325,8 +5422,9 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -5338,8 +5436,9 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5348,8 +5447,9 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -5358,8 +5458,9 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
 			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0"
 			},
@@ -5371,8 +5472,9 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -5381,15 +5483,17 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5398,8 +5502,9 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
 			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -5408,8 +5513,9 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
 			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"eventsource-parser": "^3.0.1"
 			},
@@ -5421,8 +5527,9 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
 			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			}
@@ -5431,8 +5538,9 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -5475,8 +5583,9 @@
 			"version": "8.5.2",
 			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
 			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ip-address": "^10.2.0"
 			},
@@ -5494,36 +5603,41 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/fast-sha256": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
 			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-			"dev": true,
-			"license": "Unlicense"
+			"license": "Unlicense",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/fast-string-truncated-width": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
 			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/fast-string-width": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
 			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fast-string-truncated-width": "^3.0.2"
 			}
@@ -5532,7 +5646,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
 			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5543,14 +5656,17 @@
 					"url": "https://opencollective.com/fastify"
 				}
 			],
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/fast-wrap-ansi": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
 			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fast-string-width": "^3.0.2"
 			}
@@ -5559,7 +5675,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
 			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5571,6 +5686,8 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"node-domexception": "^1.0.0",
 				"web-streams-polyfill": "^3.0.3"
@@ -5583,8 +5700,9 @@
 			"version": "22.0.1",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
 			"integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@tokenizer/inflate": "^0.4.1",
 				"strtok3": "^10.3.5",
@@ -5602,8 +5720,9 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
 			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"encodeurl": "^2.0.0",
@@ -5624,8 +5743,9 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
 			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^5.0.0",
 				"path-exists": "^4.0.0"
@@ -5638,8 +5758,9 @@
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
 			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"fetch-blob": "^3.1.2"
 			},
@@ -5651,8 +5772,9 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
 			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -5661,8 +5783,9 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
 			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -5671,8 +5794,9 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -5681,8 +5805,9 @@
 			"version": "7.1.5",
 			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
 			"integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"extend": "^3.0.2",
 				"https-proxy-agent": "^7.0.1",
@@ -5696,8 +5821,9 @@
 			"version": "8.1.2",
 			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
 			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"gaxios": "^7.0.0",
 				"google-logging-utils": "^1.0.0",
@@ -5711,8 +5837,9 @@
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
 			}
@@ -5721,8 +5848,9 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
 			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -5734,8 +5862,9 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -5759,8 +5888,9 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
@@ -5773,8 +5903,9 @@
 			"version": "13.0.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
 			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"minimatch": "^10.2.2",
 				"minipass": "^7.1.3",
@@ -5791,8 +5922,9 @@
 			"version": "10.9.0",
 			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
 			"integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"base64-js": "^1.3.0",
 				"ecdsa-sig-formatter": "^1.0.11",
@@ -5809,8 +5941,9 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
 			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -5819,8 +5952,9 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -5832,15 +5966,17 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/grammy": {
 			"version": "1.44.0",
 			"resolved": "https://registry.npmjs.org/grammy/-/grammy-1.44.0.tgz",
 			"integrity": "sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@grammyjs/types": "3.28.0",
 				"abort-controller": "^3.0.0",
@@ -5855,8 +5991,9 @@
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
 			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
 			},
@@ -5876,8 +6013,9 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -5889,8 +6027,9 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
 			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
@@ -5902,8 +6041,9 @@
 			"version": "11.11.1",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
 			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -5912,8 +6052,9 @@
 			"version": "4.12.25",
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
 			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -5922,8 +6063,9 @@
 			"version": "10.1.1",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.1.tgz",
 			"integrity": "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"lru-cache": "^11.1.0"
 			},
@@ -5935,14 +6077,14 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
 			"integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/htmlparser2": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
 			"integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
-			"dev": true,
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
 				{
@@ -5951,6 +6093,8 @@
 				}
 			],
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.3",
@@ -5962,8 +6106,9 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
 			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -5975,8 +6120,9 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
 			"integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=16"
 			}
@@ -5985,8 +6131,9 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
 			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"depd": "~2.0.0",
 				"inherits": "~2.0.4",
@@ -6006,8 +6153,9 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
 			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"agent-base": "^7.1.2",
 				"debug": "4"
@@ -6020,8 +6168,9 @@
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
 			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
@@ -6037,7 +6186,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -6052,14 +6200,17 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/ignore": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
 			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -6068,22 +6219,25 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
 			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/ip-address": {
 			"version": "10.2.0",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
 			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 12"
 			}
@@ -6092,8 +6246,9 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.10"
 			}
@@ -6102,8 +6257,9 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6112,29 +6268,33 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/jiti": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
 			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
 			}
@@ -6143,8 +6303,9 @@
 			"version": "6.2.3",
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
 			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
 			}
@@ -6153,8 +6314,9 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
 			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"bignumber.js": "^9.0.0"
 			}
@@ -6163,8 +6325,9 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
 			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"ts-algebra": "^2.0.0"
@@ -6177,22 +6340,25 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/json-schema-typed": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
 			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-			"dev": true,
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -6204,8 +6370,9 @@
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
 			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-			"dev": true,
 			"license": "(MIT OR GPL-3.0-or-later)",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"lie": "~3.3.0",
 				"pako": "~1.0.2",
@@ -6217,8 +6384,9 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
 			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"buffer-equal-constant-time": "^1.0.1",
 				"ecdsa-sig-formatter": "1.0.11",
@@ -6229,8 +6397,9 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
 			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"jwa": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -6240,8 +6409,9 @@
 			"version": "0.29.2",
 			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
 			"integrity": "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=22.0.0"
 			}
@@ -6250,8 +6420,9 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
 			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"immediate": "~3.0.5"
 			}
@@ -6260,8 +6431,9 @@
 			"version": "0.18.12",
 			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
 			"integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"css-select": "^5.1.0",
 				"cssom": "^0.5.0",
@@ -6285,8 +6457,9 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
 			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^4.1.0"
 			},
@@ -6298,15 +6471,17 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
 			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-			"dev": true,
-			"license": "Apache-2.0"
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/lru-cache": {
 			"version": "11.5.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
 			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "20 || >=22"
 			}
@@ -6315,8 +6490,9 @@
 			"version": "18.0.5",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
 			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -6328,8 +6504,9 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -6338,8 +6515,9 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
 			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -6348,8 +6526,9 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
 			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -6361,8 +6540,9 @@
 			"version": "1.54.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
 			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -6371,8 +6551,9 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -6388,15 +6569,17 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
 			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/minimatch": {
 			"version": "10.2.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
 			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^5.0.5"
 			},
@@ -6411,8 +6594,9 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -6421,8 +6605,9 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
 			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
@@ -6431,8 +6616,9 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
 			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"minipass": "^7.1.2"
 			},
@@ -6444,15 +6630,17 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/negotiator": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -6461,8 +6649,9 @@
 			"version": "8.9.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
 			"integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": "^18 || ^20 || >= 21"
 			}
@@ -6472,8 +6661,9 @@
 			"version": "1.0.28",
 			"resolved": "https://registry.npmjs.org/@nolyfill/domexception/-/domexception-1.0.28.tgz",
 			"integrity": "sha512-tlc/FcYIv5i8RYsl2iDil4A0gOihaas1R5jPcIC4Zw3GhjKsVilw90aHcVlhZPTBLGBzd379S+VcnsDjd9ChiA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12.4.0"
 			}
@@ -6482,8 +6672,9 @@
 			"version": "1.2.10",
 			"resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
 			"integrity": "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"https-proxy-agent": "^7.0.1",
 				"ws": "^8.13.0",
@@ -6497,8 +6688,9 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
 			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"data-uri-to-buffer": "^4.0.0",
 				"fetch-blob": "^3.1.4",
@@ -6516,8 +6708,9 @@
 			"version": "4.8.4",
 			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
 			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
@@ -6528,8 +6721,9 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
 			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
 			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"boolbase": "^1.0.0"
 			},
@@ -6541,8 +6735,9 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6551,8 +6746,9 @@
 			"version": "1.13.4",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
 			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -6564,8 +6760,9 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
 			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ee-first": "1.1.1"
 			},
@@ -6577,8 +6774,9 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -6587,8 +6785,9 @@
 			"version": "6.45.0",
 			"resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
 			"integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"peerDependencies": {
 				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
 				"@smithy/hash-node": ">=4.3.0 <5",
@@ -6618,8 +6817,9 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
 			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"p-try": "^2.0.0"
 			},
@@ -6634,8 +6834,9 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
 			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^2.2.0"
 			},
@@ -6647,8 +6848,9 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
 			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/retry": "0.12.0",
 				"retry": "^0.13.1"
@@ -6661,8 +6863,9 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -6671,15 +6874,17 @@
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-			"dev": true,
-			"license": "(MIT AND Zlib)"
+			"license": "(MIT AND Zlib)",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/parseurl": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -6688,15 +6893,17 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
 			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6705,8 +6912,9 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6715,8 +6923,9 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
 			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"lru-cache": "^11.0.0",
 				"minipass": "^7.1.2"
@@ -6732,8 +6941,9 @@
 			"version": "8.4.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
 			"integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
@@ -6743,8 +6953,9 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
 			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=16.20.0"
 			}
@@ -6753,8 +6964,9 @@
 			"version": "1.61.1",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
 			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -6766,8 +6978,9 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
 			"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -6776,15 +6989,17 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/proper-lockfile": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
 			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
 				"retry": "^0.12.0",
@@ -6795,8 +7010,9 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -6805,9 +7021,10 @@
 			"version": "7.6.3",
 			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
 			"integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
@@ -6830,8 +7047,9 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
 			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
@@ -6844,8 +7062,9 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
 			"integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"dijkstrajs": "^1.0.1",
 				"pngjs": "^5.0.0",
@@ -6862,8 +7081,9 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
 			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
@@ -6874,8 +7094,9 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
 			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -6889,15 +7110,17 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
 			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/qrcode/node_modules/yargs": {
 			"version": "15.4.1",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
 			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
@@ -6919,8 +7142,9 @@
 			"version": "18.1.3",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
 			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
@@ -6933,8 +7157,9 @@
 			"version": "6.15.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
 			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
-			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"side-channel": "^1.1.0"
 			},
@@ -6949,15 +7174,17 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-3.0.2.tgz",
 			"integrity": "sha512-SyfPzlrfz67/kv0SogmQgW4c2I1klkLcbvj9Y2gc1h7+VylmvuGevFljLXibGKajKJKiJV29d4S6FQLA6Sc80A==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/range-parser": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
 			"integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			},
@@ -6970,8 +7197,9 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/rastermill/-/rastermill-0.3.1.tgz",
 			"integrity": "sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@silvia-odwyer/photon-node": "0.3.4"
 			},
@@ -6983,8 +7211,9 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
 			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"bytes": "~3.1.2",
 				"http-errors": "~2.0.1",
@@ -6999,8 +7228,9 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -7015,15 +7245,17 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/readdirp": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
 			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 20.19.0"
 			},
@@ -7036,8 +7268,9 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7046,8 +7279,9 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7056,15 +7290,17 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/retry": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
 			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -7073,8 +7309,9 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
 			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"depd": "^2.0.0",
@@ -7090,7 +7327,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -7105,21 +7341,25 @@
 					"url": "https://feross.org/support"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/send": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
 			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.3",
 				"encodeurl": "^2.0.0",
@@ -7145,8 +7385,9 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
 			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"encodeurl": "^2.0.0",
 				"escape-html": "^1.0.3",
@@ -7165,29 +7406,33 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/setimmediate": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
 			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/setprototypeof": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
 			},
@@ -7199,8 +7444,9 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7209,8 +7455,9 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
 			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"object-inspect": "^1.13.4",
@@ -7229,8 +7476,9 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
 			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"object-inspect": "^1.13.4"
@@ -7246,8 +7494,9 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
 			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -7265,8 +7514,9 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
 			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -7285,22 +7535,25 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7309,8 +7562,9 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -7320,9 +7574,9 @@
 			"version": "0.1.9",
 			"resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
 			"integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
-			"dev": true,
 			"license": "MIT OR Apache",
 			"optional": true,
+			"peer": true,
 			"optionalDependencies": {
 				"sqlite-vec-darwin-arm64": "0.1.9",
 				"sqlite-vec-darwin-x64": "0.1.9",
@@ -7338,12 +7592,12 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT OR Apache",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/sqlite-vec-darwin-x64": {
 			"version": "0.1.9",
@@ -7352,12 +7606,12 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT OR Apache",
 			"optional": true,
 			"os": [
 				"darwin"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/sqlite-vec-linux-arm64": {
 			"version": "0.1.9",
@@ -7366,12 +7620,12 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT OR Apache",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/sqlite-vec-linux-x64": {
 			"version": "0.1.9",
@@ -7380,12 +7634,12 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT OR Apache",
 			"optional": true,
 			"os": [
 				"linux"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/sqlite-vec-windows-x64": {
 			"version": "0.1.9",
@@ -7394,19 +7648,20 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT OR Apache",
 			"optional": true,
 			"os": [
 				"win32"
-			]
+			],
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/standardwebhooks": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
 			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@stablelib/base64": "^1.0.0",
 				"fast-sha256": "^1.3.0"
@@ -7416,8 +7671,9 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
 			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -7426,8 +7682,9 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -7436,15 +7693,17 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -7458,8 +7717,9 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
 			},
@@ -7471,8 +7731,9 @@
 			"version": "10.3.5",
 			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
 			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@tokenizer/token": "^0.3.0"
 			},
@@ -7488,8 +7749,9 @@
 			"version": "7.5.19",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
 			"integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
 				"chownr": "^3.0.0",
@@ -7505,8 +7767,9 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
 			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.6"
 			}
@@ -7515,8 +7778,9 @@
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
 			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@borewit/text-codec": "^0.2.1",
 				"@tokenizer/token": "^0.3.0",
@@ -7534,16 +7798,18 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/tree-sitter-bash": {
 			"version": "0.25.1",
 			"resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.1.tgz",
 			"integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"node-addon-api": "^8.2.1",
 				"node-gyp-build": "^4.8.2"
@@ -7561,22 +7827,25 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
 			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
-			"license": "0BSD"
+			"license": "0BSD",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/tslog": {
 			"version": "4.10.2",
 			"resolved": "https://registry.npmjs.org/tslog/-/tslog-4.10.2.tgz",
 			"integrity": "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=16"
 			},
@@ -7588,8 +7857,9 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
 			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"content-type": "^2.0.0",
 				"media-typer": "^1.1.0",
@@ -7607,8 +7877,9 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
 			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -7621,15 +7892,17 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.3.tgz",
 			"integrity": "sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/typescript": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7642,15 +7915,17 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
 			"integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/uint8array-extras": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
 			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -7662,8 +7937,9 @@
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
 			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=22.19.0"
 			}
@@ -7672,15 +7948,17 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
 			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -7689,15 +7967,17 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -7706,8 +7986,9 @@
 			"version": "3.6.7",
 			"resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
 			"integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
-			"dev": true,
 			"license": "MPL-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"asn1.js": "^5.3.0",
 				"http_ece": "1.2.0",
@@ -7726,8 +8007,9 @@
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
 			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 8"
 			}
@@ -7736,22 +8018,25 @@
 			"version": "0.26.10",
 			"resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.10.tgz",
 			"integrity": "sha512-vengBGYS7FpAerkR3o04oBL4L8MkVmjawK50AFBu7v0HZBkmF9ZavPGKoXLSSmRhp7T/YgsJ7joAS3yAxHPEqQ==",
-			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
 			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
-			"license": "BSD-2-Clause"
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
@@ -7761,8 +8046,9 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"isexe": "^2.0.0"
 			},
@@ -7777,15 +8063,17 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
 			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
@@ -7802,15 +8090,17 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/openclaw/node_modules/ws": {
 			"version": "8.21.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
 			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -7831,8 +8121,9 @@
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -7841,8 +8132,9 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
 			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -7851,8 +8143,9 @@
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
 			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},
@@ -7867,8 +8160,9 @@
 			"version": "17.7.3",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
 			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -7886,8 +8180,9 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7896,8 +8191,9 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -7906,8 +8202,9 @@
 			"version": "3.25.2",
 			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
 			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"peerDependencies": {
 				"zod": "^3.25.28 || ^4"
 			}
@@ -8472,7 +8769,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "0BSD"
 		},
 		"node_modules/tsx": {
@@ -8902,14 +9199,17 @@
 				"usertrust": "*"
 			},
 			"devDependencies": {
-				"@mariozechner/pi-ai": "0.73.1",
-				"openclaw": "2026.7.1-2"
+				"@mariozechner/pi-ai": "0.73.1"
 			},
 			"peerDependencies": {
-				"@mariozechner/pi-ai": ">=0.1.0"
+				"@mariozechner/pi-ai": ">=0.12.0",
+				"openclaw": ">=2026.7.1-0"
 			},
 			"peerDependenciesMeta": {
 				"@mariozechner/pi-ai": {
+					"optional": true
+				},
+				"openclaw": {
 					"optional": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,367 @@
 				}
 			}
 		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1106.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1106.0.tgz",
+			"integrity": "sha512-LXi9HXgctft1WPa/aXnuw/XcK7OFoAi0myTz8nZ+FruooHnk2wZf5MWNaWZ3Paz1BuG9g+rCSzJWYS5FNqP2kw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/credential-provider-node": "^3.972.78",
+				"@aws-sdk/eventstream-handler-node": "^3.972.31",
+				"@aws-sdk/middleware-eventstream": "^3.972.26",
+				"@aws-sdk/middleware-websocket": "^3.972.49",
+				"@aws-sdk/token-providers": "3.1106.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.977.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+			"integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@aws-sdk/xml-builder": "^3.972.37",
+				"@aws/lambda-invoke-store": "^0.3.0",
+				"@smithy/core": "^3.31.1",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.67",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+			"integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.69",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+			"integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.973.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+			"integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/credential-provider-env": "^3.972.67",
+				"@aws-sdk/credential-provider-http": "^3.972.69",
+				"@aws-sdk/credential-provider-login": "^3.972.74",
+				"@aws-sdk/credential-provider-process": "^3.972.67",
+				"@aws-sdk/credential-provider-sso": "^3.973.11",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.73",
+				"@aws-sdk/nested-clients": "^3.997.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.74",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+			"integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/nested-clients": "^3.997.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.78",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+			"integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.67",
+				"@aws-sdk/credential-provider-http": "^3.972.69",
+				"@aws-sdk/credential-provider-ini": "^3.973.12",
+				"@aws-sdk/credential-provider-process": "^3.972.67",
+				"@aws-sdk/credential-provider-sso": "^3.973.11",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.73",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/credential-provider-imds": "^4.4.16",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.67",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+			"integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.973.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+			"integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/nested-clients": "^3.997.41",
+				"@aws-sdk/token-providers": "3.1103.0",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1103.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+			"integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/nested-clients": "^3.997.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.73",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+			"integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/nested-clients": "^3.997.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.31",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+			"integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+			"integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.49",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz",
+			"integrity": "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+			"integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.43",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/fetch-http-handler": "^5.6.13",
+				"@smithy/node-http-handler": "^4.9.13",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+			"integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/signature-v4": "^5.6.12",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1106.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1106.0.tgz",
+			"integrity": "sha512-5gYmxXoueX9X5QRN2T3BlFPr99mkIB35Z34QrikQDRRo61YJElNyYifxTUGHu/S3G8GI62Y0i8KsVtN5x9+VEA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.977.6",
+				"@aws-sdk/nested-clients": "^3.997.41",
+				"@aws-sdk/types": "^3.974.2",
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.974.2",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+			"integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+			"integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+			"integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -754,6 +1115,31 @@
 				"url": "https://github.com/sponsors/ayuhito"
 			}
 		},
+		"node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -804,6 +1190,119 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@mariozechner/pi-ai": {
+			"version": "0.73.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.73.1.tgz",
+			"integrity": "sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==",
+			"deprecated": "please use @earendil-works/pi-ai instead going forward",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "^2.2.0",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"typebox": "^1.1.24",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mariozechner/pi-ai/node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.6.1.tgz",
+			"integrity": "sha512-cZqouDAH1tcW3SF4dfl839eU+cvQwVyoY/17DAN7Bxjt5vwmbaI65Gvrjo8G4NZXTp5msJ5jc2172XZDcQxbqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
+				"@opentelemetry/resources": "^2.9.0",
+				"@opentelemetry/sdk-trace-base": "^2.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				},
+				"@opentelemetry/exporter-trace-otlp-http": {
+					"optional": true
+				},
+				"@opentelemetry/resources": {
+					"optional": true
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+			"integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/@oxc-project/types": {
 			"version": "0.142.0",
 			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
@@ -813,6 +1312,72 @@
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
 			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+			"integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+			"dev": true,
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/@reduxjs/toolkit": {
 			"version": "2.12.0",
@@ -1085,6 +1650,93 @@
 			"integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.31.1",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+			"integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.4.16",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+			"integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.6.13",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+			"integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.9.13",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+			"integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.6.12",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+			"integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.31.1",
+				"@smithy/types": "^4.16.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.16.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+			"integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/@stablelib/base64": {
 			"version": "1.0.1",
@@ -1669,6 +2321,13 @@
 				"url": "https://github.com/sponsors/tannerlinsley"
 			}
 		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1795,6 +2454,13 @@
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/use-sync-external-store": {
 			"version": "0.0.6",
@@ -1947,6 +2613,16 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1955,6 +2631,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/ast-v8-to-istanbul": {
@@ -1978,6 +2667,54 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
@@ -1990,6 +2727,13 @@
 				"node": "20 || >=22"
 			}
 		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/chai": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1998,6 +2742,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
 		"node_modules/clsx": {
@@ -2156,12 +2913,55 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/decimal.js-light": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
 			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
@@ -2171,6 +2971,16 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -2248,6 +3058,52 @@
 				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2256,6 +3112,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/eventemitter3": {
@@ -2274,6 +3140,13 @@
 			"engines": {
 				"node": ">=12.0.0"
 			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-sha256": {
 			"version": "1.3.0",
@@ -2324,6 +3197,43 @@
 				}
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2337,6 +3247,89 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/gaxios": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+			"integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+			"integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/graceful-fs": {
@@ -2363,6 +3356,34 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/immer": {
 			"version": "11.1.15",
 			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
@@ -2382,6 +3403,16 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+			"integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -2440,6 +3471,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
 		"node_modules/json-schema-to-ts": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -2452,6 +3493,29 @@
 			},
 			"engines": {
 				"node": ">=16"
+			}
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -2715,6 +3779,23 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2768,6 +3849,13 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.16",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
@@ -2785,6 +3873,56 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
 			}
 		},
 		"node_modules/obug": {
@@ -2834,6 +3972,4000 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/openclaw": {
+			"version": "2026.7.1-2",
+			"resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.7.1-2.tgz",
+			"integrity": "sha512-ycF3yPcbjN6bUPeaUx6Mh6vze1hQWoD3CT/wWcmD7a8xaHHHRUaAlaq+lFxMHf1ssEgODVAwjlzYqp2twkYZ7g==",
+			"dev": true,
+			"hasInstallScript": true,
+			"hasShrinkwrap": true,
+			"license": "MIT",
+			"dependencies": {
+				"@agentclientprotocol/sdk": "1.1.0",
+				"@anthropic-ai/sdk": "0.109.1",
+				"@clack/core": "1.4.2",
+				"@clack/prompts": "1.6.0",
+				"@earendil-works/pi-tui": "0.80.3",
+				"@google/genai": "2.10.0",
+				"@grammyjs/runner": "2.0.3",
+				"@grammyjs/transformer-throttler": "1.2.1",
+				"@homebridge/ciao": "1.3.9",
+				"@lydell/node-pty": "1.2.0-beta.12",
+				"@mistralai/mistralai": "2.4.0",
+				"@modelcontextprotocol/sdk": "1.29.0",
+				"@mozilla/readability": "0.6.0",
+				"@openclaw/ai": "2026.7.1-2",
+				"@openclaw/fs-safe": "0.4.1",
+				"@openclaw/proxyline": "0.3.3",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"chokidar": "5.0.0",
+				"clawpdf": "0.3.0",
+				"commander": "15.0.0",
+				"croner": "10.0.1",
+				"diff": "9.0.0",
+				"dotenv": "17.4.2",
+				"express": "5.2.1",
+				"file-type": "22.0.1",
+				"glob": "13.0.6",
+				"grammy": "1.44.0",
+				"highlight.js": "11.11.1",
+				"hosted-git-info": "10.1.1",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"json5": "2.2.3",
+				"jszip": "3.10.1",
+				"kysely": "0.29.2",
+				"linkedom": "0.18.12",
+				"minimatch": "10.2.5",
+				"node-edge-tts": "1.2.10",
+				"openai": "6.45.0",
+				"partial-json": "0.1.7",
+				"playwright-core": "1.61.1",
+				"proper-lockfile": "4.1.2",
+				"qrcode": "1.5.4",
+				"quickjs-wasi": "3.0.2",
+				"rastermill": "0.3.1",
+				"tar": "7.5.19",
+				"tree-sitter-bash": "0.25.1",
+				"tslog": "4.10.2",
+				"typebox": "1.3.3",
+				"typescript": "6.0.3",
+				"undici": "8.5.0",
+				"web-push": "3.6.7",
+				"web-tree-sitter": "0.26.10",
+				"ws": "8.21.0",
+				"yaml": "2.9.0",
+				"zod": "4.4.3"
+			},
+			"bin": {
+				"openclaw": "openclaw.mjs"
+			},
+			"engines": {
+				"node": ">=22.22.3 <23 || >=24.15.0 <25 || >=25.9.0"
+			},
+			"optionalDependencies": {
+				"sqlite-vec": "0.1.9"
+			}
+		},
+		"node_modules/openclaw/node_modules/@agentclientprotocol/sdk": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-1.1.0.tgz",
+			"integrity": "sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@anthropic-ai/sdk": {
+			"version": "0.109.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.1.tgz",
+			"integrity": "sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1",
+				"standardwebhooks": "^1.0.0"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/openclaw/node_modules/@clack/core": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.2.tgz",
+			"integrity": "sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-wrap-ansi": "^0.2.0",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 20.12.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@clack/prompts": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.6.0.tgz",
+			"integrity": "sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@clack/core": "1.4.2",
+				"fast-string-width": "^3.0.2",
+				"fast-wrap-ansi": "^0.2.0",
+				"sisteransi": "^1.0.5"
+			},
+			"engines": {
+				"node": ">= 20.12.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@earendil-works/pi-tui": {
+			"version": "0.80.3",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.80.3.tgz",
+			"integrity": "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "18.0.5"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@google/genai": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.10.0.tgz",
+			"integrity": "sha512-e4cFxj3tiuMtsgOT4G9c1hXyGJhg7/Buj7VVeBacRY3fRtkRZZ59Q3nuVp2xbq8BGQXLXCDB253qMhklMOeUDg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/@grammyjs/runner": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@grammyjs/runner/-/runner-2.0.3.tgz",
+			"integrity": "sha512-nckmTs1dPWfVQteK9cxqxzE+0m1VRvluLWB8UgFzsjg62w3qthPJt0TYtJBEdG7OedvfQq4vnFAyE6iaMkR42A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12.20.0 || >=14.13.1"
+			},
+			"peerDependencies": {
+				"grammy": "^1.13.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/@grammyjs/transformer-throttler": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@grammyjs/transformer-throttler/-/transformer-throttler-1.2.1.tgz",
+			"integrity": "sha512-CpWB0F3rJdUiKsq7826QhQsxbZi4wqfz1ccKX+fr+AOC+o8K7ZvS+wqX0suSu1QCsyUq2MDpNiKhyL2ZOJUS4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bottleneck": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || >=14.13.1"
+			},
+			"peerDependencies": {
+				"grammy": "^1.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@grammyjs/types": {
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.28.0.tgz",
+			"integrity": "sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/@homebridge/ciao": {
+			"version": "1.3.9",
+			"resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.9.tgz",
+			"integrity": "sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"fast-deep-equal": "^3.1.3",
+				"source-map-support": "^0.5.21",
+				"tslib": "^2.8.1"
+			},
+			"bin": {
+				"ciao-bcs": "lib/bonjour-conformance-testing.js"
+			}
+		},
+		"node_modules/openclaw/node_modules/@hono/node-server": {
+			"version": "1.19.14",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.14.1"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
+		"node_modules/openclaw/node_modules/@isaacs/fs-minipass": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+			"integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.4"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@lydell/node-pty": {
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+			"integrity": "sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==",
+			"dev": true,
+			"license": "MIT",
+			"optionalDependencies": {
+				"@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+				"@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+				"@lydell/node-pty-linux-arm64": "1.2.0-beta.12",
+				"@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+				"@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+				"@lydell/node-pty-win32-x64": "1.2.0-beta.12"
+			}
+		},
+		"node_modules/openclaw/node_modules/@lydell/node-pty-darwin-arm64": {
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.12.tgz",
+			"integrity": "sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/openclaw/node_modules/@lydell/node-pty-darwin-x64": {
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.12.tgz",
+			"integrity": "sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/openclaw/node_modules/@lydell/node-pty-linux-arm64": {
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.12.tgz",
+			"integrity": "sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/openclaw/node_modules/@lydell/node-pty-linux-x64": {
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.12.tgz",
+			"integrity": "sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/openclaw/node_modules/@lydell/node-pty-win32-arm64": {
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.12.tgz",
+			"integrity": "sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/openclaw/node_modules/@lydell/node-pty-win32-x64": {
+			"version": "1.2.0-beta.12",
+			"resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.12.tgz",
+			"integrity": "sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/openclaw/node_modules/@mistralai/mistralai": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.4.0.tgz",
+			"integrity": "sha512-t6hCx242MTGolB76CI+17jDtPIe/bzLsMdUTMMoMn9Qo1h02N2G5jQYHmKDGU3X//OgR2wvngTD7tO6tPp5poQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "^1.40.0",
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0"
+			},
+			"peerDependenciesMeta": {
+				"@opentelemetry/api": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.29.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/@mozilla/readability": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.6.0.tgz",
+			"integrity": "sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@openclaw/ai": {
+			"version": "2026.7.1-2",
+			"resolved": "https://registry.npmjs.org/@openclaw/ai/-/ai-2026.7.1-2.tgz",
+			"integrity": "sha512-st+NH0cxlQqdbEur//yYqM7WlYBjeEBnop3cztJTSCONKjv6LNoGguI9cH65asZG94FdM/39z857isRGPnZvEw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.109.1",
+				"@google/genai": "2.10.0",
+				"@mistralai/mistralai": "2.4.0",
+				"openai": "6.45.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.3.3"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@openclaw/fs-safe": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.4.1.tgz",
+			"integrity": "sha512-hQi+BxO10KdRFlYUot1syC+hTaUnGeQNdqX5kwkKJig8CFq1tKsYJLPm+zkiiGsSKOprPAquQl/txejEhpKPgg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			},
+			"optionalDependencies": {
+				"jszip": "^3.10.1",
+				"tar": "7.5.19"
+			}
+		},
+		"node_modules/openclaw/node_modules/@openclaw/proxyline": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@openclaw/proxyline/-/proxyline-0.3.3.tgz",
+			"integrity": "sha512-sftHnW69NHQqLjCxBTvQ8f/eQl+peZ5pHCBQtuTWBbeuYRHZ0/GXVTmw/O/YKsShMbqPWhJB0UYtPPdvCUSS8w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			},
+			"peerDependencies": {
+				"undici": ">=8.3.0 <9"
+			}
+		},
+		"node_modules/openclaw/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.41.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+			"integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/inquire": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/openclaw/node_modules/@stablelib/base64": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+			"integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/openclaw/node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/@types/node": {
+			"version": "26.1.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+			"integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/@types/retry": {
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+			"integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
+		},
+		"node_modules/openclaw/node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/openclaw/node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/openclaw/node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/asn1.js": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/openclaw/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/openclaw/node_modules/bn.js": {
+			"version": "4.12.4",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.4.tgz",
+			"integrity": "sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/body-parser": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^2.0.0",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
+				"on-finished": "^2.4.1",
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/brace-expansion": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/openclaw/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/openclaw/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/chokidar": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/openclaw/node_modules/chownr": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+			"integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/openclaw/node_modules/clawpdf": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/clawpdf/-/clawpdf-0.3.0.tgz",
+			"integrity": "sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"clawpdf": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/openclaw/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/openclaw/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/commander": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+			"integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.12.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/croner": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/croner/-/croner-10.0.1.tgz",
+			"integrity": "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "other",
+					"url": "https://paypal.me/hexagonpp"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/hexagon"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/openclaw/node_modules/css-select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/openclaw/node_modules/css-what": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/openclaw/node_modules/cssom": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/openclaw/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/diff": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/dijkstrajs": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/openclaw/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/domutils": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/dotenv": {
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/openclaw/node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/openclaw/node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/openclaw/node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/express-rate-limit": {
+			"version": "8.5.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/openclaw/node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/fast-sha256": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+			"integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+			"dev": true,
+			"license": "Unlicense"
+		},
+		"node_modules/openclaw/node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
+		"node_modules/openclaw/node_modules/fast-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
+		},
+		"node_modules/openclaw/node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/openclaw/node_modules/file-type": {
+			"version": "22.0.1",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+			"integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.5",
+				"token-types": "^6.1.2",
+				"uint8array-extras": "^1.5.0"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/gaxios": {
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.5.tgz",
+			"integrity": "sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/openclaw/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/openclaw/node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/openclaw/node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openclaw/node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/openclaw/node_modules/google-auth-library": {
+			"version": "10.9.0",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+			"integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/openclaw/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/openclaw/node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/grammy": {
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/grammy/-/grammy-1.44.0.tgz",
+			"integrity": "sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@grammyjs/types": "3.28.0",
+				"abort-controller": "^3.0.0",
+				"debug": "^4.4.3",
+				"node-fetch": "^2.7.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || >=14.13.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/grammy/node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/hasown": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/highlight.js": {
+			"version": "11.11.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+			"integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/hono": {
+			"version": "4.12.25",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/hosted-git-info": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.1.tgz",
+			"integrity": "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/html-escaper": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+			"integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/htmlparser2": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+			"integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+			"dev": true,
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.2.2",
+				"entities": "^7.0.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/htmlparser2/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/http_ece": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+			"integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/openclaw/node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/openclaw/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/openclaw/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/openclaw/node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/ip-address": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/openclaw/node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/openclaw/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/openclaw/node_modules/jose": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
+		},
+		"node_modules/openclaw/node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/openclaw/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/openclaw/node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/openclaw/node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"dev": true,
+			"license": "(MIT OR GPL-3.0-or-later)",
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/openclaw/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/kysely": {
+			"version": "0.29.2",
+			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
+			"integrity": "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"immediate": "~3.0.5"
+			}
+		},
+		"node_modules/openclaw/node_modules/linkedom": {
+			"version": "0.18.12",
+			"resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
+			"integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"css-select": "^5.1.0",
+				"cssom": "^0.5.0",
+				"html-escaper": "^3.0.3",
+				"htmlparser2": "^10.0.0",
+				"uhyphen": "^0.2.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"peerDependencies": {
+				"canvas": ">= 2"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/openclaw/node_modules/lru-cache": {
+			"version": "11.5.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/openclaw/node_modules/marked": {
+			"version": "18.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+			"integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/openclaw/node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/openclaw/node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openclaw/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/openclaw/node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/openclaw/node_modules/minizlib": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+			"integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/openclaw/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/node-addon-api": {
+			"version": "8.9.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+			"integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18 || ^20 || >= 21"
+			}
+		},
+		"node_modules/openclaw/node_modules/node-domexception": {
+			"name": "@nolyfill/domexception",
+			"version": "1.0.28",
+			"resolved": "https://registry.npmjs.org/@nolyfill/domexception/-/domexception-1.0.28.tgz",
+			"integrity": "sha512-tlc/FcYIv5i8RYsl2iDil4A0gOihaas1R5jPcIC4Zw3GhjKsVilw90aHcVlhZPTBLGBzd379S+VcnsDjd9ChiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.4.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/node-edge-tts": {
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/node-edge-tts/-/node-edge-tts-1.2.10.tgz",
+			"integrity": "sha512-bV2i4XU54D45+US0Zm1HcJRkifuB3W438dWyuJEHLQdKxnuqlI1kim2MOvR6Q3XUQZvfF9PoDyR1Rt7aeXhPdQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"https-proxy-agent": "^7.0.1",
+				"ws": "^8.13.0",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"node-edge-tts": "bin.js"
+			}
+		},
+		"node_modules/openclaw/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/openclaw/node_modules/node-gyp-build": {
+			"version": "4.8.4",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+			"integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"node-gyp-build": "bin.js",
+				"node-gyp-build-optional": "optional.js",
+				"node-gyp-build-test": "build-test.js"
+			}
+		},
+		"node_modules/openclaw/node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/openclaw/node_modules/openai": {
+			"version": "6.45.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+			"integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+				"@smithy/hash-node": ">=4.3.0 <5",
+				"@smithy/signature-v4": ">=5.4.0 <6",
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-provider-node": {
+					"optional": true
+				},
+				"@smithy/hash-node": {
+					"optional": true
+				},
+				"@smithy/signature-v4": {
+					"optional": true
+				},
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openclaw/node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/openclaw/node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true,
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/openclaw/node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/openclaw/node_modules/path-to-regexp": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+			"integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/playwright-core": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/openclaw/node_modules/pngjs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+			"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/openclaw/node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/openclaw/node_modules/protobufjs": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+			"integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/openclaw/node_modules/qrcode": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+			"integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dijkstrajs": "^1.0.1",
+				"pngjs": "^5.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"qrcode": "bin/qrcode"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/qrcode/node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/qrcode/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/qrcode/node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/qrcode/node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/qrcode/node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/openclaw/node_modules/qs": {
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/quickjs-wasi": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-3.0.2.tgz",
+			"integrity": "sha512-SyfPzlrfz67/kv0SogmQgW4c2I1klkLcbvj9Y2gc1h7+VylmvuGevFljLXibGKajKJKiJV29d4S6FQLA6Sc80A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/range-parser": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+			"integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/rastermill": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/rastermill/-/rastermill-0.3.1.tgz",
+			"integrity": "sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@silvia-odwyer/photon-node": "0.3.4"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/openclaw/node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/openclaw/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/openclaw/node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/readdirp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/openclaw/node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/openclaw/node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/openclaw/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/side-channel": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/openclaw/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/sisteransi": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/sqlite-vec": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+			"integrity": "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA==",
+			"dev": true,
+			"license": "MIT OR Apache",
+			"optional": true,
+			"optionalDependencies": {
+				"sqlite-vec-darwin-arm64": "0.1.9",
+				"sqlite-vec-darwin-x64": "0.1.9",
+				"sqlite-vec-linux-arm64": "0.1.9",
+				"sqlite-vec-linux-x64": "0.1.9",
+				"sqlite-vec-windows-x64": "0.1.9"
+			}
+		},
+		"node_modules/openclaw/node_modules/sqlite-vec-darwin-arm64": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+			"integrity": "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/openclaw/node_modules/sqlite-vec-darwin-x64": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+			"integrity": "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/openclaw/node_modules/sqlite-vec-linux-arm64": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+			"integrity": "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/openclaw/node_modules/sqlite-vec-linux-x64": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+			"integrity": "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/openclaw/node_modules/sqlite-vec-windows-x64": {
+			"version": "0.1.9",
+			"resolved": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+			"integrity": "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT OR Apache",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/openclaw/node_modules/standardwebhooks": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+			"integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@stablelib/base64": "^1.0.0",
+				"fast-sha256": "^1.3.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/openclaw/node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/openclaw/node_modules/tar": {
+			"version": "7.5.19",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+			"integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/fs-minipass": "^4.0.0",
+				"chownr": "^3.0.0",
+				"minipass": "^7.1.2",
+				"minizlib": "^3.1.0",
+				"yallist": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/openclaw/node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/openclaw/node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/openclaw/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/tree-sitter-bash": {
+			"version": "0.25.1",
+			"resolved": "https://registry.npmjs.org/tree-sitter-bash/-/tree-sitter-bash-0.25.1.tgz",
+			"integrity": "sha512-7hMytuYIMoXOq24yRulgIxthE9YmggZIOHCyPTTuJcu6EU54tYD+4G39cUb28kxC6jMf/AbPfWGLQtgPTdh3xw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-addon-api": "^8.2.1",
+				"node-gyp-build": "^4.8.2"
+			},
+			"peerDependencies": {
+				"tree-sitter": "^0.25.0"
+			},
+			"peerDependenciesMeta": {
+				"tree-sitter": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/openclaw/node_modules/tslog": {
+			"version": "4.10.2",
+			"resolved": "https://registry.npmjs.org/tslog/-/tslog-4.10.2.tgz",
+			"integrity": "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/fullstack-build/tslog?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/openclaw/node_modules/typebox": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.3.tgz",
+			"integrity": "sha512-URXGUE31PJDQC+PtRMJeLdF4kmmOdFoVPikPCtV2oOIhUpNpppEdIz7W8bH8cFYPYHdDpaRvqwdegMTmHliudg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/openclaw/node_modules/uhyphen": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+			"integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/openclaw/node_modules/undici": {
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/openclaw/node_modules/web-push": {
+			"version": "3.6.7",
+			"resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+			"integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"asn1.js": "^5.3.0",
+				"http_ece": "1.2.0",
+				"https-proxy-agent": "^7.0.0",
+				"jws": "^4.0.0",
+				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"web-push": "src/cli.js"
+			},
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/openclaw/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/openclaw/node_modules/web-tree-sitter": {
+			"version": "0.26.10",
+			"resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.10.tgz",
+			"integrity": "sha512-vengBGYS7FpAerkR3o04oBL4L8MkVmjawK50AFBu7v0HZBkmF9ZavPGKoXLSSmRhp7T/YgsJ7joAS3yAxHPEqQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/openclaw/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"dev": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/openclaw/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/openclaw/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/openclaw/node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/openclaw/node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/openclaw/node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/openclaw/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/openclaw/node_modules/yallist": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+			"integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/openclaw/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/openclaw/node_modules/yargs": {
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/openclaw/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/openclaw/node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/openclaw/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -2889,6 +8021,57 @@
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.6.5",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+			"integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/react": {
 			"version": "19.2.8",
@@ -3000,6 +8183,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/rolldown": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
@@ -3033,6 +8226,27 @@
 				"@rolldown/binding-win32-x64-msvc": "1.2.2"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3065,6 +8279,58 @@
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
 			"license": "MIT"
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+			"integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^10.1.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
@@ -3202,6 +8468,13 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
 		"node_modules/tsx": {
 			"version": "4.23.1",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
@@ -3221,6 +8494,13 @@
 				"fsevents": "~2.3.3"
 			}
 		},
+		"node_modules/typebox": {
+			"version": "1.3.11",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.11.tgz",
+			"integrity": "sha512-tZGKIS02Opbh4EYMmAEVuXl+y3EQJ9ZlkitLZ1CmFCY4ZOqr/xWR9dDSCFmIjNDICGMWkOqMh6WxGTyRXqcSGQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -3233,6 +8513,16 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
@@ -3475,6 +8765,16 @@
 				}
 			}
 		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3490,6 +8790,28 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/yaml": {
@@ -3516,9 +8838,19 @@
 				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
 		"packages/acs-adapter": {
 			"name": "usertrust-acs-adapter",
-			"version": "2.0.1",
+			"version": "3.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"usertrust": "*"
@@ -3531,7 +8863,7 @@
 		},
 		"packages/core": {
 			"name": "usertrust",
-			"version": "2.0.1",
+			"version": "3.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@clack/prompts": "^1.1.0",
@@ -3564,10 +8896,14 @@
 		},
 		"packages/openclaw": {
 			"name": "usertrust-openclaw",
-			"version": "2.0.1",
+			"version": "3.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"usertrust": "*"
+			},
+			"devDependencies": {
+				"@mariozechner/pi-ai": "0.73.1",
+				"openclaw": "2026.7.1-2"
 			},
 			"peerDependencies": {
 				"@mariozechner/pi-ai": ">=0.1.0"
@@ -3580,7 +8916,7 @@
 		},
 		"packages/server": {
 			"name": "usertrust-server",
-			"version": "2.0.1",
+			"version": "3.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"usertrust": "*",
@@ -3592,7 +8928,7 @@
 		},
 		"packages/ui": {
 			"name": "usertrust-ui",
-			"version": "2.0.1",
+			"version": "3.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"usertrust": "*",
@@ -3643,7 +8979,7 @@
 		},
 		"packages/verify": {
 			"name": "usertrust-verify",
-			"version": "2.0.1",
+			"version": "3.1.0",
 			"license": "Apache-2.0",
 			"bin": {
 				"usertrust-verify": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"test:watch": "vitest",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
-		"typecheck": "tsc -b && tsc -p packages/core/tsconfig.type-tests.json",
+		"typecheck": "tsc -b && tsc -p packages/core/tsconfig.type-tests.json && tsc -p packages/openclaw/tsconfig.type-tests.json",
 		"typecheck:types": "tsc -p packages/core/tsconfig.type-tests.json"
 	},
 	"devDependencies": {

--- a/packages/acs-adapter/src/mock.ts
+++ b/packages/acs-adapter/src/mock.ts
@@ -1,7 +1,13 @@
 import { createHash } from "node:crypto";
 import type { TrustReceipt } from "usertrust";
 import { InsufficientBalanceError } from "usertrust";
-import type { Authorization, AuthorizeParams, Governor, SettleParams } from "usertrust/headless";
+import type {
+	Authorization,
+	AuthorizeParams,
+	EnvelopeStatus,
+	Governor,
+	SettleParams,
+} from "usertrust/headless";
 import type { PolicyDecider } from "./composite.js";
 import { CompositeEvaluator } from "./composite.js";
 
@@ -69,6 +75,15 @@ export function createMockGovernor(opts: { budget?: number } = {}): { governor: 
 		},
 		budgetRemaining(): number {
 			return budget;
+		},
+		/**
+		 * No ledger and no `parentUserId`, so there are no envelopes to report on —
+		 * the same empty answer the real governor gives for a dry-run or identity-less
+		 * one. Faking scarcity numbers here would put a demo's invented percentages in
+		 * front of a model as though they came from TigerBeetle.
+		 */
+		async budgetContext(): Promise<EnvelopeStatus[]> {
+			return [];
 		},
 		// biome-ignore lint/suspicious/noExplicitAny: mock config, never read by the adapter
 		config: {} as any,

--- a/packages/core/src/budget/context.ts
+++ b/packages/core/src/budget/context.ts
@@ -132,6 +132,95 @@ function clampFraction(value: number): number {
 }
 
 /**
+ * The amplification guard, on its own so a second batch reader enforces the SAME cap
+ * with the SAME message rather than re-typing {@link MAX_ENVELOPES} at its own door.
+ * Cheapest check first: it runs before any per-entry work.
+ *
+ * @throws Error when `envelopes.length` exceeds {@link MAX_ENVELOPES}.
+ */
+export function assertEnvelopeCap(envelopes: EnvelopeDescriptor[]): void {
+	if (envelopes.length > MAX_ENVELOPES) {
+		throw new Error(
+			`budgetContext: envelopes.length (${envelopes.length}) exceeds the ${MAX_ENVELOPES} cap`,
+		);
+	}
+}
+
+/**
+ * Per-descriptor validation: every `costCenter` passes {@link costCenterUserId}'s door
+ * (reused, never a second charset check), and no two descriptors name the same envelope
+ * — two entries would resolve to one account, so a duplicate can only mean caller
+ * confusion, never two distinct envelopes to report.
+ *
+ * Split from {@link assertEnvelopeCap} because the two doors are not adjacent for every
+ * caller: `budgetContext` below refuses a bad `parentUserId` between them, and
+ * `Governor.budgetContext` returns quietly when the governor has no `parentUserId` at
+ * all (there is nothing to validate a cost center against).
+ *
+ * @throws Error when any `costCenter` (or `parentUserId`) fails {@link costCenterUserId},
+ * or when `envelopes` contains a duplicate `costCenter`.
+ */
+export function assertDistinctValidCostCenters(
+	parentUserId: string,
+	envelopes: EnvelopeDescriptor[],
+): void {
+	const seen = new Set<string>();
+	for (const envelope of envelopes) {
+		// Throws pre-I/O on an invalid costCenter (or, redundantly but harmlessly, on
+		// an already-checked parentUserId).
+		costCenterUserId(parentUserId, envelope.costCenter);
+		if (seen.has(envelope.costCenter)) {
+			throw new Error(`budgetContext: duplicate costCenter descriptor: "${envelope.costCenter}"`);
+		}
+		seen.add(envelope.costCenter);
+	}
+}
+
+/**
+ * The ONE place one envelope's scarcity numbers are computed, given its ledger
+ * `remaining` and the batch's single clock reading. Every clamp semantic documented on
+ * {@link EnvelopeStatus} lives here and nowhere else — a second reader of the same
+ * ledger balances (`Governor.budgetContext`) calls this rather than repeating the
+ * arithmetic, so `spent`/`fraction`/`runwayHours` can never drift between the two
+ * surfaces.
+ *
+ * `remaining` is the caller's truth: `0` stands for "no TigerBeetle account", which is
+ * exactly what `lookupBalances` omitting an id means.
+ *
+ * @throws Error (from `computeRunway`) when `periodStartMs` or `nowMs` is not finite —
+ * a bad clock is a caller bug, and substituting a value would fabricate a runway.
+ */
+export function envelopeStatusFrom(
+	descriptor: EnvelopeDescriptor,
+	remaining: number,
+	nowMs: number,
+): EnvelopeStatus {
+	const allocated = safeAllocated(descriptor.allocated);
+	const spent = Math.max(0, allocated - remaining);
+	const fraction = allocated <= 0 ? 0 : clampFraction(remaining / allocated);
+
+	// Reused, not reimplemented: computeRunway/runwayHours already own the burn-rate
+	// and projection math (and its own TOTALITY guarantees) — this call exists only
+	// to get runwayHours, since remaining/spent/fraction above are already final.
+	const runway = computeRunway({
+		allocated,
+		spent,
+		periodStartMs: descriptor.periodStartMs,
+		periodEndMs: descriptor.periodEndMs,
+		nowMs,
+	});
+
+	return {
+		costCenter: descriptor.costCenter,
+		allocated,
+		spent,
+		remaining,
+		fraction,
+		runwayHours: runwayHours(runway, nowMs),
+	};
+}
+
+/**
  * Read the parent's balance and every requested envelope's scarcity, in one round trip.
  *
  * VALIDATION DOORS, all pre-I/O (A3): `parentUserId` is refused by the same
@@ -160,27 +249,14 @@ export async function budgetContext(
 	envelopes: EnvelopeDescriptor[],
 	nowMs?: number,
 ): Promise<BudgetContext> {
-	if (envelopes.length > MAX_ENVELOPES) {
-		throw new Error(
-			`budgetContext: envelopes.length (${envelopes.length}) exceeds the ${MAX_ENVELOPES} cap`,
-		);
-	}
+	assertEnvelopeCap(envelopes);
 
 	const parentRefusal = parentUserIdRefusal(parentUserId);
 	if (parentRefusal !== null) {
 		throw new Error(`budget: parentUserId ${parentRefusal}`);
 	}
 
-	const seen = new Set<string>();
-	for (const envelope of envelopes) {
-		// Throws pre-I/O on an invalid costCenter (or, redundantly but harmlessly, on
-		// the parentUserId already checked above).
-		costCenterUserId(parentUserId, envelope.costCenter);
-		if (seen.has(envelope.costCenter)) {
-			throw new Error(`budgetContext: duplicate costCenter descriptor: "${envelope.costCenter}"`);
-		}
-		seen.add(envelope.costCenter);
-	}
+	assertDistinctValidCostCenters(parentUserId, envelopes);
 
 	// ONE clock read for the whole batch — every envelope's runway is computed against
 	// the same instant, so two envelopes in one response never disagree about "now".
@@ -196,32 +272,9 @@ export async function budgetContext(
 	// the implicit-zero reading below, for the parent exactly as for every envelope.
 	const balances = await tb.lookupBalances([parentAccount, ...childAccounts]);
 
-	const envelopeStatuses: EnvelopeStatus[] = envelopes.map((envelope, i) => {
-		const remaining = balances.get(childAccounts[i] as bigint) ?? 0;
-		const allocated = safeAllocated(envelope.allocated);
-		const spent = Math.max(0, allocated - remaining);
-		const fraction = allocated <= 0 ? 0 : clampFraction(remaining / allocated);
-
-		// Reused, not reimplemented: computeRunway/runwayHours already own the burn-rate
-		// and projection math (and its own TOTALITY guarantees) — this call exists only
-		// to get runwayHours, since remaining/spent/fraction above are already final.
-		const runway = computeRunway({
-			allocated,
-			spent,
-			periodStartMs: envelope.periodStartMs,
-			periodEndMs: envelope.periodEndMs,
-			nowMs: clock,
-		});
-
-		return {
-			costCenter: envelope.costCenter,
-			allocated,
-			spent,
-			remaining,
-			fraction,
-			runwayHours: runwayHours(runway, clock),
-		};
-	});
+	const envelopeStatuses: EnvelopeStatus[] = envelopes.map((envelope, i) =>
+		envelopeStatusFrom(envelope, balances.get(childAccounts[i] as bigint) ?? 0, clock),
+	);
 
 	return {
 		parent: { remaining: balances.get(parentAccount) ?? 0 },

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -45,6 +45,17 @@ import { CreateTransferStatus } from "tigerbeetle-node";
 import { type AuditWriter, createAuditWriter } from "./audit/chain.js";
 import { writeReceipt } from "./audit/rotation.js";
 import { getCurrentCostCenter } from "./budget/attribution.js";
+// The money math and the validation doors are IMPORTED from `budget/context.ts`,
+// never re-implemented: `budgetContext()` below is a second reader of the same
+// ledger balances, and a private clamp/runway copy here would let the pull-side
+// report and the standalone `budgetContext` disagree about the same envelope.
+import {
+	assertDistinctValidCostCenters,
+	assertEnvelopeCap,
+	type EnvelopeDescriptor,
+	type EnvelopeStatus,
+	envelopeStatusFrom,
+} from "./budget/context.js";
 // The cost-center envelope helpers are SHARED with `govern.ts`, not copied from
 // it (see the block comment above `ResolvedEnvelope` there). D1's throw, A2's
 // pre-gate refusal, A7's unfloored arithmetic and D5's label re-wrap all decide
@@ -88,6 +99,12 @@ import type { EndpointInfo, TrustConfig, TrustReceipt } from "./shared/types.js"
 import { TrustConfigSchema } from "./shared/types.js";
 
 // ── Public types ──
+
+// Re-exported so an integration typing a `budgetContext()` call has both shapes at
+// the SAME entry point as the `Governor` it calls — `usertrust/headless` is a
+// package entry point in its own right, and a plugin should not have to reach into
+// the root export for the argument type of a method it can already see here.
+export type { EnvelopeDescriptor, EnvelopeStatus } from "./budget/context.js";
 
 /**
  * Options for createGovernor(): TrustOpts plus a governor-wide default
@@ -273,6 +290,34 @@ export interface Governor {
 
 	/** Graceful shutdown — voids all pending holds, flushes audit. */
 	destroy(): Promise<void>;
+
+	/**
+	 * The pull-side scarcity read across this governor's own envelopes — what an
+	 * integration puts in front of the model so it can spend like it knows what
+	 * things cost. Batched: exactly ONE ledger round trip for the whole array,
+	 * answered in descriptor order.
+	 *
+	 * REPORTING ONLY (A8). Nothing here gates, delays, or decides a spend, and
+	 * the numbers are snapshots that can race a concurrent settlement — the same
+	 * observational contract `budget/context.ts` documents at length.
+	 *
+	 * TWO LAYERS, deliberately not the same layer:
+	 *  - Pre-I/O validation THROWS — the `MAX_ENVELOPES` cap, the
+	 *    per-descriptor cost-center door and duplicate rejection are caller/config
+	 *    bugs, and answering `[]` would hide a misconfiguration forever.
+	 *  - Every READ failure is quiet: dryRun, no engine, an engine without
+	 *    `lookupBalances`, a rejected lookup, or a governor with no
+	 *    `parentUserId` all answer `[]`.
+	 *
+	 * `envelopes` is CALLER TRUTH for reporting only. There is no cost-center
+	 * registry, so `allocated` and the period bounds come from the caller's own
+	 * bookkeeping — a descriptor neither creates nor funds an envelope
+	 * (`allocateBudget` does).
+	 *
+	 * @throws Error when `envelopes.length` exceeds the cap, a `costCenter` fails
+	 * validation, or two descriptors name the same one — all before any ledger I/O.
+	 */
+	budgetContext(envelopes: EnvelopeDescriptor[]): Promise<EnvelopeStatus[]>;
 
 	/** Estimate cost in usertokens for a model call. */
 	estimateCost(model: string, inputTokens: number, outputTokens: number): number;
@@ -1366,6 +1411,62 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 			if (proxyConn != null) {
 				proxyConn.destroy();
 			}
+		},
+
+		/**
+		 * REPORTING ONLY, and the failure policy is the whole design (A8).
+		 *
+		 * This is the MIRROR of `snapshotEnvelopeRemaining`: same read, never throws,
+		 * because nothing downstream decides anything from it. It is deliberately the
+		 * OPPOSITE of `preflightEnvelopeRemaining` (A2), which REFUSES an attributed
+		 * authorize when the same read fails — there the number feeds the policy gate,
+		 * so degrading it would clear a call against a wallet the money never came
+		 * from. Here the number goes into a scarcity hint a model reads; an
+		 * unreachable ledger must cost the caller a paragraph of prose, never a
+		 * denied or delayed call. DO NOT UNIFY THE TWO.
+		 *
+		 * Only the awaited `lookupBalances` is inside the catch. The pre-I/O doors
+		 * above it are caller bugs and throw, and the `envelopeStatusFrom` mapping
+		 * below it stays OUTSIDE — a non-finite `periodStartMs` propagates exactly as
+		 * it does from core `budgetContext`, rather than collapsing every envelope's
+		 * report into an empty array the caller cannot diagnose.
+		 */
+		async budgetContext(envelopes: EnvelopeDescriptor[]): Promise<EnvelopeStatus[]> {
+			// Cheapest door first, and the only one that needs no ledger identity.
+			assertEnvelopeCap(envelopes);
+
+			// No parentUserId ⇒ no envelope account is derivable. Unlike `authorize()`'s
+			// D1 throw, nothing is about to spend here, so there is nothing to refuse:
+			// a governor with no ledger identity simply has no envelopes to report on.
+			// It also has to be settled BEFORE the per-descriptor door, which validates
+			// each cost center against a parent.
+			const parentUserId = config.parentUserId;
+			if (parentUserId === undefined) return [];
+
+			assertDistinctValidCostCenters(parentUserId, envelopes);
+
+			// dryRun has no engine at all; an injected engine may predate `lookupBalances`.
+			if (isDryRun || engine == null || engine.lookupBalances === undefined) return [];
+
+			// ONE clock read for the whole batch, so two envelopes in one response never
+			// disagree about "now" — the same rule core `budgetContext` follows.
+			const clock = Date.now();
+			const accountIds = envelopes.map((envelope) =>
+				TrustTBClient.deriveCostCenterAccountId(parentUserId, envelope.costCenter),
+			);
+
+			let balances: Map<bigint, number>;
+			try {
+				balances = await engine.lookupBalances(accountIds);
+			} catch {
+				return [];
+			}
+
+			// An id the ledger omitted reads as 0 — never-allocated and fully-reclaimed
+			// are the same observable state.
+			return envelopes.map((envelope, i) =>
+				envelopeStatusFrom(envelope, balances.get(accountIds[i] as bigint) ?? 0, clock),
+			);
 		},
 
 		estimateCost(model: string, inputTokens: number, outputTokens: number): number {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,13 @@ export {
 	VaultKeyMissingError,
 	VaultNotInitializedError,
 } from "./shared/errors.js";
+// The AUTHORITATIVE parent-id door, exported so an integration that validates its
+// own operator config refuses exactly what the ledger doors refuse — charset AND
+// the `::` quarantine, with the reason each door already prints. A copy of the
+// pattern outside this package is a rule that drifts silently: it would accept an
+// id `createGovernor()` then rejects, or (worse) admit a `::` parent whose account
+// derivation lands on stranded pre-v3 cost-center money.
+export { parentUserIdRefusal } from "./shared/ids.js";
 // Types
 export type {
 	ActionDescriptor,

--- a/packages/core/tests/headless/budget-context.test.ts
+++ b/packages/core/tests/headless/budget-context.test.ts
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * `Governor.budgetContext(envelopes)` — the reporting-only scarcity read the OpenClaw
+ * plugin injects into a turn's system prompt.
+ *
+ * TWO LAYERS, and the whole point of this file is that they are NOT the same layer:
+ *
+ *  - PRE-I/O validation THROWS. The cap, the per-descriptor cost-center door and the
+ *    duplicate rejection are caller/config bugs — a plugin that asks for 200 envelopes
+ *    or names the same one twice is misconfigured, and answering `[]` would hide that
+ *    forever. The messages are asserted IDENTICAL to core `budgetContext`'s, because
+ *    both call the same exported helpers; a second copy of either door is exactly what
+ *    the assertion is there to catch.
+ *  - THE LEDGER READ NEVER THROWS. dryRun, no engine, an engine with no
+ *    `lookupBalances`, a rejected lookup, and a governor with no `parentUserId` all
+ *    answer `[]` quietly. This is A8: a scarcity report must never gate, delay, or
+ *    throw into the money path, and it is the MIRROR of `snapshotEnvelopeRemaining`'s
+ *    post-settle policy — deliberately the OPPOSITE of A2's pre-gate refusal, which
+ *    guards a number the policy gate decides on. Do not unify the two.
+ *
+ * The post-read mapping is outside the catch on purpose, so a bad clock still surfaces
+ * as the caller bug it is rather than as an empty report.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppendEventInput, AuditWriter } from "../../src/audit/chain.js";
+import {
+	budgetContext as coreBudgetContext,
+	type EnvelopeDescriptor,
+	envelopeStatusFrom,
+	MAX_ENVELOPES,
+} from "../../src/budget/context.js";
+import type { TrustEngine } from "../../src/govern.js";
+import { createGovernor, type Governor } from "../../src/headless.js";
+import { TrustTBClient } from "../../src/ledger/client.js";
+import type { AuditEvent } from "../../src/shared/types.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Fixtures ──
+
+const PARENT = "acme";
+const HOUR = 3_600_000;
+const NOW = 1_800_000_000_000;
+
+const RESEARCH: EnvelopeDescriptor = {
+	costCenter: "research",
+	allocated: 10_000,
+	periodStartMs: NOW - 4 * HOUR,
+};
+const VERIFICATION: EnvelopeDescriptor = {
+	costCenter: "verification",
+	allocated: 4_000,
+	periodStartMs: NOW - 2 * HOUR,
+	periodEndMs: NOW + 22 * HOUR,
+};
+const DESCRIPTORS = [RESEARCH, VERIFICATION];
+
+const RESEARCH_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, RESEARCH.costCenter);
+const VERIFICATION_ID = TrustTBClient.deriveCostCenterAccountId(PARENT, VERIFICATION.costCenter);
+
+interface EngineHandle extends TrustEngine {
+	lookupBalances?: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * `balances` shapes the read seam:
+ *   Map       → the balances TigerBeetle answers with (omitted id ⇒ implicit zero)
+ *   "throw"   → the batch read fails
+ *   undefined → the engine has NO `lookupBalances` at all
+ */
+function makeMockEngine(balances?: Map<bigint, number> | "throw"): EngineHandle {
+	const engine: EngineHandle = {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		voidAllPending: vi.fn(async () => {}),
+		destroy: vi.fn(),
+	};
+	if (balances !== undefined) {
+		engine.lookupBalances = vi.fn(async () => {
+			if (balances === "throw") throw new Error("tb: lookupAccounts timed out");
+			return balances;
+		});
+	}
+	return engine;
+}
+
+function makeMockAudit(): AuditWriter {
+	return {
+		appendEvent: vi.fn(
+			async (input: AppendEventInput): Promise<AuditEvent> => ({
+				id: randomUUID(),
+				timestamp: new Date().toISOString(),
+				previousHash: "0".repeat(64),
+				hash: "a".repeat(64),
+				kind: input.kind,
+				actor: input.actor,
+				data: input.data,
+			}),
+		),
+		getWriteFailures: vi.fn(() => 0),
+		isDegraded: vi.fn(() => false),
+		flush: vi.fn(async () => {}),
+		release: vi.fn(),
+	};
+}
+
+/**
+ * The message core `budgetContext` produces for the same bad input, read from a client
+ * that would THROW if the call ever reached I/O — which is itself the pin that these
+ * doors are pre-I/O on the core path too.
+ */
+async function coreRefusal(envelopes: EnvelopeDescriptor[]): Promise<string> {
+	const client = {
+		lookupBalances: () => {
+			throw new Error("core budgetContext reached I/O for an input that must be refused pre-I/O");
+		},
+	} as unknown as TrustTBClient;
+	try {
+		await coreBudgetContext(client, PARENT, envelopes, NOW);
+	} catch (err) {
+		return (err as Error).message;
+	}
+	throw new Error("core budgetContext did not refuse the input");
+}
+
+describe("Governor.budgetContext", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `headless-budget-context-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		vi.spyOn(Date, "now").mockReturnValue(NOW);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		process.env.USERTRUST_TEST = "";
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	// `parentUserId: null` means "construct this governor with NO ledger identity" —
+	// a default parameter could not express that, because passing `undefined`
+	// explicitly is what selects a default.
+	async function governorWith(
+		engine: EngineHandle | null,
+		parentUserId: string | null = PARENT,
+	): Promise<Governor> {
+		return await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			...(parentUserId !== null ? { parentUserId } : {}),
+			...(engine !== null ? { _engine: engine } : { dryRun: true }),
+			_audit: makeMockAudit(),
+		});
+	}
+
+	// ── Layer 1: pre-I/O validation THROWS, with core's exact messages ──
+
+	describe("pre-I/O validation (caller bugs — these throw)", () => {
+		it("refuses a batch over MAX_ENVELOPES, before any ledger read", async () => {
+			const engine = makeMockEngine(new Map());
+			const gov = await governorWith(engine);
+
+			const tooMany: EnvelopeDescriptor[] = Array.from(
+				{ length: MAX_ENVELOPES + 1 },
+				(_, i): EnvelopeDescriptor => ({
+					costCenter: `cc-${i}`,
+					allocated: 100,
+					periodStartMs: NOW - HOUR,
+				}),
+			);
+
+			await expect(gov.budgetContext(tooMany)).rejects.toThrow(await coreRefusal(tooMany));
+			expect(engine.lookupBalances).not.toHaveBeenCalled();
+
+			await gov.destroy();
+		});
+
+		it("refuses a descriptor whose costCenter fails the ledger door", async () => {
+			const engine = makeMockEngine(new Map());
+			const gov = await governorWith(engine);
+
+			const bad: EnvelopeDescriptor[] = [{ ...RESEARCH, costCenter: "not a cost center" }];
+
+			await expect(gov.budgetContext(bad)).rejects.toThrow(await coreRefusal(bad));
+			expect(engine.lookupBalances).not.toHaveBeenCalled();
+
+			await gov.destroy();
+		});
+
+		it("refuses a duplicate costCenter", async () => {
+			const engine = makeMockEngine(new Map());
+			const gov = await governorWith(engine);
+
+			// Two entries resolve to ONE envelope account, so a duplicate can only be
+			// caller confusion — never two distinct envelopes to report on.
+			const dupes = [RESEARCH, VERIFICATION, { ...RESEARCH }];
+
+			await expect(gov.budgetContext(dupes)).rejects.toThrow(await coreRefusal(dupes));
+			expect(engine.lookupBalances).not.toHaveBeenCalled();
+
+			await gov.destroy();
+		});
+	});
+
+	// ── Layer 2: every read failure is quiet (A8) ──
+
+	describe("read failures degrade to [] (A8 — reporting only)", () => {
+		it("answers [] in dryRun, where there is no engine to read", async () => {
+			// dryRun and "no engine" are ONE leg through `createGovernor`: a dry-run
+			// governor builds no engine at all, and a non-dry-run one always has one.
+			const gov = await governorWith(null);
+
+			await expect(gov.budgetContext(DESCRIPTORS)).resolves.toEqual([]);
+
+			await gov.destroy();
+		});
+
+		it("answers [] when the engine cannot read balances at all", async () => {
+			const engine = makeMockEngine();
+			expect(engine.lookupBalances).toBeUndefined();
+			const gov = await governorWith(engine);
+
+			await expect(gov.budgetContext(DESCRIPTORS)).resolves.toEqual([]);
+
+			await gov.destroy();
+		});
+
+		it("answers [] when the batch read rejects", async () => {
+			const engine = makeMockEngine("throw");
+			const gov = await governorWith(engine);
+
+			await expect(gov.budgetContext(DESCRIPTORS)).resolves.toEqual([]);
+			expect(engine.lookupBalances).toHaveBeenCalledOnce();
+
+			await gov.destroy();
+		});
+
+		it("answers [] when the governor has no parentUserId", async () => {
+			// No ledger identity means no envelope account is derivable — and, unlike
+			// `authorize()`'s D1 throw, nothing is about to spend, so there is nothing to
+			// refuse. The report is simply empty.
+			const engine = makeMockEngine(new Map([[RESEARCH_ID, 3_400]]));
+			const gov = await governorWith(engine, null);
+
+			await expect(gov.budgetContext(DESCRIPTORS)).resolves.toEqual([]);
+			expect(engine.lookupBalances).not.toHaveBeenCalled();
+
+			await gov.destroy();
+		});
+	});
+
+	// ── The happy path ──
+
+	describe("the read", () => {
+		it("derives every envelope account and reads them in ONE batched call", async () => {
+			const engine = makeMockEngine(
+				new Map([
+					[RESEARCH_ID, 3_400],
+					[VERIFICATION_ID, 3_560],
+				]),
+			);
+			const gov = await governorWith(engine);
+
+			await gov.budgetContext(DESCRIPTORS);
+
+			expect(engine.lookupBalances).toHaveBeenCalledOnce();
+			// Derived, never looked up — and in descriptor order, which is what lets the
+			// mapping below pair a balance with its descriptor by index.
+			expect(engine.lookupBalances?.mock.calls[0]?.[0]).toEqual([RESEARCH_ID, VERIFICATION_ID]);
+
+			await gov.destroy();
+		});
+
+		it("returns exactly `envelopeStatusFrom` on the same inputs — one money-math source", async () => {
+			const engine = makeMockEngine(
+				new Map([
+					[RESEARCH_ID, 3_400],
+					[VERIFICATION_ID, 3_560],
+				]),
+			);
+			const gov = await governorWith(engine);
+
+			const statuses = await gov.budgetContext(DESCRIPTORS);
+
+			// Not a hand-recomputed expectation: the SHARED helper is the expectation, so
+			// a second copy of the clamp/runway arithmetic in the governor would fail here.
+			expect(statuses).toEqual([
+				envelopeStatusFrom(RESEARCH, 3_400, NOW),
+				envelopeStatusFrom(VERIFICATION, 3_560, NOW),
+			]);
+
+			await gov.destroy();
+		});
+
+		it("reads an envelope TigerBeetle omits as an implicit zero", async () => {
+			// Never allocated and fully reclaimed are the same observable state — the
+			// batch read omits the account and this reports 0, exactly as core does.
+			const engine = makeMockEngine(new Map([[RESEARCH_ID, 3_400]]));
+			const gov = await governorWith(engine);
+
+			const statuses = await gov.budgetContext(DESCRIPTORS);
+
+			expect(statuses[1]).toEqual(envelopeStatusFrom(VERIFICATION, 0, NOW));
+			expect(statuses[1]?.remaining).toBe(0);
+			expect(statuses[1]?.fraction).toBe(0);
+
+			await gov.destroy();
+		});
+
+		it("lets a bad clock on a descriptor propagate — the mapping is OUTSIDE the catch", async () => {
+			// The catch covers the awaited `lookupBalances` and nothing else. A non-finite
+			// `periodStartMs` is a caller bug that `computeRunway` refuses to paper over,
+			// and swallowing it into `[]` would silently drop every OTHER envelope's
+			// report too — the caller would read "no envelopes" and never learn why.
+			const engine = makeMockEngine(new Map([[RESEARCH_ID, 3_400]]));
+			const gov = await governorWith(engine);
+
+			await expect(
+				gov.budgetContext([{ ...RESEARCH, periodStartMs: Number.NaN }]),
+			).rejects.toThrow();
+			expect(engine.lookupBalances).toHaveBeenCalledOnce();
+
+			await gov.destroy();
+		});
+	});
+});

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -57,8 +57,143 @@ agent call → OpenClaw → usertrust wrapStreamFn
 | `dryRun` | `boolean` | Skip TigerBeetle; policy gate + audit still run. |
 | `vaultBase` | `string` | Vault location (defaults to the project root). |
 | `proxy` / `proxyKey` | `string` | Point at the hosted proxy for cross-agent budget enforcement. |
+| `costCenters` | `object` | Operator-declared tool→envelope attribution + scarcity injection. See below. Absent: no attribution, no scarcity block. |
 
 Budget enforcement is **pre-spend**: because a stream's cost isn't known until it finishes, the estimate assumes the model's full output budget, so calls are denied conservatively rather than allowed to overshoot. Size `budget` accordingly.
+
+## Budget envelopes: tool→cost-center attribution
+
+`costCenters` routes a governed call's spend to a named, operator-capped envelope based on
+which tools the agent used, and layers an ambient per-turn scarcity signal on top:
+
+```typescript
+const plugin = createUsertrustPlugin({
+  budget: 100_000,
+  costCenters: {
+    parentUserId: "acct:123",
+    tools: { web_search: "research", run_tests: "verification" },
+    default: "general",
+    envelopes: {
+      research: { allocated: 20_000, periodStartMs: Date.now() },
+      verification: { allocated: 30_000, periodStartMs: Date.now() },
+      general: { allocated: 10_000, periodStartMs: Date.now() },
+    },
+    // scarcityContext: true,  // default; set false to opt out of injection
+  },
+});
+```
+
+Validated once, at plugin construction (`createUsertrustPlugin` / `register`), through core's
+own doors — `parentUserId`, every envelope's charset + metadata, and the `tools`/`default`
+membership checks — never lazily on the first call. The validated config is normalized into a
+deep-frozen copy that every wrapper reads; nothing downstream can mutate routing after
+construction. A second plugin instance constructed with a **different** config is rejected
+loudly (the governor is a module-wide singleton), never silently handed the first instance's
+`parentUserId`.
+
+### Attribution rule (stateless, per call)
+
+At each governed call, attribution is derived fresh from the context the caller already handed
+the wrapper — there is no cross-call state, so nothing goes stale on an error, a consumer
+`break`, or an abandoned stream:
+
+1. Find the most recent contiguous run of host-inserted tool-**result** messages that are the
+   **trailing** entries of the context — i.e. the host asking the model to continue right after
+   executing tools. Anything after that run (a final answer, a new user turn) resets
+   attribution to `default`; a tool call from three turns ago never bills the current one.
+2. Each result is correlated to the immediately preceding assistant turn's tool calls by
+   `toolCallId`/`toolName`; results with `isError: true` are **excluded** (the host represents
+   validation failures as error results without a real execution — the conservative choice,
+   under-attributing rather than over-attributing).
+3. The first correlated, non-error, mapped tool name wins, in message order → that cost
+   center. No mapped name, or no tool-result run at all (including turn 1) → `costCenters.default`
+   → else `undefined` (unattributed — the call bills the session wallet, exactly as before this
+   feature existed).
+
+Matching is **structured-field equality only** — `toolName`/`toolCallId`/`isError` are
+first-class fields on the host's tool-result message shape. Nothing in the attribution path
+ever reads message *text*: a model that types the string `web_search` into its prose cannot
+produce a `role: "toolResult"` message, and cannot influence which envelope pays.
+
+### Security model — attribution authority vs. labeling (the carve-out)
+
+Reproduced verbatim from the design spec (`docs/superpowers/specs/2026-08-07-ship2-openclaw-envelopes-design.md`,
+"Security model — attribution authority vs. labeling"):
+
+> The core invariant stands: **no cc string ever originates outside operator config.** Map
+> values and `default` are the only strings that reach `withCostCenter`; they are validated at
+> plugin construction through core's canonical door.
+>
+> What this ship explicitly changes: *which* operator-capped pool pays a given call is selected
+> by the agent's own activity (which tools it used). Three properties make that safe and honest:
+>
+> 1. **Bounded operator-delegated selection** (not "cannot increase spend" — configuring the
+>    map DELEGATES access to the mapped envelopes' funds beyond the session wallet, and the
+>    selected envelope drives the call's policy inputs: `budget_remaining`, fraction, runway,
+>    `cost_center`). The bounds: selection can never exceed any envelope's ledger cap, reach an
+>    unmapped envelope, or author a cc; total exposure is exactly the sum of operator
+>    allocations the operator delegated by writing the map.
+> 2. **Executed evidence, correlated and current.** Attribution derives from host-inserted
+>    tool-RESULT blocks — and only a TRAILING run: the run must be the last message(s) of the
+>    context (the host asking the model to continue after execution). Anything after the run
+>    (assistant final answer, new user message) resets attribution to `default` — no stale
+>    carry-over into later turns. Each result is correlated by `toolCallId`/name to the
+>    immediately preceding assistant message's tool calls; results with `isError: true` are
+>    EXCLUDED (pi represents validation failures as error results without real execution —
+>    conservative choice, tested both ways). Matching is structured-field equality per the
+>    contract task; never free-text.
+> 3. **Evidence boundary, stated honestly:** in plugin mode the context is assembled by the
+>    OpenClaw host, so message STRUCTURE (roles, result blocks) is host-written code structure.
+>    In programmatic mode (`createGovernedStreamFn`) the caller supplies `messages` directly —
+>    attribution there is **caller-trusted labeling** on the same trust boundary as the operator
+>    config (the caller already holds the governor). Documented, not hidden.
+> 4. **Documented residual:** a prompt-injected agent can still *choose* activity that lands on
+>    a mapped envelope — cc labels on openclaw-attributed traffic are model-activity-influenced
+>    categorization, bounded per (1). The audit chain records the selected `costCenter` only;
+>    the attribution evidence (tool name/id) is NOT in the chain today — documented limitation,
+>    future audit seam if operators need it. Operators who need adversarial-grade attribution
+>    wrap phases in host code (`withCostCenter` is public).
+>
+> The scarcity block reveals envelope levels to the model — that is the feature (planning
+> signal) and also financial-metadata egress to the provider; documented, and configuring
+> `costCenters` is the opt-in (`scarcityContext: false` opts back out).
+
+**Where governance actually applies.** OpenClaw resolves `wrapStreamFn` per-provider, matching
+the call's provider id against the plugin's registered `id`/`aliases` — there is no host-wide
+stream-wrapper seam. Attribution and scarcity injection are wired everywhere the wrapper runs
+(`createGovernedStreamFn`, and any provider whose id the operator maps to `usertrust`), but a
+plugin registered under an id no live call ever routes through wraps nothing. This is a
+pre-existing gap in "zero code changes, every call governed," not something this feature
+introduces — register under the real provider ids in use, or wrap in host code via
+`createGovernedStreamFn`.
+
+### Scarcity injection
+
+When `costCenters` is configured and `scarcityContext` is not `false`, every governed call gets
+a system-prompt block built from the frozen `envelopes`' live ledger balances:
+
+```
+[usertrust scarcity] research: 34% left (~2.1h runway) · verification: 89% left
+```
+
+The block is appended to the caller's existing `systemPrompt` (never replacing it), on a
+**copy** of the context — the caller's own object is never mutated. A read/format failure, or
+an empty envelope set, omits the block silently; scarcity context is reporting-only and never
+gates, delays, or throws into the money path (AGENTS.md "A8"). The full effective system prompt
+(pre-existing plus the scarcity block, when injected) is represented exactly once in the
+messages handed to the pre-call budget estimate, so the hold covers what actually egresses to
+the provider.
+
+`envelopes` metadata handed to `budgetContext` (`allocated`, `periodStartMs`, `periodEndMs`) is
+**reporting-truth only** — it neither creates nor funds an envelope. An envelope is funded
+exclusively by `allocateBudget` (`packages/core`); a `costCenters.envelopes` entry with no
+matching ledger allocation reports honest-but-empty scarcity, never a shortfall.
+
+### Compatibility
+
+Pinned against `openclaw@2026.7.1-2` and `@mariozechner/pi-ai@0.73.1` (exact `devDependencies`);
+declared as optional peers at `openclaw >=2026.7.1` / `@mariozechner/pi-ai >=0.12.0`. Both are
+type-only at runtime — neither is required to build or ship the plugin.
 
 ## License
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -192,8 +192,15 @@ matching ledger allocation reports honest-but-empty scarcity, never a shortfall.
 ### Compatibility
 
 Pinned against `openclaw@2026.7.1-2` and `@mariozechner/pi-ai@0.73.1` (exact `devDependencies`);
-declared as optional peers at `openclaw >=2026.7.1` / `@mariozechner/pi-ai >=0.12.0`. Both are
+declared as optional peers at `openclaw >=2026.7.1-0` / `@mariozechner/pi-ai >=0.12.0`. Both are
 type-only at runtime — neither is required to build or ship the plugin.
+
+The `-0` on the openclaw peer floor is load-bearing, not a typo. OpenClaw ships its releases with
+a numeric build suffix (`latest` is currently `2026.7.1-2`), which node-semver treats as a
+*prerelease*; a prerelease version never satisfies a release-only range, so `>=2026.7.1` would
+exclude the very build this package pins. `>=2026.7.1-0` admits it. The separate
+`openclaw.compat.pluginApi` range deliberately keeps the plain `>=2026.7.1` form: the host strips
+the `-N` suffix before comparing, so that check is unaffected.
 
 ## License
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -191,14 +191,37 @@ matching ledger allocation reports honest-but-empty scarcity, never a shortfall.
 
 ### Compatibility
 
-Pinned against `openclaw@2026.7.1-2` and `@mariozechner/pi-ai@0.73.1` (exact `devDependencies`);
-declared as optional peers at `openclaw >=2026.7.1-0` / `@mariozechner/pi-ai >=0.12.0`. Both are
-type-only at runtime — neither is required to build or ship the plugin.
+Both hosts are declared as optional peers — `openclaw >=2026.7.1-0` and
+`@mariozechner/pi-ai >=0.12.0` — and both are type-only: neither is required to build, ship, or run
+the plugin.
+
+The contract is *proven* against an exact version of each, and the two are proven differently
+because only one of them is installed:
+
+| Host | Pinned as | Contract gate |
+|---|---|---|
+| `@mariozechner/pi-ai` | exact `devDependency` (`0.73.1`) | `tests/contract.test-d.ts`, compiled by `npm run typecheck` on **every push** |
+| `openclaw` | `openclaw-contract.env` — **the only place the version appears** | `tests/contract-openclaw.test-d.ts` + `tests/contract.test.ts`, run by the `openclaw-contract` CI job after an out-of-tree install |
+
+openclaw is not a `devDependency` because it is a full agent CLI: pulling its tree into every
+`npm ci`, for four type-only imports in two test files, cost far more than proving the contract once
+per run in a job of its own. `npm ci` does not install optional peers, so no other job sees it. Run
+that job's gates locally with:
+
+```bash
+source packages/openclaw/openclaw-contract.env
+npm install --no-save --ignore-scripts openclaw@"$OPENCLAW_CONTRACT_VERSION"
+USERTRUST_OPENCLAW_CONTRACT=1 npx tsc -p packages/openclaw/tsconfig.contract-openclaw.json
+USERTRUST_OPENCLAW_CONTRACT=1 npx vitest run packages/openclaw/tests/contract.test.ts
+```
+
+`USERTRUST_OPENCLAW_CONTRACT=1` is what makes an absent or mismatched openclaw a hard failure;
+without it the host-smoke suite skips itself with a notice naming that job.
 
 The `-0` on the openclaw peer floor is load-bearing, not a typo. OpenClaw ships its releases with
-a numeric build suffix (`latest` is currently `2026.7.1-2`), which node-semver treats as a
-*prerelease*; a prerelease version never satisfies a release-only range, so `>=2026.7.1` would
-exclude the very build this package pins. `>=2026.7.1-0` admits it. The separate
+a numeric build suffix, which node-semver treats as a *prerelease*; a prerelease version never
+satisfies a release-only range, so `>=2026.7.1` would exclude the very build this package pins.
+`>=2026.7.1-0` admits it. The separate
 `openclaw.compat.pluginApi` range deliberately keeps the plain `>=2026.7.1` form: the host strips
 the `-N` suffix before comparing, so that check is unaffected.
 

--- a/packages/openclaw/demo/runaway-agent.ts
+++ b/packages/openclaw/demo/runaway-agent.ts
@@ -19,7 +19,14 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createUsertrustPlugin } from "../src/index.js";
-import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+import type {
+	AssistantMessage,
+	AssistantMessageEventStreamLike,
+	Context,
+	Model,
+	StreamEvent,
+	StreamFn,
+} from "../src/types.js";
 
 // ── 1. Tiny budget — 1,200 usertokens (~$0.50 at typical rates) ──
 const BUDGET = 1_200;
@@ -33,29 +40,70 @@ console.log("  agent:         buggy loop, ~250 usertokens per call");
 console.log("");
 
 // ── 2. The "runaway" mock streamFn — pretends to be a real LLM stream ──
-const runawayStreamFn: StreamFn = async function* (_model, _ctx) {
-	yield { type: "start" } as StreamEvent;
-	yield { type: "text_start" } as StreamEvent;
-	for (let i = 0; i < 25; i++) {
-		yield { type: "text_delta", text: `tok-${i} ` } as StreamEvent;
-	}
-	yield { type: "text_end" } as StreamEvent;
-	yield {
-		type: "done",
+const MODEL: Model = {
+	id: "claude-sonnet-4-6",
+	name: "Claude Sonnet 4.6",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://api.anthropic.com",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+	contextWindow: 200_000,
+	maxTokens: 8192,
+};
+
+function finalMessage(input: number, output: number): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: MODEL.api,
+		provider: MODEL.provider,
+		model: MODEL.id,
+		usage: {
+			input,
+			output,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: input + output,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
 		stopReason: "stop",
-		usage: { inputTokens: 500, outputTokens: 1500 }, // ~240 usertokens / call
-	} as StreamEvent;
+		timestamp: Date.now(),
+	};
+}
+
+const runawayStreamFn: StreamFn = (): AssistantMessageEventStreamLike => {
+	// ~240 usertokens / call
+	const message = finalMessage(500, 1500);
+	const events = (async function* (): AsyncGenerator<StreamEvent> {
+		yield { type: "start", partial: message };
+		yield { type: "text_start", contentIndex: 0, partial: message };
+		for (let i = 0; i < 25; i++) {
+			yield { type: "text_delta", contentIndex: 0, delta: `tok-${i} ` };
+		}
+		yield { type: "text_end", contentIndex: 0, content: "", partial: message };
+		yield { type: "done", reason: "stop", message };
+	})();
+
+	return {
+		[Symbol.asyncIterator]: () => events[Symbol.asyncIterator](),
+		result: async () => message,
+	};
 };
 
 // ── 3. Wire the governance plugin ──
 const plugin = createUsertrustPlugin({ budget: BUDGET, dryRun: true, vaultBase });
-const governedStream = plugin.wrapStreamFn?.(runawayStreamFn);
+const governedStream = plugin.wrapStreamFn?.({
+	provider: MODEL.provider,
+	modelId: MODEL.id,
+	streamFn: runawayStreamFn,
+});
 if (!governedStream) throw new Error("plugin missing wrapStreamFn");
 
 // ── 4. Run the agent loop. Each iteration costs ~$0.10 — it gets ~5 calls. ──
-const ctx: StreamContext = {
-	messages: [{ role: "user", content: "do the thing forever" }],
-	model: "claude-sonnet-4-6",
+const ctx: Context = {
+	messages: [{ role: "user", content: "do the thing forever", timestamp: Date.now() }],
 };
 
 let call = 0;
@@ -64,7 +112,7 @@ while (!cutoff && call < 40) {
 	call += 1;
 	try {
 		let chunks = 0;
-		for await (const _e of governedStream("claude-sonnet-4-6", ctx)) {
+		for await (const _e of await governedStream(MODEL, ctx)) {
 			chunks += 1;
 		}
 		console.log(`  call #${String(call).padStart(2)}  OK     chunks=${chunks}  → call settled`);

--- a/packages/openclaw/openclaw-contract.env
+++ b/packages/openclaw/openclaw-contract.env
@@ -1,0 +1,23 @@
+# The exact openclaw release this plugin's host contract is pinned to.
+#
+# THE SINGLE SOURCE OF THIS PIN. It is deliberately NOT a devDependency of
+# packages/openclaw: openclaw is a full agent CLI, and pulling its whole tree
+# into every `npm ci` — for four type-only imports in two test files — bought a
+# large install and a large lockfile surface for a contract that only ever needs
+# to be proven once per run. (`@mariozechner/pi-ai` STAYS an exact devDependency:
+# it is small, and the assertions that read it run on every push.)
+#
+# Who reads this file:
+#   - .github/workflows/ci.yml, job `openclaw-contract` — sources it, installs
+#     exactly this version out-of-tree (`--no-save --package-lock=false`), and
+#     runs the openclaw half of the contract with USERTRUST_OPENCLAW_CONTRACT=1.
+#     That job is the proving ground; nothing else in CI sees openclaw at all.
+#   - packages/openclaw/tests/contract.test.ts — reads it to hard-fail on a
+#     version MISMATCH, so an install that silently resolved something else
+#     cannot pass as a proof of this pin.
+#
+# Rationale for every field name the contract asserts on: contract-notes §2.
+# Bumping the pin: change the value here, then run the `openclaw-contract` job's
+# commands locally and fix whatever the compile reports. Nothing else references
+# the version number.
+OPENCLAW_CONTRACT_VERSION=2026.7.1-2

--- a/packages/openclaw/openclaw-contract.env
+++ b/packages/openclaw/openclaw-contract.env
@@ -9,8 +9,9 @@
 #
 # Who reads this file:
 #   - .github/workflows/ci.yml, job `openclaw-contract` — sources it, installs
-#     exactly this version out-of-tree (`--no-save --package-lock=false`), and
-#     runs the openclaw half of the contract with USERTRUST_OPENCLAW_CONTRACT=1.
+#     exactly this version out-of-tree (`--no-save --ignore-scripts`; NOT
+#     `--package-lock=false`, which crashes arborist — see that job's comment),
+#     and runs the openclaw half of the contract with USERTRUST_OPENCLAW_CONTRACT=1.
 #     That job is the proving ground; nothing else in CI sees openclaw at all.
 #   - packages/openclaw/tests/contract.test.ts — reads it to hard-fail on a
 #     version MISMATCH, so an install that silently resolved something else

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -31,6 +31,55 @@
 			"proxyKey": {
 				"type": "string",
 				"description": "API key for the governance proxy."
+			},
+			"costCenters": {
+				"type": "object",
+				"additionalProperties": false,
+				"description": "Operator-declared tool→cost-center attribution + per-turn scarcity injection (Ship 2). Absent: no attribution, no scarcity block.",
+				"properties": {
+					"parentUserId": {
+						"type": "string",
+						"pattern": "^(?!.*::)[a-zA-Z0-9._@:-]{1,128}$",
+						"description": "Envelope account identity — forwarded to createGovernor as parentUserId. A single ':' is legal (e.g. 'acct:123'); '::' is reserved for pre-v3 cost-center accounts and refused."
+					},
+					"tools": {
+						"type": "object",
+						"additionalProperties": { "type": "string" },
+						"description": "toolName -> costCenter. Every value must name a key in envelopes."
+					},
+					"default": {
+						"type": "string",
+						"description": "Fallback cost center for unmapped tools / no tool-result run. Must name a key in envelopes."
+					},
+					"envelopes": {
+						"type": "object",
+						"maxProperties": 128,
+						"propertyNames": { "pattern": "^[a-zA-Z0-9._-]{1,64}$" },
+						"additionalProperties": {
+							"type": "object",
+							"additionalProperties": false,
+							"properties": {
+								"allocated": {
+									"type": "number",
+									"minimum": 0,
+									"description": "Envelope size, in usertokens."
+								},
+								"periodStartMs": { "type": "number", "description": "Epoch ms." },
+								"periodEndMs": {
+									"type": "number",
+									"description": "Epoch ms. Absent means an open-ended period."
+								}
+							},
+							"required": ["allocated", "periodStartMs"]
+						},
+						"description": "costCenter -> { allocated, periodStartMs, periodEndMs? }. At most 128 entries; each key must match ^[a-zA-Z0-9._-]{1,64}$."
+					},
+					"scarcityContext": {
+						"type": "boolean",
+						"description": "Inject the per-turn scarcity block into the system prompt. Default true when costCenters is present."
+					}
+				},
+				"required": ["parentUserId", "tools", "envelopes"]
 			}
 		},
 		"required": ["budget"]

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -50,7 +50,7 @@
 	},
 	"peerDependencies": {
 		"@mariozechner/pi-ai": ">=0.12.0",
-		"openclaw": ">=2026.7.1"
+		"openclaw": ">=2026.7.1-0"
 	},
 	"peerDependenciesMeta": {
 		"@mariozechner/pi-ai": {

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -33,7 +33,13 @@
 	"scripts": {
 		"build": "tsc",
 		"prepublishOnly": "tsc",
-		"demo": "tsx demo/runaway-agent.ts"
+		"demo": "tsx demo/runaway-agent.ts",
+		"typecheck:contract": "tsc -p tsconfig.type-tests.json"
+	},
+	"openclaw": {
+		"compat": {
+			"pluginApi": ">=2026.7.1"
+		}
 	},
 	"files": [
 		"dist",
@@ -43,11 +49,19 @@
 		"usertrust": "*"
 	},
 	"peerDependencies": {
-		"@mariozechner/pi-ai": ">=0.1.0"
+		"@mariozechner/pi-ai": ">=0.12.0",
+		"openclaw": ">=2026.7.1"
 	},
 	"peerDependenciesMeta": {
 		"@mariozechner/pi-ai": {
 			"optional": true
+		},
+		"openclaw": {
+			"optional": true
 		}
+	},
+	"devDependencies": {
+		"@mariozechner/pi-ai": "0.73.1",
+		"openclaw": "2026.7.1-2"
 	}
 }

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -34,7 +34,8 @@
 		"build": "tsc",
 		"prepublishOnly": "tsc",
 		"demo": "tsx demo/runaway-agent.ts",
-		"typecheck:contract": "tsc -p tsconfig.type-tests.json"
+		"typecheck:contract": "tsc -p tsconfig.type-tests.json",
+		"typecheck:contract:openclaw": "tsc -p tsconfig.contract-openclaw.json"
 	},
 	"openclaw": {
 		"compat": {
@@ -61,7 +62,6 @@
 		}
 	},
 	"devDependencies": {
-		"@mariozechner/pi-ai": "0.73.1",
-		"openclaw": "2026.7.1-2"
+		"@mariozechner/pi-ai": "0.73.1"
 	}
 }

--- a/packages/openclaw/src/attribution.ts
+++ b/packages/openclaw/src/attribution.ts
@@ -97,10 +97,14 @@ export function deriveAttribution(
 		const { toolCallId, toolName } = result;
 		if (typeof toolCallId !== "string" || typeof toolName !== "string") continue;
 		if (issued.get(toolCallId) !== toolName) continue;
-		// `Object.hasOwn`, never `in` and never a bare lookup: `tools` is a plain
-		// object, so a tool named `toString` would otherwise resolve to
-		// Object.prototype's function and be handed to `withCostCenter` as a
-		// cost center. Every own value is a validated `envelopes` key.
+		// `Object.hasOwn`, never `in` and never a bare lookup. `normalizeCostCenters`
+		// builds `tools` with a NULL prototype, which is the write-side half of the
+		// same rule — a tool named `__proto__` gets a real own key instead of being
+		// eaten by `Object.prototype`'s setter. This is the read-side half, and it
+		// stays correct either way: a tool named `toString` or `constructor` matches
+		// nothing, rather than resolving to an inherited function and being handed
+		// to `withCostCenter` as a cost center. Every own value is a validated
+		// `envelopes` key.
 		if (Object.hasOwn(costCenters.tools, toolName)) return costCenters.tools[toolName];
 	}
 

--- a/packages/openclaw/src/attribution.ts
+++ b/packages/openclaw/src/attribution.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * attribution.ts — which operator envelope pays THIS call.
+ *
+ * One pure function, derived from nothing but the context the caller already
+ * handed the wrapper and the operator's frozen config. There is no state here
+ * on purpose: attribution is per-conversation by construction, so there is
+ * nothing to isolate between callers and nothing to go stale on an error, a
+ * consumer `break`, or an abandoned stream.
+ *
+ * The security model (design spec, "Security model — attribution authority vs.
+ * labeling") is enforced by four rules, each one a class of failure:
+ *
+ *   TRAILING ONLY   — the tool-result run must be the LAST message(s) of the
+ *                     context, i.e. the host asking the model to continue right
+ *                     after executing tools. Anything after the run (a final
+ *                     answer, a new user turn) resets attribution, so a single
+ *                     `web_search` early in a conversation cannot silently bill
+ *                     every later turn to `research`.
+ *   CORRELATED      — each result must match, by `toolCallId` AND `toolName`, a
+ *                     `ToolCall` the IMMEDIATELY preceding assistant turn
+ *                     actually issued. A result block that correlates to
+ *                     nothing is evidence of nothing.
+ *   isError EXCLUDED— the host represents validation failures as error results
+ *                     without a real execution, so only `isError === false`
+ *                     counts. Anything else — `true`, missing, non-boolean — is
+ *                     excluded; the conservative direction is to under-attribute
+ *                     and fall back to `default`.
+ *   STRUCTURED ONLY — every read is a structured field. Prose that says
+ *                     "I called web_search" is text in a `content` block and can
+ *                     never produce a `role: "toolResult"` message, so it can
+ *                     never reach this function's comparisons.
+ *
+ * And the invariant that bounds all of it: the only strings this function can
+ * RETURN are values of the operator's frozen `tools` map or its `default` —
+ * both already validated to be `envelopes` keys. A tool name is only ever a
+ * lookup key, never a cost center.
+ *
+ * Field names are CONTRACT-DETERMINED (contract-notes §2) and never guessed.
+ */
+
+import type { FrozenCostCenters } from "./types.js";
+
+/**
+ * Derive the cost center for a call from its context.
+ *
+ * `messages` is `unknown[]`, not `Message[]`, deliberately: in programmatic
+ * mode the caller supplies the array directly, and a host that drifts from the
+ * pinned contract must degrade to `default` rather than throw INTO the money
+ * path. Every entry is narrowed before it is read.
+ *
+ * @returns the mapped cost center, else the config's `default`, else
+ * `undefined` (unattributed — the call bills the session wallet).
+ */
+export function deriveAttribution(
+	messages: unknown[],
+	costCenters: FrozenCostCenters,
+): string | undefined {
+	const fallback = costCenters.default;
+
+	// 1. The TRAILING run. Walking backwards from the end is what makes it
+	//    trailing: the first entry that is not a tool-result message ends the
+	//    run, so a run buried mid-context is never even considered.
+	const run: Record<string, unknown>[] = [];
+	let runStart = messages.length;
+	while (runStart > 0) {
+		const candidate = asRecord(messages[runStart - 1]);
+		if (candidate?.role !== "toolResult") break;
+		run.push(candidate);
+		runStart--;
+	}
+	if (run.length === 0) return fallback;
+	run.reverse();
+
+	// 2. The turn that ISSUED those calls. `messages[-1]` is `undefined` for a
+	//    run at index 0, which correlates to nothing — exactly right.
+	const issued = issuedToolCalls(messages[runStart - 1]);
+	if (issued === undefined) return fallback;
+
+	// 3. First correlated, non-error, mapped name wins — in message order.
+	for (const result of run) {
+		// Only an explicit `false` is a real execution. `isError` is REQUIRED in
+		// the pinned contract, so a missing one is malformed, not "not an error".
+		if (result.isError !== false) continue;
+		const { toolCallId, toolName } = result;
+		if (typeof toolCallId !== "string" || typeof toolName !== "string") continue;
+		if (issued.get(toolCallId) !== toolName) continue;
+		// `Object.hasOwn`, never `in` and never a bare lookup: `tools` is a plain
+		// object, so a tool named `toString` would otherwise resolve to
+		// Object.prototype's function and be handed to `withCostCenter` as a
+		// cost center. Every own value is a validated `envelopes` key.
+		if (Object.hasOwn(costCenters.tools, toolName)) return costCenters.tools[toolName];
+	}
+
+	return fallback;
+}
+
+/** A non-null, non-array object, or `undefined` for anything else. */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+/**
+ * `ToolCall.id` → `ToolCall.name` for the tool calls an assistant turn issued,
+ * or `undefined` when `message` is not an assistant turn at all (in which case
+ * nothing in the run can correlate). Malformed blocks are skipped, so a single
+ * bad entry cannot suppress the rest of the turn.
+ */
+function issuedToolCalls(message: unknown): Map<string, string> | undefined {
+	const record = asRecord(message);
+	if (record?.role !== "assistant" || !Array.isArray(record.content)) return undefined;
+
+	const issued = new Map<string, string>();
+	for (const block of record.content) {
+		const call = asRecord(block);
+		if (call?.type !== "toolCall") continue;
+		if (typeof call.id !== "string" || typeof call.name !== "string") continue;
+		issued.set(call.id, call.name);
+	}
+	return issued;
+}

--- a/packages/openclaw/src/attribution.ts
+++ b/packages/openclaw/src/attribution.ts
@@ -49,7 +49,7 @@ import type { FrozenCostCenters } from "./types.js";
  * `messages` is `unknown[]`, not `Message[]`, deliberately: in programmatic
  * mode the caller supplies the array directly, and a host that drifts from the
  * pinned contract must degrade to `default` rather than throw INTO the money
- * path. Every entry is narrowed before it is read.
+ * path. The array itself is narrowed first, then every entry in it.
  *
  * @returns the mapped cost center, else the config's `default`, else
  * `undefined` (unattributed — the call bills the session wallet).
@@ -59,6 +59,16 @@ export function deriveAttribution(
 	costCenters: FrozenCostCenters,
 ): string | undefined {
 	const fallback = costCenters.default;
+
+	// 0. The ARRAY itself, before any entry. Every entry below is narrowed, but
+	//    `messages` is `unknown[]` by declaration only: a host that drops the
+	//    field, or a programmatic caller that forwards a context it never built,
+	//    hands us `undefined` — and `undefined.length` would throw INTO the
+	//    money path, which is exactly what the degrade-to-`default` contract
+	//    above exists to prevent. Non-arrays with a `length` (a string, a
+	//    hand-rolled array-like) are refused here too, so nothing indexes an
+	//    object that only LOOKS iterable.
+	if (!Array.isArray(messages)) return fallback;
 
 	// 1. The TRAILING run. Walking backwards from the end is what makes it
 	//    trailing: the first entry that is not a tool-result message ends the

--- a/packages/openclaw/src/fingerprint.ts
+++ b/packages/openclaw/src/fingerprint.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * fingerprint.ts — the identity of the config that CLAIMED the singleton governor.
+ *
+ * `index.ts` holds one governor per module, so a second plugin instance either
+ * reuses it (same config) or is refused (different config). "Same config" is
+ * decided here, and the deciding value is held at module scope in `index.ts`
+ * for the whole process lifetime — which is why it must not be the config
+ * itself: a plugin config carries `proxyKey`, an operator's API key, and the
+ * canonical JSON of it would keep that key resident in the clear in a
+ * module-level variable, reachable from any heap dump or `--inspect` session,
+ * long after the value was needed.
+ *
+ * Equality is the ONLY operation ever performed on a fingerprint, and a digest
+ * supports equality exactly as well as the JSON does — so the JSON is hashed
+ * and discarded. Semantics are unchanged; the retained secret is gone.
+ */
+
+import { createHash } from "node:crypto";
+import type { FrozenCostCenters, UsertrustPluginConfig } from "./types.js";
+
+/**
+ * Canonical-JSON-then-sha-256 fingerprint of the config that determines the
+ * module-singleton governor's identity. Key order never matters — the JSON is
+ * canonicalized before hashing — so two semantically identical configs written
+ * with different key orders fingerprint the same.
+ *
+ * @returns a 64-character lowercase hex digest. Never the config text.
+ */
+export function fingerprintConfig(
+	config: UsertrustPluginConfig,
+	frozenCostCenters?: FrozenCostCenters,
+): string {
+	const canonical = JSON.stringify(sortKeysDeep({ ...config, costCenters: frozenCostCenters }));
+	return createHash("sha256").update(canonical, "utf8").digest("hex");
+}
+
+function sortKeysDeep(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(sortKeysDeep);
+	if (value !== null && typeof value === "object") {
+		const out: Record<string, unknown> = {};
+		for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+			out[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+		}
+		return out;
+	}
+	return value;
+}

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -32,7 +32,7 @@
  *     5. Return governed stream to OpenClaw
  */
 
-import type { Governor } from "usertrust";
+import type { Governor, TrustOpts } from "usertrust";
 import { createGovernor, parentUserIdRefusal, withCostCenter } from "usertrust";
 import type { GovernanceOptions } from "./stream-governor.js";
 import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "./stream-governor.js";
@@ -357,18 +357,59 @@ export function createUsertrustPlugin(config: UsertrustPluginConfig): ProviderPl
 export async function createGovernedStreamFn(
 	streamFn: StreamFn,
 	config: UsertrustPluginConfig,
+	options?: GovernedStreamFnOptions,
 ): Promise<{ governedStreamFn: StreamFn; governor: Governor }> {
 	const frozenCostCenters =
 		config.costCenters !== undefined ? normalizeCostCenters(config.costCenters) : undefined;
-	const gov = await initGovernor(config, frozenCostCenters);
+	const gov = await initGovernor(config, frozenCostCenters, options?.engine);
 	// This path builds its OWN wrapper rather than going through
 	// `createUsertrustPlugin`, so it needs the same opts bag explicitly —
 	// otherwise the programmatic entry point would silently ignore a
 	// `costCenters` config it just finished validating.
 	const governedStreamFn = wrapStreamWithGovernance(streamFn, gov, {
 		costCenters: frozenCostCenters,
+		...(options?.onReceipt !== undefined ? { onReceipt: options.onReceipt } : {}),
 	});
 	return { governedStreamFn, governor: gov };
+}
+
+/**
+ * Non-JSON options for {@link createGovernedStreamFn} — everything a programmatic
+ * caller can hand the wrapper that could never come from `openclaw.json`.
+ *
+ * They are a SEPARATE argument rather than fields on `UsertrustPluginConfig` for
+ * three reasons: `openclaw.plugin.json` declares the config
+ * `additionalProperties: false`, so a function-valued key there would be refused
+ * by the manifest the plugin path is validated against; the config is
+ * canonical-JSON fingerprinted to decide governor identity, and `JSON.stringify`
+ * flattens every function to nothing (two distinct engines would fingerprint
+ * identically); and the plugin path — the one an operator configures — must keep
+ * exactly the surface the manifest describes.
+ */
+export interface GovernedStreamFnOptions {
+	/**
+	 * Fires with the `TrustReceipt` after each successful `settle()`. Forwarded
+	 * verbatim to {@link GovernanceOptions.onReceipt}, including its isolation
+	 * and fire-and-forget guarantees.
+	 */
+	onReceipt?: GovernanceOptions["onReceipt"];
+	/**
+	 * TEST/ADVANCED: the `TrustEngine` the governor spends through, instead of a
+	 * TigerBeetle client — core's own `GovernorOpts._engine`, forwarded. This is
+	 * how a test drives the real attribution path (envelope holds, receipt budget
+	 * snapshots, `budgetContext` reads) with no cluster, the same seam core's
+	 * headless tests use.
+	 *
+	 * NOT a governance bypass: core accepts an injected engine only under
+	 * `USERTRUST_TEST=1` / `NODE_ENV=test` (AUD-470) and ignores it in production,
+	 * so passing one from shipped code buys nothing.
+	 *
+	 * It deliberately does NOT participate in the governor fingerprint — the
+	 * governor is a module singleton, so the FIRST caller's engine is the one the
+	 * process uses; a later call with the same config reuses that governor, engine
+	 * included. Call `shutdown()` between engines.
+	 */
+	engine?: TrustOpts["_engine"];
 }
 
 /**
@@ -407,6 +448,7 @@ let governorFingerprint: string | null = null;
 function initGovernor(
 	config: UsertrustPluginConfig,
 	frozenCostCenters?: FrozenCostCenters,
+	engine?: TrustOpts["_engine"],
 ): Promise<Governor> {
 	const fingerprint = fingerprintConfig(config, frozenCostCenters);
 
@@ -461,6 +503,11 @@ function initGovernor(
 		// `normalizeCostCenters` at construction time, never re-read off the
 		// caller's raw (possibly since-mutated) `config.costCenters`.
 		...(frozenCostCenters != null ? { parentUserId: frozenCostCenters.parentUserId } : {}),
+		// TEST/ADVANCED seam (`GovernedStreamFnOptions.engine`). Core honours it
+		// only in a test environment; everywhere else it is ignored, so this
+		// spread cannot weaken a shipped governor. `null` is a MEANINGFUL value
+		// there ("no engine"), so the key is forwarded whenever it was given.
+		...(engine !== undefined ? { _engine: engine } : {}),
 	})
 		.then((gov) => {
 			governor = gov;

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -63,6 +63,7 @@ export {
 export type {
 	AssistantMessage,
 	AssistantMessageEventStreamLike,
+	CacheRetention,
 	Context,
 	CostCentersConfig,
 	EnvelopeConfig,
@@ -71,6 +72,14 @@ export type {
 	Message,
 	Model,
 	ProviderPlugin,
+	ProviderResponse,
+	// The OPEN options bag. `package.json` publishes exactly ONE export subpath
+	// (`.` → `dist/index.js`), so a name missing from this list is unreachable
+	// for every consumer — `src/types.js` is not importable from outside. That
+	// made the documented escape hatch for provider-specific knobs
+	// (`reasoning` / `thinkingBudgets`, which cannot be named on `StreamOptions`
+	// because the two hosts' thinking enums disagree) a dead reference.
+	ProviderStreamOptions,
 	ProviderWrapStreamFnContext,
 	StreamContext,
 	StreamEvent,
@@ -78,6 +87,7 @@ export type {
 	StreamOptions,
 	StreamUsage,
 	ToolResultMessage,
+	Transport,
 	Usage,
 	UsertrustPluginConfig,
 } from "./types.js";

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -34,6 +34,7 @@
 
 import type { Governor } from "usertrust";
 import { createGovernor, parentUserIdRefusal, withCostCenter } from "usertrust";
+import type { GovernanceOptions } from "./stream-governor.js";
 import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "./stream-governor.js";
 import type {
 	AssistantMessageEventStreamLike,
@@ -49,6 +50,8 @@ import type {
 } from "./types.js";
 
 // Re-export for consumers
+export { deriveAttribution } from "./attribution.js";
+export type { GovernanceOptions } from "./stream-governor.js";
 export { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "./stream-governor.js";
 export {
 	createAccumulator,
@@ -321,7 +324,9 @@ export function createUsertrustPlugin(config: UsertrustPluginConfig): ProviderPl
 			const next = ctx.streamFn;
 			if (next == null) return undefined;
 			return (model, context, options) =>
-				governedStreamLazy(getGovernor, next, model, context, options);
+				governedStreamLazy(getGovernor, next, model, context, options, {
+					costCenters: frozenCostCenters,
+				});
 		},
 	};
 }
@@ -356,7 +361,13 @@ export async function createGovernedStreamFn(
 	const frozenCostCenters =
 		config.costCenters !== undefined ? normalizeCostCenters(config.costCenters) : undefined;
 	const gov = await initGovernor(config, frozenCostCenters);
-	const governedStreamFn = wrapStreamWithGovernance(streamFn, gov);
+	// This path builds its OWN wrapper rather than going through
+	// `createUsertrustPlugin`, so it needs the same opts bag explicitly —
+	// otherwise the programmatic entry point would silently ignore a
+	// `costCenters` config it just finished validating.
+	const governedStreamFn = wrapStreamWithGovernance(streamFn, gov, {
+		costCenters: frozenCostCenters,
+	});
 	return { governedStreamFn, governor: gov };
 }
 
@@ -491,10 +502,11 @@ function governedStreamLazy(
 	streamFn: StreamFn,
 	model: Model,
 	context: Context,
-	options?: StreamOptions,
+	options: StreamOptions | undefined,
+	opts: GovernanceOptions,
 ): AssistantMessageEventStreamLike {
 	const inner = getGovernor().then((gov) =>
-		wrapStreamWithGovernance(streamFn, gov)(model, context, options),
+		wrapStreamWithGovernance(streamFn, gov, opts)(model, context, options),
 	);
 	// Consumers still see the rejection through their own await; this only
 	// stops an init failure from surfacing as an unhandled rejection.

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -33,11 +33,13 @@
  */
 
 import type { Governor } from "usertrust";
-import { createGovernor } from "usertrust";
+import { createGovernor, parentUserIdRefusal, withCostCenter } from "usertrust";
 import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "./stream-governor.js";
 import type {
 	AssistantMessageEventStreamLike,
 	Context,
+	EnvelopeConfig,
+	FrozenCostCenters,
 	Model,
 	OpenClawPluginApi,
 	ProviderPlugin,
@@ -58,6 +60,9 @@ export type {
 	AssistantMessage,
 	AssistantMessageEventStreamLike,
 	Context,
+	CostCentersConfig,
+	EnvelopeConfig,
+	FrozenCostCenters,
 	GovernedStreamMeta,
 	Message,
 	Model,
@@ -72,6 +77,186 @@ export type {
 	Usage,
 	UsertrustPluginConfig,
 } from "./types.js";
+
+/**
+ * Config-time cap on `costCenters.envelopes`, mirroring core's `MAX_ENVELOPES`
+ * (`packages/core/src/budget/context.ts`). Not imported — core's public entry
+ * points (`.`, `./headless`, `./pricing`) don't export it, and Task 4 is
+ * scoped to `packages/openclaw` — so the value is duplicated here, the same
+ * mirror pattern `shared/ids.ts` documents for `cli/budget.ts`'s
+ * `COST_CENTER_PATTERN` copy. If core's constant changes, this one must too.
+ */
+const MAX_ENVELOPES = 128;
+
+/** Mirrors `openclaw.plugin.json`'s `configSchema.properties.costCenters` (`additionalProperties: false`). */
+const KNOWN_COST_CENTERS_FIELDS = new Set([
+	"parentUserId",
+	"tools",
+	"default",
+	"envelopes",
+	"scarcityContext",
+]);
+
+/** Mirrors the manifest's per-envelope schema node (`additionalProperties: false`). */
+const KNOWN_ENVELOPE_FIELDS = new Set(["allocated", "periodStartMs", "periodEndMs"]);
+
+/**
+ * Validates AND normalizes `UsertrustPluginConfig.costCenters` into a
+ * deep-frozen {@link FrozenCostCenters} — the ONLY shape any wrapper reads
+ * downstream. Called at plugin CONSTRUCTION time (`createUsertrustPlugin`,
+ * `register`, `createGovernedStreamFn`), never lazily: a malformed config
+ * fails loudly before the plugin is handed to the host, not on the first
+ * governed call.
+ *
+ * Reuses core's own validation doors rather than re-implementing them:
+ * {@link parentUserIdRefusal} (the canonical parent-id rule) and
+ * `withCostCenter`'s charset + envelope-metadata checks (the canonical
+ * cost-center doors — see `packages/core/src/budget/attribution.ts`).
+ * `withCostCenter(key, () => {}, metadata)` is called purely for its
+ * validation side effect; the no-op callback runs no governed work and opens
+ * no ALS scope any caller can observe.
+ *
+ * Every `tools`/`default` membership check against `envelopes` uses
+ * `Object.hasOwn`, never the `in` operator: `in` also matches properties
+ * inherited from `Object.prototype` (`toString`, `constructor`, …), which
+ * would let an operator config accidentally — or an attacker deliberately —
+ * route spend to a phantom "envelope" that was never declared.
+ *
+ * @throws Error — config-shaped, naming the offending field — on any
+ * malformed shape.
+ */
+export function normalizeCostCenters(cc: unknown): FrozenCostCenters {
+	if (cc === null || typeof cc !== "object" || Array.isArray(cc)) {
+		throw new Error(
+			`usertrust: costCenters must be an object, got ${cc === null ? "null" : typeof cc}`,
+		);
+	}
+	const raw = cc as Record<string, unknown>;
+	for (const key of Object.keys(raw)) {
+		if (!KNOWN_COST_CENTERS_FIELDS.has(key)) {
+			throw new Error(`usertrust: costCenters has an unknown field "${key}"`);
+		}
+	}
+
+	if (typeof raw.parentUserId !== "string") {
+		throw new Error("usertrust: costCenters.parentUserId is required and must be a string");
+	}
+	const parentRefusal = parentUserIdRefusal(raw.parentUserId);
+	if (parentRefusal !== null) {
+		throw new Error(`usertrust: costCenters.parentUserId ${parentRefusal}`);
+	}
+
+	if (raw.envelopes === null || typeof raw.envelopes !== "object" || Array.isArray(raw.envelopes)) {
+		throw new Error("usertrust: costCenters.envelopes must be an object");
+	}
+	const rawEnvelopes = raw.envelopes as Record<string, unknown>;
+	const envelopeKeys = Object.keys(rawEnvelopes);
+	if (envelopeKeys.length > MAX_ENVELOPES) {
+		throw new Error(
+			`usertrust: costCenters.envelopes has ${envelopeKeys.length} entries, exceeds the ${MAX_ENVELOPES} cap`,
+		);
+	}
+
+	const envelopes: Record<string, EnvelopeConfig> = {};
+	for (const key of envelopeKeys) {
+		const entry = rawEnvelopes[key];
+		if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+			throw new Error(`usertrust: costCenters.envelopes["${key}"] must be an object`);
+		}
+		const e = entry as Record<string, unknown>;
+		for (const field of Object.keys(e)) {
+			if (!KNOWN_ENVELOPE_FIELDS.has(field)) {
+				throw new Error(
+					`usertrust: costCenters.envelopes["${key}"] has an unknown field "${field}"`,
+				);
+			}
+		}
+		const metadata = {
+			allocated: e.allocated as number,
+			periodStartMs: e.periodStartMs as number,
+			...(e.periodEndMs !== undefined ? { periodEndMs: e.periodEndMs as number } : {}),
+		};
+		// Core's own charset + metadata validation door — reused, never
+		// re-implemented (money-math/validation single-source). The no-op
+		// callback means nothing governed actually runs; only the doors fire.
+		withCostCenter(key, () => {}, metadata);
+		envelopes[key] = metadata;
+	}
+	const frozenEnvelopes = Object.freeze(
+		Object.fromEntries(Object.entries(envelopes).map(([k, v]) => [k, Object.freeze({ ...v })])),
+	) as Readonly<Record<string, Readonly<EnvelopeConfig>>>;
+
+	if (raw.tools === null || typeof raw.tools !== "object" || Array.isArray(raw.tools)) {
+		throw new Error("usertrust: costCenters.tools must be an object");
+	}
+	const rawTools = raw.tools as Record<string, unknown>;
+	const tools: Record<string, string> = {};
+	for (const toolName of Object.keys(rawTools)) {
+		const target = rawTools[toolName];
+		if (typeof target !== "string" || !Object.hasOwn(frozenEnvelopes, target)) {
+			throw new Error(
+				`usertrust: costCenters.tools["${toolName}"] must name an envelopes key, got ${JSON.stringify(target)}`,
+			);
+		}
+		tools[toolName] = target;
+	}
+	const frozenTools = Object.freeze({ ...tools });
+
+	if (raw.default !== undefined) {
+		if (typeof raw.default !== "string" || !Object.hasOwn(frozenEnvelopes, raw.default)) {
+			throw new Error(
+				`usertrust: costCenters.default must name an envelopes key, got ${JSON.stringify(raw.default)}`,
+			);
+		}
+	}
+
+	if (raw.scarcityContext !== undefined && typeof raw.scarcityContext !== "boolean") {
+		throw new Error("usertrust: costCenters.scarcityContext must be a boolean");
+	}
+
+	return Object.freeze({
+		parentUserId: raw.parentUserId,
+		tools: frozenTools,
+		...(raw.default !== undefined ? { default: raw.default as string } : {}),
+		envelopes: frozenEnvelopes,
+		scarcityContext: raw.scarcityContext === undefined ? true : (raw.scarcityContext as boolean),
+	});
+}
+
+/**
+ * Canonical-JSON fingerprint of the config that determines the module-
+ * singleton governor's identity — key order never matters, so two
+ * semantically identical configs written with different key orders
+ * fingerprint the same.
+ */
+function fingerprintConfig(
+	config: UsertrustPluginConfig,
+	frozenCostCenters?: FrozenCostCenters,
+): string {
+	return JSON.stringify(sortKeysDeep({ ...config, costCenters: frozenCostCenters }));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(sortKeysDeep);
+	if (value !== null && typeof value === "object") {
+		const out: Record<string, unknown> = {};
+		for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+			out[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+		}
+		return out;
+	}
+	return value;
+}
+
+function configMismatchError(): Error {
+	return new Error(
+		"usertrust: plugin already initialized with a DIFFERENT config — the governor is a " +
+			"module-wide singleton (one process, one governor), so a second config would either " +
+			"silently take over the first plugin instance's budget/parentUserId or be silently " +
+			"ignored. Construct every plugin instance with the SAME config, or call shutdown() " +
+			"before switching to a different one.",
+	);
+}
 
 /** Active governor instance — singleton per plugin lifecycle. */
 let governor: Governor | null = null;
@@ -115,9 +300,16 @@ export default function register(api: OpenClawPluginApi): void {
  * const wrapped = plugin.wrapStreamFn!({ provider, modelId, streamFn: rawStreamFn });
  * for await (const event of wrapped!(model, context)) { ... }
  * ```
+ *
+ * `config.costCenters`, when present, is validated and normalized HERE — at
+ * construction time, synchronously — via `normalizeCostCenters`, even though
+ * governor init itself stays lazy. A malformed `costCenters` config throws
+ * before this function returns, not on the plugin's first governed call.
  */
 export function createUsertrustPlugin(config: UsertrustPluginConfig): ProviderPlugin {
-	const getGovernor = lazyGovernor(config);
+	const frozenCostCenters =
+		config.costCenters !== undefined ? normalizeCostCenters(config.costCenters) : undefined;
+	const getGovernor = lazyGovernor(config, frozenCostCenters);
 
 	return {
 		id: "usertrust",
@@ -152,12 +344,18 @@ export function createUsertrustPlugin(config: UsertrustPluginConfig): ProviderPl
  *   // events flow through with governance applied
  * }
  * ```
+ *
+ * `config.costCenters`, when present, is validated at call time via
+ * `normalizeCostCenters` — the same construction-time door `createUsertrustPlugin`
+ * uses, since this function is this API's entire "construction" step.
  */
 export async function createGovernedStreamFn(
 	streamFn: StreamFn,
 	config: UsertrustPluginConfig,
 ): Promise<{ governedStreamFn: StreamFn; governor: Governor }> {
-	const gov = await initGovernor(config);
+	const frozenCostCenters =
+		config.costCenters !== undefined ? normalizeCostCenters(config.costCenters) : undefined;
+	const gov = await initGovernor(config, frozenCostCenters);
 	const governedStreamFn = wrapStreamWithGovernance(streamFn, gov);
 	return { governedStreamFn, governor: gov };
 }
@@ -179,6 +377,7 @@ export async function shutdown(): Promise<void> {
 		await governor.destroy();
 		governor = null;
 		initPromise = null;
+		governorFingerprint = null;
 	}
 }
 
@@ -187,52 +386,96 @@ export async function shutdown(): Promise<void> {
 /** Module-level promise to prevent concurrent initialization race. */
 let initPromise: Promise<Governor> | null = null;
 
-function initGovernor(config: UsertrustPluginConfig): Promise<Governor> {
+/**
+ * Canonical-JSON fingerprint of whichever config CLAIMED the singleton
+ * governor — set the moment an init starts, cleared on `shutdown()` and on a
+ * failed init. See `initGovernor` for the three lifecycle legs.
+ */
+let governorFingerprint: string | null = null;
+
+function initGovernor(
+	config: UsertrustPluginConfig,
+	frozenCostCenters?: FrozenCostCenters,
+): Promise<Governor> {
+	const fingerprint = fingerprintConfig(config, frozenCostCenters);
+
 	if (governor != null) {
+		// A governor already exists. Reuse it ONLY for the config that built
+		// it — a second, DIFFERENT config must never silently take over an
+		// already-governed budget/parentUserId (module-singleton governor).
+		if (fingerprint !== governorFingerprint) {
+			return Promise.reject(configMismatchError());
+		}
 		return Promise.resolve(governor);
 	}
 
-	// Memoize the init promise to prevent TOCTOU race — two concurrent
-	// callers both see governor == null but only one createGovernor runs.
-	if (initPromise == null) {
-		initPromise = createGovernor({
-			budget: config.budget,
-			...(config.dryRun != null ? { dryRun: config.dryRun } : {}),
-			...(config.configPath != null ? { configPath: config.configPath } : {}),
-			...(config.proxy != null ? { proxy: config.proxy } : {}),
-			...(config.proxyKey != null ? { key: config.proxyKey } : {}),
-			...(config.vaultBase != null ? { vaultBase: config.vaultBase } : {}),
-			// M2: forward the operator's endpoint declaration into the headless
-			// governor (GovernorOpts.endpoint). Without this, every OpenClaw call
-			// defaults to cloud scope — local models would meter at frontier
-			// fallback and inherit strict cloud anomaly thresholds. runtime defaults
-			// to "unknown"; baseURL is omitted (never undefined) when absent.
-			...(config.endpoint != null
-				? {
-						endpoint: {
-							class: config.endpoint.class,
-							runtime: config.endpoint.runtime ?? "unknown",
-							...(config.endpoint.baseURL !== undefined
-								? { baseURL: config.endpoint.baseURL }
-								: {}),
-						},
-					}
-				: {}),
-		}).then((gov) => {
+	if (initPromise != null) {
+		// An init is already in flight. Same rule as above, but pre-resolution:
+		// a DIFFERENT config racing against an in-flight init must not silently
+		// piggyback on whichever governor happens to land first.
+		if (fingerprint !== governorFingerprint) {
+			return Promise.reject(configMismatchError());
+		}
+		return initPromise;
+	}
+
+	// CLAIM SYNCHRONOUSLY, before any await/microtask gap — this is what makes
+	// two different configs racing in the same tick race-safe: the second call
+	// sees `initPromise != null` (set below) and the fingerprint already
+	// claimed, rather than both proceeding to build competing governors
+	// (classic TOCTOU: two concurrent callers both observe `governor == null`).
+	governorFingerprint = fingerprint;
+	initPromise = createGovernor({
+		budget: config.budget,
+		...(config.dryRun != null ? { dryRun: config.dryRun } : {}),
+		...(config.configPath != null ? { configPath: config.configPath } : {}),
+		...(config.proxy != null ? { proxy: config.proxy } : {}),
+		...(config.proxyKey != null ? { key: config.proxyKey } : {}),
+		...(config.vaultBase != null ? { vaultBase: config.vaultBase } : {}),
+		// M2: forward the operator's endpoint declaration into the headless
+		// governor (GovernorOpts.endpoint). Without this, every OpenClaw call
+		// defaults to cloud scope — local models would meter at frontier
+		// fallback and inherit strict cloud anomaly thresholds. runtime defaults
+		// to "unknown"; baseURL is omitted (never undefined) when absent.
+		...(config.endpoint != null
+			? {
+					endpoint: {
+						class: config.endpoint.class,
+						runtime: config.endpoint.runtime ?? "unknown",
+						...(config.endpoint.baseURL !== undefined ? { baseURL: config.endpoint.baseURL } : {}),
+					},
+				}
+			: {}),
+		// Ship 2: the envelope account identity — validated + frozen by
+		// `normalizeCostCenters` at construction time, never re-read off the
+		// caller's raw (possibly since-mutated) `config.costCenters`.
+		...(frozenCostCenters != null ? { parentUserId: frozenCostCenters.parentUserId } : {}),
+	})
+		.then((gov) => {
 			governor = gov;
 			return gov;
+		})
+		.catch((err: unknown) => {
+			// Clear the claim so a retry — same config OR a different one — after
+			// a failed init is accepted rather than permanently wedged on a
+			// fingerprint no governor ever actually landed for.
+			initPromise = null;
+			governorFingerprint = null;
+			throw err;
 		});
-	}
 
 	return initPromise;
 }
 
-function lazyGovernor(config: UsertrustPluginConfig): () => Promise<Governor> {
+function lazyGovernor(
+	config: UsertrustPluginConfig,
+	frozenCostCenters?: FrozenCostCenters,
+): () => Promise<Governor> {
 	let promise: Promise<Governor> | null = null;
 
 	return () => {
 		if (promise == null) {
-			promise = initGovernor(config);
+			promise = initGovernor(config, frozenCostCenters);
 		}
 		return promise;
 	};

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -105,6 +105,17 @@ const KNOWN_COST_CENTERS_FIELDS = new Set([
 const KNOWN_ENVELOPE_FIELDS = new Set(["allocated", "periodStartMs", "periodEndMs"]);
 
 /**
+ * An empty string-keyed map with NO prototype — the only kind safe to build by
+ * assignment from operator-supplied keys. See `normalizeCostCenters`'s doc for
+ * why (`__proto__` is a legal key on both maps, and a plain object silently
+ * eats it). Membership is still read with `Object.hasOwn`, which works
+ * identically on a null-prototype object.
+ */
+function emptyMap<T>(): Record<string, T> {
+	return Object.create(null) as Record<string, T>;
+}
+
+/**
  * Validates AND normalizes `UsertrustPluginConfig.costCenters` into a
  * deep-frozen {@link FrozenCostCenters} — the ONLY shape any wrapper reads
  * downstream. Called at plugin CONSTRUCTION time (`createUsertrustPlugin`,
@@ -125,6 +136,18 @@ const KNOWN_ENVELOPE_FIELDS = new Set(["allocated", "periodStartMs", "periodEndM
  * inherited from `Object.prototype` (`toString`, `constructor`, …), which
  * would let an operator config accidentally — or an attacker deliberately —
  * route spend to a phantom "envelope" that was never declared.
+ *
+ * And every map this builds is NULL-PROTOTYPE ({@link emptyMap}), which is the
+ * WRITE-side half of that same rule. `__proto__` is a legal cost-center string
+ * (core's `COST_CENTER_PATTERN` is `/^[a-zA-Z0-9._-]{1,64}$/`), a legal tool
+ * name, and a genuine own property when it arrives via `JSON.parse`. Assigning
+ * it into an ordinary object invokes `Object.prototype`'s `__proto__` SETTER
+ * instead of creating the key: a string value is silently discarded, and an
+ * object value silently re-points the map's prototype. Either way the entry
+ * disappears with no error, attribution falls through to `default`, and a
+ * correlated call debits the wrong envelope. A null-prototype map has no such
+ * setter to inherit, so the assignment creates the own key it looks like it
+ * creates.
  *
  * @throws Error — config-shaped, naming the offending field — on any
  * malformed shape.
@@ -161,7 +184,7 @@ export function normalizeCostCenters(cc: unknown): FrozenCostCenters {
 		);
 	}
 
-	const envelopes: Record<string, EnvelopeConfig> = {};
+	const envelopes = emptyMap<EnvelopeConfig>();
 	for (const key of envelopeKeys) {
 		const entry = rawEnvelopes[key];
 		if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
@@ -186,15 +209,23 @@ export function normalizeCostCenters(cc: unknown): FrozenCostCenters {
 		withCostCenter(key, () => {}, metadata);
 		envelopes[key] = metadata;
 	}
-	const frozenEnvelopes = Object.freeze(
-		Object.fromEntries(Object.entries(envelopes).map(([k, v]) => [k, Object.freeze({ ...v })])),
-	) as Readonly<Record<string, Readonly<EnvelopeConfig>>>;
+	// Built by assignment into a null-prototype map, NOT `Object.fromEntries`:
+	// the result is read back with `Object.hasOwn` and indexed by operator-
+	// supplied keys, so it has to stay free of an inherited `__proto__` accessor
+	// for exactly the reason the source map does.
+	const envelopeCopies = emptyMap<Readonly<EnvelopeConfig>>();
+	for (const [k, v] of Object.entries(envelopes)) {
+		envelopeCopies[k] = Object.freeze({ ...v });
+	}
+	const frozenEnvelopes = Object.freeze(envelopeCopies) as Readonly<
+		Record<string, Readonly<EnvelopeConfig>>
+	>;
 
 	if (raw.tools === null || typeof raw.tools !== "object" || Array.isArray(raw.tools)) {
 		throw new Error("usertrust: costCenters.tools must be an object");
 	}
 	const rawTools = raw.tools as Record<string, unknown>;
-	const tools: Record<string, string> = {};
+	const tools = emptyMap<string>();
 	for (const toolName of Object.keys(rawTools)) {
 		const target = rawTools[toolName];
 		if (typeof target !== "string" || !Object.hasOwn(frozenEnvelopes, target)) {
@@ -204,7 +235,11 @@ export function normalizeCostCenters(cc: unknown): FrozenCostCenters {
 		}
 		tools[toolName] = target;
 	}
-	const frozenTools = Object.freeze({ ...tools });
+	// `Object.freeze(tools)`, never `Object.freeze({ ...tools })`: spreading into
+	// an object LITERAL would hand the frozen map back an `Object.prototype`, and
+	// with it the `__proto__` accessor this whole map was built to avoid. Nothing
+	// mutates `tools` after this point, so there is no copy to make.
+	const frozenTools = Object.freeze(tools);
 
 	if (raw.default !== undefined) {
 		if (typeof raw.default !== "string" || !Object.hasOwn(frozenEnvelopes, raw.default)) {

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -34,6 +34,7 @@
 
 import type { Governor, TrustOpts } from "usertrust";
 import { createGovernor, parentUserIdRefusal, withCostCenter } from "usertrust";
+import { fingerprintConfig } from "./fingerprint.js";
 import type { GovernanceOptions } from "./stream-governor.js";
 import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "./stream-governor.js";
 import type {
@@ -226,31 +227,6 @@ export function normalizeCostCenters(cc: unknown): FrozenCostCenters {
 	});
 }
 
-/**
- * Canonical-JSON fingerprint of the config that determines the module-
- * singleton governor's identity — key order never matters, so two
- * semantically identical configs written with different key orders
- * fingerprint the same.
- */
-function fingerprintConfig(
-	config: UsertrustPluginConfig,
-	frozenCostCenters?: FrozenCostCenters,
-): string {
-	return JSON.stringify(sortKeysDeep({ ...config, costCenters: frozenCostCenters }));
-}
-
-function sortKeysDeep(value: unknown): unknown {
-	if (Array.isArray(value)) return value.map(sortKeysDeep);
-	if (value !== null && typeof value === "object") {
-		const out: Record<string, unknown> = {};
-		for (const key of Object.keys(value as Record<string, unknown>).sort()) {
-			out[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
-		}
-		return out;
-	}
-	return value;
-}
-
 function configMismatchError(): Error {
 	return new Error(
 		"usertrust: plugin already initialized with a DIFFERENT config — the governor is a " +
@@ -439,9 +415,13 @@ export async function shutdown(): Promise<void> {
 let initPromise: Promise<Governor> | null = null;
 
 /**
- * Canonical-JSON fingerprint of whichever config CLAIMED the singleton
+ * {@link fingerprintConfig} digest of whichever config CLAIMED the singleton
  * governor — set the moment an init starts, cleared on `shutdown()` and on a
  * failed init. See `initGovernor` for the three lifecycle legs.
+ *
+ * A DIGEST, not the config JSON, because this variable outlives the call that
+ * set it by the whole process lifetime and the JSON contains `proxyKey`. See
+ * `fingerprint.ts`.
  */
 let governorFingerprint: string | null = null;
 

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -36,11 +36,13 @@ import type { Governor } from "usertrust";
 import { createGovernor } from "usertrust";
 import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "./stream-governor.js";
 import type {
+	AssistantMessageEventStreamLike,
+	Context,
+	Model,
 	OpenClawPluginApi,
 	ProviderPlugin,
-	StreamContext,
-	StreamEvent,
 	StreamFn,
+	StreamOptions,
 	UsertrustPluginConfig,
 } from "./types.js";
 
@@ -53,12 +55,21 @@ export {
 	extractUsageFromProviderChunk,
 } from "./token-extractor.js";
 export type {
+	AssistantMessage,
+	AssistantMessageEventStreamLike,
+	Context,
 	GovernedStreamMeta,
+	Message,
+	Model,
 	ProviderPlugin,
+	ProviderWrapStreamFnContext,
 	StreamContext,
 	StreamEvent,
 	StreamFn,
+	StreamOptions,
 	StreamUsage,
+	ToolResultMessage,
+	Usage,
 	UsertrustPluginConfig,
 } from "./types.js";
 
@@ -72,31 +83,17 @@ let governor: Governor | null = null;
  * governance engine and registers the stream wrapper.
  */
 export default function register(api: OpenClawPluginApi): void {
-	// Config is injected by OpenClaw from openclaw.json → plugins.entries.usertrust.config
-	// We register a hook that initializes on first use (lazy)
-	// since config isn't available at register time in all OpenClaw versions.
+	// OpenClaw delivers openclaw.json → plugins.entries.usertrust.config on the
+	// api object as `pluginConfig`, at register() time. It is NOT a second
+	// argument to any hook.
+	const config = api.pluginConfig as UsertrustPluginConfig | undefined;
+	if (config == null) {
+		throw new Error(
+			"usertrust: plugin config missing — set plugins.entries.usertrust.config.budget in openclaw.json",
+		);
+	}
 
-	const plugin = {
-		id: "usertrust",
-		label: "usertrust Governance",
-
-		/**
-		 * wrapStreamFn — the core integration point.
-		 *
-		 * OpenClaw calls this with the existing stream function.
-		 * We return a wrapped version that adds governance.
-		 */
-		wrapStreamFn(originalStreamFn: StreamFn, config: UsertrustPluginConfig): StreamFn {
-			// Lazy-initialize governor on first call
-			const getGovernor = lazyGovernor(config);
-
-			return (model, context, options) => {
-				return governedStreamLazy(getGovernor, originalStreamFn, model, context, options);
-			};
-		},
-	};
-
-	api.registerProvider(plugin);
+	api.registerProvider(createUsertrustPlugin(config));
 }
 
 /**
@@ -104,8 +101,8 @@ export default function register(api: OpenClawPluginApi): void {
  *
  * Use this when programmatically wiring usertrust into an OpenClaw runtime
  * (rather than going through the auto-discovery `register()` default).
- * The returned plugin's `wrapStreamFn` follows OpenClaw's middleware shape:
- * `(next: StreamFn) => StreamFn`.
+ * The returned plugin's `wrapStreamFn` follows OpenClaw's provider-hook shape:
+ * one context argument carrying the inner `streamFn`.
  *
  * Init is lazy — the governor is created on the first wrapped call, not
  * at plugin construction time. This matches OpenClaw's lifecycle (plugins
@@ -115,8 +112,8 @@ export default function register(api: OpenClawPluginApi): void {
  * import { createUsertrustPlugin } from "usertrust-openclaw";
  *
  * const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true });
- * const wrapped = plugin.wrapStreamFn!(rawStreamFn);
- * for await (const event of wrapped(model, context)) { ... }
+ * const wrapped = plugin.wrapStreamFn!({ provider, modelId, streamFn: rawStreamFn });
+ * for await (const event of wrapped!(model, context)) { ... }
  * ```
  */
 export function createUsertrustPlugin(config: UsertrustPluginConfig): ProviderPlugin {
@@ -125,7 +122,12 @@ export function createUsertrustPlugin(config: UsertrustPluginConfig): ProviderPl
 	return {
 		id: "usertrust",
 		label: "usertrust Governance",
-		wrapStreamFn(next: StreamFn): StreamFn {
+		// `auth` is required by OpenClaw's ProviderPlugin contract. usertrust
+		// governs someone else's provider credentials and holds none of its own.
+		auth: [],
+		wrapStreamFn(ctx): StreamFn | undefined {
+			const next = ctx.streamFn;
+			if (next == null) return undefined;
 			return (model, context, options) =>
 				governedStreamLazy(getGovernor, next, model, context, options);
 		},
@@ -236,14 +238,31 @@ function lazyGovernor(config: UsertrustPluginConfig): () => Promise<Governor> {
 	};
 }
 
-async function* governedStreamLazy(
+/**
+ * Governor init is async but the wrap seam is synchronous, so both halves of
+ * the stream surface (iteration and `result()`) read from the same lazily
+ * created inner stream.
+ */
+function governedStreamLazy(
 	getGovernor: () => Promise<Governor>,
 	streamFn: StreamFn,
-	model: string,
-	context: StreamContext,
-	options?: Record<string, unknown>,
-): AsyncGenerator<StreamEvent> {
-	const gov = await getGovernor();
-	const governed = wrapStreamWithGovernance(streamFn, gov);
-	yield* governed(model, context, options);
+	model: Model,
+	context: Context,
+	options?: StreamOptions,
+): AssistantMessageEventStreamLike {
+	const inner = getGovernor().then((gov) =>
+		wrapStreamWithGovernance(streamFn, gov)(model, context, options),
+	);
+	// Consumers still see the rejection through their own await; this only
+	// stops an init failure from surfacing as an unhandled rejection.
+	inner.catch(() => {});
+
+	return {
+		async *[Symbol.asyncIterator]() {
+			yield* await inner;
+		},
+		async result() {
+			return (await inner).result();
+		},
+	};
 }

--- a/packages/openclaw/src/scarcity-block.ts
+++ b/packages/openclaw/src/scarcity-block.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * scarcity-block.ts — pure helpers for the per-turn scarcity injection.
+ *
+ * Three pure, independently testable steps; `stream-governor.ts` is the only
+ * place that sequences them with a real `Governor` and wraps the ledger read
+ * in a try/catch (A8 — REPORTING ONLY, so a read failure degrades to no block
+ * rather than gating, delaying, or throwing into the money path):
+ *
+ *   1. {@link envelopeDescriptorsFrom} — the operator's frozen `envelopes` as
+ *      `EnvelopeDescriptor[]`, the shape `Governor.budgetContext` reads.
+ *   2. {@link formatScarcityBlock} — `EnvelopeStatus[]` (the ledger read's
+ *      answer) → the `[usertrust scarcity] …` string, or `null` when there is
+ *      nothing to report.
+ *   3. {@link injectScarcityBlock} — merges that string onto a COPY of the
+ *      caller's `Context.systemPrompt` (contract-notes §4's valid injected-
+ *      content shape); the caller's own object is never mutated.
+ *   4. {@link estimationMessages} — the array `authorize()` actually receives:
+ *      the FULL effective system prompt represented exactly once, since
+ *      `authorize()` only ever sees `AuthorizeParams.messages`, never
+ *      `Context.systemPrompt` (estimation honesty, contract-notes §4).
+ */
+
+import type { EnvelopeDescriptor, EnvelopeStatus } from "usertrust";
+import type { Context, FrozenCostCenters } from "./types.js";
+
+/**
+ * The operator's frozen `envelopes` as the batch `Governor.budgetContext`
+ * reads — every configured envelope, not only the one THIS call is
+ * attributed to, so the model sees the whole picture it can plan against.
+ */
+export function envelopeDescriptorsFrom(costCenters: FrozenCostCenters): EnvelopeDescriptor[] {
+	return Object.entries(costCenters.envelopes).map(([costCenter, envelope]) => ({
+		costCenter,
+		allocated: envelope.allocated,
+		periodStartMs: envelope.periodStartMs,
+		...(envelope.periodEndMs !== undefined ? { periodEndMs: envelope.periodEndMs } : {}),
+	}));
+}
+
+/**
+ * `EnvelopeStatus[]` → `[usertrust scarcity] research: 34% left (~2.1h
+ * runway) · verification: 89% left`, or `null` for an empty batch (nothing to
+ * report — e.g. the operator declared no envelopes at all).
+ *
+ * Format, pinned by tests: percent is `round(fraction · 100)`; the runway
+ * clause is present only when `runwayHours` is non-null (`~X.Xh runway`, one
+ * decimal); entries join on ` · `.
+ */
+export function formatScarcityBlock(statuses: EnvelopeStatus[]): string | null {
+	if (statuses.length === 0) return null;
+	const entries = statuses.map((status) => {
+		const percent = Math.round(status.fraction * 100);
+		const runway = status.runwayHours != null ? ` (~${status.runwayHours.toFixed(1)}h runway)` : "";
+		return `${status.costCenter}: ${percent}% left${runway}`;
+	});
+	return `[usertrust scarcity] ${entries.join(" · ")}`;
+}
+
+/**
+ * Merge a scarcity block onto a COPY of `context` — never the caller's own
+ * object (contract-notes §4's valid injected-content shape, reproduced
+ * verbatim). `block === null` means there is nothing to inject (disabled,
+ * empty read, or a read/format failure already degraded upstream), so the
+ * original `context` reference is returned untouched — still never mutated,
+ * just not copied when there is no reason to.
+ */
+export function injectScarcityBlock(context: Context, block: string | null): Context {
+	if (block === null) return context;
+	return {
+		...context,
+		systemPrompt:
+			context.systemPrompt == null || context.systemPrompt === ""
+				? block
+				: `${context.systemPrompt}\n\n${block}`,
+	};
+}
+
+/**
+ * The array `authorize()` receives for `estimateInputTokens` + `detectPII`
+ * (headless.ts) — the ONLY two things that read `AuthorizeParams.messages`.
+ * `authorize()` never sees `Context.systemPrompt`, so without this the
+ * pre-call hold would under-cover what the stream call actually sends.
+ *
+ * `context` here is the ALREADY-INJECTED context (`injectScarcityBlock`'s
+ * result), so its `systemPrompt` is the full effective value — pre-existing
+ * plus the scarcity block when one was injected, or the pre-existing value
+ * alone when it was not. Represented as ONE synthetic entry, prepended, so
+ * the full effective prompt appears in the array exactly once. Never a
+ * `Message` union member — the pinned contract has no system role
+ * (contract-notes §4) — so this only ever feeds `AuthorizeParams.messages`
+ * (typed `unknown[]`), never `Context.messages` itself.
+ */
+export function estimationMessages(context: Context): unknown[] {
+	const prompt = context.systemPrompt;
+	if (prompt == null || prompt === "") return context.messages;
+	return [{ role: "system", content: prompt }, ...context.messages];
+}

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -8,14 +8,12 @@
  *   1. Before stream: attribute (which envelope pays — `attribution.ts`), then
  *      authorize (budget check, PENDING hold)
  *   2. During stream: forward events, accumulate token usage
- *   3. After stream: EXACTLY ONE terminal ledger action per authorization —
- *      settle with the provider's usage once a `done` event has been seen,
- *      settle at the ESTIMATE when the stream ends with no terminal event at
- *      all (including a consumer who walked away mid-stream), abort when it
- *      fails (a throw, or an in-band `error` event). The terminal event the
- *      loop OBSERVED decides the action, not where the generator happened to
- *      unwind — a consumer that breaks straight after `done`/`error` gets the
- *      same treatment as one that drains to the end.
+ *   3. On the terminal event: EXACTLY ONE terminal ledger action per
+ *      authorization — settle with the provider's usage on `done`, settle the
+ *      PARTIAL usage on a consumer abort (`error` with `reason: "aborted"`),
+ *      abort/void on a provider failure (a throw, or `error` with
+ *      `reason: "error"`), and settle at the ESTIMATE when the stream ends with
+ *      no terminal event at all (including a consumer who walked away).
  *
  * The full path→action matrix, including what `result()` does on each, is in
  * contract-notes §6 and pinned by `tests/terminal-modes.test.ts`.
@@ -23,6 +21,33 @@
  * The wrapped function has the same signature AND the same surface as the
  * original — the pinned boundary is not a bare `AsyncIterable`, it also
  * exposes `result()`, so the wrapper is a proxy rather than a generator.
+ *
+ * ── TWO PINNED-HOST BEHAVIOURS THIS FILE IS SHAPED BY ──
+ *
+ * (a) The host awaits `result()` from INSIDE its loop body. `openclaw`
+ *     `dist/proxy-BzhBz8iM.js:395-408` (`streamAssistantResponse`):
+ *
+ *         case "done":
+ *         case "error": {
+ *           const finalMessage = removeNonExecutableToolCalls(await response.result());
+ *           …
+ *           return finalMessage;        // ← returns from inside the for-await
+ *         }
+ *
+ *     so the host is suspended in the loop body, holding the generator at its
+ *     terminal `yield`, when it blocks on `result()`. The pinned stream class
+ *     survives that because `EventStream.push()` resolves the final-result
+ *     promise BEFORE delivering the terminal event to the waiting consumer
+ *     (`pi-ai/dist/utils/event-stream.js:20-31`). Governance therefore has to
+ *     FINISH, and `final` has to be settled, BEFORE the terminal `yield` —
+ *     anything deferred past it can never run, because nothing will resume us.
+ *
+ * (b) `result()` upstream is PASSIVE — it returns a promise and consumes
+ *     nothing (`event-stream.js:60-62`), so a caller may await it and iterate
+ *     afterwards and still see every event. Ours cannot be passive: nothing
+ *     else pumps governance for a `result()`-only consumer. It drains, and
+ *     therefore it REPLAYS what that drain captured to any iterator that
+ *     arrives later, rather than silently eating the stream.
  */
 
 import type {
@@ -47,6 +72,7 @@ import type {
 	AssistantMessage,
 	AssistantMessageEventStreamLike,
 	Context,
+	DoneEvent,
 	ErrorEvent,
 	FrozenCostCenters,
 	Model,
@@ -143,22 +169,88 @@ export function wrapStreamWithGovernance(
 		// is handed over through a deferred the generator settles.
 		const final = createDeferred<AssistantMessage>();
 		const events = governedStream(streamFn, governor, model, context, options, final, opts);
-		let consumed = false;
+
+		// Exactly one of the two entry points may drive `events`, and WHICH one
+		// claimed it decides how the other is served.
+		let claimed = false;
+		// Set only when `result()` claimed it — i.e. a hidden drain owns the
+		// generator and a later iterator has to be served from the replay log.
+		let drain: Promise<void> | undefined;
+		const replayed: StreamEvent[] = [];
+		let replayEnded = false;
+		let replayFailure: { error: unknown } | undefined;
+		// Swapped-and-resolved on every append so a replaying iterator can wait
+		// for the next event without polling.
+		let nextTick = createDeferred<void>();
+
+		function announce(): void {
+			const tick = nextTick;
+			nextTick = createDeferred<void>();
+			tick.resolve();
+		}
+
+		/**
+		 * Serve an iterator that arrived after `result()` claimed the generator.
+		 * Upstream `result()` consumes nothing, so this consumer is entitled to
+		 * the whole stream — including a mid-stream throw, which the drain
+		 * recorded rather than swallowed.
+		 */
+		async function* replay(): AsyncGenerator<StreamEvent> {
+			let i = 0;
+			for (;;) {
+				const event = replayed[i];
+				if (event !== undefined) {
+					i++;
+					yield event;
+					continue;
+				}
+				if (replayEnded) {
+					if (replayFailure !== undefined) throw replayFailure.error;
+					return;
+				}
+				await nextTick.promise;
+			}
+		}
 
 		return {
 			[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
-				consumed = true;
+				if (!claimed) {
+					claimed = true;
+					return events[Symbol.asyncIterator]();
+				}
+				// A `result()`-driven drain owns the generator — replay into it.
+				if (drain !== undefined) return replay()[Symbol.asyncIterator]();
+				// A SECOND iterator on a stream already being iterated. An async
+				// generator returns itself, so this picks up where the first left
+				// off, exactly as it always has.
 				return events[Symbol.asyncIterator]();
 			},
 			async result(): Promise<AssistantMessage> {
 				// A `result()`-only consumer never iterates, so drain the governed
 				// stream here — otherwise neither governance nor `final` ever runs.
-				if (!consumed) {
-					consumed = true;
-					try {
-						for await (const _event of events) {
-							// drain
+				if (!claimed) {
+					claimed = true;
+					drain = (async () => {
+						try {
+							for await (const event of events) {
+								replayed.push(event);
+								announce();
+							}
+						} catch (err) {
+							replayFailure = { error: err };
+							throw err;
+						} finally {
+							replayEnded = true;
+							announce();
 						}
+					})();
+					// A consumer may never await the drain (it can iterate the replay
+					// instead), so pre-mark the rejection leg handled.
+					drain.catch(() => {});
+				}
+				if (drain !== undefined) {
+					try {
+						await drain;
 					} catch (err) {
 						// The governed run settles `final` on every terminal path, so
 						// this is normally the same rejection arriving twice. Rethrow
@@ -213,15 +305,6 @@ async function* governedStream(
 	// without reaching any branch — from one that already terminated.
 	let terminated = false;
 
-	// A terminal `error` event does NOT throw — per contract-notes §3 the host
-	// yields it like any other event and the iteration simply ends. Declared
-	// OUTSIDE the try so the `finally` can consult it too: a consumer that breaks
-	// (or calls `iterator.return()`) immediately AFTER the error event unwinds the
-	// generator at the `yield` and never reaches the post-loop branch. What the
-	// loop already observed still decides the hold, so a call the provider
-	// reported as failed is voided rather than charged at the estimate.
-	let failure: ErrorEvent | undefined;
-
 	try {
 		const stream = await streamFn(model, forwardedContext, options);
 		// Hold on to the host's final-message promise, but do NOT wire it to
@@ -235,58 +318,141 @@ async function* governedStream(
 
 		for await (const event of stream) {
 			accumulator.update(event);
-			if (event.type === "error") failure = event;
-			yield event;
-		}
 
-		if (failure !== undefined) {
-			// 3a. The provider reported failure in-band — VOID, same as a throw.
-			// The iteration itself does not rethrow — the consumer already saw the
-			// event — but there is no successful message for `result()` to report.
-			const err = await abortForFailureEvent(governor, auth, failure);
+			if (event.type !== "done" && event.type !== "error") {
+				yield event;
+				continue;
+			}
+
+			// 3. TERMINAL EVENT. Governance runs, and `final` is settled, BEFORE
+			// the yield — see (a) in the file header. The pinned host awaits
+			// `result()` while it is suspended handling this very event, so a
+			// settle deferred until after the yield would wait for a resumption
+			// that can never come, and the agent turn would hang forever.
+			//
+			// Finalising here also makes "the terminal event the loop OBSERVED
+			// decides the action" STRUCTURAL rather than a flag consulted from the
+			// `finally`: by the time the consumer can break, it is already decided.
+			const failed = await finalizeTerminal(
+				governor,
+				auth,
+				event,
+				accumulator.result(),
+				providerResult,
+				final,
+				opts,
+			);
 			terminated = true;
-			final.reject(err);
+			// The consumer still sees the event — a settle failure is ours, not a
+			// reason to hide the provider's own terminal event from the caller.
+			yield event;
+			if (failed !== undefined) throw failed.error;
 			return;
 		}
 
-		// 3b. Settle — POST actual cost.
+		// 4. The stream closed with NO terminal event at all. Settle at the
+		// ESTIMATE, then TERMINATE `result()` explicitly.
+		//
+		// It must not adopt `providerResult` here: the pinned `EventStream.end()`
+		// resolves its final-result promise only when handed an explicit result
+		// (`event-stream.js:33-43`), and a stream that reaches this branch was
+		// ended without one. Adopting it would mark `final` settled while it hangs
+		// forever — invisible to the `!final.settled` guard below, and a hard hang
+		// at the host's post-loop `await response.result()`
+		// (`proxy-BzhBz8iM.js:411`).
 		const receipt = await governor.settle(auth, settleParamsFor(accumulator.result()));
 		terminated = true;
 		fireOnReceipt(opts, receipt);
-
-		// Governance is done and the money path succeeded — only now may
-		// `result()` report the host's final message.
-		final.resolve(providerResult);
+		final.reject(new Error("usertrust: provider stream closed without a terminal event"));
 	} catch (err) {
-		// 4. Abort — VOID the hold (catch abort errors to preserve original).
-		// Reachable only before `terminated` flips: the settle above is the last
-		// thing that can throw, and a settle that rejected mutated nothing.
-		await governor.abort(auth, err).catch(() => {});
-		terminated = true;
-		final.reject(err);
+		// 5. Abort — VOID the hold (catch abort errors to preserve original).
+		// Guarded by `terminated` because a settle that failed on the terminal
+		// event above rethrows THROUGH here after already voiding the hold; a
+		// second abort would be a second ledger action for one authorization.
+		if (!terminated) {
+			await governor.abort(auth, err).catch(() => {});
+			terminated = true;
+			final.reject(err);
+		}
 		throw err;
 	} finally {
-		// 5. Abandonment — the consumer walked away, unwinding the generator at a
-		// `yield` without reaching any branch above. The hold is still open, and
-		// what the loop OBSERVED before the unwind decides its fate.
+		// 6. Abandonment — the consumer walked away, unwinding the generator at a
+		// `yield` without reaching any branch above. Reachable ONLY before a
+		// terminal event was seen (one would have flipped `terminated` before its
+		// own yield), so this is always the no-terminal-event case: a clean early
+		// termination, not a failure, and it SETTLES the partial rather than
+		// voiding (AGENTS.md, "The settle/void asymmetry is deliberate") — at the
+		// ESTIMATE, because usage only ever arrives on a terminal event.
 		if (!terminated) {
-			if (failure !== undefined) {
-				// The provider had already reported failure in-band; the consumer just
-				// left before the loop ended. VOID, exactly as the 3a branch would.
-				final.reject(await abortForFailureEvent(governor, auth, failure));
-			} else {
-				// A clean early termination, not a failure, so it SETTLES the partial
-				// rather than voiding (AGENTS.md, "The settle/void asymmetry is
-				// deliberate") — at the provider's usage if a `done` event already
-				// carried it, otherwise at the ESTIMATE.
-				await settleAbandoned(governor, auth, accumulator.result(), opts);
-			}
+			await settleAbandoned(governor, auth, accumulator.result(), opts);
 		}
 		// `result()` must never be left pending. The abandonment path has no final
 		// assistant message to hand back, so it rejects.
 		if (!final.settled) {
 			final.reject(new Error("usertrust: stream abandoned before completion"));
 		}
+	}
+}
+
+/**
+ * Take the single terminal ledger action for a `done` / `error` event and
+ * settle `final` with what the pinned stream class would have reported.
+ *
+ * NEVER THROWS — it runs before a `yield`, and its caller decides whether the
+ * generator rethrows. Returns the error to rethrow (a failed settle), or
+ * `undefined` when the run ends cleanly.
+ *
+ * Two things here are pinned host behaviour, not choices:
+ *
+ *  - **`reason: "aborted"` SETTLES, it does not void.** That event is the
+ *    CALLER's `AbortSignal` firing, not a provider failure — every pinned
+ *    provider derives it from `signal?.aborted` and attaches the usage it had
+ *    accumulated so far (`pi-ai/dist/providers/anthropic.js:500-517`,
+ *    `openclaw/dist/openai-transport-stream-B0WkSqXp.js:757-772`). Those tokens
+ *    were really spent, so voiding them would let any consumer cancel its way
+ *    out of paying for work the provider actually did. Only `reason: "error"`
+ *    is a failure.
+ *
+ *  - **`result()` RESOLVES on an in-band error event, it does not reject.** The
+ *    pinned `AssistantMessageEventStream`'s `extractResult` returns
+ *    `event.error` for it (`event-stream.js:66-74`), and OpenClaw consumes that
+ *    AssistantMessage as the terminal assistant turn, branching on
+ *    `message.stopReason` afterwards (`proxy-BzhBz8iM.js:264`). Rejecting would
+ *    convert an ordinary failed turn into a thrown agent-loop error. Rejection
+ *    stays reserved for THROWN failures, where there is no message at all.
+ */
+async function finalizeTerminal(
+	governor: Governor,
+	auth: Authorization,
+	event: DoneEvent | ErrorEvent,
+	usage: AccumulatedUsage,
+	providerResult: Promise<AssistantMessage>,
+	final: Deferred<AssistantMessage>,
+	opts: GovernanceOptions | undefined,
+): Promise<{ error: unknown } | undefined> {
+	if (event.type === "error" && event.reason === "error") {
+		const err = new Error(
+			`usertrust: provider stream ended with error: ${event.error.errorMessage ?? event.reason}`,
+		);
+		await governor.abort(auth, err).catch(() => {});
+		final.resolve(event.error);
+		return undefined;
+	}
+
+	try {
+		const receipt = await governor.settle(auth, settleParamsFor(usage));
+		fireOnReceipt(opts, receipt);
+		// `done` reports the PROVIDER's own `result()` — a stream wrapper may have
+		// post-processed the message, and by the pinned push-before-deliver
+		// ordering it is already resolved by the time we see the event. An abort
+		// has no such promise to wait on (the provider `end()`s without one), so
+		// it reports the partial message the event itself carried.
+		final.resolve(event.type === "done" ? providerResult : event.error);
+		return undefined;
+	} catch (err) {
+		await governor.abort(auth, err).catch(() => {});
+		final.reject(err);
+		return { error: err };
 	}
 }
 
@@ -467,24 +633,6 @@ async function settleAbandoned(
 		// The hold would otherwise dangle PENDING until destroy/timeout.
 		await governor.abort(auth, err).catch(() => {});
 	}
-}
-
-/**
- * Void the hold for a stream the provider ended with an in-band `error` event,
- * and return the error `result()` should reject with. Shared by the post-loop
- * branch and the `finally`, so the two cannot drift into treating the same
- * observed failure differently. Never throws — the `finally` calls it too.
- */
-async function abortForFailureEvent(
-	governor: Governor,
-	auth: Authorization,
-	failure: ErrorEvent,
-): Promise<Error> {
-	const err = new Error(
-		`usertrust: provider stream ended with error: ${failure.error.errorMessage ?? failure.reason}`,
-	);
-	await governor.abort(auth, err).catch(() => {});
-	return err;
 }
 
 /**

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -7,8 +7,13 @@
  * Wraps a host stream function with usertrust governance:
  *   1. Before stream: authorize (budget check, PENDING hold)
  *   2. During stream: forward events, accumulate token usage
- *   3. After stream: settle with actual cost
- *   4. On error: abort (VOID the hold)
+ *   3. After stream: EXACTLY ONE terminal ledger action per authorization —
+ *      settle with the provider's usage on a clean `done`, settle at the
+ *      ESTIMATE when the stream ends early (no terminal event, or the consumer
+ *      walked away), abort when it fails (a throw, or an in-band `error` event)
+ *
+ * The full path→action matrix, including what `result()` does on each, is in
+ * contract-notes §6 and pinned by `tests/terminal-modes.test.ts`.
  *
  * The wrapped function has the same signature AND the same surface as the
  * original — the pinned boundary is not a bare `AsyncIterable`, it also
@@ -21,6 +26,7 @@ import type {
 	AssistantMessage,
 	AssistantMessageEventStreamLike,
 	Context,
+	ErrorEvent,
 	Model,
 	StreamEvent,
 	StreamFn,
@@ -159,6 +165,13 @@ async function* governedStream(
 	// 2. Stream with token accumulation
 	const accumulator = createAccumulator();
 
+	// Exactly one terminal ledger action per authorization (AGENTS.md, "Money").
+	// The flag flips only once a settle or an abort has actually been issued, so
+	// the `finally` guard below can tell an ABANDONED stream — the consumer
+	// `break`s or calls `iterator.return()`, unwinding the generator at `yield`
+	// without reaching any branch — from one that already terminated.
+	let terminated = false;
+
 	try {
 		const stream = await streamFn(model, context, options);
 		// Hold on to the host's final-message promise, but do NOT wire it to
@@ -170,12 +183,33 @@ async function* governedStream(
 		// Nothing awaits it until adoption, so pre-mark it handled.
 		providerResult.catch(() => {});
 
+		// A terminal `error` event does NOT throw — per contract-notes §3 the host
+		// yields it like any other event and the iteration simply ends. Remember it
+		// so the post-loop branch voids instead of settling.
+		let failure: ErrorEvent | undefined;
+
 		for await (const event of stream) {
 			accumulator.update(event);
+			if (event.type === "error") failure = event;
 			yield event;
 		}
 
-		// 3. Settle — POST actual cost
+		if (failure !== undefined) {
+			// 3a. The provider reported failure in-band — VOID, same as a throw.
+			const err = new Error(
+				`usertrust: provider stream ended with error: ${
+					failure.error.errorMessage ?? failure.reason
+				}`,
+			);
+			await governor.abort(auth, err).catch(() => {});
+			terminated = true;
+			// The iteration itself does not rethrow — the consumer already saw the
+			// event — but there is no successful message for `result()` to report.
+			final.reject(err);
+			return;
+		}
+
+		// 3b. Settle — POST actual cost.
 		const usage = accumulator.result();
 
 		await governor.settle(auth, {
@@ -189,25 +223,54 @@ async function* governedStream(
 			// never `computeMs: undefined` (plan A6).
 			...(usage.computeMs != null ? { computeMs: usage.computeMs } : {}),
 		});
+		terminated = true;
 
 		// Governance is done and the money path succeeded — only now may
 		// `result()` report the host's final message.
 		final.resolve(providerResult);
 	} catch (err) {
-		// 4. Abort — VOID the hold (catch abort errors to preserve original)
+		// 4. Abort — VOID the hold (catch abort errors to preserve original).
+		// Reachable only before `terminated` flips: the settle above is the last
+		// thing that can throw, and a settle that rejected mutated nothing.
 		await governor.abort(auth, err).catch(() => {});
+		terminated = true;
 		final.reject(err);
 		throw err;
 	} finally {
-		// A consumer that `break`s (or otherwise calls `return()` on the iterator)
-		// unwinds the generator without reaching either branch above. `result()`
-		// must never be left pending, so settle it here as a last resort.
-		// NOTE: this guard settles the DEFERRED only — it deliberately does not
-		// touch the hold. Aborting/settling governance on abandonment is Task 3's
-		// terminal-mode work.
+		// 5. Abandonment — the consumer walked away mid-stream. That is a clean
+		// early termination, not a failure, so it SETTLES the partial rather than
+		// voiding (AGENTS.md, "The settle/void asymmetry is deliberate"), and at
+		// the ESTIMATE: usage only ever arrives on a terminal event, so a stream
+		// abandoned before one carries no provider tokens to settle with.
+		if (!terminated) {
+			await settleAtEstimate(governor, auth, accumulator.result().chunksDelivered);
+		}
+		// `result()` must never be left pending. The abandonment path has no final
+		// assistant message to hand back, so it rejects.
 		if (!final.settled) {
 			final.reject(new Error("usertrust: stream abandoned before completion"));
 		}
+	}
+}
+
+/**
+ * Settle an abandoned stream's hold at the pre-call estimate, falling back to an
+ * abort if the ledger refuses the settle. Nothing here may throw: it runs in the
+ * generator's `finally`, where an escaping error would replace the consumer's
+ * own control flow (a `break`, an outer `throw`) with a governance error.
+ */
+async function settleAtEstimate(
+	governor: Governor,
+	auth: Authorization,
+	chunksDelivered: number,
+): Promise<void> {
+	try {
+		// Omitting the token fields is what selects the estimate — `settle()` reads
+		// `auth.estimatedCost` when neither inputTokens nor outputTokens is given.
+		await governor.settle(auth, { chunksDelivered, usageSource: "estimated" });
+	} catch (err) {
+		// The hold would otherwise dangle PENDING until destroy/timeout.
+		await governor.abort(auth, err).catch(() => {});
 	}
 }
 

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -2,68 +2,125 @@
 // Copyright 2026 Usertools, Inc.
 
 /**
- * stream-governor.ts — Governed Stream Wrapper for pi-ai
+ * stream-governor.ts — Governed Stream Wrapper for the OpenClaw/pi-ai seam
  *
- * Wraps a pi-ai stream function with usertrust governance:
+ * Wraps a host stream function with usertrust governance:
  *   1. Before stream: authorize (budget check, PENDING hold)
  *   2. During stream: forward events, accumulate token usage
  *   3. After stream: settle with actual cost
  *   4. On error: abort (VOID the hold)
  *
- * The wrapped function has the same signature as the original —
- * it's a transparent middleware layer.
+ * The wrapped function has the same signature AND the same surface as the
+ * original — the pinned boundary is not a bare `AsyncIterable`, it also
+ * exposes `result()`, so the wrapper is a proxy rather than a generator.
  */
 
 import type { Authorization, Governor } from "usertrust";
 import { createAccumulator } from "./token-extractor.js";
-import type { StreamContext, StreamEvent, StreamFn } from "./types.js";
+import type {
+	AssistantMessage,
+	AssistantMessageEventStreamLike,
+	Context,
+	Model,
+	StreamEvent,
+	StreamFn,
+	StreamOptions,
+	Usage,
+} from "./types.js";
+
+/** A promise plus its settlers, pre-marked as handled to avoid stray rejections. */
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve(value: T | PromiseLike<T>): void;
+	reject(reason: unknown): void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	// A consumer that only iterates never touches `result()`; without this the
+	// rejection leg would surface as an unhandled rejection.
+	promise.catch(() => {});
+	return { promise, resolve, reject };
+}
 
 /**
- * Wrap a pi-ai stream function with usertrust governance.
+ * Wrap a host stream function with usertrust governance.
  *
  * Returns a new stream function with the same signature. Every call:
  *   - Checks budget and creates a PENDING hold
  *   - Forwards all stream events unchanged
  *   - Settles with actual token usage on completion
  *   - Voids the hold on error
- *
- * The governance receipt is emitted as a custom `usertrust:receipt`
- * property on the `done` event for consumers that want it.
  */
 export function wrapStreamWithGovernance(streamFn: StreamFn, governor: Governor): StreamFn {
 	return (
-		model: string,
-		context: StreamContext,
-		options?: Record<string, unknown>,
-	): AsyncIterable<StreamEvent> => {
-		return governedStream(streamFn, governor, model, context, options);
+		model: Model,
+		context: Context,
+		options?: StreamOptions,
+	): AssistantMessageEventStreamLike => {
+		// The governed run is a single-consumer async generator, and `result()`
+		// has to resolve from that SAME run — so the inner stream's final message
+		// is handed over through a deferred the generator settles.
+		const final = createDeferred<AssistantMessage>();
+		const events = governedStream(streamFn, governor, model, context, options, final);
+		let consumed = false;
+
+		return {
+			[Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+				consumed = true;
+				return events[Symbol.asyncIterator]();
+			},
+			async result(): Promise<AssistantMessage> {
+				// A `result()`-only consumer never iterates, so drain the governed
+				// stream here — otherwise neither governance nor `final` ever runs.
+				if (!consumed) {
+					consumed = true;
+					try {
+						for await (const _event of events) {
+							// drain
+						}
+					} catch (err) {
+						final.reject(err);
+					}
+				}
+				return final.promise;
+			},
+		};
 	};
 }
 
 async function* governedStream(
 	streamFn: StreamFn,
 	governor: Governor,
-	model: string,
-	context: StreamContext,
-	options?: Record<string, unknown>,
+	model: Model,
+	context: Context,
+	options: StreamOptions | undefined,
+	final: Deferred<AssistantMessage>,
 ): AsyncGenerator<StreamEvent> {
 	// 1a. Pre-flight budget check.
 	// In dry-run mode (no TigerBeetle) the engine cannot enforce balance,
 	// so we explicitly refuse calls when budget_remaining ≤ 0. This matches
 	// the behaviour users expect from a "budget" config: hit zero, get cut off.
 	if (governor.budgetRemaining() <= 0) {
-		throw new Error(
+		const denial = new Error(
 			`usertrust: budget exhausted (${governor.budgetRemaining()} remaining); call denied`,
 		);
+		final.reject(denial);
+		throw denial;
 	}
 
 	// 1b. Authorize — policy gate, PENDING hold
 	const auth: Authorization = await governor.authorize({
-		model,
+		model: model.id,
 		messages: context.messages,
-		...(context.maxTokens != null ? { maxOutputTokens: context.maxTokens } : {}),
+		...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
 		params: {
-			...(context.temperature != null ? { temperature: context.temperature } : {}),
+			...(options?.temperature != null ? { temperature: options.temperature } : {}),
 		},
 	});
 
@@ -71,7 +128,9 @@ async function* governedStream(
 	const accumulator = createAccumulator();
 
 	try {
-		const stream = streamFn(model, context, options);
+		const stream = await streamFn(model, context, options);
+		// Forward the host's own final-message promise onto our surface.
+		stream.result().then(final.resolve, final.reject);
 
 		for await (const event of stream) {
 			accumulator.update(event);
@@ -95,6 +154,7 @@ async function* governedStream(
 	} catch (err) {
 		// 4. Abort — VOID the hold (catch abort errors to preserve original)
 		await governor.abort(auth, err).catch(() => {});
+		final.reject(err);
 		throw err;
 	}
 }
@@ -102,24 +162,15 @@ async function* governedStream(
 /**
  * Wrap a non-streaming completion function with governance.
  *
- * For pi-ai's `completeSimple()` / `complete()` functions that
- * return a Promise instead of an async iterable.
+ * For the host's `completeSimple()` / `complete()` functions that return a
+ * Promise instead of a stream. Usage lands on the returned assistant message
+ * as the host's `Usage` shape (`input`/`output`), not `inputTokens`.
  */
-export function wrapCompleteWithGovernance<
-	T extends { usage?: { inputTokens: number; outputTokens: number } },
->(
-	completeFn: (
-		model: string,
-		context: StreamContext,
-		options?: Record<string, unknown>,
-	) => Promise<T>,
+export function wrapCompleteWithGovernance<T extends { usage?: Usage }>(
+	completeFn: (model: Model, context: Context, options?: StreamOptions) => Promise<T>,
 	governor: Governor,
-): (model: string, context: StreamContext, options?: Record<string, unknown>) => Promise<T> {
-	return async (
-		model: string,
-		context: StreamContext,
-		options?: Record<string, unknown>,
-	): Promise<T> => {
+): (model: Model, context: Context, options?: StreamOptions) => Promise<T> {
+	return async (model: Model, context: Context, options?: StreamOptions): Promise<T> => {
 		// 1a. Pre-flight budget check (see governedStream for rationale).
 		if (governor.budgetRemaining() <= 0) {
 			throw new Error(
@@ -129,11 +180,11 @@ export function wrapCompleteWithGovernance<
 
 		// 1b. Authorize
 		const auth = await governor.authorize({
-			model,
+			model: model.id,
 			messages: context.messages,
-			...(context.maxTokens != null ? { maxOutputTokens: context.maxTokens } : {}),
+			...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
 			params: {
-				...(context.temperature != null ? { temperature: context.temperature } : {}),
+				...(options?.temperature != null ? { temperature: options.temperature } : {}),
 			},
 		});
 
@@ -145,8 +196,8 @@ export function wrapCompleteWithGovernance<
 			await governor.settle(auth, {
 				...(result.usage != null
 					? {
-							inputTokens: result.usage.inputTokens,
-							outputTokens: result.usage.outputTokens,
+							inputTokens: result.usage.input,
+							outputTokens: result.usage.output,
 							usageSource: "provider" as const,
 						}
 					: { usageSource: "estimated" as const }),

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -25,9 +25,22 @@
  * exposes `result()`, so the wrapper is a proxy rather than a generator.
  */
 
-import type { Authorization, AuthorizeParams, Governor, SettleParams } from "usertrust";
+import type {
+	Authorization,
+	AuthorizeParams,
+	EnvelopeStatus,
+	Governor,
+	SettleParams,
+	TrustReceipt,
+} from "usertrust";
 import { withCostCenter } from "usertrust";
 import { deriveAttribution } from "./attribution.js";
+import {
+	envelopeDescriptorsFrom,
+	estimationMessages,
+	formatScarcityBlock,
+	injectScarcityBlock,
+} from "./scarcity-block.js";
 import type { AccumulatedUsage } from "./token-extractor.js";
 import { createAccumulator } from "./token-extractor.js";
 import type {
@@ -58,6 +71,15 @@ export interface GovernanceOptions {
 	 * `withCostCenter`.
 	 */
 	costCenters?: FrozenCostCenters | undefined;
+
+	/**
+	 * Fires with the `TrustReceipt` after a successful `settle()` — the wrapper
+	 * used to discard it. Fire-and-forget (see `fireOnReceipt`): a synchronous
+	 * throw and a returned rejection are both isolated, and the callback never
+	 * delays stream termination — `result()`/the settle path have already moved
+	 * on by the time it runs.
+	 */
+	onReceipt?: ((receipt: TrustReceipt) => void | Promise<void>) | undefined;
 }
 
 /** A promise plus its settlers, pre-marked as handled to avoid stray rejections. */
@@ -161,15 +183,21 @@ async function* governedStream(
 	final: Deferred<AssistantMessage>,
 	opts: GovernanceOptions | undefined,
 ): AsyncGenerator<StreamEvent> {
-	// 1. Attribute, pre-flight, authorize (see `authorizeGoverned`).
+	// 1. Attribute, pre-flight, authorize, inject scarcity (see `authorizeGoverned`).
 	// A denial — from the pre-flight or from the policy gate — is a terminal
 	// path like any other: `final` must be settled here, or a consumer that
 	// iterates AND awaits `result()` sees the iteration reject while `result()`
 	// hangs forever. There is no hold to abort yet, so this needs its own try
 	// rather than the streaming one below.
 	let auth: Authorization;
+	// The scarcity block (when injected) is delivered on `Context.systemPrompt`
+	// — a COPY, never the caller's own object — so every downstream use of
+	// `context` in this generator reads `forwardedContext`, not the parameter.
+	let forwardedContext: Context;
 	try {
-		auth = await authorizeGoverned(governor, model, context, options, opts);
+		const authorized = await authorizeGoverned(governor, model, context, options, opts);
+		auth = authorized.auth;
+		forwardedContext = authorized.context;
 	} catch (err) {
 		final.reject(err);
 		throw err;
@@ -195,7 +223,7 @@ async function* governedStream(
 	let failure: ErrorEvent | undefined;
 
 	try {
-		const stream = await streamFn(model, context, options);
+		const stream = await streamFn(model, forwardedContext, options);
 		// Hold on to the host's final-message promise, but do NOT wire it to
 		// `final` yet: it settles when the PROVIDER stream ends, which is before
 		// `governor.settle()` runs. Resolving here would let a `result()`-only
@@ -222,8 +250,9 @@ async function* governedStream(
 		}
 
 		// 3b. Settle — POST actual cost.
-		await governor.settle(auth, settleParamsFor(accumulator.result()));
+		const receipt = await governor.settle(auth, settleParamsFor(accumulator.result()));
 		terminated = true;
+		fireOnReceipt(opts, receipt);
 
 		// Governance is done and the money path succeeded — only now may
 		// `result()` report the host's final message.
@@ -250,7 +279,7 @@ async function* governedStream(
 				// rather than voiding (AGENTS.md, "The settle/void asymmetry is
 				// deliberate") — at the provider's usage if a `done` event already
 				// carried it, otherwise at the ESTIMATE.
-				await settleAbandoned(governor, auth, accumulator.result());
+				await settleAbandoned(governor, auth, accumulator.result(), opts);
 			}
 		}
 		// `result()` must never be left pending. The abandonment path has no final
@@ -261,10 +290,19 @@ async function* governedStream(
 	}
 }
 
+/** What {@link authorizeGoverned} hands back: the hold, and the context every
+ * downstream use (the streamFn/completeFn call) must read instead of the
+ * caller's original — the scarcity block, when injected, lives on its copy. */
+interface GovernedAuthorization {
+	auth: Authorization;
+	context: Context;
+}
+
 /**
- * The single place a governed call is attributed, pre-flighted and authorized.
- * Both wrappers go through it, so the streaming and completion paths can never
- * drift into gating or attributing the same call differently.
+ * The single place a governed call is attributed, pre-flighted, scarcity-
+ * injected and authorized. Both wrappers go through it, so the streaming and
+ * completion paths can never drift into gating, attributing, or injecting the
+ * same call differently.
  *
  * ALS DISCIPLINE. `withCostCenter` wraps `governor.authorize()` and NOTHING
  * else. Its scope has already exited by the time the caller's `await` resolves,
@@ -279,7 +317,7 @@ async function authorizeGoverned(
 	context: Context,
 	options: StreamOptions | undefined,
 	opts: GovernanceOptions | undefined,
-): Promise<Authorization> {
+): Promise<GovernedAuthorization> {
 	const costCenters = opts?.costCenters;
 	// Stateless and per-call: derived from this call's own context every time,
 	// so nothing survives a previous call to go stale on a later one.
@@ -302,22 +340,88 @@ async function authorizeGoverned(
 		);
 	}
 
+	// Scarcity injection (A8: reporting only — never gates, delays, or throws
+	// into the money path; see `readScarcityBlock`). `costCenters === undefined`
+	// means the operator never configured envelopes, so there is nothing to
+	// read — same as before this feature existed, byte-identical behavior.
+	const block = costCenters !== undefined ? await readScarcityBlock(governor, costCenters) : null;
+	const forwardedContext = injectScarcityBlock(context, block);
+
 	const params: AuthorizeParams = {
 		model: model.id,
-		messages: context.messages,
+		// Estimation honesty (contract-notes §4): `authorize()` only ever sees
+		// this array, never `Context.systemPrompt` — so the FULL effective
+		// system prompt (pre-existing + the scarcity block just injected above)
+		// has to be represented here, or the pre-call hold under-covers what
+		// the stream call is about to actually send.
+		messages: estimationMessages(forwardedContext),
 		...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
 		params: {
 			...(options?.temperature != null ? { temperature: options.temperature } : {}),
 		},
 	};
 
-	if (active === undefined || costCenters === undefined) return governor.authorize(params);
+	const auth =
+		active === undefined || costCenters === undefined
+			? await governor.authorize(params)
+			: // `envelopes[active]` is the metadata half (D4): without it the governor
+				// knows WHICH envelope to debit but not how large it is, and the policy
+				// tier fields come back `undefined`. `deriveAttribution` only ever
+				// returns a validated `envelopes` key, so this lookup always hits.
+				await withCostCenter(
+					active,
+					() => governor.authorize(params),
+					costCenters.envelopes[active],
+				);
 
-	// `envelopes[active]` is the metadata half (D4): without it the governor
-	// knows WHICH envelope to debit but not how large it is, and the policy
-	// tier fields come back `undefined`. `deriveAttribution` only ever returns
-	// a validated `envelopes` key, so this lookup always hits.
-	return withCostCenter(active, () => governor.authorize(params), costCenters.envelopes[active]);
+	return { auth, context: forwardedContext };
+}
+
+/**
+ * Read + format the per-turn scarcity block. REPORTING ONLY (A8): every
+ * failure leg — `scarcityContext: false` (skips the read entirely), an
+ * empty/failed `budgetContext` read, or a throw from the formatter itself —
+ * degrades to `null` rather than gating, delaying, or throwing into the money
+ * path. The two try/catches are separate (rather than one wrapping both calls)
+ * so each failure mode stays independently observable and testable: a read
+ * failure and a formatter failure are different bugs in different code.
+ */
+async function readScarcityBlock(
+	governor: Governor,
+	costCenters: FrozenCostCenters,
+): Promise<string | null> {
+	if (!costCenters.scarcityContext) return null;
+
+	let statuses: EnvelopeStatus[];
+	try {
+		statuses = await governor.budgetContext(envelopeDescriptorsFrom(costCenters));
+	} catch {
+		return null;
+	}
+
+	try {
+		return formatScarcityBlock(statuses);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Fire `opts.onReceipt` fire-and-forget. Neither a synchronous throw nor a
+ * returned rejection may propagate into the governed stream — the settle that
+ * produced `receipt` already committed — and the callback must never delay
+ * stream termination, so this is never awaited.
+ */
+function fireOnReceipt(opts: GovernanceOptions | undefined, receipt: TrustReceipt): void {
+	const cb = opts?.onReceipt;
+	if (cb === undefined) return;
+	try {
+		void Promise.resolve(cb(receipt)).catch(() => {
+			// Returned rejection — isolated, same as the synchronous throw below.
+		});
+	} catch {
+		// Synchronous throw from the callback itself — isolated.
+	}
 }
 
 /**
@@ -354,9 +458,11 @@ async function settleAbandoned(
 	governor: Governor,
 	auth: Authorization,
 	usage: AccumulatedUsage,
+	opts: GovernanceOptions | undefined,
 ): Promise<void> {
 	try {
-		await governor.settle(auth, settleParamsFor(usage));
+		const receipt = await governor.settle(auth, settleParamsFor(usage));
+		fireOnReceipt(opts, receipt);
 	} catch (err) {
 		// The hold would otherwise dangle PENDING until destroy/timeout.
 		await governor.abort(auth, err).catch(() => {});
@@ -394,16 +500,22 @@ export function wrapCompleteWithGovernance<T extends { usage?: Usage }>(
 	opts?: GovernanceOptions,
 ): (model: Model, context: Context, options?: StreamOptions) => Promise<T> {
 	return async (model: Model, context: Context, options?: StreamOptions): Promise<T> => {
-		// 1. Attribute, pre-flight, authorize — the SAME derivation the streaming
-		// path uses, from this call's own context.
-		const auth = await authorizeGoverned(governor, model, context, options, opts);
+		// 1. Attribute, pre-flight, authorize, inject scarcity — the SAME
+		// derivation the streaming path uses, from this call's own context.
+		const { auth, context: forwardedContext } = await authorizeGoverned(
+			governor,
+			model,
+			context,
+			options,
+			opts,
+		);
 
 		try {
 			// 2. Execute
-			const result = await completeFn(model, context, options);
+			const result = await completeFn(model, forwardedContext, options);
 
 			// 3. Settle with actual usage if available
-			await governor.settle(auth, {
+			const receipt = await governor.settle(auth, {
 				...(result.usage != null
 					? {
 							inputTokens: result.usage.input,
@@ -412,6 +524,7 @@ export function wrapCompleteWithGovernance<T extends { usage?: Usage }>(
 						}
 					: { usageSource: "estimated" as const }),
 			});
+			fireOnReceipt(opts, receipt);
 
 			return result;
 		} catch (err) {

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -5,7 +5,8 @@
  * stream-governor.ts — Governed Stream Wrapper for the OpenClaw/pi-ai seam
  *
  * Wraps a host stream function with usertrust governance:
- *   1. Before stream: authorize (budget check, PENDING hold)
+ *   1. Before stream: attribute (which envelope pays — `attribution.ts`), then
+ *      authorize (budget check, PENDING hold)
  *   2. During stream: forward events, accumulate token usage
  *   3. After stream: EXACTLY ONE terminal ledger action per authorization —
  *      settle with the provider's usage once a `done` event has been seen,
@@ -24,7 +25,9 @@
  * exposes `result()`, so the wrapper is a proxy rather than a generator.
  */
 
-import type { Authorization, Governor, SettleParams } from "usertrust";
+import type { Authorization, AuthorizeParams, Governor, SettleParams } from "usertrust";
+import { withCostCenter } from "usertrust";
+import { deriveAttribution } from "./attribution.js";
 import type { AccumulatedUsage } from "./token-extractor.js";
 import { createAccumulator } from "./token-extractor.js";
 import type {
@@ -32,12 +35,30 @@ import type {
 	AssistantMessageEventStreamLike,
 	Context,
 	ErrorEvent,
+	FrozenCostCenters,
 	Model,
 	StreamEvent,
 	StreamFn,
 	StreamOptions,
 	Usage,
 } from "./types.js";
+
+/**
+ * Per-wrapper governance options. Both wrappers take the same bag, so a
+ * capability added for one is never quietly missing from the other.
+ */
+export interface GovernanceOptions {
+	/**
+	 * The operator's validated, deep-frozen cost-center config
+	 * (`normalizeCostCenters`). Absent → no attribution is derived at all and
+	 * both wrappers behave exactly as they did before envelopes existed.
+	 *
+	 * SECURITY: this is the ONLY source of cost-center strings. Nothing derived
+	 * from a message, a tool name, or any other request content ever reaches
+	 * `withCostCenter`.
+	 */
+	costCenters?: FrozenCostCenters | undefined;
+}
 
 /** A promise plus its settlers, pre-marked as handled to avoid stray rejections. */
 interface Deferred<T> {
@@ -85,7 +106,11 @@ function createDeferred<T>(): Deferred<T> {
  *   - Settles with actual token usage on completion
  *   - Voids the hold on error
  */
-export function wrapStreamWithGovernance(streamFn: StreamFn, governor: Governor): StreamFn {
+export function wrapStreamWithGovernance(
+	streamFn: StreamFn,
+	governor: Governor,
+	opts?: GovernanceOptions,
+): StreamFn {
 	return (
 		model: Model,
 		context: Context,
@@ -95,7 +120,7 @@ export function wrapStreamWithGovernance(streamFn: StreamFn, governor: Governor)
 		// has to resolve from that SAME run — so the inner stream's final message
 		// is handed over through a deferred the generator settles.
 		const final = createDeferred<AssistantMessage>();
-		const events = governedStream(streamFn, governor, model, context, options, final);
+		const events = governedStream(streamFn, governor, model, context, options, final, opts);
 		let consumed = false;
 
 		return {
@@ -134,34 +159,17 @@ async function* governedStream(
 	context: Context,
 	options: StreamOptions | undefined,
 	final: Deferred<AssistantMessage>,
+	opts: GovernanceOptions | undefined,
 ): AsyncGenerator<StreamEvent> {
-	// 1a. Pre-flight budget check.
-	// In dry-run mode (no TigerBeetle) the engine cannot enforce balance,
-	// so we explicitly refuse calls when budget_remaining ≤ 0. This matches
-	// the behaviour users expect from a "budget" config: hit zero, get cut off.
-	if (governor.budgetRemaining() <= 0) {
-		const denial = new Error(
-			`usertrust: budget exhausted (${governor.budgetRemaining()} remaining); call denied`,
-		);
-		final.reject(denial);
-		throw denial;
-	}
-
-	// 1b. Authorize — policy gate, PENDING hold.
-	// A policy DENY is a terminal path like any other: `final` must be settled
-	// here, or a consumer that iterates AND awaits `result()` sees the iteration
-	// reject while `result()` hangs forever. There is no hold to abort yet, so
-	// this needs its own try rather than the streaming one below.
+	// 1. Attribute, pre-flight, authorize (see `authorizeGoverned`).
+	// A denial — from the pre-flight or from the policy gate — is a terminal
+	// path like any other: `final` must be settled here, or a consumer that
+	// iterates AND awaits `result()` sees the iteration reject while `result()`
+	// hangs forever. There is no hold to abort yet, so this needs its own try
+	// rather than the streaming one below.
 	let auth: Authorization;
 	try {
-		auth = await governor.authorize({
-			model: model.id,
-			messages: context.messages,
-			...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
-			params: {
-				...(options?.temperature != null ? { temperature: options.temperature } : {}),
-			},
-		});
+		auth = await authorizeGoverned(governor, model, context, options, opts);
 	} catch (err) {
 		final.reject(err);
 		throw err;
@@ -254,6 +262,65 @@ async function* governedStream(
 }
 
 /**
+ * The single place a governed call is attributed, pre-flighted and authorized.
+ * Both wrappers go through it, so the streaming and completion paths can never
+ * drift into gating or attributing the same call differently.
+ *
+ * ALS DISCIPLINE. `withCostCenter` wraps `governor.authorize()` and NOTHING
+ * else. Its scope has already exited by the time the caller's `await` resolves,
+ * which is the point: `settle()`/`abort()` run later, from a `finally` or an
+ * entirely different task, and they read the governor's own authorize-time
+ * capture rather than an AsyncLocalStorage store that is long gone. Nothing in
+ * this package ever calls `getCurrentCostCenter()`.
+ */
+async function authorizeGoverned(
+	governor: Governor,
+	model: Model,
+	context: Context,
+	options: StreamOptions | undefined,
+	opts: GovernanceOptions | undefined,
+): Promise<Authorization> {
+	const costCenters = opts?.costCenters;
+	// Stateless and per-call: derived from this call's own context every time,
+	// so nothing survives a previous call to go stale on a later one.
+	const active =
+		costCenters !== undefined ? deriveAttribution(context.messages, costCenters) : undefined;
+
+	// Pre-flight budget check — the SESSION wallet's gate. In dry-run mode (no
+	// TigerBeetle) the engine cannot enforce a balance, so we explicitly refuse
+	// calls when budget_remaining ≤ 0. This matches the behaviour users expect
+	// from a "budget" config: hit zero, get cut off.
+	//
+	// SKIPPED for an ATTRIBUTED call. The session wallet is not the wallet that
+	// pays it, so denying here would make an operator's independently funded
+	// envelope unreachable the moment the session ran dry — a budget the
+	// operator allocated and can never spend. `authorize()` gates the envelope
+	// the hold will actually debit, atomically, which is the real enforcement.
+	if (active === undefined && governor.budgetRemaining() <= 0) {
+		throw new Error(
+			`usertrust: budget exhausted (${governor.budgetRemaining()} remaining); call denied`,
+		);
+	}
+
+	const params: AuthorizeParams = {
+		model: model.id,
+		messages: context.messages,
+		...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
+		params: {
+			...(options?.temperature != null ? { temperature: options.temperature } : {}),
+		},
+	};
+
+	if (active === undefined || costCenters === undefined) return governor.authorize(params);
+
+	// `envelopes[active]` is the metadata half (D4): without it the governor
+	// knows WHICH envelope to debit but not how large it is, and the policy
+	// tier fields come back `undefined`. `deriveAttribution` only ever returns
+	// a validated `envelopes` key, so this lookup always hits.
+	return withCostCenter(active, () => governor.authorize(params), costCenters.envelopes[active]);
+}
+
+/**
  * The single place accumulated stream usage becomes `SettleParams`.
  *
  * Omitting the token fields is what selects the ESTIMATE — `settle()` reads
@@ -324,24 +391,12 @@ async function abortForFailureEvent(
 export function wrapCompleteWithGovernance<T extends { usage?: Usage }>(
 	completeFn: (model: Model, context: Context, options?: StreamOptions) => Promise<T>,
 	governor: Governor,
+	opts?: GovernanceOptions,
 ): (model: Model, context: Context, options?: StreamOptions) => Promise<T> {
 	return async (model: Model, context: Context, options?: StreamOptions): Promise<T> => {
-		// 1a. Pre-flight budget check (see governedStream for rationale).
-		if (governor.budgetRemaining() <= 0) {
-			throw new Error(
-				`usertrust: budget exhausted (${governor.budgetRemaining()} remaining); call denied`,
-			);
-		}
-
-		// 1b. Authorize
-		const auth = await governor.authorize({
-			model: model.id,
-			messages: context.messages,
-			...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
-			params: {
-				...(options?.temperature != null ? { temperature: options.temperature } : {}),
-			},
-		});
+		// 1. Attribute, pre-flight, authorize — the SAME derivation the streaming
+		// path uses, from this call's own context.
+		const auth = await authorizeGoverned(governor, model, context, options, opts);
 
 		try {
 			// 2. Execute

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -33,19 +33,36 @@ interface Deferred<T> {
 	promise: Promise<T>;
 	resolve(value: T | PromiseLike<T>): void;
 	reject(reason: unknown): void;
+	/** True once `resolve`/`reject` has been called — lets callers assert that
+	 *  every terminal path settled, instead of silently leaving `result()` pending. */
+	readonly settled: boolean;
 }
 
 function createDeferred<T>(): Deferred<T> {
-	let resolve!: (value: T | PromiseLike<T>) => void;
-	let reject!: (reason: unknown) => void;
+	let resolveFn!: (value: T | PromiseLike<T>) => void;
+	let rejectFn!: (reason: unknown) => void;
+	let settled = false;
 	const promise = new Promise<T>((res, rej) => {
-		resolve = res;
-		reject = rej;
+		resolveFn = res;
+		rejectFn = rej;
 	});
 	// A consumer that only iterates never touches `result()`; without this the
 	// rejection leg would surface as an unhandled rejection.
 	promise.catch(() => {});
-	return { promise, resolve, reject };
+	return {
+		promise,
+		resolve(value) {
+			settled = true;
+			resolveFn(value);
+		},
+		reject(reason) {
+			settled = true;
+			rejectFn(reason);
+		},
+		get settled() {
+			return settled;
+		},
+	};
 }
 
 /**
@@ -85,7 +102,12 @@ export function wrapStreamWithGovernance(streamFn: StreamFn, governor: Governor)
 							// drain
 						}
 					} catch (err) {
+						// The governed run settles `final` on every terminal path, so
+						// this is normally the same rejection arriving twice. Rethrow
+						// rather than falling through to `final.promise`: a drain that
+						// threw must never be reported as a successful message.
 						final.reject(err);
+						throw err;
 					}
 				}
 				return final.promise;
@@ -114,23 +136,39 @@ async function* governedStream(
 		throw denial;
 	}
 
-	// 1b. Authorize — policy gate, PENDING hold
-	const auth: Authorization = await governor.authorize({
-		model: model.id,
-		messages: context.messages,
-		...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
-		params: {
-			...(options?.temperature != null ? { temperature: options.temperature } : {}),
-		},
-	});
+	// 1b. Authorize — policy gate, PENDING hold.
+	// A policy DENY is a terminal path like any other: `final` must be settled
+	// here, or a consumer that iterates AND awaits `result()` sees the iteration
+	// reject while `result()` hangs forever. There is no hold to abort yet, so
+	// this needs its own try rather than the streaming one below.
+	let auth: Authorization;
+	try {
+		auth = await governor.authorize({
+			model: model.id,
+			messages: context.messages,
+			...(options?.maxTokens != null ? { maxOutputTokens: options.maxTokens } : {}),
+			params: {
+				...(options?.temperature != null ? { temperature: options.temperature } : {}),
+			},
+		});
+	} catch (err) {
+		final.reject(err);
+		throw err;
+	}
 
 	// 2. Stream with token accumulation
 	const accumulator = createAccumulator();
 
 	try {
 		const stream = await streamFn(model, context, options);
-		// Forward the host's own final-message promise onto our surface.
-		stream.result().then(final.resolve, final.reject);
+		// Hold on to the host's final-message promise, but do NOT wire it to
+		// `final` yet: it settles when the PROVIDER stream ends, which is before
+		// `governor.settle()` runs. Resolving here would let a `result()`-only
+		// consumer see a successful assistant message for a call that governance
+		// went on to abort. `final` is settled from the governed run below.
+		const providerResult = stream.result();
+		// Nothing awaits it until adoption, so pre-mark it handled.
+		providerResult.catch(() => {});
 
 		for await (const event of stream) {
 			accumulator.update(event);
@@ -151,11 +189,25 @@ async function* governedStream(
 			// never `computeMs: undefined` (plan A6).
 			...(usage.computeMs != null ? { computeMs: usage.computeMs } : {}),
 		});
+
+		// Governance is done and the money path succeeded — only now may
+		// `result()` report the host's final message.
+		final.resolve(providerResult);
 	} catch (err) {
 		// 4. Abort — VOID the hold (catch abort errors to preserve original)
 		await governor.abort(auth, err).catch(() => {});
 		final.reject(err);
 		throw err;
+	} finally {
+		// A consumer that `break`s (or otherwise calls `return()` on the iterator)
+		// unwinds the generator without reaching either branch above. `result()`
+		// must never be left pending, so settle it here as a last resort.
+		// NOTE: this guard settles the DEFERRED only — it deliberately does not
+		// touch the hold. Aborting/settling governance on abandonment is Task 3's
+		// terminal-mode work.
+		if (!final.settled) {
+			final.reject(new Error("usertrust: stream abandoned before completion"));
+		}
 	}
 }
 

--- a/packages/openclaw/src/stream-governor.ts
+++ b/packages/openclaw/src/stream-governor.ts
@@ -8,9 +8,13 @@
  *   1. Before stream: authorize (budget check, PENDING hold)
  *   2. During stream: forward events, accumulate token usage
  *   3. After stream: EXACTLY ONE terminal ledger action per authorization —
- *      settle with the provider's usage on a clean `done`, settle at the
- *      ESTIMATE when the stream ends early (no terminal event, or the consumer
- *      walked away), abort when it fails (a throw, or an in-band `error` event)
+ *      settle with the provider's usage once a `done` event has been seen,
+ *      settle at the ESTIMATE when the stream ends with no terminal event at
+ *      all (including a consumer who walked away mid-stream), abort when it
+ *      fails (a throw, or an in-band `error` event). The terminal event the
+ *      loop OBSERVED decides the action, not where the generator happened to
+ *      unwind — a consumer that breaks straight after `done`/`error` gets the
+ *      same treatment as one that drains to the end.
  *
  * The full path→action matrix, including what `result()` does on each, is in
  * contract-notes §6 and pinned by `tests/terminal-modes.test.ts`.
@@ -20,7 +24,8 @@
  * exposes `result()`, so the wrapper is a proxy rather than a generator.
  */
 
-import type { Authorization, Governor } from "usertrust";
+import type { Authorization, Governor, SettleParams } from "usertrust";
+import type { AccumulatedUsage } from "./token-extractor.js";
 import { createAccumulator } from "./token-extractor.js";
 import type {
 	AssistantMessage,
@@ -172,6 +177,15 @@ async function* governedStream(
 	// without reaching any branch — from one that already terminated.
 	let terminated = false;
 
+	// A terminal `error` event does NOT throw — per contract-notes §3 the host
+	// yields it like any other event and the iteration simply ends. Declared
+	// OUTSIDE the try so the `finally` can consult it too: a consumer that breaks
+	// (or calls `iterator.return()`) immediately AFTER the error event unwinds the
+	// generator at the `yield` and never reaches the post-loop branch. What the
+	// loop already observed still decides the hold, so a call the provider
+	// reported as failed is voided rather than charged at the estimate.
+	let failure: ErrorEvent | undefined;
+
 	try {
 		const stream = await streamFn(model, context, options);
 		// Hold on to the host's final-message promise, but do NOT wire it to
@@ -183,11 +197,6 @@ async function* governedStream(
 		// Nothing awaits it until adoption, so pre-mark it handled.
 		providerResult.catch(() => {});
 
-		// A terminal `error` event does NOT throw — per contract-notes §3 the host
-		// yields it like any other event and the iteration simply ends. Remember it
-		// so the post-loop branch voids instead of settling.
-		let failure: ErrorEvent | undefined;
-
 		for await (const event of stream) {
 			accumulator.update(event);
 			if (event.type === "error") failure = event;
@@ -196,33 +205,16 @@ async function* governedStream(
 
 		if (failure !== undefined) {
 			// 3a. The provider reported failure in-band — VOID, same as a throw.
-			const err = new Error(
-				`usertrust: provider stream ended with error: ${
-					failure.error.errorMessage ?? failure.reason
-				}`,
-			);
-			await governor.abort(auth, err).catch(() => {});
-			terminated = true;
 			// The iteration itself does not rethrow — the consumer already saw the
 			// event — but there is no successful message for `result()` to report.
+			const err = await abortForFailureEvent(governor, auth, failure);
+			terminated = true;
 			final.reject(err);
 			return;
 		}
 
 		// 3b. Settle — POST actual cost.
-		const usage = accumulator.result();
-
-		await governor.settle(auth, {
-			...(usage.usageReported
-				? { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens }
-				: {}),
-			chunksDelivered: usage.chunksDelivered,
-			usageSource: usage.usageReported ? "provider" : "estimated",
-			// Ollama-native eval_duration (when the stream carried it) flows to
-			// receipt.meter.computeMs. Spread keeps the key OMITTED when absent —
-			// never `computeMs: undefined` (plan A6).
-			...(usage.computeMs != null ? { computeMs: usage.computeMs } : {}),
-		});
+		await governor.settle(auth, settleParamsFor(accumulator.result()));
 		terminated = true;
 
 		// Governance is done and the money path succeeded — only now may
@@ -237,13 +229,21 @@ async function* governedStream(
 		final.reject(err);
 		throw err;
 	} finally {
-		// 5. Abandonment — the consumer walked away mid-stream. That is a clean
-		// early termination, not a failure, so it SETTLES the partial rather than
-		// voiding (AGENTS.md, "The settle/void asymmetry is deliberate"), and at
-		// the ESTIMATE: usage only ever arrives on a terminal event, so a stream
-		// abandoned before one carries no provider tokens to settle with.
+		// 5. Abandonment — the consumer walked away, unwinding the generator at a
+		// `yield` without reaching any branch above. The hold is still open, and
+		// what the loop OBSERVED before the unwind decides its fate.
 		if (!terminated) {
-			await settleAtEstimate(governor, auth, accumulator.result().chunksDelivered);
+			if (failure !== undefined) {
+				// The provider had already reported failure in-band; the consumer just
+				// left before the loop ended. VOID, exactly as the 3a branch would.
+				final.reject(await abortForFailureEvent(governor, auth, failure));
+			} else {
+				// A clean early termination, not a failure, so it SETTLES the partial
+				// rather than voiding (AGENTS.md, "The settle/void asymmetry is
+				// deliberate") — at the provider's usage if a `done` event already
+				// carried it, otherwise at the ESTIMATE.
+				await settleAbandoned(governor, auth, accumulator.result());
+			}
 		}
 		// `result()` must never be left pending. The abandonment path has no final
 		// assistant message to hand back, so it rejects.
@@ -254,24 +254,64 @@ async function* governedStream(
 }
 
 /**
- * Settle an abandoned stream's hold at the pre-call estimate, falling back to an
- * abort if the ledger refuses the settle. Nothing here may throw: it runs in the
- * generator's `finally`, where an escaping error would replace the consumer's
- * own control flow (a `break`, an outer `throw`) with a governance error.
+ * The single place accumulated stream usage becomes `SettleParams`.
+ *
+ * Omitting the token fields is what selects the ESTIMATE — `settle()` reads
+ * `auth.estimatedCost` when neither `inputTokens` nor `outputTokens` is given.
+ * So a stream that never carried a terminal event settles at the estimate,
+ * while one that did settles at the provider's own numbers — including when the
+ * consumer walked away immediately after that event, where the estimate (sized
+ * above expected actuals) would overcharge a fully served call.
  */
-async function settleAtEstimate(
+function settleParamsFor(usage: AccumulatedUsage): SettleParams {
+	return {
+		...(usage.usageReported
+			? { inputTokens: usage.inputTokens, outputTokens: usage.outputTokens }
+			: {}),
+		chunksDelivered: usage.chunksDelivered,
+		usageSource: usage.usageReported ? "provider" : "estimated",
+		// Ollama-native eval_duration (when the stream carried it) flows to
+		// receipt.meter.computeMs. Spread keeps the key OMITTED when absent —
+		// never `computeMs: undefined` (plan A6).
+		...(usage.computeMs != null ? { computeMs: usage.computeMs } : {}),
+	};
+}
+
+/**
+ * Settle an abandoned stream's hold, falling back to an abort if the ledger
+ * refuses the settle. Nothing here may throw: it runs in the generator's
+ * `finally`, where an escaping error would replace the consumer's own control
+ * flow (a `break`, an outer `throw`) with a governance error.
+ */
+async function settleAbandoned(
 	governor: Governor,
 	auth: Authorization,
-	chunksDelivered: number,
+	usage: AccumulatedUsage,
 ): Promise<void> {
 	try {
-		// Omitting the token fields is what selects the estimate — `settle()` reads
-		// `auth.estimatedCost` when neither inputTokens nor outputTokens is given.
-		await governor.settle(auth, { chunksDelivered, usageSource: "estimated" });
+		await governor.settle(auth, settleParamsFor(usage));
 	} catch (err) {
 		// The hold would otherwise dangle PENDING until destroy/timeout.
 		await governor.abort(auth, err).catch(() => {});
 	}
+}
+
+/**
+ * Void the hold for a stream the provider ended with an in-band `error` event,
+ * and return the error `result()` should reject with. Shared by the post-loop
+ * branch and the `finally`, so the two cannot drift into treating the same
+ * observed failure differently. Never throws — the `finally` calls it too.
+ */
+async function abortForFailureEvent(
+	governor: Governor,
+	auth: Authorization,
+	failure: ErrorEvent,
+): Promise<Error> {
+	const err = new Error(
+		`usertrust: provider stream ended with error: ${failure.error.errorMessage ?? failure.reason}`,
+	);
+	await governor.abort(auth, err).catch(() => {});
+	return err;
 }
 
 /**

--- a/packages/openclaw/src/token-extractor.ts
+++ b/packages/openclaw/src/token-extractor.ts
@@ -4,16 +4,18 @@
 /**
  * token-extractor.ts — Stream Token Extraction
  *
- * Extracts token usage from pi-ai's normalized stream events AND from
+ * Extracts token usage from the host's normalized stream events AND from
  * raw provider chunk shapes (Anthropic, OpenAI, Gemini) via duck-typing.
  *
- * pi-ai reports usage on `done` / `error` events. Raw provider chunks
- * scatter usage across multiple shapes — we duck-type each one.
+ * The host reports usage on the terminal `done` / `error` events, nested on
+ * the final assistant message (`done.message.usage` / `error.error.usage`).
+ * Raw provider chunks scatter usage across multiple shapes — we duck-type
+ * each one. Everything normalizes into `StreamUsage`.
  */
 
-import type { StreamEvent, StreamUsage } from "./types.js";
+import type { StreamEvent, StreamUsage, Usage } from "./types.js";
 
-/** Accumulated usage from a pi-ai stream. */
+/** Accumulated usage from a host stream. */
 export interface AccumulatedUsage {
 	inputTokens: number;
 	outputTokens: number;
@@ -184,15 +186,15 @@ export function extractComputeMs(chunk: unknown): number | undefined {
  *   OpenAI:    chunk.choices[0].delta.content
  *   Gemini:    chunk.candidates[0].content.parts[0].text
  *   Ollama:    chunk.message.content  (native /api/chat, non-final only)
- *   pi-ai:     chunk.text  (text_delta event)
+ *   host:      chunk.delta  (text_delta event)
  */
 export function extractTextDeltaLength(chunk: unknown): number {
 	if (chunk == null || typeof chunk !== "object") return 0;
 	const c = chunk as Record<string, unknown>;
 
-	// pi-ai text_delta
-	if (c.type === "text_delta" && typeof c.text === "string") {
-		return c.text.length;
+	// Host text_delta — the text is on `delta`, not `text`.
+	if (c.type === "text_delta" && typeof c.delta === "string") {
+		return c.delta.length;
 	}
 
 	// Anthropic content_block_delta
@@ -241,24 +243,31 @@ function readNum(v: unknown): number | null {
 }
 
 /**
- * Extract token usage from a pi-ai stream event.
- * Returns non-zero usage only for `done` and `error` events.
+ * Normalize the host's `Usage` (input/output/cacheRead/cacheWrite) into
+ * usertrust's `StreamUsage` (…Tokens). Cache fields are OMITTED, never
+ * `undefined`-valued, when the host did not report them.
+ */
+function normalizeHostUsage(usage: Usage | undefined): StreamUsage | null {
+	if (usage == null) return null;
+	return {
+		inputTokens: clampTokens(readNum(usage.input) ?? 0),
+		outputTokens: clampTokens(readNum(usage.output) ?? 0),
+		...(readNum(usage.cacheRead) != null ? { cacheReadTokens: clampTokens(usage.cacheRead) } : {}),
+		...(readNum(usage.cacheWrite) != null
+			? { cacheWriteTokens: clampTokens(usage.cacheWrite) }
+			: {}),
+	};
+}
+
+/**
+ * Extract token usage from a host stream event.
+ *
+ * Only the two terminal events carry usage, and both nest it on the final
+ * assistant message: `done.message.usage` and `error.error.usage`.
  */
 export function extractUsageFromEvent(event: StreamEvent): StreamUsage | null {
-	if (event.type === "done" && event.usage != null) {
-		return {
-			...event.usage,
-			inputTokens: clampTokens(event.usage.inputTokens),
-			outputTokens: clampTokens(event.usage.outputTokens),
-		};
-	}
-	if (event.type === "error" && event.usage != null) {
-		return {
-			...event.usage,
-			inputTokens: clampTokens(event.usage.inputTokens),
-			outputTokens: clampTokens(event.usage.outputTokens),
-		};
-	}
+	if (event.type === "done") return normalizeHostUsage(event.message?.usage);
+	if (event.type === "error") return normalizeHostUsage(event.error?.usage);
 	return null;
 }
 

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -283,17 +283,78 @@ export interface Model {
 	headers?: Record<string, string>;
 }
 
+/** Preferred wire transport for providers that support more than one. */
+export type Transport = "sse" | "websocket" | "websocket-cached" | "auto";
+
+/** Prompt-cache retention preference; providers map it to their own values. */
+export type CacheRetention = "none" | "short" | "long";
+
+/** The HTTP response summary `StreamOptions.onResponse` is handed. */
+export interface ProviderResponse {
+	status: number;
+	headers: Record<string, string>;
+}
+
 /**
  * Per-call knobs. `maxTokens` and `temperature` live HERE, not on `Context` —
  * they are what the pre-call hold estimates against.
+ *
+ * This mirrors the pinned host's `StreamOptions` FIELD FOR FIELD
+ * (`openclaw/dist/types-CFIUY_La.d.ts:50-119`,
+ * `pi-ai/dist/types.d.ts:24-85`), and that completeness is load-bearing rather
+ * than tidiness. A field the host declares and the mirror drops is not an
+ * assignability failure — extra optional properties never break assignability
+ * in either direction — so nothing about the wrap seam complains. What breaks
+ * is the EXCESS-PROPERTY check on a caller's object literal: with `headers`
+ * missing here, `governed(model, ctx, { headers })` stops compiling for a
+ * caller passing something the host has always supported, and their only way
+ * out is a cast. The contract tests therefore assert this surface with VALUES,
+ * not just `Extends`, because a type-level assertion cannot see it.
+ *
+ * `signal` is the one field with governance meaning: when it fires, the pinned
+ * providers end the stream with `{ type: "error", reason: "aborted" }` carrying
+ * the partial usage, which `stream-governor.ts` SETTLES rather than voids.
  */
 export interface StreamOptions {
 	temperature?: number;
 	maxTokens?: number;
+	/** Stop sequences, mapped to each provider's native field. openclaw only. */
 	stop?: string[];
 	signal?: AbortSignal;
 	apiKey?: string;
+	transport?: Transport;
+	cacheRetention?: CacheRetention;
+	sessionId?: string;
+	/** Cache-affinity key distinct from session identity. openclaw only. */
+	promptCacheKey?: string;
+	/** Inspect or replace the provider payload before it is sent. */
+	onPayload?: (payload: unknown, model: Model) => unknown | Promise<unknown>;
+	/** Fires after the HTTP response arrives, before its body is consumed. */
+	onResponse?: (response: ProviderResponse, model: Model) => void | Promise<void>;
+	/** Extra HTTP headers, merged with (and able to override) provider defaults. */
+	headers?: Record<string, string>;
+	timeoutMs?: number;
+	maxRetries?: number;
+	maxRetryDelayMs?: number;
+	/** Provider-extracted request metadata (Anthropic reads `user_id`, …). */
+	metadata?: Record<string, unknown>;
 }
+
+/**
+ * The OPEN options bag, mirroring the host's own alias
+ * (`openclaw/dist/types-CFIUY_La.d.ts:123`, `pi-ai/dist/types.d.ts:86`):
+ *
+ *     type ProviderStreamOptions = StreamOptions & Record<string, unknown>;
+ *
+ * Not decoration. The pinned agent loop spreads its WHOLE config into the bag
+ * it hands a stream fn — `streamFunction(config.model, llmContext, { ...config,
+ * apiKey, signal })` (`openclaw/dist/proxy-BzhBz8iM.js:356-360`) — so the value
+ * that actually arrives at runtime always carries keys no interface declares.
+ * Callers with provider-specific knobs (including `reasoning` /
+ * `thinkingBudgets`, whose enums differ between the two hosts and so are not
+ * mirrored — contract-notes §7) type their literal as this.
+ */
+export type ProviderStreamOptions = StreamOptions & Record<string, unknown>;
 
 /**
  * The stream function shape on both sides of the wrap seam: the host hands one

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -321,6 +321,57 @@ export interface GovernedStreamMeta {
 	model: string;
 }
 
+/**
+ * One operator-declared spending envelope within `costCenters.envelopes`.
+ * Mirrors core's `EnvelopeDescriptor` minus `costCenter` (the envelope's key
+ * in the map already carries that).
+ */
+export interface EnvelopeConfig {
+	allocated: number;
+	periodStartMs: number;
+	periodEndMs?: number;
+}
+
+/**
+ * Operator-declared tool→cost-center attribution config (spec shape, as
+ * written in openclaw.json — unvalidated). Lives on
+ * `UsertrustPluginConfig.costCenters`; `normalizeCostCenters` (index.ts)
+ * validates it against core's canonical doors and returns the deep-frozen
+ * {@link FrozenCostCenters} every wrapper actually reads.
+ *
+ * SECURITY: `tools` values and `default` are the ONLY strings that ever reach
+ * `withCostCenter` (see the design's attribution security model) — both are
+ * OPERATOR config, never request content, so no agent-controlled text can
+ * author or relabel a cost center.
+ */
+export interface CostCentersConfig {
+	/** → `GovernorOpts.parentUserId`. Required — the envelope account identity. */
+	parentUserId: string;
+	/** toolName → costCenter. Every value must be an `envelopes` key. */
+	tools: Record<string, string>;
+	/** Fallback cost center for unmapped/no tool-result runs. Must be an `envelopes` key. */
+	default?: string;
+	envelopes: Record<string, EnvelopeConfig>;
+	/** Inject the per-turn scarcity block. Default `true` when `costCenters` is present. */
+	scarcityContext?: boolean;
+}
+
+/**
+ * The validated, normalized, deep-frozen form of {@link CostCentersConfig} —
+ * the ONLY shape any wrapper may read. Producing it is `normalizeCostCenters`'s
+ * entire job: a caller's later mutation of the raw object it built config from
+ * can never change routing, because nothing downstream holds a reference to
+ * that raw object. `scarcityContext` is normalized to its default (`true`) so
+ * no reader re-derives the default-when-absent rule.
+ */
+export type FrozenCostCenters = Readonly<{
+	parentUserId: string;
+	tools: Readonly<Record<string, string>>;
+	default?: string;
+	envelopes: Readonly<Record<string, Readonly<EnvelopeConfig>>>;
+	scarcityContext: boolean;
+}>;
+
 /** Configuration passed to the plugin from openclaw.json. */
 export interface UsertrustPluginConfig {
 	budget: number;
@@ -343,6 +394,13 @@ export interface UsertrustPluginConfig {
 		runtime?: LocalRuntime;
 		baseURL?: string;
 	};
+	/**
+	 * Operator-declared tool→cost-center attribution + per-turn scarcity
+	 * injection (Ship 2). Absent → no attribution, no scarcity block, byte-
+	 * identical behavior to before this config existed. Validated + normalized
+	 * by `normalizeCostCenters` at plugin CONSTRUCTION time, never lazily.
+	 */
+	costCenters?: CostCentersConfig;
 }
 
 // ── OpenClaw plugin registration ──

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -2,79 +2,234 @@
 // Copyright 2026 Usertools, Inc.
 
 /**
- * types.ts — OpenClaw Plugin API Types
+ * types.ts — pinned OpenClaw / pi-ai contract mirrors
  *
- * Type definitions for the OpenClaw plugin system and pi-ai streaming
- * events. These mirror the OpenClaw/pi-ai interfaces without requiring
- * the packages at compile time.
+ * The plugin must compile and ship without either host package installed at
+ * runtime, so every host shape it touches is mirrored here. The mirrors are
+ * NOT freehand: they are pinned to
+ *
+ *   - openclaw 2026.7.1-2         (plugin registration + the llm-core stream contract)
+ *   - @mariozechner/pi-ai 0.73.1  (programmatic pi-ai callers)
+ *
+ * and `tests/contract.test-d.ts` type-asserts each one against the pinned
+ * packages. Never hand-edit a mirror without re-running the gate:
+ *
+ *   npx tsc -p packages/openclaw/tsconfig.type-tests.json
+ *
+ * Where the two hosts differ, the mirror carries the shape that is assignable
+ * in BOTH directions at the wrap seam (openclaw hands us a stream fn and takes
+ * ours back), and widens optionality so either host's events are accepted.
  */
 
 import type { EndpointClass, LocalRuntime } from "usertrust";
 
-// ── pi-ai Stream Events ──
+// ── llm-core content blocks ──
 
-export interface StreamUsage {
-	inputTokens: number;
-	outputTokens: number;
-	cacheReadTokens?: number;
-	cacheWriteTokens?: number;
+export interface TextContent {
+	type: "text";
+	text: string;
+	textSignature?: string;
 }
 
-export interface TextDeltaEvent {
-	type: "text_delta";
-	text: string;
+export interface ThinkingContent {
+	type: "thinking";
+	thinking: string;
+	thinkingSignature?: string;
+	redacted?: boolean;
+}
+
+export interface ImageContent {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+export interface ToolCall {
+	type: "toolCall";
+	id: string;
+	name: string;
+	arguments: Record<string, unknown>;
+	thoughtSignature?: string;
+	executionMode?: "sequential" | "parallel";
+}
+
+// ── llm-core messages ──
+
+/** Normalized per-response token + cost accounting reported by the host. */
+export interface Usage {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalTokens: number;
+	cost: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		total: number;
+	};
+}
+
+export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
+
+export interface UserMessage {
+	role: "user";
+	content: string | (TextContent | ImageContent)[];
+	timestamp: number;
+	runtimeContextCarrier?: boolean;
+}
+
+export interface AssistantMessage {
+	role: "assistant";
+	content: (TextContent | ThinkingContent | ToolCall)[];
+	api: string;
+	provider: string;
+	model: string;
+	responseModel?: string;
+	responseId?: string;
+	usage: Usage;
+	stopReason: StopReason;
+	errorMessage?: string;
+	timestamp: number;
+}
+
+/**
+ * Host-inserted result of a previously executed tool call.
+ *
+ * This is the ONLY structured evidence the plugin has that a tool actually
+ * ran: `toolName` carries the name, `toolCallId` correlates back to the
+ * `ToolCall.id` on the preceding assistant message, and `isError` marks
+ * results the host produced without a real execution.
+ */
+export interface ToolResultMessage {
+	role: "toolResult";
+	toolCallId: string;
+	toolName: string;
+	content: (TextContent | ImageContent)[];
+	details?: unknown;
+	isError: boolean;
+	timestamp: number;
+}
+
+export type Message = UserMessage | AssistantMessage | ToolResultMessage;
+
+/**
+ * TypeBox `TSchema` at the pinned boundary.
+ *
+ * The plugin never inspects tool parameter schemas, and mirroring TypeBox's
+ * symbol-keyed `TSchema` would drag a typebox dependency into a package that
+ * has to compile without one — so the schema stays deliberately opaque, and
+ * `any` keeps it assignable in both directions at the wrap seam.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: opaque passthrough of TypeBox TSchema — see above.
+export type ToolParameterSchema = any;
+
+export interface Tool {
+	name: string;
+	description: string;
+	parameters: ToolParameterSchema;
+}
+
+/**
+ * The request context the host hands to a stream function.
+ *
+ * `systemPrompt` is the host's system-prompt surface — there is NO system-role
+ * message in the pinned contract (`Message` has exactly three roles).
+ */
+export interface Context {
+	systemPrompt?: string;
+	messages: Message[];
+	tools?: Tool[];
+}
+
+/** Legacy alias kept for the package's published type surface. */
+export type StreamContext = Context;
+
+// ── llm-core stream events ──
+
+export interface StartEvent {
+	type: "start";
+	partial: AssistantMessage;
 }
 
 export interface TextStartEvent {
 	type: "text_start";
+	contentIndex: number;
+	partial: AssistantMessage;
+}
+
+/**
+ * `partial` is REQUIRED by pi-ai and OPTIONAL by openclaw (which drops it on
+ * plain text deltas to avoid retaining a full assistant snapshot per token),
+ * so the mirror takes the optional form and accepts both.
+ */
+export interface TextDeltaEvent {
+	type: "text_delta";
+	contentIndex: number;
+	delta: string;
+	partial?: AssistantMessage;
 }
 
 export interface TextEndEvent {
 	type: "text_end";
-}
-
-export interface ThinkingDeltaEvent {
-	type: "thinking_delta";
-	text: string;
+	contentIndex: number;
+	content: string;
+	partial: AssistantMessage;
 }
 
 export interface ThinkingStartEvent {
 	type: "thinking_start";
+	contentIndex: number;
+	partial: AssistantMessage;
+}
+
+export interface ThinkingDeltaEvent {
+	type: "thinking_delta";
+	contentIndex: number;
+	delta: string;
+	partial: AssistantMessage;
 }
 
 export interface ThinkingEndEvent {
 	type: "thinking_end";
+	contentIndex: number;
+	content: string;
+	partial: AssistantMessage;
 }
 
 export interface ToolCallStartEvent {
 	type: "toolcall_start";
-	name: string;
-	id: string;
+	contentIndex: number;
+	partial: AssistantMessage;
 }
 
 export interface ToolCallDeltaEvent {
 	type: "toolcall_delta";
-	args: string;
+	contentIndex: number;
+	delta: string;
+	partial: AssistantMessage;
 }
 
 export interface ToolCallEndEvent {
 	type: "toolcall_end";
+	contentIndex: number;
+	toolCall: ToolCall;
+	partial: AssistantMessage;
 }
 
-export interface StartEvent {
-	type: "start";
-}
-
+/** Terminal success event. Token usage lives on `message.usage`. */
 export interface DoneEvent {
 	type: "done";
-	stopReason: "stop" | "toolUse" | "length" | "error" | "aborted";
-	usage: StreamUsage;
+	reason: Extract<StopReason, "stop" | "length" | "toolUse">;
+	message: AssistantMessage;
 }
 
+/** Terminal failure event. Token usage lives on `error.usage`. */
 export interface ErrorEvent {
 	type: "error";
-	error: unknown;
-	usage?: StreamUsage;
+	reason: Extract<StopReason, "aborted" | "error">;
+	error: AssistantMessage;
 }
 
 export type StreamEvent =
@@ -91,13 +246,79 @@ export type StreamEvent =
 	| DoneEvent
 	| ErrorEvent;
 
-// ── OpenClaw Plugin API ──
+/**
+ * The stream surface returned at the plugin boundary.
+ *
+ * NOT a bare `AsyncIterable` — the host also calls `result()` for the final
+ * assistant message, so any wrapper has to forward that too.
+ */
+export interface AssistantMessageEventStreamLike extends AsyncIterable<StreamEvent> {
+	result(): Promise<AssistantMessage>;
+}
 
-export interface OpenClawPluginApi {
-	registerTool(tool: unknown): void;
-	registerProvider(provider: unknown): void;
-	registerChannel(channel: unknown): void;
-	registerHttpRoute(route: unknown): void;
+// ── llm-core model + options ──
+
+export interface Model {
+	id: string;
+	name: string;
+	api: string;
+	provider: string;
+	baseUrl: string;
+	reasoning: boolean;
+	input: ("text" | "image")[];
+	cost: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+	};
+	contextWindow: number;
+	maxTokens: number;
+	headers?: Record<string, string>;
+}
+
+/**
+ * Per-call knobs. `maxTokens` and `temperature` live HERE, not on `Context` —
+ * they are what the pre-call hold estimates against.
+ */
+export interface StreamOptions {
+	temperature?: number;
+	maxTokens?: number;
+	stop?: string[];
+	signal?: AbortSignal;
+	apiKey?: string;
+}
+
+/**
+ * The stream function shape on both sides of the wrap seam: the host hands one
+ * in and takes one back, so the mirror has to be assignable in both directions.
+ */
+export type StreamFn = (
+	model: Model,
+	context: Context,
+	options?: StreamOptions,
+) => AssistantMessageEventStreamLike | Promise<AssistantMessageEventStreamLike>;
+
+// ── usertrust-owned types ──
+
+/**
+ * usertrust's normalized usage shape — NOT a host mirror.
+ *
+ * `token-extractor.ts` duck-types raw provider chunks (Anthropic, OpenAI,
+ * Gemini, Ollama) as well as host `StreamEvent`s into this one shape.
+ */
+export interface StreamUsage {
+	inputTokens: number;
+	outputTokens: number;
+	cacheReadTokens?: number;
+	cacheWriteTokens?: number;
+}
+
+/** Receipt attached to governed stream events. */
+export interface GovernedStreamMeta {
+	transferId: string;
+	estimatedCost: number;
+	model: string;
 }
 
 /** Configuration passed to the plugin from openclaw.json. */
@@ -124,46 +345,57 @@ export interface UsertrustPluginConfig {
 	};
 }
 
-// ── Stream Function Types ──
-
-export interface StreamContext {
-	messages: unknown[];
-	model: string;
-	maxTokens?: number;
-	temperature?: number;
-	[key: string]: unknown;
-}
-
-export type StreamFn = (
-	model: string,
-	context: StreamContext,
-	options?: Record<string, unknown>,
-) => AsyncIterable<StreamEvent>;
-
-/** Receipt attached to governed stream events. */
-export interface GovernedStreamMeta {
-	transferId: string;
-	estimatedCost: number;
-	model: string;
-}
-
-// ── OpenClaw ProviderPlugin shape ──
+// ── OpenClaw plugin registration ──
 
 /**
- * The plugin shape that OpenClaw's plugin loader expects.
+ * The subset of openclaw's `OpenClawPluginApi` this plugin uses.
  *
- * Mirrors `ProviderPlugin` from openclaw/src/plugins/types.ts. The two
- * primary integration hooks are `wrapStreamFn` (middleware-style wrap of
- * an existing stream function) and `createStreamFn` (custom factory).
- *
- * We only implement `wrapStreamFn` — middleware is the path of least
- * surprise for governance: budget check → forward → settle.
+ * Config is delivered on the api object as `pluginConfig` at register() time —
+ * it is NOT a second argument to any hook.
  */
+export interface OpenClawPluginApi {
+	id: string;
+	name: string;
+	pluginConfig?: Record<string, unknown>;
+	registerProvider(provider: ProviderPlugin): void;
+}
+
+/**
+ * Context handed to `ProviderPlugin.wrapStreamFn`.
+ *
+ * The hook takes ONE argument and reads the inner stream fn off it; it does
+ * not receive `(next, config)`.
+ */
+export interface ProviderWrapStreamFnContext {
+	provider: string;
+	modelId: string;
+	streamFn?: StreamFn;
+}
+
+/**
+ * The text-inference provider capability openclaw's loader expects.
+ *
+ * `auth` is REQUIRED upstream, and the hook is provider-scoped: openclaw
+ * resolves it by matching the call's provider id against this plugin's `id`
+ * and aliases, so it fires only for calls routed to this provider.
+ */
+/**
+ * An entry in openclaw's `ProviderPlugin.auth` array.
+ *
+ * usertrust governs someone else's provider credentials and declares none of
+ * its own, so the mirror keeps the shape opaque rather than reproducing
+ * openclaw's wizard/auth-method surface.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: opaque passthrough of openclaw's ProviderAuthMethod.
+export type ProviderAuthMethod = any;
+
 export interface ProviderPlugin {
 	id: string;
 	label: string;
-	/** Middleware: receives an existing stream fn, returns a wrapped one. */
-	wrapStreamFn?: (next: StreamFn) => StreamFn;
+	auth: ProviderAuthMethod[];
+	aliases?: string[];
+	/** Middleware: reads `ctx.streamFn` and returns a wrapped one. */
+	wrapStreamFn?: (ctx: ProviderWrapStreamFnContext) => StreamFn | null | undefined;
 	/** Optional: provide a fully custom stream fn. We do not use this. */
-	createStreamFn?: () => StreamFn;
+	createStreamFn?: (ctx: unknown) => StreamFn | null | undefined;
 }

--- a/packages/openclaw/src/types.ts
+++ b/packages/openclaw/src/types.ts
@@ -6,15 +6,21 @@
  *
  * The plugin must compile and ship without either host package installed at
  * runtime, so every host shape it touches is mirrored here. The mirrors are
- * NOT freehand: they are pinned to
+ * NOT freehand: they are type-asserted against the pinned host packages, in
+ * two halves, because only one of the two is ever installed.
  *
- *   - openclaw 2026.7.1-2         (plugin registration + the llm-core stream contract)
- *   - @mariozechner/pi-ai 0.73.1  (programmatic pi-ai callers)
+ *   - @mariozechner/pi-ai (exact devDependency; programmatic pi-ai callers)
+ *     `tests/contract.test-d.ts`, compiled on EVERY push by
+ *       npx tsc -p packages/openclaw/tsconfig.type-tests.json
+ *     which `npm run typecheck` runs.
  *
- * and `tests/contract.test-d.ts` type-asserts each one against the pinned
- * packages. Never hand-edit a mirror without re-running the gate:
+ *   - openclaw (optional peer, NOT installed by `npm ci`; plugin registration
+ *     plus the llm-core stream contract). Version pinned in exactly one place,
+ *     `openclaw-contract.env`. `tests/contract-openclaw.test-d.ts`, compiled by
+ *     the `openclaw-contract` CI job after an out-of-tree install:
+ *       npx tsc -p packages/openclaw/tsconfig.contract-openclaw.json
  *
- *   npx tsc -p packages/openclaw/tsconfig.type-tests.json
+ * Never hand-edit a mirror without re-running BOTH.
  *
  * Where the two hosts differ, the mirror carries the shape that is assignable
  * in BOTH directions at the wrap seam (openclaw hands us a stream fn and takes

--- a/packages/openclaw/tests/attribution.test.ts
+++ b/packages/openclaw/tests/attribution.test.ts
@@ -1,0 +1,799 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * attribution.test.ts — Ship 2, Task 5.
+ *
+ * Two halves, and the split is the security model:
+ *
+ *  1. `deriveAttribution` is PURE and STATELESS. Everything about which
+ *     envelope pays a call is decided here, from the caller's own context and
+ *     the operator's frozen config — so the table below is the whole trust
+ *     boundary written out. TRAILING run only, correlated by `toolCallId`,
+ *     `isError` excluded, structured fields only, malformed input skipped.
+ *  2. The wrappers thread that decision into `withCostCenter(…, authorize)` and
+ *     nothing else, and skip the session-wallet preflight for an attributed
+ *     call. Those tests run a REAL headless governor with an injected engine,
+ *     so what they observe is the account the hold actually debited and the
+ *     record the audit chain actually kept — not a mock of our own wrapper.
+ *
+ * Shapes come from `contract-notes.md` §2 (`role: "toolResult"`, `toolName`,
+ * `toolCallId` → the preceding assistant message's `ToolCall.id`, required
+ * `isError`) via `host-fixtures.ts`; nothing here guesses a field name.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Governor, TrustOpts } from "usertrust";
+import { createGovernor, TrustTBClient } from "usertrust";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { deriveAttribution } from "../src/attribution.js";
+import { normalizeCostCenters } from "../src/index.js";
+import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "../src/stream-governor.js";
+import type { Context, FrozenCostCenters, Message, StreamEvent, Usage } from "../src/types.js";
+import {
+	assistantToolCalls,
+	doneEvent,
+	makeAssistantMessage,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+	toolResult,
+	userMessage,
+} from "./host-fixtures.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// ── Frozen operator config (the ONLY source of cost-center strings) ──
+
+const PARENT = "acme";
+const PERIOD_START = Date.UTC(2026, 7, 3, 0, 0, 0);
+
+/** The map every table row below is read against — normalized through the real door. */
+const CC: FrozenCostCenters = normalizeCostCenters({
+	parentUserId: PARENT,
+	tools: { web_search: "research", read_file: "verification" },
+	default: "general",
+	envelopes: {
+		research: { allocated: 10_000, periodStartMs: PERIOD_START },
+		verification: { allocated: 5_000, periodStartMs: PERIOD_START },
+		general: { allocated: 1_000, periodStartMs: PERIOD_START },
+	},
+});
+
+/** Same map with NO `default` — the "unattributed rather than fall back" config. */
+const CC_NO_DEFAULT: FrozenCostCenters = normalizeCostCenters({
+	parentUserId: PARENT,
+	tools: { web_search: "research", read_file: "verification" },
+	envelopes: {
+		research: { allocated: 10_000, periodStartMs: PERIOD_START },
+		verification: { allocated: 5_000, periodStartMs: PERIOD_START },
+	},
+});
+
+// ── Part 1: deriveAttribution (pure) ──
+
+/** `messages` is `unknown[]`, so a row may hold deliberately malformed entries. */
+interface Row {
+	name: string;
+	messages: unknown[];
+	expected: string | undefined;
+	cc?: FrozenCostCenters;
+}
+
+const ROWS: Row[] = [
+	// — the happy path —
+	{
+		name: "a trailing correlated tool-result run attributes to the mapped envelope",
+		messages: [userMessage("find it"), assistantToolCalls("web_search"), toolResult("web_search")],
+		expected: "research",
+	},
+	{
+		name: "the FIRST mapped name in the run wins, not the last",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("read_file", "web_search"),
+			toolResult("read_file"),
+			toolResult("web_search"),
+		],
+		expected: "verification",
+	},
+	{
+		name: "an unmapped name earlier in the run does not shadow a mapped one after it",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("unknown_tool", "web_search"),
+			toolResult("unknown_tool"),
+			toolResult("web_search"),
+		],
+		expected: "research",
+	},
+	{
+		name: "only the LAST turn's run is read — the previous turn's results are not",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search"),
+			toolResult("web_search"),
+			assistantToolCalls("read_file"),
+			toolResult("read_file"),
+		],
+		expected: "verification",
+	},
+
+	// — TRAILING only: no stale carry-over into later turns —
+	{
+		name: "a run followed by the assistant's final answer resets to default",
+		messages: [
+			userMessage("find it"),
+			assistantToolCalls("web_search"),
+			toolResult("web_search"),
+			makeAssistantMessage(),
+		],
+		expected: "general",
+	},
+	{
+		name: "a run followed by a NEW user message resets to default (stale carry-over pin)",
+		messages: [
+			userMessage("find it"),
+			assistantToolCalls("web_search"),
+			toolResult("web_search"),
+			makeAssistantMessage(),
+			userMessage("now summarize it"),
+		],
+		expected: "general",
+	},
+
+	// — correlation —
+	{
+		name: "an uncorrelated result (no such toolCallId on the preceding turn) never attributes",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("read_file"),
+			toolResult("web_search", { toolCallId: "call_from_some_other_turn" }),
+		],
+		expected: "general",
+	},
+	{
+		name: "a correlated id whose NAME disagrees with the issued call never attributes",
+		messages: [
+			// `call_read_file` was issued for `read_file`; the result claims `web_search`.
+			userMessage("go"),
+			assistantToolCalls("read_file"),
+			toolResult("web_search", { toolCallId: "call_read_file" }),
+		],
+		expected: "general",
+	},
+	{
+		name: "an uncorrelated result does not poison a correlated one later in the same run",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("read_file"),
+			toolResult("web_search", { toolCallId: "call_elsewhere" }),
+			toolResult("read_file"),
+		],
+		expected: "verification",
+	},
+	{
+		name: "a run whose preceding message is not an assistant turn never attributes",
+		messages: [userMessage("go"), toolResult("web_search")],
+		expected: "general",
+	},
+	{
+		name: "a run preceded by an assistant turn that issued NO tool calls never attributes",
+		messages: [userMessage("go"), makeAssistantMessage(), toolResult("web_search")],
+		expected: "general",
+	},
+	{
+		name: "a run at the very start of the context never attributes",
+		messages: [toolResult("web_search")],
+		expected: "general",
+	},
+
+	// — isError: both ways —
+	{
+		name: "an error-only run attributes to default",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search"),
+			toolResult("web_search", { isError: true }),
+		],
+		expected: "general",
+	},
+	{
+		name: "a mixed run takes the first NON-ERROR mapped name (error first)",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search", "read_file"),
+			toolResult("web_search", { isError: true }),
+			toolResult("read_file"),
+		],
+		expected: "verification",
+	},
+	{
+		name: "a mixed run takes the first NON-ERROR mapped name (error second)",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search", "read_file"),
+			toolResult("web_search"),
+			toolResult("read_file", { isError: true }),
+		],
+		expected: "research",
+	},
+
+	// — the fallbacks —
+	{
+		name: "a run of only unmapped names attributes to default",
+		messages: [userMessage("go"), assistantToolCalls("unknown_tool"), toolResult("unknown_tool")],
+		expected: "general",
+	},
+	{
+		name: "no tool results at all attributes to default",
+		messages: [userMessage("hi")],
+		expected: "general",
+	},
+	{ name: "turn 1 (an empty context) attributes to default", messages: [], expected: "general" },
+	{
+		name: "no default configured leaves an unmapped run UNATTRIBUTED",
+		messages: [userMessage("go"), assistantToolCalls("unknown_tool"), toolResult("unknown_tool")],
+		expected: undefined,
+		cc: CC_NO_DEFAULT,
+	},
+	{
+		name: "no default configured leaves a context with no tool results UNATTRIBUTED",
+		messages: [userMessage("hi")],
+		expected: undefined,
+		cc: CC_NO_DEFAULT,
+	},
+	{
+		name: "no default configured still attributes a mapped run",
+		messages: [userMessage("go"), assistantToolCalls("web_search"), toolResult("web_search")],
+		expected: "research",
+		cc: CC_NO_DEFAULT,
+	},
+
+	// — structured fields ONLY: free text never matches —
+	{
+		name: 'a user message reading "I called web_search" never attributes',
+		messages: [userMessage("I called web_search and it worked")],
+		expected: "general",
+	},
+	{
+		name: "an assistant message whose TEXT names a mapped tool never attributes",
+		messages: [
+			userMessage("go"),
+			{ ...makeAssistantMessage(), content: [{ type: "text", text: "web_search" }] },
+		],
+		expected: "general",
+	},
+	{
+		name: "a tool result whose CONTENT names a mapped tool never attributes on that text",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("unknown_tool"),
+			toolResult("unknown_tool", { content: [{ type: "text", text: "ran web_search" }] }),
+		],
+		expected: "general",
+	},
+
+	// — prototype hazards: the map is read with Object.hasOwn, never `in` —
+	{
+		name: 'a tool named "toString" does not resolve through Object.prototype',
+		messages: [userMessage("go"), assistantToolCalls("toString"), toolResult("toString")],
+		expected: "general",
+	},
+	{
+		name: 'a tool named "constructor" does not resolve through Object.prototype',
+		messages: [userMessage("go"), assistantToolCalls("constructor"), toolResult("constructor")],
+		expected: "general",
+	},
+
+	// — malformed input is SKIPPED, never thrown on —
+	{
+		name: "null / primitive entries at the tail of the context are not a run",
+		messages: [userMessage("go"), assistantToolCalls("web_search"), null, "toolResult", 42],
+		expected: "general",
+	},
+	{
+		name: "an ARRAY entry at the tail of the context is not a run",
+		messages: [userMessage("go"), assistantToolCalls("web_search"), [toolResult("web_search")]],
+		expected: "general",
+	},
+	{
+		name: "an ARRAY block inside the preceding assistant turn's content is skipped",
+		messages: [
+			userMessage("go"),
+			{
+				...makeAssistantMessage(),
+				content: [[{ type: "toolCall", id: "call_web_search", name: "web_search" }]],
+			},
+			toolResult("web_search"),
+		],
+		expected: "general",
+	},
+	{
+		name: "a tool result with a non-string toolName is skipped",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search"),
+			{ ...toolResult("web_search"), toolName: 7 },
+		],
+		expected: "general",
+	},
+	{
+		name: "a tool result with a non-string toolCallId is skipped",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search"),
+			{ ...toolResult("web_search"), toolCallId: { id: "call_web_search" } },
+		],
+		expected: "general",
+	},
+	{
+		name: "a tool result with a MISSING isError is excluded (only an explicit false counts)",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search"),
+			{ role: "toolResult", toolCallId: "call_web_search", toolName: "web_search" },
+		],
+		expected: "general",
+	},
+	{
+		name: "a malformed result does not stop a well-formed one later in the same run",
+		messages: [
+			userMessage("go"),
+			assistantToolCalls("web_search", "read_file"),
+			{ role: "toolResult", toolCallId: null, toolName: "web_search", isError: false },
+			toolResult("read_file"),
+		],
+		expected: "verification",
+	},
+	{
+		name: "malformed toolCall blocks on the preceding assistant turn are skipped",
+		messages: [
+			userMessage("go"),
+			{
+				...makeAssistantMessage(),
+				content: [null, { type: "toolCall", id: 5, name: "web_search" }, "toolCall"],
+			},
+			toolResult("web_search"),
+		],
+		expected: "general",
+	},
+	{
+		name: "an assistant turn whose content is not an array never correlates",
+		messages: [
+			userMessage("go"),
+			{ ...makeAssistantMessage(), content: "web_search" },
+			toolResult("web_search"),
+		],
+		expected: "general",
+	},
+];
+
+describe("deriveAttribution", () => {
+	for (const row of ROWS) {
+		it(row.name, () => {
+			expect(deriveAttribution(row.messages, row.cc ?? CC)).toBe(row.expected);
+		});
+	}
+
+	it("never mutates the context it reads", () => {
+		const messages: Message[] = [
+			userMessage("go"),
+			assistantToolCalls("web_search"),
+			toolResult("web_search"),
+		];
+		const before = JSON.stringify(messages);
+		deriveAttribution(messages, CC);
+		expect(JSON.stringify(messages)).toBe(before);
+	});
+
+	it("returns only strings the OPERATOR wrote — never a tool name", () => {
+		// The whole cc-provenance invariant in one assertion: every value the
+		// function can return is a key of the operator's own `envelopes` map, so
+		// no agent-authored string can become a cost center.
+		const allowed = new Set(Object.keys(CC.envelopes));
+		for (const row of ROWS) {
+			const derived = deriveAttribution(row.messages, row.cc ?? CC);
+			if (derived !== undefined) expect(allowed.has(derived)).toBe(true);
+		}
+	});
+});
+
+// ── Part 2: the wrappers ──
+
+const MODEL = makeModel();
+
+const ENVELOPE_RESEARCH = TrustTBClient.deriveCostCenterAccountId(PARENT, "research");
+const ENVELOPE_VERIFICATION = TrustTBClient.deriveCostCenterAccountId(PARENT, "verification");
+
+/** A context whose trailing run maps to `research` / `verification` / nothing. */
+function contextFor(toolName: string): Context {
+	return {
+		messages: [userMessage("go"), assistantToolCalls(toolName), toolResult(toolName)],
+	};
+}
+const UNATTRIBUTED: Context = { messages: [userMessage("hi")] };
+
+function makeMockEngine(balance: number) {
+	return {
+		spendPending: vi.fn(
+			async (p: { transferId: string; amount: number; debitAccountId?: bigint | undefined }) => ({
+				transferId: p.transferId,
+			}),
+		),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		voidAllPending: vi.fn(async () => {}),
+		destroy: vi.fn(),
+		lookupBalances: vi.fn(
+			async (ids: bigint[]) => new Map<bigint, number>(ids.map((id) => [id, balance])),
+		),
+	};
+}
+type MockEngine = ReturnType<typeof makeMockEngine>;
+
+type AppendInput = Parameters<NonNullable<TrustOpts["_audit"]>["appendEvent"]>[0];
+
+function makeMockAudit(): { writer: NonNullable<TrustOpts["_audit"]>; events: AppendInput[] } {
+	const events: AppendInput[] = [];
+	return {
+		events,
+		writer: {
+			appendEvent: vi.fn(async (input: AppendInput) => {
+				events.push(input);
+				return {
+					id: randomUUID(),
+					timestamp: new Date().toISOString(),
+					previousHash: "0".repeat(64),
+					hash: "a".repeat(64),
+					kind: input.kind,
+					actor: input.actor,
+					data: input.data,
+				};
+			}),
+			getWriteFailures: vi.fn(() => 0),
+			isDegraded: vi.fn(() => false),
+			flush: vi.fn(async () => {}),
+			release: vi.fn(),
+		},
+	};
+}
+
+/** The account each `spendPending` call debited, in order (`undefined` = session wallet). */
+function debitedAccounts(engine: MockEngine): (bigint | undefined)[] {
+	return engine.spendPending.mock.calls.map((call) => call[0].debitAccountId);
+}
+
+function auditData(events: AppendInput[], kind: string): Record<string, unknown> {
+	const event = events.find((e) => e.kind === kind);
+	if (event === undefined) {
+		throw new Error(`no ${kind} audit event (saw: ${events.map((e) => e.kind).join(", ")})`);
+	}
+	return event.data;
+}
+
+/** A host stream that carries provider usage, so the settle is a real one. */
+function okStream(usage: Usage = makeUsage(50, 20)) {
+	return streamOf([startEvent(), doneEvent(usage)]);
+}
+
+async function drain(stream: AsyncIterable<StreamEvent>): Promise<void> {
+	for await (const _event of stream) {
+		// consume
+	}
+}
+
+describe("governed wrappers route attributed calls to the mapped envelope", () => {
+	let vaultBase: string;
+	let engine: MockEngine;
+	let audit: ReturnType<typeof makeMockAudit>;
+	let gov: Governor;
+
+	beforeEach(async () => {
+		vaultBase = join(tmpdir(), `openclaw-attribution-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		engine = makeMockEngine(4_000);
+		audit = makeMockAudit();
+		gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: audit.writer,
+		});
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		await gov.destroy();
+		vi.restoreAllMocks();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("places the PENDING hold against the envelope the trailing tool-result run names", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC });
+
+		await drain(await wrapped(MODEL, contextFor("web_search")));
+
+		expect(engine.spendPending).toHaveBeenCalledOnce();
+		expect(debitedAccounts(engine)).toEqual([ENVELOPE_RESEARCH]);
+	});
+
+	it("re-derives per call — the same wrapped fn routes each context to its own envelope", async () => {
+		// The statelessness pin. One wrapper, three calls, three different
+		// answers: nothing about the previous call survives into the next, so
+		// there is no per-conversation state to isolate or to go stale.
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC });
+
+		await drain(await wrapped(MODEL, contextFor("web_search")));
+		await drain(await wrapped(MODEL, contextFor("read_file")));
+		await drain(await wrapped(MODEL, contextFor("unknown_tool")));
+
+		expect(debitedAccounts(engine)).toEqual([
+			ENVELOPE_RESEARCH,
+			ENVELOPE_VERIFICATION,
+			// `unknown_tool` is unmapped → the config's `default` envelope.
+			TrustTBClient.deriveCostCenterAccountId(PARENT, "general"),
+		]);
+	});
+
+	it("settles AFTER the stream, outside every scope, still on the handle's envelope", async () => {
+		// `withCostCenter` wraps `authorize()` and nothing else — its scope has
+		// already exited by the time the stream is even subscribed to, let alone
+		// settled. So a settle that lands on `research` proves the governor's own
+		// authorize-time capture carried it, which is the ALS discipline this
+		// wrapper depends on.
+		const settleSpy = vi.spyOn(gov, "settle");
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC });
+
+		await drain(await wrapped(MODEL, contextFor("web_search")));
+
+		expect(engine.postPendingSpend).toHaveBeenCalledOnce();
+		expect(auditData(audit.events, "llm_call").costCenter).toBe("research");
+		// The post-settle snapshot read the envelope the hold debited.
+		expect(engine.lookupBalances.mock.calls.at(-1)?.[0]).toEqual([ENVELOPE_RESEARCH]);
+
+		// And the envelope METADATA reached the scope: 4_000 available against the
+		// frozen config's `allocated: 10_000`. A wrapper that passed the cc string
+		// without `envelopes[cc]` would report `remaining` and no `fraction`.
+		const receipt = await settleSpy.mock.results[0]?.value;
+		expect(receipt.budget).toEqual({ costCenter: "research", remaining: 4_000, fraction: 0.4 });
+	});
+
+	it("leaves an unattributed call on the SESSION wallet", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC_NO_DEFAULT });
+
+		await drain(await wrapped(MODEL, UNATTRIBUTED));
+
+		expect(debitedAccounts(engine)).toEqual([undefined]);
+		// No envelope to read, so none is read.
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect("costCenter" in auditData(audit.events, "llm_call")).toBe(false);
+	});
+
+	it("is byte-identical to the pre-envelope wrapper when no costCenters are configured", async () => {
+		// Same context that WOULD attribute — without the config there is nothing
+		// to attribute against, so the hold stays on the session wallet.
+		const wrapped = wrapStreamWithGovernance(okStream(), gov);
+
+		await drain(await wrapped(MODEL, contextFor("web_search")));
+
+		expect(debitedAccounts(engine)).toEqual([undefined]);
+		expect(engine.lookupBalances).not.toHaveBeenCalled();
+		expect("costCenter" in auditData(audit.events, "llm_call")).toBe(false);
+	});
+
+	it("routes the completion wrapper from the SAME derivation", async () => {
+		const complete = wrapCompleteWithGovernance(async () => ({ usage: makeUsage(50, 20) }), gov, {
+			costCenters: CC,
+		});
+
+		await complete(MODEL, contextFor("read_file"));
+		await complete(MODEL, UNATTRIBUTED);
+
+		expect(debitedAccounts(engine)).toEqual([
+			ENVELOPE_VERIFICATION,
+			// Unmapped/no run → the config's `default`, exactly as the stream path.
+			TrustTBClient.deriveCostCenterAccountId(PARENT, "general"),
+		]);
+	});
+});
+
+describe("the session-wallet preflight is skipped for an ATTRIBUTED call", () => {
+	let vaultBase: string;
+	let engine: MockEngine;
+	let gov: Governor;
+
+	beforeEach(async () => {
+		vaultBase = join(tmpdir(), `openclaw-attribution-preflight-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+		engine = makeMockEngine(4_000);
+		gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: PARENT,
+			_engine: engine,
+			_audit: makeMockAudit().writer,
+		});
+		// The gate under test is literally `governor.budgetRemaining() <= 0`.
+		// Stubbing the reader is what isolates it: spending the wallet down for
+		// real would also change what the POLICY gate sees, and then a denial
+		// could no longer be attributed to the preflight specifically.
+		vi.spyOn(gov, "budgetRemaining").mockReturnValue(0);
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		vi.restoreAllMocks();
+		await gov.destroy();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	it("lets an attributed stream call PROCEED to authorize on an exhausted session wallet", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC });
+
+		await drain(await wrapped(MODEL, contextFor("web_search")));
+
+		// The envelope is independently funded; the session wallet never pays it.
+		expect(debitedAccounts(engine)).toEqual([ENVELOPE_RESEARCH]);
+	});
+
+	it("still DENIES an unattributed stream call at the preflight", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC_NO_DEFAULT });
+
+		await expect(drain(await wrapped(MODEL, UNATTRIBUTED))).rejects.toThrow(/budget exhausted/);
+		expect(engine.spendPending).not.toHaveBeenCalled();
+	});
+
+	it("still denies EVERY call when no costCenters are configured", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov);
+
+		await expect(drain(await wrapped(MODEL, contextFor("web_search")))).rejects.toThrow(
+			/budget exhausted/,
+		);
+		expect(engine.spendPending).not.toHaveBeenCalled();
+	});
+
+	it("rejects result() with the denial, not just the iteration", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov);
+		const stream = await wrapped(MODEL, UNATTRIBUTED);
+
+		await expect(stream.result()).rejects.toThrow(/budget exhausted/);
+	});
+
+	it("applies the same bypass and the same denial to the completion wrapper", async () => {
+		const complete = wrapCompleteWithGovernance(async () => ({ usage: makeUsage(50, 20) }), gov, {
+			costCenters: CC,
+		});
+
+		await complete(MODEL, contextFor("web_search"));
+		expect(debitedAccounts(engine)).toEqual([ENVELOPE_RESEARCH]);
+
+		const unattributed = wrapCompleteWithGovernance(
+			async () => ({ usage: makeUsage(50, 20) }),
+			gov,
+			{ costCenters: CC_NO_DEFAULT },
+		);
+		await expect(unattributed(MODEL, UNATTRIBUTED)).rejects.toThrow(/budget exhausted/);
+		expect(engine.spendPending).toHaveBeenCalledOnce();
+	});
+});
+
+// ── Part 3: index.ts threads the frozen config into BOTH wrap seams ──
+
+describe("the frozen config reaches every wrap seam index.ts owns", () => {
+	let vaultBase: string;
+
+	const PLUGIN_CONFIG = {
+		budget: 100_000,
+		dryRun: true,
+		costCenters: {
+			parentUserId: PARENT,
+			tools: { web_search: "research" },
+			envelopes: { research: { allocated: 10_000, periodStartMs: PERIOD_START } },
+		},
+	};
+
+	beforeEach(() => {
+		vaultBase = join(tmpdir(), `openclaw-attribution-seam-${randomUUID()}`);
+		mkdirSync(vaultBase, { recursive: true });
+		process.env.USERTRUST_TEST = "1";
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		vi.restoreAllMocks();
+		const mod = await import("../src/index.js");
+		await mod.shutdown();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	});
+
+	/**
+	 * The cost center the governor was standing in when it authorized — read off
+	 * the handle it returned, which is where an active scope lands it. Init is
+	 * lazy, so the caller has to make one warm-up call before the governor the
+	 * spy attaches to exists.
+	 */
+	async function costCenterOfNextAuthorize(
+		call: () => Promise<void>,
+		warmup: () => Promise<void>,
+	): Promise<string | undefined> {
+		const { getGovernor } = await import("../src/index.js");
+		await warmup();
+		const gov = getGovernor();
+		expect(gov).not.toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the expect above
+		const spy = vi.spyOn(gov!, "authorize");
+		await call();
+		const auth = await spy.mock.results[0]?.value;
+		return auth.costCenter;
+	}
+
+	it("createUsertrustPlugin's wrapStreamFn attributes from the plugin config", async () => {
+		const { createUsertrustPlugin } = await import("../src/index.js");
+		const plugin = createUsertrustPlugin({ ...PLUGIN_CONFIG, vaultBase });
+		const wrapped = plugin.wrapStreamFn?.({
+			provider: "anthropic",
+			modelId: MODEL.id,
+			streamFn: okStream(),
+		});
+		expect(wrapped).toBeDefined();
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the expect above
+		const run = async (ctx: Context) => drain(await wrapped!(MODEL, ctx));
+
+		const costCenter = await costCenterOfNextAuthorize(
+			() => run(contextFor("web_search")),
+			() => run(UNATTRIBUTED),
+		);
+
+		expect(costCenter).toBe("research");
+	});
+
+	it("createGovernedStreamFn attributes from the same config (its own wrap seam)", async () => {
+		const { createGovernedStreamFn } = await import("../src/index.js");
+		const { governedStreamFn } = await createGovernedStreamFn(okStream(), {
+			...PLUGIN_CONFIG,
+			vaultBase,
+		});
+		const run = async (ctx: Context) => drain(await governedStreamFn(MODEL, ctx));
+
+		const costCenter = await costCenterOfNextAuthorize(
+			() => run(contextFor("web_search")),
+			() => run(UNATTRIBUTED),
+		);
+
+		expect(costCenter).toBe("research");
+	});
+});

--- a/packages/openclaw/tests/attribution.test.ts
+++ b/packages/openclaw/tests/attribution.test.ts
@@ -405,6 +405,27 @@ describe("deriveAttribution", () => {
 		});
 	}
 
+	// The doc contract says a host that drifts from the pinned shape "must
+	// degrade to `default` rather than throw INTO the money path". Every ENTRY
+	// is narrowed before it is read; these pin the ARRAY itself, which a host
+	// handing us a context with no `messages` at all supplies as `undefined`.
+	const NON_ARRAYS: [name: string, value: unknown][] = [
+		["undefined", undefined],
+		["null", null],
+		["a string", "web_search"],
+		["a number", 7],
+		["a bare object", { 0: toolResult("web_search"), length: 1 }],
+	];
+	for (const [name, value] of NON_ARRAYS) {
+		it(`degrades to default when messages is ${name}, never throwing into the money path`, () => {
+			expect(deriveAttribution(value as unknown[], CC)).toBe("general");
+		});
+	}
+
+	it("degrades to UNATTRIBUTED on a non-array when the operator wrote no default", () => {
+		expect(deriveAttribution(undefined as unknown as unknown[], CC_NO_DEFAULT)).toBeUndefined();
+	});
+
 	it("never mutates the context it reads", () => {
 		const messages: Message[] = [
 			userMessage("go"),

--- a/packages/openclaw/tests/attribution.test.ts
+++ b/packages/openclaw/tests/attribution.test.ts
@@ -99,6 +99,25 @@ const CC_NO_DEFAULT: FrozenCostCenters = normalizeCostCenters({
 	scarcityContext: false,
 });
 
+/**
+ * A config that MAPS the string `__proto__` — legal on both maps: it satisfies
+ * core's `COST_CENTER_PATTERN` (`/^[a-zA-Z0-9._-]{1,64}$/`), and `JSON.parse`
+ * gives it to us as a genuine own property. Built through the real door so the
+ * row below is read against whatever `normalizeCostCenters` actually produced.
+ */
+const CC_PROTO: FrozenCostCenters = normalizeCostCenters({
+	parentUserId: PARENT,
+	// COMPUTED key, deliberately: `{ __proto__: "research" }` written as a plain
+	// literal is the object-literal prototype-setter form and creates no own
+	// property at all. `{ ["__proto__"]: … }` creates the real key.
+	tools: { ["__proto__"]: "research", web_search: "research" },
+	default: "general",
+	envelopes: {
+		research: { allocated: 10_000, periodStartMs: PERIOD_START },
+		general: { allocated: 1_000, periodStartMs: PERIOD_START },
+	},
+});
+
 // ── Part 1: deriveAttribution (pure) ──
 
 /** `messages` is `unknown[]`, so a row may hold deliberately malformed entries. */
@@ -313,6 +332,22 @@ const ROWS: Row[] = [
 		name: 'a tool named "constructor" does not resolve through Object.prototype',
 		messages: [userMessage("go"), assistantToolCalls("constructor"), toolResult("constructor")],
 		expected: "general",
+	},
+	{
+		name: 'an UNMAPPED tool named "__proto__" falls back to default like any other',
+		messages: [userMessage("go"), assistantToolCalls("__proto__"), toolResult("__proto__")],
+		expected: "general",
+	},
+	{
+		// The inverse hazard, and the expensive one: `__proto__` is a legal tool
+		// name AND a legal cost-center string (`COST_CENTER_PATTERN` accepts it),
+		// so an operator can map it. If normalization drops the entry — which
+		// plain `map["__proto__"] = value` does, silently — this correlated call
+		// falls through to `default` and debits the WRONG wallet with no error.
+		name: 'a MAPPED tool named "__proto__" routes to its configured envelope',
+		messages: [userMessage("go"), assistantToolCalls("__proto__"), toolResult("__proto__")],
+		expected: "research",
+		cc: CC_PROTO,
 	},
 
 	// — malformed input is SKIPPED, never thrown on —

--- a/packages/openclaw/tests/attribution.test.ts
+++ b/packages/openclaw/tests/attribution.test.ts
@@ -78,7 +78,17 @@ const CC: FrozenCostCenters = normalizeCostCenters({
 	},
 });
 
-/** Same map with NO `default` — the "unattributed rather than fall back" config. */
+/**
+ * Same map with NO `default` — the "unattributed rather than fall back" config.
+ *
+ * `scarcityContext: false`: this fixture pins ATTRIBUTION routing (this file's
+ * Part 2), which is orthogonal to per-turn scarcity injection (Ship 2 Task 6)
+ * — the block reads every configured envelope on every governed call the
+ * operator enables it for, independent of any one call's own attribution. Left
+ * at its `true` default here, every `lookupBalances` assertion below would be
+ * pinning Task 6's behavior instead of Task 5's; turned off, this file stays
+ * about what it says it's about.
+ */
 const CC_NO_DEFAULT: FrozenCostCenters = normalizeCostCenters({
 	parentUserId: PARENT,
 	tools: { web_search: "research", read_file: "verification" },
@@ -86,6 +96,7 @@ const CC_NO_DEFAULT: FrozenCostCenters = normalizeCostCenters({
 		research: { allocated: 10_000, periodStartMs: PERIOD_START },
 		verification: { allocated: 5_000, periodStartMs: PERIOD_START },
 	},
+	scarcityContext: false,
 });
 
 // ── Part 1: deriveAttribution (pure) ──

--- a/packages/openclaw/tests/contract-openclaw.test-d.ts
+++ b/packages/openclaw/tests/contract-openclaw.test-d.ts
@@ -11,8 +11,8 @@
  * own project and is compiled by exactly one thing:
  *
  *   .github/workflows/ci.yml, job `openclaw-contract`
- *     npm install --no-save --package-lock=false --ignore-scripts \
- *       openclaw@"$OPENCLAW_CONTRACT_VERSION"
+ *     source packages/openclaw/openclaw-contract.env
+ *     npm install --no-save --ignore-scripts openclaw@"$OPENCLAW_CONTRACT_VERSION"
  *     USERTRUST_OPENCLAW_CONTRACT=1 npx tsc -p packages/openclaw/tsconfig.contract-openclaw.json
  *
  * `tsc` has no notion of "skip this file if a package is missing", which is the

--- a/packages/openclaw/tests/contract-openclaw.test-d.ts
+++ b/packages/openclaw/tests/contract-openclaw.test-d.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Contract test — `src/types.ts` mirrors vs. the PINNED **openclaw** host.
+ *
+ * The openclaw HALF of the contract. Its sibling `contract.test-d.ts` holds the
+ * `@mariozechner/pi-ai` half and the assertions that read only our own mirror;
+ * that file compiles on every push. This one cannot, because openclaw is not a
+ * devDependency — see `../openclaw-contract.env` for why — so it lives in its
+ * own project and is compiled by exactly one thing:
+ *
+ *   .github/workflows/ci.yml, job `openclaw-contract`
+ *     npm install --no-save --package-lock=false --ignore-scripts \
+ *       openclaw@"$OPENCLAW_CONTRACT_VERSION"
+ *     USERTRUST_OPENCLAW_CONTRACT=1 npx tsc -p packages/openclaw/tsconfig.contract-openclaw.json
+ *
+ * `tsc` has no notion of "skip this file if a package is missing", which is the
+ * whole reason the split is a second tsconfig rather than a conditional include.
+ * Run it locally the same way, after the same ad-hoc install.
+ *
+ * The pinned host is the one the plugin actually loads into. Its version lives
+ * in `../openclaw-contract.env` and NOWHERE else — not here, deliberately: a
+ * version restated in a doc comment is a version that goes stale on the next
+ * bump. Imported type-only, so nothing here reaches runtime and the package is
+ * not required to build or ship the plugin.
+ *
+ * Variance, and why each direction is asserted:
+ *   - Events flow host → us, so the host's event union must be assignable to
+ *     ours (`Extends<Host, Ours>`).
+ *   - The wrap seam is bidirectional: openclaw hands us `ctx.streamFn` and
+ *     takes our wrapped fn back, so `StreamFn` must be assignable BOTH ways.
+ *   - Fields the money/attribution paths read by name are pinned with exact
+ *     equality — a rename upstream has to fail this compile, not production.
+ */
+
+import type {
+	OpenClawPluginApi as OcPluginApi,
+	OpenClawPluginDefinition as OcPluginDefinition,
+	ProviderWrapStreamFnContext as OcWrapCtx,
+} from "openclaw/plugin-sdk/core";
+import type {
+	AssistantMessage as OcAssistantMessage,
+	Context as OcContext,
+	AssistantMessageEvent as OcEvent,
+	Message as OcMessage,
+	Model as OcModel,
+	StreamFunction as OcStreamFunction,
+	ToolCall as OcToolCall,
+	ToolResultMessage as OcToolResult,
+	Usage as OcUsage,
+} from "openclaw/plugin-sdk/llm";
+import type { ProviderPlugin as OcProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+	Context,
+	Message,
+	Model,
+	OpenClawPluginApi,
+	ProviderPlugin,
+	ProviderWrapStreamFnContext,
+	StreamEvent,
+	StreamFn,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.js";
+
+type Assert<T extends true> = T;
+type IsExact<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Extends<A, B> = A extends B ? true : false;
+
+/** The stream fn openclaw hands in on `ctx.streamFn` and expects back. */
+type OcStreamFn = NonNullable<OcWrapCtx["streamFn"]>;
+
+// ── (2) tool-RESULT message: role, name field, correlation id, error flag ──
+
+export type _OcToolResultRole = Assert<IsExact<OcToolResult["role"], "toolResult">>;
+
+// The tool NAME lives on `toolName`, at the top level of the message.
+export type _OcToolName = Assert<IsExact<OcToolResult["toolName"], string>>;
+
+// Correlation back to the preceding assistant turn's `ToolCall.id`.
+export type _OcToolCallId = Assert<IsExact<OcToolResult["toolCallId"], string>>;
+export type _OcToolCallIdMatchesCallId = Assert<
+	IsExact<OcToolCall["id"], OcToolResult["toolCallId"]>
+>;
+
+// `isError` is REQUIRED (not optional) — excluded results are distinguishable
+// without inspecting any text.
+export type _OcIsErrorRequired = Assert<IsExact<OcToolResult["isError"], boolean>>;
+
+// The host's tool results are accepted by the mirror.
+export type _OcToolResultAssignable = Assert<Extends<OcToolResult, ToolResultMessage>>;
+
+// The message union has exactly three roles — there is no system-role message.
+export type _OcMessageRoles = Assert<
+	IsExact<OcMessage["role"], "user" | "assistant" | "toolResult">
+>;
+export type _OcMessagesAssignable = Assert<Extends<OcMessage, Message>>;
+
+// ── (3) done / error terminal events and where usage lives ──
+
+export type _EventTypes = Assert<IsExact<StreamEvent["type"], OcEvent["type"]>>;
+
+// The terminal discriminant is `reason`, not `stopReason`.
+export type _OcDoneReason = Assert<
+	IsExact<Extract<OcEvent, { type: "done" }>["reason"], "stop" | "length" | "toolUse">
+>;
+export type _OcErrorReason = Assert<
+	IsExact<Extract<OcEvent, { type: "error" }>["reason"], "aborted" | "error">
+>;
+
+// Usage is nested on the terminal assistant message, NOT on the event.
+export type _DoneCarriesMessage = Assert<
+	IsExact<Extract<OcEvent, { type: "done" }>["message"], OcAssistantMessage>
+>;
+export type _ErrorCarriesMessage = Assert<
+	IsExact<Extract<OcEvent, { type: "error" }>["error"], OcAssistantMessage>
+>;
+export type _OcUsageOnMessage = Assert<IsExact<OcAssistantMessage["usage"], OcUsage>>;
+
+// Token counts are `input`/`output`, not `inputTokens`/`outputTokens`.
+export type _OcUsageFields = Assert<Extends<OcUsage, Usage>>;
+
+// Whole-union acceptance: the host's events flow through the mirror.
+export type _OcEventsAssignable = Assert<Extends<OcEvent, StreamEvent>>;
+
+// ── (4) system-prompt surface ──
+
+// `Context.systemPrompt` is the delivery surface; injection has nowhere else
+// to go because `Message` carries no system role (asserted above).
+export type _OcSystemPrompt = Assert<IsExact<OcContext["systemPrompt"], string | undefined>>;
+export type _OcContextAccepted = Assert<Extends<OcContext, Context>>;
+export type _ContextForwardable = Assert<Extends<Context, OcContext>>;
+
+// ── (5) `model` is an OBJECT at the wrapper boundary, not a string ──
+
+export type _ModelIsNotString = Assert<IsExact<Extends<OcStreamFn, (m: string) => unknown>, false>>;
+export type _OcModelIdIsString = Assert<IsExact<OcModel["id"], string>>;
+export type _OcModelAccepted = Assert<Extends<OcModel, Model>>;
+export type _ModelForwardable = Assert<Extends<Model, OcModel>>;
+
+// ── stream surface ──
+
+// The wrap seam is bidirectional: we accept openclaw's `ctx.streamFn` and
+// openclaw accepts what we hand back.
+export type _HostStreamFnAccepted = Assert<Extends<OcStreamFn, StreamFn>>;
+export type _OurStreamFnReturnable = Assert<Extends<StreamFn, OcStreamFn>>;
+export type _OcStreamFunctionAccepted = Assert<Extends<OcStreamFunction, StreamFn>>;
+
+// ── plugin registration + config delivery ──
+
+// `register(api)` — the bare-function plugin module form is still supported.
+export type _RegisterIsPluginModule = Assert<
+	Extends<(api: OcPluginApi) => void, NonNullable<OcPluginDefinition["register"]>>
+>;
+
+// Config arrives on the api object, not as a hook argument.
+export type _OcPluginConfigOnApi = Assert<
+	IsExact<OcPluginApi["pluginConfig"], Record<string, unknown> | undefined>
+>;
+export type _OcApiAccepted = Assert<Extends<OcPluginApi, OpenClawPluginApi>>;
+
+// `wrapStreamFn` takes ONE context argument carrying the inner stream fn.
+export type _WrapCtxCarriesStreamFn = Assert<Extends<OcWrapCtx, ProviderWrapStreamFnContext>>;
+export type _WrapHookArity = Assert<
+	IsExact<Parameters<NonNullable<OcProviderPlugin["wrapStreamFn"]>>["length"], 1>
+>;
+
+// Our ProviderPlugin is a valid openclaw provider registration.
+export type _ProviderPluginRegistrable = Assert<Extends<ProviderPlugin, OcProviderPlugin>>;

--- a/packages/openclaw/tests/contract-openclaw.test-d.ts
+++ b/packages/openclaw/tests/contract-openclaw.test-d.ts
@@ -45,6 +45,7 @@ import type {
 	AssistantMessageEvent as OcEvent,
 	Message as OcMessage,
 	Model as OcModel,
+	ProviderStreamOptions as OcProviderStreamOptions,
 	StreamFunction as OcStreamFunction,
 	ToolCall as OcToolCall,
 	ToolResultMessage as OcToolResult,
@@ -57,9 +58,11 @@ import type {
 	Model,
 	OpenClawPluginApi,
 	ProviderPlugin,
+	ProviderStreamOptions,
 	ProviderWrapStreamFnContext,
 	StreamEvent,
 	StreamFn,
+	StreamOptions,
 	ToolResultMessage,
 	Usage,
 } from "../src/types.js";
@@ -147,6 +150,54 @@ export type _ModelForwardable = Assert<Extends<Model, OcModel>>;
 export type _HostStreamFnAccepted = Assert<Extends<OcStreamFn, StreamFn>>;
 export type _OurStreamFnReturnable = Assert<Extends<StreamFn, OcStreamFn>>;
 export type _OcStreamFunctionAccepted = Assert<Extends<OcStreamFunction, StreamFn>>;
+
+// ── per-call options: the host's surface, and it is OPEN ──
+
+/** The options bag openclaw's own stream fn takes, read off the seam itself. */
+type OcStreamOptions = NonNullable<Parameters<OcStreamFn>[2]>;
+
+export type _OcOptionsAccepted = Assert<Extends<OcStreamOptions, StreamOptions>>;
+export type _OptionsForwardableToOc = Assert<Extends<StreamOptions, OcStreamOptions>>;
+
+/**
+ * The mirror's named fields must be fields the HOST actually declares — not
+ * invented ones — and a caller must be able to write them as a fresh object
+ * literal. Asserted with a VALUE, because excess-property checking fires only
+ * on a fresh literal and is therefore invisible to the `Extends` assertions
+ * above: a field the mirror drops breaks callers without breaking either
+ * direction of assignability.
+ */
+export const _mirrorFieldsExistOnHost: OcStreamOptions = {
+	temperature: 0.2,
+	maxTokens: 1024,
+	stop: ["\n\n"],
+	apiKey: "sk-test",
+	transport: "sse",
+	cacheRetention: "long",
+	sessionId: "session-1",
+	promptCacheKey: "cache-1",
+	headers: { "x-usertrust-trace": "1" },
+	timeoutMs: 30_000,
+	maxRetries: 2,
+	maxRetryDelayMs: 60_000,
+	metadata: { user_id: "u-1" },
+};
+
+/** …and the same literal has to be writable against the mirror. */
+export const _hostOptionFieldsAreWritable: StreamOptions = _mirrorFieldsExistOnHost;
+
+/**
+ * The OPEN half. `ProviderStreamOptions` is the host's own escape hatch, and
+ * the pinned agent loop depends on it: it spreads its WHOLE config into the bag
+ * (`dist/proxy-BzhBz8iM.js:356-360`), so the value that reaches a stream fn at
+ * runtime always carries keys no interface declares.
+ */
+export const _providerOptionsAreOpen: ProviderStreamOptions = {
+	maxTokens: 64,
+	reasoning: "high",
+	someProviderSpecificKnob: true,
+};
+export type _OcProviderOptionsAccepted = Assert<Extends<OcProviderStreamOptions, StreamOptions>>;
 
 // ── plugin registration + config delivery ──
 

--- a/packages/openclaw/tests/contract.test-d.ts
+++ b/packages/openclaw/tests/contract.test-d.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Contract test — `src/types.ts` mirrors vs. the PINNED host packages.
+ *
+ * These are compile-time assertions. `tsc -b` never compiles this file (the
+ * package tsconfig's `rootDir: "src"` excludes `tests/`), so the real gate is
+ *
+ *   npx tsc -p packages/openclaw/tsconfig.type-tests.json
+ *
+ * Pins:
+ *   - openclaw 2026.7.1-2         — the host the plugin actually loads into
+ *   - @mariozechner/pi-ai 0.73.1  — programmatic pi-ai callers
+ *
+ * Both are devDependencies, imported type-only: nothing here reaches runtime
+ * and neither package is required to build or ship the plugin.
+ *
+ * Variance, and why each direction is asserted:
+ *   - Events flow host → us, so the host's event union must be assignable to
+ *     ours (`Extends<Host, Ours>`).
+ *   - The wrap seam is bidirectional: openclaw hands us `ctx.streamFn` and
+ *     takes our wrapped fn back, so `StreamFn` must be assignable BOTH ways.
+ *   - Fields the money/attribution paths read by name are pinned with exact
+ *     equality — a rename upstream has to fail this compile, not production.
+ */
+
+import type {
+	AssistantMessage as PiAssistantMessage,
+	Context as PiContext,
+	AssistantMessageEvent as PiEvent,
+	Message as PiMessage,
+	Model as PiModel,
+	StreamFunction as PiStreamFunction,
+	ToolResultMessage as PiToolResult,
+	Usage as PiUsage,
+} from "@mariozechner/pi-ai";
+import type {
+	OpenClawPluginApi as OcPluginApi,
+	OpenClawPluginDefinition as OcPluginDefinition,
+	ProviderWrapStreamFnContext as OcWrapCtx,
+} from "openclaw/plugin-sdk/core";
+import type {
+	AssistantMessage as OcAssistantMessage,
+	Context as OcContext,
+	AssistantMessageEvent as OcEvent,
+	Message as OcMessage,
+	Model as OcModel,
+	StreamFunction as OcStreamFunction,
+	ToolCall as OcToolCall,
+	ToolResultMessage as OcToolResult,
+	Usage as OcUsage,
+} from "openclaw/plugin-sdk/llm";
+import type { ProviderPlugin as OcProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+	AssistantMessage,
+	AssistantMessageEventStreamLike,
+	Context,
+	Message,
+	Model,
+	OpenClawPluginApi,
+	ProviderPlugin,
+	ProviderWrapStreamFnContext,
+	StreamEvent,
+	StreamFn,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.js";
+
+type Assert<T extends true> = T;
+type IsExact<A, B> =
+	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Extends<A, B> = A extends B ? true : false;
+
+/** The stream fn openclaw hands in on `ctx.streamFn` and expects back. */
+type OcStreamFn = NonNullable<OcWrapCtx["streamFn"]>;
+
+// ── (2) tool-RESULT message: role, name field, correlation id, error flag ──
+
+export type _ToolResultRoleIsToolResult = Assert<IsExact<ToolResultMessage["role"], "toolResult">>;
+export type _OcToolResultRole = Assert<IsExact<OcToolResult["role"], "toolResult">>;
+export type _PiToolResultRole = Assert<IsExact<PiToolResult["role"], "toolResult">>;
+
+// The tool NAME lives on `toolName`, at the top level of the message.
+export type _ToolNameIsString = Assert<IsExact<ToolResultMessage["toolName"], string>>;
+export type _OcToolName = Assert<IsExact<OcToolResult["toolName"], string>>;
+export type _PiToolName = Assert<IsExact<PiToolResult["toolName"], string>>;
+
+// Correlation back to the preceding assistant turn's `ToolCall.id`.
+export type _ToolCallIdIsString = Assert<IsExact<ToolResultMessage["toolCallId"], string>>;
+export type _OcToolCallId = Assert<IsExact<OcToolResult["toolCallId"], string>>;
+export type _PiToolCallId = Assert<IsExact<PiToolResult["toolCallId"], string>>;
+export type _OcToolCallIdMatchesCallId = Assert<
+	IsExact<OcToolCall["id"], OcToolResult["toolCallId"]>
+>;
+
+// `isError` is REQUIRED (not optional) on both hosts — excluded results are
+// distinguishable without inspecting any text.
+export type _IsErrorRequiredBoolean = Assert<IsExact<ToolResultMessage["isError"], boolean>>;
+export type _OcIsErrorRequired = Assert<IsExact<OcToolResult["isError"], boolean>>;
+export type _PiIsErrorRequired = Assert<IsExact<PiToolResult["isError"], boolean>>;
+
+// Both hosts' tool results are accepted by the mirror.
+export type _OcToolResultAssignable = Assert<Extends<OcToolResult, ToolResultMessage>>;
+export type _PiToolResultAssignable = Assert<Extends<PiToolResult, ToolResultMessage>>;
+
+// The message union has exactly three roles — there is no system-role message.
+export type _MessageRoles = Assert<IsExact<Message["role"], "user" | "assistant" | "toolResult">>;
+export type _OcMessageRoles = Assert<
+	IsExact<OcMessage["role"], "user" | "assistant" | "toolResult">
+>;
+export type _PiMessageRoles = Assert<
+	IsExact<PiMessage["role"], "user" | "assistant" | "toolResult">
+>;
+export type _OcMessagesAssignable = Assert<Extends<OcMessage, Message>>;
+export type _PiMessagesAssignable = Assert<Extends<PiMessage, Message>>;
+
+// ── (3) done / error terminal events and where usage lives ──
+
+export type _EventTypes = Assert<IsExact<StreamEvent["type"], OcEvent["type"]>>;
+export type _PiEventTypes = Assert<IsExact<StreamEvent["type"], PiEvent["type"]>>;
+
+// The terminal discriminant is `reason`, not `stopReason`.
+export type _DoneReason = Assert<
+	IsExact<Extract<StreamEvent, { type: "done" }>["reason"], "stop" | "length" | "toolUse">
+>;
+export type _OcDoneReason = Assert<
+	IsExact<Extract<OcEvent, { type: "done" }>["reason"], "stop" | "length" | "toolUse">
+>;
+export type _PiDoneReason = Assert<
+	IsExact<Extract<PiEvent, { type: "done" }>["reason"], "stop" | "length" | "toolUse">
+>;
+export type _ErrorReason = Assert<
+	IsExact<Extract<StreamEvent, { type: "error" }>["reason"], "aborted" | "error">
+>;
+export type _OcErrorReason = Assert<
+	IsExact<Extract<OcEvent, { type: "error" }>["reason"], "aborted" | "error">
+>;
+
+// Usage is nested on the terminal assistant message, NOT on the event.
+export type _DoneCarriesMessage = Assert<
+	IsExact<Extract<OcEvent, { type: "done" }>["message"], OcAssistantMessage>
+>;
+export type _PiDoneCarriesMessage = Assert<
+	IsExact<Extract<PiEvent, { type: "done" }>["message"], PiAssistantMessage>
+>;
+export type _ErrorCarriesMessage = Assert<
+	IsExact<Extract<OcEvent, { type: "error" }>["error"], OcAssistantMessage>
+>;
+export type _OcUsageOnMessage = Assert<IsExact<OcAssistantMessage["usage"], OcUsage>>;
+export type _PiUsageOnMessage = Assert<IsExact<PiAssistantMessage["usage"], PiUsage>>;
+
+// Token counts are `input`/`output`, not `inputTokens`/`outputTokens`.
+export type _UsageInput = Assert<IsExact<Usage["input"], number>>;
+export type _UsageOutput = Assert<IsExact<Usage["output"], number>>;
+export type _OcUsageFields = Assert<Extends<OcUsage, Usage>>;
+export type _PiUsageFields = Assert<Extends<PiUsage, Usage>>;
+
+// Whole-union acceptance: either host's events flow through the mirror.
+export type _OcEventsAssignable = Assert<Extends<OcEvent, StreamEvent>>;
+export type _PiEventsAssignable = Assert<Extends<PiEvent, StreamEvent>>;
+
+// ── (4) system-prompt surface ──
+
+// `Context.systemPrompt` is the delivery surface; injection has nowhere else
+// to go because `Message` carries no system role (asserted above).
+export type _SystemPromptIsOptionalString = Assert<
+	IsExact<Context["systemPrompt"], string | undefined>
+>;
+export type _OcSystemPrompt = Assert<IsExact<OcContext["systemPrompt"], string | undefined>>;
+export type _PiSystemPrompt = Assert<IsExact<PiContext["systemPrompt"], string | undefined>>;
+export type _OcContextAccepted = Assert<Extends<OcContext, Context>>;
+export type _PiContextAccepted = Assert<Extends<PiContext, Context>>;
+export type _ContextForwardable = Assert<Extends<Context, OcContext>>;
+
+// ── (5) `model` is an OBJECT at the wrapper boundary, not a string ──
+
+export type _ModelIsNotString = Assert<IsExact<Extends<OcStreamFn, (m: string) => unknown>, false>>;
+export type _ModelIdIsString = Assert<IsExact<Model["id"], string>>;
+export type _OcModelIdIsString = Assert<IsExact<OcModel["id"], string>>;
+export type _PiModelIdIsString = Assert<IsExact<PiModel<"anthropic-messages">["id"], string>>;
+export type _OcModelAccepted = Assert<Extends<OcModel, Model>>;
+export type _ModelForwardable = Assert<Extends<Model, OcModel>>;
+
+// ── stream surface: richer than AsyncIterable ──
+
+// A bare async iterable is NOT a valid return at this boundary — `result()`
+// has to be forwarded too, which is why the wrapper is a proxy.
+export type _BareIterableIsInsufficient = Assert<
+	IsExact<Extends<AsyncIterable<StreamEvent>, AssistantMessageEventStreamLike>, false>
+>;
+export type _StreamResultIsFinalMessage = Assert<
+	IsExact<ReturnType<AssistantMessageEventStreamLike["result"]>, Promise<AssistantMessage>>
+>;
+
+// The wrap seam is bidirectional: we accept openclaw's `ctx.streamFn` and
+// openclaw accepts what we hand back.
+export type _HostStreamFnAccepted = Assert<Extends<OcStreamFn, StreamFn>>;
+export type _OurStreamFnReturnable = Assert<Extends<StreamFn, OcStreamFn>>;
+
+// pi-ai's `StreamFunction` is the synchronous-return variant of the same shape.
+export type _PiStreamFunctionAccepted = Assert<Extends<PiStreamFunction, StreamFn>>;
+export type _OcStreamFunctionAccepted = Assert<Extends<OcStreamFunction, StreamFn>>;
+
+// ── plugin registration + config delivery ──
+
+// `register(api)` — the bare-function plugin module form is still supported.
+export type _RegisterIsPluginModule = Assert<
+	Extends<(api: OcPluginApi) => void, NonNullable<OcPluginDefinition["register"]>>
+>;
+
+// Config arrives on the api object, not as a hook argument.
+export type _PluginConfigOnApi = Assert<
+	IsExact<OpenClawPluginApi["pluginConfig"], Record<string, unknown> | undefined>
+>;
+export type _OcPluginConfigOnApi = Assert<
+	IsExact<OcPluginApi["pluginConfig"], Record<string, unknown> | undefined>
+>;
+export type _OcApiAccepted = Assert<Extends<OcPluginApi, OpenClawPluginApi>>;
+
+// `wrapStreamFn` takes ONE context argument carrying the inner stream fn.
+export type _WrapCtxCarriesStreamFn = Assert<Extends<OcWrapCtx, ProviderWrapStreamFnContext>>;
+export type _WrapHookArity = Assert<
+	IsExact<Parameters<NonNullable<OcProviderPlugin["wrapStreamFn"]>>["length"], 1>
+>;
+
+// Our ProviderPlugin is a valid openclaw provider registration.
+export type _ProviderPluginRegistrable = Assert<Extends<ProviderPlugin, OcProviderPlugin>>;

--- a/packages/openclaw/tests/contract.test-d.ts
+++ b/packages/openclaw/tests/contract.test-d.ts
@@ -2,25 +2,30 @@
 // Copyright 2026 Usertools, Inc.
 
 /**
- * Contract test — `src/types.ts` mirrors vs. the PINNED host packages.
+ * Contract test — `src/types.ts` mirrors vs. the PINNED `@mariozechner/pi-ai`,
+ * plus every assertion that reads only our own mirror.
  *
  * These are compile-time assertions. `tsc -b` never compiles this file (the
  * package tsconfig's `rootDir: "src"` excludes `tests/`), so the real gate is
  *
  *   npx tsc -p packages/openclaw/tsconfig.type-tests.json
  *
- * Pins:
- *   - openclaw 2026.7.1-2         — the host the plugin actually loads into
- *   - @mariozechner/pi-ai 0.73.1  — programmatic pi-ai callers
+ * which `npm run typecheck` runs — meaning this file compiles on EVERY push.
  *
- * Both are devDependencies, imported type-only: nothing here reaches runtime
- * and neither package is required to build or ship the plugin.
+ * Pin: `@mariozechner/pi-ai` 0.73.1 — the surface programmatic pi-ai callers
+ * hand the wrapper. An exact devDependency, imported type-only: nothing here
+ * reaches runtime and the package is not required to build or ship the plugin.
+ *
+ * The **openclaw** half of the same contract lives in
+ * `contract-openclaw.test-d.ts`, compiled by the `openclaw-contract` CI job
+ * after an out-of-tree install of the pinned host. openclaw is not a
+ * devDependency (see `../openclaw-contract.env`), and `tsc` cannot conditionally
+ * include a file, so the split is two projects rather than one. Every assertion
+ * runs in CI; they just run in two different jobs.
  *
  * Variance, and why each direction is asserted:
  *   - Events flow host → us, so the host's event union must be assignable to
  *     ours (`Extends<Host, Ours>`).
- *   - The wrap seam is bidirectional: openclaw hands us `ctx.streamFn` and
- *     takes our wrapped fn back, so `StreamFn` must be assignable BOTH ways.
  *   - Fields the money/attribution paths read by name are pinned with exact
  *     equality — a rename upstream has to fail this compile, not production.
  */
@@ -36,31 +41,12 @@ import type {
 	Usage as PiUsage,
 } from "@mariozechner/pi-ai";
 import type {
-	OpenClawPluginApi as OcPluginApi,
-	OpenClawPluginDefinition as OcPluginDefinition,
-	ProviderWrapStreamFnContext as OcWrapCtx,
-} from "openclaw/plugin-sdk/core";
-import type {
-	AssistantMessage as OcAssistantMessage,
-	Context as OcContext,
-	AssistantMessageEvent as OcEvent,
-	Message as OcMessage,
-	Model as OcModel,
-	StreamFunction as OcStreamFunction,
-	ToolCall as OcToolCall,
-	ToolResultMessage as OcToolResult,
-	Usage as OcUsage,
-} from "openclaw/plugin-sdk/llm";
-import type { ProviderPlugin as OcProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import type {
 	AssistantMessage,
 	AssistantMessageEventStreamLike,
 	Context,
 	Message,
 	Model,
 	OpenClawPluginApi,
-	ProviderPlugin,
-	ProviderWrapStreamFnContext,
 	StreamEvent,
 	StreamFn,
 	ToolResultMessage,
@@ -72,60 +58,41 @@ type IsExact<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 type Extends<A, B> = A extends B ? true : false;
 
-/** The stream fn openclaw hands in on `ctx.streamFn` and expects back. */
-type OcStreamFn = NonNullable<OcWrapCtx["streamFn"]>;
-
 // ── (2) tool-RESULT message: role, name field, correlation id, error flag ──
 
 export type _ToolResultRoleIsToolResult = Assert<IsExact<ToolResultMessage["role"], "toolResult">>;
-export type _OcToolResultRole = Assert<IsExact<OcToolResult["role"], "toolResult">>;
 export type _PiToolResultRole = Assert<IsExact<PiToolResult["role"], "toolResult">>;
 
 // The tool NAME lives on `toolName`, at the top level of the message.
 export type _ToolNameIsString = Assert<IsExact<ToolResultMessage["toolName"], string>>;
-export type _OcToolName = Assert<IsExact<OcToolResult["toolName"], string>>;
 export type _PiToolName = Assert<IsExact<PiToolResult["toolName"], string>>;
 
 // Correlation back to the preceding assistant turn's `ToolCall.id`.
 export type _ToolCallIdIsString = Assert<IsExact<ToolResultMessage["toolCallId"], string>>;
-export type _OcToolCallId = Assert<IsExact<OcToolResult["toolCallId"], string>>;
 export type _PiToolCallId = Assert<IsExact<PiToolResult["toolCallId"], string>>;
-export type _OcToolCallIdMatchesCallId = Assert<
-	IsExact<OcToolCall["id"], OcToolResult["toolCallId"]>
->;
 
 // `isError` is REQUIRED (not optional) on both hosts — excluded results are
 // distinguishable without inspecting any text.
 export type _IsErrorRequiredBoolean = Assert<IsExact<ToolResultMessage["isError"], boolean>>;
-export type _OcIsErrorRequired = Assert<IsExact<OcToolResult["isError"], boolean>>;
 export type _PiIsErrorRequired = Assert<IsExact<PiToolResult["isError"], boolean>>;
 
-// Both hosts' tool results are accepted by the mirror.
-export type _OcToolResultAssignable = Assert<Extends<OcToolResult, ToolResultMessage>>;
+// pi-ai's tool results are accepted by the mirror.
 export type _PiToolResultAssignable = Assert<Extends<PiToolResult, ToolResultMessage>>;
 
 // The message union has exactly three roles — there is no system-role message.
 export type _MessageRoles = Assert<IsExact<Message["role"], "user" | "assistant" | "toolResult">>;
-export type _OcMessageRoles = Assert<
-	IsExact<OcMessage["role"], "user" | "assistant" | "toolResult">
->;
 export type _PiMessageRoles = Assert<
 	IsExact<PiMessage["role"], "user" | "assistant" | "toolResult">
 >;
-export type _OcMessagesAssignable = Assert<Extends<OcMessage, Message>>;
 export type _PiMessagesAssignable = Assert<Extends<PiMessage, Message>>;
 
 // ── (3) done / error terminal events and where usage lives ──
 
-export type _EventTypes = Assert<IsExact<StreamEvent["type"], OcEvent["type"]>>;
 export type _PiEventTypes = Assert<IsExact<StreamEvent["type"], PiEvent["type"]>>;
 
 // The terminal discriminant is `reason`, not `stopReason`.
 export type _DoneReason = Assert<
 	IsExact<Extract<StreamEvent, { type: "done" }>["reason"], "stop" | "length" | "toolUse">
->;
-export type _OcDoneReason = Assert<
-	IsExact<Extract<OcEvent, { type: "done" }>["reason"], "stop" | "length" | "toolUse">
 >;
 export type _PiDoneReason = Assert<
 	IsExact<Extract<PiEvent, { type: "done" }>["reason"], "stop" | "length" | "toolUse">
@@ -133,31 +100,19 @@ export type _PiDoneReason = Assert<
 export type _ErrorReason = Assert<
 	IsExact<Extract<StreamEvent, { type: "error" }>["reason"], "aborted" | "error">
 >;
-export type _OcErrorReason = Assert<
-	IsExact<Extract<OcEvent, { type: "error" }>["reason"], "aborted" | "error">
->;
 
 // Usage is nested on the terminal assistant message, NOT on the event.
-export type _DoneCarriesMessage = Assert<
-	IsExact<Extract<OcEvent, { type: "done" }>["message"], OcAssistantMessage>
->;
 export type _PiDoneCarriesMessage = Assert<
 	IsExact<Extract<PiEvent, { type: "done" }>["message"], PiAssistantMessage>
 >;
-export type _ErrorCarriesMessage = Assert<
-	IsExact<Extract<OcEvent, { type: "error" }>["error"], OcAssistantMessage>
->;
-export type _OcUsageOnMessage = Assert<IsExact<OcAssistantMessage["usage"], OcUsage>>;
 export type _PiUsageOnMessage = Assert<IsExact<PiAssistantMessage["usage"], PiUsage>>;
 
 // Token counts are `input`/`output`, not `inputTokens`/`outputTokens`.
 export type _UsageInput = Assert<IsExact<Usage["input"], number>>;
 export type _UsageOutput = Assert<IsExact<Usage["output"], number>>;
-export type _OcUsageFields = Assert<Extends<OcUsage, Usage>>;
 export type _PiUsageFields = Assert<Extends<PiUsage, Usage>>;
 
-// Whole-union acceptance: either host's events flow through the mirror.
-export type _OcEventsAssignable = Assert<Extends<OcEvent, StreamEvent>>;
+// Whole-union acceptance: pi-ai's events flow through the mirror.
 export type _PiEventsAssignable = Assert<Extends<PiEvent, StreamEvent>>;
 
 // ── (4) system-prompt surface ──
@@ -167,20 +122,13 @@ export type _PiEventsAssignable = Assert<Extends<PiEvent, StreamEvent>>;
 export type _SystemPromptIsOptionalString = Assert<
 	IsExact<Context["systemPrompt"], string | undefined>
 >;
-export type _OcSystemPrompt = Assert<IsExact<OcContext["systemPrompt"], string | undefined>>;
 export type _PiSystemPrompt = Assert<IsExact<PiContext["systemPrompt"], string | undefined>>;
-export type _OcContextAccepted = Assert<Extends<OcContext, Context>>;
 export type _PiContextAccepted = Assert<Extends<PiContext, Context>>;
-export type _ContextForwardable = Assert<Extends<Context, OcContext>>;
 
 // ── (5) `model` is an OBJECT at the wrapper boundary, not a string ──
 
-export type _ModelIsNotString = Assert<IsExact<Extends<OcStreamFn, (m: string) => unknown>, false>>;
 export type _ModelIdIsString = Assert<IsExact<Model["id"], string>>;
-export type _OcModelIdIsString = Assert<IsExact<OcModel["id"], string>>;
 export type _PiModelIdIsString = Assert<IsExact<PiModel<"anthropic-messages">["id"], string>>;
-export type _OcModelAccepted = Assert<Extends<OcModel, Model>>;
-export type _ModelForwardable = Assert<Extends<Model, OcModel>>;
 
 // ── stream surface: richer than AsyncIterable ──
 
@@ -193,36 +141,12 @@ export type _StreamResultIsFinalMessage = Assert<
 	IsExact<ReturnType<AssistantMessageEventStreamLike["result"]>, Promise<AssistantMessage>>
 >;
 
-// The wrap seam is bidirectional: we accept openclaw's `ctx.streamFn` and
-// openclaw accepts what we hand back.
-export type _HostStreamFnAccepted = Assert<Extends<OcStreamFn, StreamFn>>;
-export type _OurStreamFnReturnable = Assert<Extends<StreamFn, OcStreamFn>>;
-
 // pi-ai's `StreamFunction` is the synchronous-return variant of the same shape.
 export type _PiStreamFunctionAccepted = Assert<Extends<PiStreamFunction, StreamFn>>;
-export type _OcStreamFunctionAccepted = Assert<Extends<OcStreamFunction, StreamFn>>;
 
 // ── plugin registration + config delivery ──
-
-// `register(api)` — the bare-function plugin module form is still supported.
-export type _RegisterIsPluginModule = Assert<
-	Extends<(api: OcPluginApi) => void, NonNullable<OcPluginDefinition["register"]>>
->;
 
 // Config arrives on the api object, not as a hook argument.
 export type _PluginConfigOnApi = Assert<
 	IsExact<OpenClawPluginApi["pluginConfig"], Record<string, unknown> | undefined>
 >;
-export type _OcPluginConfigOnApi = Assert<
-	IsExact<OcPluginApi["pluginConfig"], Record<string, unknown> | undefined>
->;
-export type _OcApiAccepted = Assert<Extends<OcPluginApi, OpenClawPluginApi>>;
-
-// `wrapStreamFn` takes ONE context argument carrying the inner stream fn.
-export type _WrapCtxCarriesStreamFn = Assert<Extends<OcWrapCtx, ProviderWrapStreamFnContext>>;
-export type _WrapHookArity = Assert<
-	IsExact<Parameters<NonNullable<OcProviderPlugin["wrapStreamFn"]>>["length"], 1>
->;
-
-// Our ProviderPlugin is a valid openclaw provider registration.
-export type _ProviderPluginRegistrable = Assert<Extends<ProviderPlugin, OcProviderPlugin>>;

--- a/packages/openclaw/tests/contract.test-d.ts
+++ b/packages/openclaw/tests/contract.test-d.ts
@@ -47,8 +47,10 @@ import type {
 	Message,
 	Model,
 	OpenClawPluginApi,
+	ProviderStreamOptions,
 	StreamEvent,
 	StreamFn,
+	StreamOptions,
 	ToolResultMessage,
 	Usage,
 } from "../src/types.js";
@@ -143,6 +145,56 @@ export type _StreamResultIsFinalMessage = Assert<
 
 // pi-ai's `StreamFunction` is the synchronous-return variant of the same shape.
 export type _PiStreamFunctionAccepted = Assert<Extends<PiStreamFunction, StreamFn>>;
+
+// ── per-call options: the host's surface, and it is OPEN ──
+
+/** The options bag the pinned pi-ai stream function actually takes. */
+type PiStreamOptions = NonNullable<Parameters<PiStreamFunction>[2]>;
+
+export type _PiOptionsAccepted = Assert<Extends<PiStreamOptions, StreamOptions>>;
+export type _OptionsForwardableToPi = Assert<Extends<StreamOptions, PiStreamOptions>>;
+
+/**
+ * Excess-property checking is invisible to a type-level `Extends` assertion —
+ * it fires only on a FRESH object literal — so the mirror's surface has to be
+ * asserted with a VALUE. A field the host declares and the mirror drops is not
+ * an assignability failure; it is a caller who cannot write
+ * `stream(model, ctx, { headers })` without a cast.
+ *
+ * Every field below is declared on the pinned `StreamOptions`
+ * (`pi-ai/dist/types.d.ts:24-85`, `openclaw/dist/types-CFIUY_La.d.ts:50-119`).
+ */
+export const _hostOptionFieldsAreWritable: StreamOptions = {
+	temperature: 0.2,
+	maxTokens: 1024,
+	stop: ["\n\n"],
+	apiKey: "sk-test",
+	transport: "sse",
+	cacheRetention: "long",
+	sessionId: "session-1",
+	promptCacheKey: "cache-1",
+	headers: { "x-usertrust-trace": "1" },
+	timeoutMs: 30_000,
+	maxRetries: 2,
+	maxRetryDelayMs: 60_000,
+	metadata: { user_id: "u-1" },
+};
+
+/**
+ * And the OPEN half. The host's own escape hatch for provider-specific extras
+ * is `ProviderStreamOptions = StreamOptions & Record<string, unknown>`
+ * (`pi-ai/dist/types.d.ts:86`, `openclaw/dist/types-CFIUY_La.d.ts:123`), which
+ * is not decoration: the pinned agent loop spreads its WHOLE config into the
+ * bag — `streamFunction(config.model, llmContext, { ...config, apiKey, signal })`
+ * (`openclaw/dist/proxy-BzhBz8iM.js:356-360`) — so the values that reach a
+ * stream fn at runtime always carry keys no interface declares.
+ */
+export const _providerOptionsAreOpen: ProviderStreamOptions = {
+	maxTokens: 64,
+	reasoning: "high",
+	thinkingBudgets: { low: 1024 },
+	someProviderSpecificKnob: true,
+};
 
 // ── plugin registration + config delivery ──
 

--- a/packages/openclaw/tests/contract.test-d.ts
+++ b/packages/openclaw/tests/contract.test-d.ts
@@ -40,18 +40,29 @@ import type {
 	ToolResultMessage as PiToolResult,
 	Usage as PiUsage,
 } from "@mariozechner/pi-ai";
+// Deliberately the PACKAGE ENTRY POINT — see the entry-point block below.
+import type {
+	CacheRetention as EntryCacheRetention,
+	ProviderResponse as EntryProviderResponse,
+	ProviderStreamOptions as EntryProviderStreamOptions,
+	StreamOptions as EntryStreamOptions,
+	Transport as EntryTransport,
+} from "../src/index.js";
 import type {
 	AssistantMessage,
 	AssistantMessageEventStreamLike,
+	CacheRetention,
 	Context,
 	Message,
 	Model,
 	OpenClawPluginApi,
+	ProviderResponse,
 	ProviderStreamOptions,
 	StreamEvent,
 	StreamFn,
 	StreamOptions,
 	ToolResultMessage,
+	Transport,
 	Usage,
 } from "../src/types.js";
 
@@ -194,6 +205,43 @@ export const _providerOptionsAreOpen: ProviderStreamOptions = {
 	reasoning: "high",
 	thinkingBudgets: { low: 1024 },
 	someProviderSpecificKnob: true,
+};
+
+// ── the PACKAGE ENTRY POINT, not the module the mirrors live in ──
+
+/**
+ * Everything above imports from `../src/types.js`. **No consumer can do that.**
+ * `package.json` publishes exactly ONE export subpath (`.` → `dist/index.js`),
+ * so a type that `src/types.ts` exports but `src/index.ts` does not re-export
+ * is unreachable outside this package — and no assertion written against
+ * `src/types.js` can see the difference. That blind spot is precisely how
+ * `ProviderStreamOptions` shipped as a documented escape hatch that failed
+ * TS2614 at the entry point.
+ *
+ * These assertions therefore import from the ENTRY POINT and pin that the
+ * published surface is the same type as the internal one. Anything a doc
+ * comment or a README tells a consumer to import belongs here.
+ */
+export type _EntryProviderStreamOptions = Assert<
+	IsExact<EntryProviderStreamOptions, ProviderStreamOptions>
+>;
+export type _EntryStreamOptions = Assert<IsExact<EntryStreamOptions, StreamOptions>>;
+export type _EntryTransport = Assert<IsExact<EntryTransport, Transport>>;
+export type _EntryCacheRetention = Assert<IsExact<EntryCacheRetention, CacheRetention>>;
+export type _EntryProviderResponse = Assert<IsExact<EntryProviderResponse, ProviderResponse>>;
+
+/**
+ * And the reason the escape hatch exists at all, exercised as a VALUE through
+ * the entry point: `reasoning` cannot be a named field on `StreamOptions`
+ * (openclaw's thinking enum carries `"max"`/`"off"`, pi-ai's carries neither),
+ * so a caller who needs it types the literal as `ProviderStreamOptions`.
+ * Against a bare `StreamOptions` this same literal is a TS2353 excess-property
+ * error — which is the whole point of the alias being reachable.
+ */
+export const _entryEscapeHatchIsUsable: EntryProviderStreamOptions = {
+	maxTokens: 64,
+	reasoning: "high",
+	thinkingBudgets: { low: 1024 },
 };
 
 // ── plugin registration + config delivery ──

--- a/packages/openclaw/tests/contract.test.ts
+++ b/packages/openclaw/tests/contract.test.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Host-level smoke check of `register()` / config delivery against the PINNED
+ * openclaw contract (2026.7.1-2).
+ *
+ * The fake host below is TYPED as openclaw's own `OpenClawPluginApi`, so the
+ * shape it hands the plugin — including where the config lives — is checked
+ * against the pinned package at compile time and exercised at runtime here.
+ * Field-level type equality lives in `contract.test-d.ts`.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { describe, expect, it, vi } from "vitest";
+import register, { createUsertrustPlugin } from "../src/index.js";
+import {
+	doneEvent,
+	makeContext,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+} from "./host-fixtures.js";
+
+// Mock tigerbeetle-node — the smoke check is about registration, not the ledger.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+/**
+ * A minimal stand-in for openclaw's plugin host. Only the members the plugin
+ * touches are real; the rest are absent, and the cast is what pins the claim
+ * "this is the surface openclaw hands us" to the pinned package.
+ */
+function fakeHost(pluginConfig?: Record<string, unknown>): {
+	api: OpenClawPluginApi;
+	registered: ProviderPlugin[];
+} {
+	const registered: ProviderPlugin[] = [];
+	const api = {
+		id: "usertrust",
+		name: "usertrust",
+		...(pluginConfig != null ? { pluginConfig } : {}),
+		registerProvider: (provider: ProviderPlugin) => {
+			registered.push(provider);
+		},
+	} as unknown as OpenClawPluginApi;
+	return { api, registered };
+}
+
+describe("openclaw host contract", () => {
+	it("register() reads config from api.pluginConfig and registers a provider", () => {
+		const { api, registered } = fakeHost({ budget: 100_000, dryRun: true });
+
+		register(api);
+
+		expect(registered).toHaveLength(1);
+		const plugin = registered[0];
+		expect(plugin?.id).toBe("usertrust");
+		expect(plugin?.label).toBe("usertrust Governance");
+		// `auth` is required by the pinned ProviderPlugin contract.
+		expect(Array.isArray(plugin?.auth)).toBe(true);
+		expect(typeof plugin?.wrapStreamFn).toBe("function");
+	});
+
+	it("register() fails loudly when the host delivers no plugin config", () => {
+		const { api, registered } = fakeHost();
+
+		expect(() => register(api)).toThrow(/plugin config missing/);
+		expect(registered).toHaveLength(0);
+	});
+
+	it("wrapStreamFn takes one context argument and reads the inner fn off it", async () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true });
+
+		expect(plugin.wrapStreamFn?.length).toBe(1);
+
+		const inner = streamOf([startEvent(), doneEvent(makeUsage(50, 20))]);
+		const wrapped = plugin.wrapStreamFn?.({
+			provider: "anthropic",
+			modelId: "claude-sonnet-4-6",
+			streamFn: inner,
+		});
+
+		expect(wrapped).toBeTypeOf("function");
+		if (wrapped == null) return;
+
+		const collected: string[] = [];
+		for await (const event of await wrapped(makeModel(), makeContext())) {
+			collected.push(event.type);
+		}
+		expect(collected).toEqual(["start", "done"]);
+	});
+
+	it("wrapStreamFn declines when the host supplies no inner stream fn", () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true });
+
+		expect(plugin.wrapStreamFn?.({ provider: "anthropic", modelId: "x" })).toBeUndefined();
+	});
+
+	it("the governed stream preserves the host surface — result(), not just iteration", async () => {
+		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true });
+		const wrapped = plugin.wrapStreamFn?.({
+			provider: "anthropic",
+			modelId: "claude-sonnet-4-6",
+			streamFn: streamOf([startEvent(), doneEvent(makeUsage(50, 20))]),
+		});
+
+		const stream = await wrapped?.(makeModel(), makeContext());
+		expect(typeof stream?.result).toBe("function");
+
+		const final = await stream?.result();
+		expect(final?.role).toBe("assistant");
+	});
+});

--- a/packages/openclaw/tests/contract.test.ts
+++ b/packages/openclaw/tests/contract.test.ts
@@ -3,14 +3,29 @@
 
 /**
  * Host-level smoke check of `register()` / config delivery against the PINNED
- * openclaw contract (2026.7.1-2).
+ * openclaw contract.
  *
  * The fake host below is TYPED as openclaw's own `OpenClawPluginApi`, so the
  * shape it hands the plugin — including where the config lives — is checked
  * against the pinned package at compile time and exercised at runtime here.
- * Field-level type equality lives in `contract.test-d.ts`.
+ * Field-level type equality lives in `contract-openclaw.test-d.ts`.
+ *
+ * openclaw is NOT a devDependency (see `../openclaw-contract.env`), so this
+ * file has two modes and no third:
+ *
+ *   - `USERTRUST_OPENCLAW_CONTRACT=1` — the `openclaw-contract` CI job, after
+ *     an out-of-tree install of the pinned version. A MISSING or MISMATCHED
+ *     openclaw throws here, before a single test runs: a job whose whole
+ *     purpose is proving the pin must never pass by proving nothing.
+ *   - unset — every other run, local or CI. If openclaw is absent the suite
+ *     SKIPS, loudly, naming the job that does prove it. The type-only imports
+ *     below are erased by the transform, so nothing here fails to load; what
+ *     would be missing is the claim, not the runtime.
  */
 
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { describe, expect, it, vi } from "vitest";
@@ -23,6 +38,101 @@ import {
 	startEvent,
 	streamOf,
 } from "./host-fixtures.js";
+
+// ── the pin, and whether this process can actually prove it ──
+
+const CONTRACT_JOB = "the `openclaw-contract` CI job (.github/workflows/ci.yml)";
+
+/** The one place the pin lives. Parsed, never duplicated. */
+function pinnedVersion(): string {
+	const env = readFileSync(new URL("../openclaw-contract.env", import.meta.url), "utf8");
+	const match = env.match(/^OPENCLAW_CONTRACT_VERSION=(.+)$/m);
+	if (match?.[1] == null) {
+		throw new Error(
+			"usertrust: packages/openclaw/openclaw-contract.env has no OPENCLAW_CONTRACT_VERSION — " +
+				"that file is the single source of the openclaw pin and cannot be empty.",
+		);
+	}
+	return match[1].trim();
+}
+
+/**
+ * The installed openclaw's version, or `null` when the package is absent.
+ *
+ * Resolved through an entry point rather than `openclaw/package.json`: the
+ * manifest is not in openclaw's `exports` map, so requiring it directly throws
+ * ERR_PACKAGE_PATH_NOT_EXPORTED even when the package is perfectly present.
+ */
+function installedVersion(): string | null {
+	const require = createRequire(import.meta.url);
+	let dir: string;
+	try {
+		dir = dirname(require.resolve("openclaw/plugin-sdk/core"));
+	} catch {
+		return null;
+	}
+	// Walk up to the package root — `dist/plugin-sdk/core.js` is several levels
+	// below the manifest, and the layout is openclaw's to change.
+	for (let cursor = dir; ; ) {
+		try {
+			const manifest = JSON.parse(readFileSync(join(cursor, "package.json"), "utf8")) as {
+				name?: string;
+				version?: string;
+			};
+			if (manifest.name === "openclaw" && typeof manifest.version === "string") {
+				return manifest.version;
+			}
+		} catch {
+			// no manifest at this level; keep walking
+		}
+		const parent = dirname(cursor);
+		if (parent === cursor) return null;
+		cursor = parent;
+	}
+}
+
+const PINNED = pinnedVersion();
+const INSTALLED = installedVersion();
+const CONTRACT_MODE = process.env.USERTRUST_OPENCLAW_CONTRACT === "1";
+
+if (CONTRACT_MODE && INSTALLED == null) {
+	throw new Error(
+		`usertrust: USERTRUST_OPENCLAW_CONTRACT=1 but openclaw is NOT INSTALLED. This mode exists ` +
+			`to prove the host contract against openclaw@${PINNED}; skipping would make the proof ` +
+			`vacuous. Install it out-of-tree first:\n` +
+			`  npm install --no-save --package-lock=false --ignore-scripts openclaw@${PINNED}`,
+	);
+}
+if (CONTRACT_MODE && INSTALLED !== PINNED) {
+	throw new Error(
+		`usertrust: openclaw VERSION MISMATCH — installed ${INSTALLED}, pinned ${PINNED} ` +
+			`(packages/openclaw/openclaw-contract.env). The contract is a claim about one exact ` +
+			`release; proving it against a different one proves nothing about the pin.`,
+	);
+}
+if (!CONTRACT_MODE && INSTALLED !== PINNED) {
+	// `process.stderr`, NOT `console.warn`: vitest intercepts console output and
+	// attributes it to the running task, and its default reporter drops what it
+	// collects during module load of a file that then runs no tests — which is
+	// exactly this case, so a `console.warn` here is invisible in `npx vitest run`
+	// and the skip is silent instead of loud. Writing to the stream directly
+	// bypasses the interception and always reaches the terminal.
+	process.stderr.write(
+		`\n[contract.test.ts] SKIPPING the openclaw host-smoke suite — openclaw@${PINNED} is ` +
+			`${INSTALLED == null ? "not installed" : `not what is installed (found ${INSTALLED})`}.\n` +
+			`  openclaw is deliberately not a dependency of this repo (it is an OPTIONAL PEER, and\n` +
+			`  \`npm ci\` does not install those). ${CONTRACT_JOB}\n` +
+			`  installs the pinned version out-of-tree and runs this file with\n` +
+			`  USERTRUST_OPENCLAW_CONTRACT=1, where an absent or mismatched openclaw is a HARD\n` +
+			`  FAILURE. Nothing is being waved through; the proof just happens there. To run it here:\n` +
+			`    source packages/openclaw/openclaw-contract.env\n` +
+			`    npm install --no-save --package-lock=false --ignore-scripts openclaw@"$OPENCLAW_CONTRACT_VERSION"\n` +
+			`    USERTRUST_OPENCLAW_CONTRACT=1 npx vitest run packages/openclaw/tests/contract.test.ts\n\n`,
+	);
+}
+
+/** The suite runs only where the pinned host is actually present. */
+const describeHostContract = INSTALLED === PINNED ? describe : describe.skip;
 
 // Mock tigerbeetle-node — the smoke check is about registration, not the ledger.
 vi.mock("tigerbeetle-node", () => ({
@@ -61,7 +171,7 @@ function fakeHost(pluginConfig?: Record<string, unknown>): {
 	return { api, registered };
 }
 
-describe("openclaw host contract", () => {
+describeHostContract(`openclaw host contract (openclaw@${PINNED})`, () => {
 	it("register() reads config from api.pluginConfig and registers a provider", () => {
 		const { api, registered } = fakeHost({ budget: 100_000, dryRun: true });
 

--- a/packages/openclaw/tests/contract.test.ts
+++ b/packages/openclaw/tests/contract.test.ts
@@ -100,7 +100,7 @@ if (CONTRACT_MODE && INSTALLED == null) {
 		`usertrust: USERTRUST_OPENCLAW_CONTRACT=1 but openclaw is NOT INSTALLED. This mode exists ` +
 			`to prove the host contract against openclaw@${PINNED}; skipping would make the proof ` +
 			`vacuous. Install it out-of-tree first:\n` +
-			`  npm install --no-save --package-lock=false --ignore-scripts openclaw@${PINNED}`,
+			`  npm install --no-save --ignore-scripts openclaw@${PINNED}`,
 	);
 }
 if (CONTRACT_MODE && INSTALLED !== PINNED) {
@@ -126,7 +126,7 @@ if (!CONTRACT_MODE && INSTALLED !== PINNED) {
 			`  USERTRUST_OPENCLAW_CONTRACT=1, where an absent or mismatched openclaw is a HARD\n` +
 			`  FAILURE. Nothing is being waved through; the proof just happens there. To run it here:\n` +
 			`    source packages/openclaw/openclaw-contract.env\n` +
-			`    npm install --no-save --package-lock=false --ignore-scripts openclaw@"$OPENCLAW_CONTRACT_VERSION"\n` +
+			`    npm install --no-save --ignore-scripts openclaw@"$OPENCLAW_CONTRACT_VERSION"\n` +
 			`    USERTRUST_OPENCLAW_CONTRACT=1 npx vitest run packages/openclaw/tests/contract.test.ts\n\n`,
 	);
 }

--- a/packages/openclaw/tests/cost-centers-config.test.ts
+++ b/packages/openclaw/tests/cost-centers-config.test.ts
@@ -137,6 +137,60 @@ describe("normalizeCostCenters — construction-time validation", () => {
 		).toThrow(/default.*envelopes key/);
 	});
 
+	// ── "__proto__" is a LEGAL key on both maps, and must behave like any other ──
+	//
+	// `COST_CENTER_PATTERN` is `/^[a-zA-Z0-9._-]{1,64}$/` (core `shared/ids.ts:47`),
+	// which accepts `__proto__` — so core's own charset door lets it through. And
+	// `JSON.parse` creates `__proto__` as a genuine OWN property, so an operator's
+	// config file can carry one. Plain-object assignment (`map[key] = value`) hits
+	// `Object.prototype`'s `__proto__` SETTER instead of creating that own key:
+	// a string value is silently discarded, an object value silently re-points the
+	// map's prototype. Either way the entry vanishes and routing falls through to
+	// `default` — the wrong wallet, with no error anywhere.
+	//
+	// The key is read back through this constant rather than as `map.__proto__`,
+	// which is the ACCESSOR both tests are asserting the absence of.
+	const PROTO = "__proto__";
+
+	it("keeps a tool literally named `__proto__` mapped to its envelope", () => {
+		const cfg = JSON.parse(
+			`{"parentUserId":"agent-1","tools":{"__proto__":"research","web_search":"research"},
+			 "default":"verification","envelopes":{"research":{"allocated":500,"periodStartMs":0},
+			 "verification":{"allocated":200,"periodStartMs":0}}}`,
+		) as unknown;
+		// The key really is an own property of what the operator handed us.
+		expect(Object.hasOwn((cfg as { tools: object }).tools, PROTO)).toBe(true);
+
+		const normalized = normalizeCostCenters(cfg);
+
+		expect(Object.hasOwn(normalized.tools, PROTO)).toBe(true);
+		expect(normalized.tools[PROTO]).toBe("research");
+		// Nothing was smuggled onto the map's prototype in the process.
+		expect(Object.getPrototypeOf(normalized.tools)).toBe(null);
+		// The sibling mapping is untouched.
+		expect(normalized.tools.web_search).toBe("research");
+	});
+
+	it("keeps an envelope literally named `__proto__`, without re-pointing the map's prototype", () => {
+		const cfg = JSON.parse(
+			`{"parentUserId":"agent-1","tools":{"web_search":"__proto__"},"default":"__proto__",
+			 "envelopes":{"__proto__":{"allocated":500,"periodStartMs":0},
+			 "other":{"allocated":10,"periodStartMs":0}}}`,
+		) as unknown;
+
+		const normalized = normalizeCostCenters(cfg);
+
+		expect(Object.hasOwn(normalized.envelopes, PROTO)).toBe(true);
+		expect(normalized.envelopes[PROTO]).toMatchObject({ allocated: 500, periodStartMs: 0 });
+		// The prototype must still be null — NOT the envelope metadata object,
+		// which is what `envelopes["__proto__"] = metadata` would have made it.
+		expect(Object.getPrototypeOf(normalized.envelopes)).toBe(null);
+		expect(Object.keys(normalized.envelopes).sort()).toEqual(["__proto__", "other"]);
+		// And the mapping that references it resolves.
+		expect(normalized.tools.web_search).toBe("__proto__");
+		expect(normalized.default).toBe("__proto__");
+	});
+
 	it("validates every envelopes KEY's charset via core's withCostCenter door, with core's message", () => {
 		const cfg = validConfig({
 			envelopes: { "bad key!": { allocated: 500, periodStartMs: 0 } },

--- a/packages/openclaw/tests/cost-centers-config.test.ts
+++ b/packages/openclaw/tests/cost-centers-config.test.ts
@@ -1,0 +1,632 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * cost-centers-config.test.ts — `UsertrustPluginConfig.costCenters` validation,
+ * normalization, and the module-singleton governor's config-mismatch guard.
+ *
+ * `normalizeCostCenters` is the construction-time door: it must reuse core's
+ * OWN validation doors (`parentUserIdRefusal`, `withCostCenter`'s charset +
+ * metadata checks) rather than re-implementing them, so every test that pins
+ * a rejection message asserts CORE's wording, not a local paraphrase.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parentUserIdRefusal } from "usertrust";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock tigerbeetle-node so no test touches a real ledger.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+import {
+	createGovernedStreamFn,
+	createUsertrustPlugin,
+	normalizeCostCenters,
+} from "../src/index.js";
+import type { CostCentersConfig, StreamFn } from "../src/types.js";
+import {
+	doneEvent,
+	makeContext,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+} from "./host-fixtures.js";
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `openclaw-cc-config-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+/** The hook context openclaw hands `wrapStreamFn`, with the inner fn on it. */
+function wrapCtx(streamFn: StreamFn) {
+	return { provider: "anthropic", modelId: "claude-sonnet-4-6", streamFn };
+}
+
+const MODEL = makeModel();
+
+function validConfig(overrides: Partial<CostCentersConfig> = {}): CostCentersConfig {
+	return {
+		parentUserId: "agent-1",
+		tools: { web_search: "research" },
+		default: "research",
+		envelopes: {
+			research: { allocated: 500, periodStartMs: 0 },
+			verification: { allocated: 200, periodStartMs: 0, periodEndMs: 1_000 },
+		},
+		...overrides,
+	};
+}
+
+async function drain(wrapped: StreamFn | undefined) {
+	if (wrapped == null) throw new Error("wrapStreamFn returned undefined");
+	for await (const _e of await wrapped(MODEL, makeContext())) {
+		// drain
+	}
+}
+
+describe("normalizeCostCenters — construction-time validation", () => {
+	it("rejects a missing parentUserId, naming the field", () => {
+		const bad = { tools: {}, envelopes: {} } as unknown;
+		expect(() => normalizeCostCenters(bad)).toThrow(/parentUserId/);
+	});
+
+	it("rejects an invalid parentUserId via core's own parentUserIdRefusal, with core's message", () => {
+		const badId = "acme::billing"; // legacy separator — refused by core
+		const reason = parentUserIdRefusal(badId);
+		expect(reason).not.toBeNull();
+
+		expect(() => normalizeCostCenters(validConfig({ parentUserId: badId }))).toThrowError(
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			new RegExp(reason!.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+		);
+	});
+
+	it("rejects a `tools` value that is not an `envelopes` key", () => {
+		expect(() =>
+			normalizeCostCenters(validConfig({ tools: { web_search: "not_a_real_envelope" } })),
+		).toThrow(/tools\["web_search"\].*envelopes key/);
+	});
+
+	it("rejects a `default` that is not an `envelopes` key", () => {
+		expect(() => normalizeCostCenters(validConfig({ default: "ghost" }))).toThrow(
+			/default.*envelopes key/,
+		);
+	});
+
+	it("Object.hasOwn semantics — a prototype-inherited envelope key is REJECTED, not silently accepted", () => {
+		// `"toString" in envelopes` is true (inherited from Object.prototype) even
+		// though `envelopes` never declares it as an OWN key. `tools`/`default`
+		// membership must use `Object.hasOwn`, not the `in` operator, or a caller
+		// could route spend to a phantom "envelope" that was never configured.
+		const cfg = validConfig({ tools: { web_search: "toString" } });
+		expect(() => normalizeCostCenters(cfg)).toThrow(/envelopes key/);
+	});
+
+	it("Object.hasOwn semantics — envelopes whose keys live only on the prototype chain are treated as empty", () => {
+		const proto = { research: { allocated: 500, periodStartMs: 0 } };
+		const prototypeBackedEnvelopes = Object.create(proto);
+		// `"research" in prototypeBackedEnvelopes` is true; `Object.hasOwn` is false.
+		expect(Object.hasOwn(prototypeBackedEnvelopes, "research")).toBe(false);
+
+		expect(() =>
+			normalizeCostCenters({
+				parentUserId: "agent-1",
+				tools: {},
+				default: "research",
+				envelopes: prototypeBackedEnvelopes,
+			}),
+		).toThrow(/default.*envelopes key/);
+	});
+
+	it("validates every envelopes KEY's charset via core's withCostCenter door, with core's message", () => {
+		const cfg = validConfig({
+			envelopes: { "bad key!": { allocated: 500, periodStartMs: 0 } },
+			tools: {},
+			default: undefined,
+		});
+		expect(() => normalizeCostCenters(cfg)).toThrow(/costCenter must match/);
+	});
+
+	it("validates every envelope's metadata via core's withCostCenter door (non-finite allocated), with core's message", () => {
+		const cfg = validConfig({
+			envelopes: { research: { allocated: Number.NaN, periodStartMs: 0 } },
+			tools: {},
+			default: undefined,
+		});
+		expect(() => normalizeCostCenters(cfg)).toThrow(/opts\.allocated must be a finite number/);
+	});
+
+	it("validates every envelope's metadata via core's withCostCenter door (non-finite periodStartMs), with core's message", () => {
+		const cfg = validConfig({
+			envelopes: { research: { allocated: 500, periodStartMs: Number.NaN } },
+			tools: {},
+			default: undefined,
+		});
+		expect(() => normalizeCostCenters(cfg)).toThrow(/opts\.periodStartMs must be a finite number/);
+	});
+
+	it("rejects more than 128 envelopes", () => {
+		const envelopes: CostCentersConfig["envelopes"] = {};
+		for (let i = 0; i < 129; i++) {
+			envelopes[`cc${i}`] = { allocated: 1, periodStartMs: 0 };
+		}
+		expect(() =>
+			normalizeCostCenters(validConfig({ envelopes, tools: {}, default: undefined })),
+		).toThrow(/129.*128|exceeds/);
+	});
+
+	it("accepts exactly 128 envelopes", () => {
+		const envelopes: CostCentersConfig["envelopes"] = {};
+		for (let i = 0; i < 128; i++) {
+			envelopes[`cc${i}`] = { allocated: 1, periodStartMs: 0 };
+		}
+		const frozen = normalizeCostCenters(validConfig({ envelopes, tools: {}, default: undefined }));
+		expect(Object.keys(frozen.envelopes)).toHaveLength(128);
+	});
+
+	it("rejects malformed non-object shapes", () => {
+		expect(() => normalizeCostCenters(null)).toThrow();
+		expect(() => normalizeCostCenters("nope")).toThrow();
+		expect(() => normalizeCostCenters(42)).toThrow();
+		expect(() => normalizeCostCenters([])).toThrow();
+	});
+
+	it("rejects a non-object envelope entry", () => {
+		expect(() =>
+			normalizeCostCenters(
+				validConfig({
+					envelopes: { research: "not an object" } as unknown as CostCentersConfig["envelopes"],
+					tools: {},
+					default: undefined,
+				}),
+			),
+		).toThrow();
+	});
+
+	it("defaults scarcityContext to true when absent, and normalizes an explicit value", () => {
+		const withoutIt = normalizeCostCenters(validConfig({ scarcityContext: undefined }));
+		expect(withoutIt.scarcityContext).toBe(true);
+
+		const withFalse = normalizeCostCenters(validConfig({ scarcityContext: false }));
+		expect(withFalse.scarcityContext).toBe(false);
+	});
+
+	it("returns a deep-frozen copy; later mutation of the caller's raw object does not change routing", () => {
+		const raw = validConfig();
+		const frozen = normalizeCostCenters(raw);
+
+		// Mutate the CALLER's object after normalization.
+		raw.tools.web_search = "verification";
+		// biome-ignore lint/style/noNonNullAssertion: `validConfig()` always sets this key
+		raw.envelopes.research!.allocated = 999_999;
+		(raw as { default?: string }).default = "verification";
+
+		expect(frozen.tools.web_search).toBe("research");
+		expect(frozen.envelopes.research?.allocated).toBe(500);
+		expect(frozen.default).toBe("research");
+
+		expect(Object.isFrozen(frozen)).toBe(true);
+		expect(Object.isFrozen(frozen.tools)).toBe(true);
+		expect(Object.isFrozen(frozen.envelopes)).toBe(true);
+		expect(Object.isFrozen(frozen.envelopes.research)).toBe(true);
+		expect(Object.isFrozen(frozen.envelopes.verification)).toBe(true);
+	});
+});
+
+describe("construction-time call site — createUsertrustPlugin/register, not lazy init", () => {
+	it("createUsertrustPlugin throws SYNCHRONOUSLY on an invalid costCenters config", () => {
+		expect(() =>
+			createUsertrustPlugin({
+				budget: 100_000,
+				dryRun: true,
+				costCenters: validConfig({ parentUserId: "" }),
+			}),
+		).toThrow();
+	});
+
+	it("a valid costCenters config forwards parentUserId into createGovernor", async () => {
+		const vaultBase = makeTmpVault();
+		try {
+			const { governor } = await createGovernedStreamFn(
+				streamOf([startEvent(), doneEvent(makeUsage(1, 1))]),
+				{
+					budget: 100_000,
+					dryRun: true,
+					vaultBase,
+					costCenters: validConfig({ parentUserId: "agent-parent-forwarded" }),
+				},
+			);
+			// budgetContext([]) with a configured parentUserId returns [] quietly
+			// (Task 2 contract) rather than throwing "no parentUserId" — the
+			// cheapest observable proof the id actually reached createGovernor.
+			await expect(governor.budgetContext([])).resolves.toEqual([]);
+		} finally {
+			// `shutdown()`, not `governor.destroy()` — this test's config differs
+			// from every other describe block's, so leaving the module-singleton
+			// `governor`/`governorFingerprint` set would poison the NEXT test's
+			// fingerprint check with a stale claim (destroy() alone only tears
+			// down the ledger client; it does not clear index.ts's own state).
+			const { shutdown } = await import("../src/index.js");
+			await shutdown();
+			rmSync(vaultBase, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("governor config-mismatch guard (index.ts module-singleton governor/initPromise)", () => {
+	let vaultBase: string;
+
+	beforeEach(() => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		const mod = await import("../src/index.js");
+		await mod.shutdown();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup best-effort
+		}
+	});
+
+	it("a second plugin instance with a DIFFERENT config rejects loudly instead of silently reusing the first governor", async () => {
+		const pluginA = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+		await drain(
+			pluginA.wrapStreamFn?.(wrapCtx(streamOf([startEvent(), doneEvent(makeUsage(1, 1))]))),
+		);
+
+		const pluginB = createUsertrustPlugin({ budget: 200_000, dryRun: true, vaultBase });
+		await expect(drain(pluginB.wrapStreamFn?.(wrapCtx(streamOf([startEvent()]))))).rejects.toThrow(
+			/config/i,
+		);
+	});
+
+	it("a second plugin instance with the SAME config reuses the singleton governor", async () => {
+		const pluginA = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+		await drain(
+			pluginA.wrapStreamFn?.(wrapCtx(streamOf([startEvent(), doneEvent(makeUsage(1, 1))]))),
+		);
+
+		const { getGovernor } = await import("../src/index.js");
+		const gov1 = getGovernor();
+
+		const pluginB = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+		await drain(
+			pluginB.wrapStreamFn?.(wrapCtx(streamOf([startEvent(), doneEvent(makeUsage(1, 1))]))),
+		);
+
+		expect(getGovernor()).toBe(gov1);
+	});
+
+	it("claims the fingerprint SYNCHRONOUSLY — two different configs racing in the same tick never both build a governor", async () => {
+		const p1 = createGovernedStreamFn(streamOf([startEvent(), doneEvent(makeUsage(1, 1))]), {
+			budget: 100_000,
+			dryRun: true,
+			vaultBase,
+		});
+		const p2 = createGovernedStreamFn(streamOf([startEvent(), doneEvent(makeUsage(1, 1))]), {
+			budget: 200_000,
+			dryRun: true,
+			vaultBase,
+		});
+
+		const results = await Promise.allSettled([p1, p2]);
+		expect(results.filter((r) => r.status === "fulfilled")).toHaveLength(1);
+		expect(results.filter((r) => r.status === "rejected")).toHaveLength(1);
+		const rejection = results.find((r) => r.status === "rejected");
+		if (rejection?.status === "rejected") {
+			expect(String(rejection.reason)).toMatch(/config/i);
+		}
+	});
+
+	it("clears the claim on shutdown() so a legitimate post-shutdown re-config is accepted", async () => {
+		const { governor: gov1 } = await createGovernedStreamFn(streamOf([startEvent()]), {
+			budget: 100_000,
+			dryRun: true,
+			vaultBase,
+		});
+
+		const { shutdown } = await import("../src/index.js");
+		await shutdown();
+
+		const { governor: gov2 } = await createGovernedStreamFn(streamOf([startEvent()]), {
+			budget: 200_000,
+			dryRun: true,
+			vaultBase,
+		});
+
+		expect(gov2).not.toBe(gov1);
+		await gov2.destroy();
+	});
+
+	it("clears the claim on a FAILED init so a retry (even with a different config) is accepted", async () => {
+		// budget must be a positive integer (core's TrustConfigSchema) — this
+		// rejects before any ledger I/O, purely from config validation.
+		await expect(
+			createGovernedStreamFn(streamOf([startEvent()]), {
+				budget: -1,
+				dryRun: true,
+				vaultBase,
+			}),
+		).rejects.toThrow();
+
+		const { getGovernor } = await import("../src/index.js");
+		expect(getGovernor()).toBeNull();
+
+		const { governor } = await createGovernedStreamFn(streamOf([startEvent()]), {
+			budget: 200_000,
+			dryRun: true,
+			vaultBase,
+		});
+		expect(governor).toBeDefined();
+		await governor.destroy();
+	});
+});
+
+// ── Manifest ⟷ normalizeCostCenters parity (Step 3) ──
+
+/**
+ * A minimal JSON Schema interpreter — NOT a general one, only the exact
+ * keyword subset `openclaw.plugin.json`'s `costCenters` node uses (`type`,
+ * `properties`, `required`, `additionalProperties`, `pattern`, `minimum`,
+ * `maxProperties`, `propertyNames`). Standing in for the "ajv dev-dep" option
+ * the brief offers: this repo has no ajv anywhere (`grep -r ajv` in
+ * `node_modules` and every `package.json` comes up empty), and adding one
+ * purely for a single parity test is a heavier footprint than a ~40-line
+ * mirror of the four keywords actually in play — the same
+ * duplicate-a-small-authoritative-rule tradeoff `shared/ids.ts` documents for
+ * `cli/budget.ts`'s `COST_CENTER_PATTERN` copy.
+ *
+ * Reads the schema node LIVE off the manifest file below — never a
+ * hand-copied regex — so an edit to the manifest that this interpreter
+ * doesn't understand fails LOUD (the `throw` in the default case), not
+ * silently green.
+ */
+interface JsonSchemaNode {
+	type?: string;
+	properties?: Record<string, JsonSchemaNode>;
+	required?: string[];
+	additionalProperties?: boolean | JsonSchemaNode;
+	pattern?: string;
+	minimum?: number;
+	maxProperties?: number;
+	propertyNames?: { pattern?: string };
+}
+
+function matchesJsonSchema(schema: JsonSchemaNode, value: unknown): boolean {
+	switch (schema.type) {
+		case "object": {
+			if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+			const obj = value as Record<string, unknown>;
+			const keys = Object.keys(obj);
+			if (schema.maxProperties !== undefined && keys.length > schema.maxProperties) return false;
+			if (schema.propertyNames?.pattern !== undefined) {
+				const re = new RegExp(schema.propertyNames.pattern);
+				if (!keys.every((k) => re.test(k))) return false;
+			}
+			if (schema.required !== undefined && !schema.required.every((r) => Object.hasOwn(obj, r))) {
+				return false;
+			}
+			const declared = schema.properties ?? {};
+			for (const key of keys) {
+				if (Object.hasOwn(declared, key)) {
+					// biome-ignore lint/style/noNonNullAssertion: guarded by hasOwn above
+					if (!matchesJsonSchema(declared[key]!, obj[key])) return false;
+				} else if (schema.additionalProperties === false) {
+					return false;
+				} else if (typeof schema.additionalProperties === "object") {
+					if (!matchesJsonSchema(schema.additionalProperties, obj[key])) return false;
+				}
+				// additionalProperties === true / undefined → unrecognized key passes unchecked
+			}
+			return true;
+		}
+		case "string":
+			return (
+				typeof value === "string" &&
+				(schema.pattern === undefined || new RegExp(schema.pattern).test(value))
+			);
+		case "number":
+			// NOTE: no Number.isFinite check — a config that reaches this
+			// interpreter came from JSON (openclaw.json), which cannot encode
+			// NaN/Infinity in the first place. Non-finite `allocated`/`periodStartMs`
+			// is a TS-API-only concern, covered separately above — deliberately
+			// excluded from this table (see its header comment).
+			return typeof value === "number" && (schema.minimum === undefined || value >= schema.minimum);
+		case "boolean":
+			return typeof value === "boolean";
+		default:
+			throw new Error(`matchesJsonSchema: unsupported schema node ${JSON.stringify(schema)}`);
+	}
+}
+
+const manifestPath = fileURLToPath(new URL("../openclaw.plugin.json", import.meta.url));
+const manifest = JSON.parse(readFileSync(manifestPath, "utf-8")) as {
+	configSchema: { properties: { costCenters: JsonSchemaNode } };
+};
+const costCentersSchema = manifest.configSchema.properties.costCenters;
+
+/**
+ * The shared valid/invalid table both validators run against. Every entry is
+ * JSON-representable (no `NaN`/`Infinity`/`undefined` literals) — a real
+ * openclaw.json on disk cannot encode those, so a divergence there would not
+ * be a genuine parity bug; `normalizeCostCenters`'s own tests above cover that
+ * ground with core's message pinned.
+ *
+ * DELIBERATELY EXCLUDED: `tools`/`default` values that fail to name an
+ * `envelopes` key. Plain JSON Schema (no custom `$data` keyword, not used
+ * here) cannot express "this string must equal one of that OTHER property's
+ * keys" — that is a genuine, unavoidable expressiveness gap between a static
+ * manifest schema and `normalizeCostCenters`'s runtime business rule, not a
+ * bug either side should be made to hide. `normalizeCostCenters`'s own tests
+ * above cover that rule directly.
+ */
+const parityTable: { name: string; config: unknown; valid: boolean }[] = [
+	{
+		name: "valid — minimal (empty tools/envelopes, no default, no scarcityContext)",
+		config: { parentUserId: "agent-1", tools: {}, envelopes: {} },
+		valid: true,
+	},
+	{
+		name: "valid — full shape",
+		config: {
+			parentUserId: "agent-1",
+			tools: { web_search: "research" },
+			default: "research",
+			envelopes: {
+				research: { allocated: 500, periodStartMs: 0 },
+				verification: { allocated: 200, periodStartMs: 0, periodEndMs: 1_000 },
+			},
+			scarcityContext: false,
+		},
+		valid: true,
+	},
+	{
+		name: "invalid — missing parentUserId",
+		config: { tools: {}, envelopes: {} },
+		valid: false,
+	},
+	{
+		name: "invalid — missing tools",
+		config: { parentUserId: "agent-1", envelopes: {} },
+		valid: false,
+	},
+	{
+		name: "invalid — missing envelopes",
+		config: { parentUserId: "agent-1", tools: {} },
+		valid: false,
+	},
+	{
+		name: "invalid — unknown top-level field",
+		config: { parentUserId: "agent-1", tools: {}, envelopes: {}, extra: "nope" },
+		valid: false,
+	},
+	{
+		name: "invalid — unknown field inside an envelope entry",
+		config: {
+			parentUserId: "agent-1",
+			tools: {},
+			envelopes: { research: { allocated: 100, periodStartMs: 0, bogus: true } },
+		},
+		valid: false,
+	},
+	{
+		name: "invalid — parentUserId contains the legacy '::' separator",
+		config: { parentUserId: "acme::billing", tools: {}, envelopes: {} },
+		valid: false,
+	},
+	{
+		name: "invalid — parentUserId fails the charset (space)",
+		config: { parentUserId: "has space", tools: {}, envelopes: {} },
+		valid: false,
+	},
+	{
+		name: "invalid — envelope key fails the charset",
+		config: {
+			parentUserId: "agent-1",
+			tools: {},
+			envelopes: { "bad key!": { allocated: 100, periodStartMs: 0 } },
+		},
+		valid: false,
+	},
+	{
+		name: "invalid — allocated is negative",
+		config: {
+			parentUserId: "agent-1",
+			tools: {},
+			envelopes: { research: { allocated: -1, periodStartMs: 0 } },
+		},
+		valid: false,
+	},
+	{
+		name: "invalid — allocated is a string, not a number",
+		config: {
+			parentUserId: "agent-1",
+			tools: {},
+			envelopes: { research: { allocated: "100", periodStartMs: 0 } },
+		},
+		valid: false,
+	},
+	{
+		name: "invalid — envelope entry missing periodStartMs",
+		config: {
+			parentUserId: "agent-1",
+			tools: {},
+			envelopes: { research: { allocated: 100 } },
+		},
+		valid: false,
+	},
+	{
+		name: "invalid — tools value is a number, not a string",
+		config: {
+			parentUserId: "agent-1",
+			tools: { web_search: 123 },
+			envelopes: { research: { allocated: 100, periodStartMs: 0 } },
+		},
+		valid: false,
+	},
+	{
+		name: "invalid — scarcityContext is a string, not a boolean",
+		config: { parentUserId: "agent-1", tools: {}, envelopes: {}, scarcityContext: "yes" },
+		valid: false,
+	},
+	{
+		name: "invalid — 129 envelopes exceeds the 128 cap",
+		config: {
+			parentUserId: "agent-1",
+			tools: {},
+			envelopes: Object.fromEntries(
+				Array.from({ length: 129 }, (_, i) => [`cc${i}`, { allocated: 1, periodStartMs: 0 }]),
+			),
+		},
+		valid: false,
+	},
+	{
+		name: "valid — exactly 128 envelopes",
+		config: {
+			parentUserId: "agent-1",
+			tools: {},
+			envelopes: Object.fromEntries(
+				Array.from({ length: 128 }, (_, i) => [`cc${i}`, { allocated: 1, periodStartMs: 0 }]),
+			),
+		},
+		valid: true,
+	},
+];
+
+describe("manifest schema ⟷ normalizeCostCenters parity", () => {
+	it.each(parityTable)("$name", ({ config, valid }) => {
+		const schemaVerdict = matchesJsonSchema(costCentersSchema, config);
+		let normalizeVerdict = true;
+		try {
+			normalizeCostCenters(config);
+		} catch {
+			normalizeVerdict = false;
+		}
+		expect(schemaVerdict).toBe(valid);
+		expect(normalizeVerdict).toBe(valid);
+		expect(schemaVerdict).toBe(normalizeVerdict);
+	});
+});

--- a/packages/openclaw/tests/cost-centers-config.test.ts
+++ b/packages/openclaw/tests/cost-centers-config.test.ts
@@ -255,10 +255,24 @@ describe("construction-time call site — createUsertrustPlugin/register, not la
 					costCenters: validConfig({ parentUserId: "agent-parent-forwarded" }),
 				},
 			);
-			// budgetContext([]) with a configured parentUserId returns [] quietly
-			// (Task 2 contract) rather than throwing "no parentUserId" — the
-			// cheapest observable proof the id actually reached createGovernor.
-			await expect(governor.budgetContext([])).resolves.toEqual([]);
+			// `budgetContext([])` is NOT discriminating: with `dryRun: true` and an
+			// EMPTY envelopes array, core's `Governor.budgetContext`
+			// (packages/core/src/headless.ts) returns `[]` on every path — the
+			// `parentUserId === undefined` early exit fires identically to the
+			// isDryRun short-circuit reached after a no-op validation loop over
+			// zero envelopes. A forwarding regression would still pass that
+			// assertion. A non-empty array with a descriptor whose `costCenter`
+			// fails core's charset only reaches (and throws from) core's
+			// `assertDistinctValidCostCenters` door if `parentUserId` was actually
+			// forwarded into `createGovernor` — with no `parentUserId`, the early
+			// exit in headless.ts skips that validation entirely and returns `[]`
+			// regardless of the descriptor's shape. This is the cheapest
+			// observable proof the id actually reached `createGovernor`.
+			await expect(
+				governor.budgetContext([
+					{ costCenter: "bad cost center!", allocated: 1, periodStartMs: 0 },
+				]),
+			).rejects.toThrow(/costCenter must match/);
 		} finally {
 			// `shutdown()`, not `governor.destroy()` — this test's config differs
 			// from every other describe block's, so leaving the module-singleton

--- a/packages/openclaw/tests/endpoint-scope.test.ts
+++ b/packages/openclaw/tests/endpoint-scope.test.ts
@@ -17,7 +17,16 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+import type { Context, StreamFn } from "../src/types.js";
+import {
+	doneEvent,
+	makeContext,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+	textDelta,
+} from "./host-fixtures.js";
 
 // Mock tigerbeetle-node (native module; dry-run never touches it, keep hermetic)
 vi.mock("tigerbeetle-node", () => ({
@@ -41,23 +50,13 @@ function makeTmpVault(): string {
 	return dir;
 }
 
-/** A pi-ai stream that reports 26 input / 298 output tokens on its done event. */
+/** A host stream that reports 26 input / 298 output tokens on its done event. */
 function llamaStream(): StreamFn {
-	const events: StreamEvent[] = [
-		{ type: "start" },
-		{ type: "text_delta", text: "hello world" },
-		{ type: "done", stopReason: "stop", usage: { inputTokens: 26, outputTokens: 298 } },
-	];
-	return (_model: string, _context: StreamContext, _options?: Record<string, unknown>) =>
-		(async function* () {
-			for (const e of events) yield e;
-		})();
+	return streamOf([startEvent(), textDelta("hello world"), doneEvent(makeUsage(26, 298))]);
 }
 
-const CONTEXT: StreamContext = {
-	messages: [{ role: "user", content: "hi" }],
-	model: "llama3.3:70b",
-};
+const MODEL = makeModel("llama3.3:70b");
+const CONTEXT: Context = makeContext();
 
 const BUDGET = 100_000;
 
@@ -91,7 +90,7 @@ describe("UsertrustPluginConfig.endpoint threading (F1)", () => {
 			endpoint: { class: "local", runtime: "ollama" },
 		});
 
-		for await (const _event of governedStreamFn("llama3.3:70b", CONTEXT)) {
+		for await (const _event of await governedStreamFn(MODEL, CONTEXT)) {
 			// drain — settlement runs after the final event
 		}
 
@@ -115,7 +114,7 @@ describe("UsertrustPluginConfig.endpoint threading (F1)", () => {
 			vaultBase,
 		});
 
-		for await (const _event of governedStreamFn("llama3.3:70b", CONTEXT)) {
+		for await (const _event of await governedStreamFn(MODEL, CONTEXT)) {
 			// drain
 		}
 

--- a/packages/openclaw/tests/envelope-integration.test.ts
+++ b/packages/openclaw/tests/envelope-integration.test.ts
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * envelope-integration.test.ts — the Ship 2 mechanism end to end.
+ *
+ * Every other test in this package pins one piece against a fake: the pure
+ * attribution rule, the pure scarcity formatter, the terminal-mode matrix. This
+ * file runs a REAL headless governor through `createGovernedStreamFn` over a
+ * multi-turn conversation and asserts the only things an operator can actually
+ * observe — which account each hold debited, what the receipts say, and what the
+ * model was told about its own budget.
+ *
+ * TWO LEDGERS, one file:
+ *
+ *   1. An INJECTED engine (`GovernedStreamFnOptions.engine`) for the scripted
+ *      turns. It is a real spend lifecycle — holds, posts, refunds, balance
+ *      reads — with no cluster, which is why this file deliberately does NOT
+ *      `vi.mock("tigerbeetle-node")` the way the other openclaw tests do: the
+ *      injected engine IS the isolation seam, and mocking the native module
+ *      would break case 2 in the same file.
+ *   2. A REAL TigerBeetle cluster, self-skipping (`describe.skipIf`) when
+ *      `USERTRUST_TB_ADDRESS` is absent — the same pattern as core's
+ *      `budget-envelope.tb.test.ts`, which is also where the allocate → spend →
+ *      status → reclaim shape comes from. Nothing cluster-touching runs at
+ *      collection time.
+ *
+ * Field names are CONTRACT-DETERMINED (contract-notes §2/§4); the host shapes
+ * come from `host-fixtures.ts`, never inline.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TrustOpts, TrustReceipt } from "usertrust";
+import {
+	allocateBudget,
+	getBudgetStatus,
+	reclaimBudget,
+	TrustTBClient,
+	VAULT_DIR,
+} from "usertrust";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// `XFER_PURCHASE` is not on core's public root export, and funding a parent
+// wallet from the treasury is exactly what core's own `budget-envelope.tb.test.ts`
+// does with it — read the code from the same module rather than hard-code a bare
+// `1` that would silently rot if the transfer codes were ever renumbered.
+import { XFER_PURCHASE } from "../../core/src/ledger/client.js";
+import { createGovernedStreamFn, shutdown } from "../src/index.js";
+import type { Context, CostCentersConfig, Message, StreamFn } from "../src/types.js";
+import {
+	assistantToolCalls,
+	doneEvent,
+	makeAssistantMessage,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+	textDelta,
+	toolResult,
+	userMessage,
+} from "./host-fixtures.js";
+
+const TB_ADDRESS = process.env.USERTRUST_TB_ADDRESS;
+
+const MODEL = makeModel();
+
+const RESEARCH = "research";
+const GENERAL = "general";
+/**
+ * Each envelope's allocation. Sized so one turn's ~614 UT hold fits comfortably
+ * and its ~240 UT settlement is a visible bite out of the envelope — the scarcity
+ * block reports whole percents, so a lavish allocation would round every turn back
+ * to "100% left" and the level test could not tell spend from no spend.
+ */
+const ALLOCATED = 2_000;
+/** The session holding wallet an attributed call never debits. */
+const SESSION_BUDGET = 1_000_000;
+
+// ── The conversation ──
+// One script, replayed by both halves of the file: the host asks, the model calls
+// `web_search`, the host appends the result, the model answers.
+
+const ASK: Message = userMessage("find the retention spec");
+const SEARCHED: Message = assistantToolCalls("web_search");
+const READ: Message = assistantToolCalls("read_file");
+const ANSWERED: Message = {
+	...makeAssistantMessage(),
+	content: [{ type: "text", text: "retention is 30 days" }],
+};
+
+/** The turn the host sends after executing `toolName` — result run TRAILING. */
+function afterTool(issued: Message, toolName: string): Message[] {
+	return [ASK, issued, toolResult(toolName)];
+}
+
+// ── Host stream ──
+
+/** A stream fn that records the context it was FORWARDED (post-injection). */
+function recordingStream(seen: Context[]): StreamFn {
+	const inner = streamOf([startEvent(), textDelta("ok"), doneEvent(makeUsage(500, 1500))]);
+	return (model, context) => {
+		seen.push(context);
+		return inner(model, context);
+	};
+}
+
+async function runTurn(governedStreamFn: StreamFn, messages: Message[]): Promise<Context> {
+	const context: Context = { messages };
+	for await (const _event of await governedStreamFn(MODEL, context)) {
+		// drain — settlement runs after the terminal event
+	}
+	return context;
+}
+
+// ── The injected engine ──
+
+type TestEngine = NonNullable<TrustOpts["_engine"]>;
+
+interface HoldRecord {
+	transferId: string;
+	amount: number;
+	/** The envelope account the hold debited; `undefined` = session wallet. */
+	debitAccountId: bigint | undefined;
+}
+
+interface FakeLedger {
+	engine: TestEngine;
+	/** Every `spendPending` the governor issued, in order — one per governed turn. */
+	holds: HoldRecord[];
+	available(accountId: bigint): number;
+}
+
+/**
+ * The smallest engine that behaves like TigerBeetle for the three things this
+ * file reads back: which account a hold debited, what a settle leaves behind
+ * (posts cap at the hold, the remainder is refunded), and what `lookupBalances`
+ * reports afterwards. An account the seed never named is ABSENT from a lookup,
+ * not zero — the batch semantics `TrustEngine.lookupBalances` documents.
+ */
+function fakeLedger(seed: Map<bigint, number>): FakeLedger {
+	const available = new Map(seed);
+	const pending = new Map<string, { amount: number; accountId: bigint | undefined }>();
+	const holds: HoldRecord[] = [];
+
+	const credit = (accountId: bigint | undefined, delta: number): void => {
+		if (accountId === undefined) return;
+		available.set(accountId, (available.get(accountId) ?? 0) + delta);
+	};
+
+	const engine: TestEngine = {
+		spendPending: async ({ transferId, amount, debitAccountId }) => {
+			holds.push({ transferId, amount, debitAccountId });
+			pending.set(transferId, { amount, accountId: debitAccountId });
+			credit(debitAccountId, -amount);
+			return { transferId };
+		},
+		postPendingSpend: async (transferId, actualAmount) => {
+			const held = pending.get(transferId);
+			if (held === undefined) return { posted: 0, shortfall: 0 };
+			pending.delete(transferId);
+			const requested = actualAmount ?? held.amount;
+			const posted = Math.min(requested, held.amount);
+			credit(held.accountId, held.amount - posted);
+			return { posted, shortfall: requested - posted };
+		},
+		voidPendingSpend: async (transferId) => {
+			const held = pending.get(transferId);
+			if (held === undefined) return;
+			pending.delete(transferId);
+			credit(held.accountId, held.amount);
+		},
+		lookupBalances: async (accountIds) => {
+			const balances = new Map<bigint, number>();
+			for (const accountId of accountIds) {
+				const balance = available.get(accountId);
+				if (balance !== undefined) balances.set(accountId, balance);
+			}
+			return balances;
+		},
+	};
+
+	return { engine, holds, available: (accountId) => available.get(accountId) ?? 0 };
+}
+
+// ── Assertion helpers ──
+
+/** The `NN` in `<costCenter>: NN% left` inside a scarcity block, else null. */
+function scarcityPercent(systemPrompt: string | undefined, costCenter: string): number | null {
+	const match = new RegExp(`${costCenter}: (\\d+)% left`).exec(systemPrompt ?? "");
+	return match?.[1] === undefined ? null : Number(match[1]);
+}
+
+const tmpDirs: string[] = [];
+
+function makeTmpDir(prefix: string): string {
+	const dir = join(tmpdir(), `${prefix}-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	tmpDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	// The governor is a module-wide singleton: leaving one alive would hand the
+	// NEXT test this test's engine, budget and parentUserId.
+	await shutdown();
+	for (const dir of tmpDirs.splice(0)) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup
+		}
+	}
+});
+
+// ── 1. Injected engine ──
+
+describe("envelope attribution end-to-end (injected engine)", () => {
+	beforeEach(() => {
+		process.env.USERTRUST_TEST = "1";
+	});
+
+	afterEach(() => {
+		process.env.USERTRUST_TEST = "";
+	});
+
+	interface Run {
+		account(costCenter: string): bigint;
+		/** The contexts the inner stream fn was handed — copies, post-injection. */
+		forwarded: Context[];
+		governedStreamFn: StreamFn;
+		ledger: FakeLedger;
+		receipts: TrustReceipt[];
+	}
+
+	async function governedRun(): Promise<Run> {
+		const parentUserId = `openclaw-envelope-${randomUUID()}`;
+		const periodStartMs = Date.now();
+		const account = (costCenter: string): bigint =>
+			TrustTBClient.deriveCostCenterAccountId(parentUserId, costCenter);
+		const ledger = fakeLedger(
+			new Map([
+				[account(RESEARCH), ALLOCATED],
+				[account(GENERAL), ALLOCATED],
+			]),
+		);
+		const forwarded: Context[] = [];
+		const receipts: TrustReceipt[] = [];
+		const costCenters: CostCentersConfig = {
+			parentUserId,
+			tools: { web_search: RESEARCH },
+			default: GENERAL,
+			envelopes: {
+				[RESEARCH]: { allocated: ALLOCATED, periodStartMs },
+				[GENERAL]: { allocated: ALLOCATED, periodStartMs },
+			},
+		};
+
+		const { governedStreamFn } = await createGovernedStreamFn(
+			recordingStream(forwarded),
+			{ budget: SESSION_BUDGET, vaultBase: makeTmpDir("openclaw-envelope-int"), costCenters },
+			{
+				engine: ledger.engine,
+				onReceipt: (receipt) => {
+					receipts.push(receipt);
+				},
+			},
+		);
+
+		return { account, forwarded, governedStreamFn, ledger, receipts };
+	}
+
+	/**
+	 * The script, in host order: a plain turn, the turn that follows a `web_search`
+	 * execution, and the turn after the model has answered. Returns the contexts as
+	 * the CALLER wrote them, so a test can check they were never mutated.
+	 */
+	async function runScript(run: Run): Promise<Context[]> {
+		const searched = afterTool(SEARCHED, "web_search");
+		return [
+			await runTurn(run.governedStreamFn, [ASK]),
+			await runTurn(run.governedStreamFn, searched),
+			await runTurn(run.governedStreamFn, [...searched, ANSWERED]),
+		];
+	}
+
+	it("bills the turn after a mapped tool to its envelope, and every other turn to the default", async () => {
+		const run = await governedRun();
+		await runScript(run);
+
+		// Turn 1 has no tool results at all and turn 3's run is no longer trailing
+		// (the model has answered) — both reset to `default`. Only turn 2, the host
+		// asking the model to continue right after executing `web_search`, is
+		// attributed to `research`. This is the stale-carry-over pin, end to end:
+		// one search early in a conversation must not bill every later turn.
+		expect(run.ledger.holds.map((hold) => hold.debitAccountId)).toEqual([
+			run.account(GENERAL),
+			run.account(RESEARCH),
+			run.account(GENERAL),
+		]);
+		// The receipt seam reports the same three, in the same order.
+		expect(run.receipts.map((receipt) => receipt.budget?.costCenter)).toEqual([
+			GENERAL,
+			RESEARCH,
+			GENERAL,
+		]);
+		// And the attributed receipt's envelope snapshot is the ledger's OWN
+		// post-settle balance for the account the hold debited — not an estimate.
+		expect(run.receipts[1]?.budget?.remaining).toBe(run.ledger.available(run.account(RESEARCH)));
+	});
+
+	it("shows the model every envelope's live level, on a copy of the caller's context", async () => {
+		const run = await governedRun();
+		const inputs = await runScript(run);
+
+		const [turn1, turn2, turn3] = run.forwarded;
+		expect(turn1?.systemPrompt).toContain("[usertrust scarcity]");
+		// Turn 1 read the ledger before anything had spent: both envelopes full.
+		expect(scarcityPercent(turn1?.systemPrompt, RESEARCH)).toBe(100);
+		expect(scarcityPercent(turn1?.systemPrompt, GENERAL)).toBe(100);
+		// Turn 2 sees turn 1's settled spend on `general`, and `research` still
+		// untouched — the tool result it is about to be billed for only just arrived.
+		expect(scarcityPercent(turn2?.systemPrompt, GENERAL)).toBeLessThan(100);
+		expect(scarcityPercent(turn2?.systemPrompt, RESEARCH)).toBe(100);
+		// Turn 3 sees turn 2's spend on `research`: the attributed hold really did
+		// debit that envelope, all the way through to what the model is told next.
+		expect(scarcityPercent(turn3?.systemPrompt, RESEARCH)).toBeLessThan(100);
+
+		// The block lives on a COPY — the caller's own context objects are untouched.
+		expect(inputs.map((context) => context.systemPrompt)).toEqual([
+			undefined,
+			undefined,
+			undefined,
+		]);
+	});
+
+	it("bills the turn after an UNMAPPED tool to the default envelope", async () => {
+		const run = await governedRun();
+		await runTurn(run.governedStreamFn, afterTool(READ, "read_file"));
+
+		// `read_file` is a real, correlated, non-error execution — it is simply not
+		// in the operator's map, so it selects nothing and `default` pays.
+		expect(run.ledger.holds[0]?.debitAccountId).toBe(run.account(GENERAL));
+		expect(run.receipts[0]?.budget?.costCenter).toBe(GENERAL);
+	});
+});
+
+// ── 2. Real TigerBeetle ──
+
+describe.skipIf(!TB_ADDRESS)("real TigerBeetle — an attributed OpenClaw turn", () => {
+	/** A vault whose config points the governor's own engine at the live cluster. */
+	function makeClusterVault(budget: number): string {
+		const dir = makeTmpDir("openclaw-envelope-tb");
+		mkdirSync(join(dir, VAULT_DIR), { recursive: true });
+		writeFileSync(
+			join(dir, VAULT_DIR, "usertrust.config.json"),
+			// `addresses`/`clusterId` are the exact TrustTBClient config keys.
+			JSON.stringify({ budget, tigerbeetle: { addresses: [TB_ADDRESS], clusterId: 0 } }),
+		);
+		return dir;
+	}
+
+	it("allocates an envelope, bills an attributed turn to it, and reclaims the remainder", async () => {
+		// A fresh parent per run — `(parent, costCenter)` IS the envelope account,
+		// and this cluster is long-lived.
+		const parentUserId = `openclaw-envelope-tb-${randomUUID()}`;
+		const periodStartMs = Date.now();
+
+		const tb = new TrustTBClient({ addresses: [TB_ADDRESS as string], clusterId: 0n });
+		try {
+			// ── Fund the parent, allocate the envelope — the operator's own tooling ──
+			const treasury = await tb.createTreasury();
+			const parentAccount = await tb.createUserWallet(parentUserId);
+			await tb.immediateTransfer({
+				debitAccountId: treasury,
+				creditAccountId: parentAccount,
+				amount: ALLOCATED,
+				code: XFER_PURCHASE,
+			});
+			const allocation = await allocateBudget(tb, {
+				parentUserId,
+				costCenter: RESEARCH,
+				amount: ALLOCATED,
+			});
+			expect(allocation.allocated).toBe(ALLOCATED);
+
+			// ── One attributed turn through the plugin's programmatic entry point ──
+			const forwarded: Context[] = [];
+			const receipts: TrustReceipt[] = [];
+			const { governedStreamFn } = await createGovernedStreamFn(
+				recordingStream(forwarded),
+				{
+					budget: SESSION_BUDGET,
+					vaultBase: makeClusterVault(SESSION_BUDGET),
+					costCenters: {
+						parentUserId,
+						tools: { web_search: RESEARCH },
+						envelopes: { [RESEARCH]: { allocated: ALLOCATED, periodStartMs } },
+					},
+				},
+				{
+					onReceipt: (receipt) => {
+						receipts.push(receipt);
+					},
+				},
+			);
+			await runTurn(governedStreamFn, afterTool(SEARCHED, "web_search"));
+
+			const receipt = receipts[0];
+			expect(receipt?.budget?.costCenter).toBe(RESEARCH);
+			// What the ledger actually posted: the metered cost, or the hold when the
+			// engine capped a settle above it.
+			const posted = receipt?.postedCost ?? receipt?.cost ?? 0;
+			expect(posted).toBeGreaterThan(0);
+
+			// The scarcity block the model saw came off this cluster too — read
+			// before the turn's own hold, so the envelope is still whole.
+			expect(scarcityPercent(forwarded[0]?.systemPrompt, RESEARCH)).toBe(100);
+
+			// ── The real envelope shows the real spend ──
+			const statusArgs = {
+				parentUserId,
+				costCenter: RESEARCH,
+				allocated: ALLOCATED,
+				periodStartMs,
+			};
+			const status = await getBudgetStatus(tb, statusArgs);
+			expect(status.balance).toBe(ALLOCATED - posted);
+			expect(status.runway.remaining).toBe(ALLOCATED - posted);
+
+			// ── Reclaim what the agent did not spend ──
+			const reclaim = await reclaimBudget(tb, { parentUserId, costCenter: RESEARCH });
+			expect(reclaim.reclaimed).toBe(ALLOCATED - posted);
+			expect((await getBudgetStatus(tb, statusArgs)).balance).toBe(0);
+		} finally {
+			tb.destroy();
+		}
+	});
+});

--- a/packages/openclaw/tests/fingerprint.test.ts
+++ b/packages/openclaw/tests/fingerprint.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * fingerprint.test.ts — the governor-identity fingerprint.
+ *
+ * `index.ts` keeps the winning config's fingerprint at MODULE scope for the
+ * whole process lifetime (`governorFingerprint`), because that string is what
+ * decides whether a second `createUsertrustPlugin` reuses the singleton
+ * governor or is refused. The canonical JSON of a plugin config contains
+ * `proxyKey` — an operator's API key — so retaining the JSON itself would keep
+ * that key resident, in the clear, in a module-level variable for as long as
+ * the process runs, reachable from any heap dump or `--inspect` session.
+ *
+ * A digest decides identity exactly as well as the JSON does (equality is the
+ * only operation ever performed on it) and retains nothing. These tests pin
+ * both halves: the semantics are unchanged, and the plaintext is gone.
+ */
+
+import { describe, expect, it } from "vitest";
+import { fingerprintConfig } from "../src/fingerprint.js";
+import { normalizeCostCenters } from "../src/index.js";
+import type { UsertrustPluginConfig } from "../src/types.js";
+
+const SECRET = "sk-ut-super-secret-operator-key-2026";
+
+const BASE: UsertrustPluginConfig = {
+	budget: 100_000,
+	dryRun: true,
+	proxy: "https://proxy.usertrust.ai",
+	proxyKey: SECRET,
+	vaultBase: "/tmp/vault",
+};
+
+const CC = normalizeCostCenters({
+	parentUserId: "acme",
+	tools: { web_search: "research" },
+	default: "general",
+	envelopes: {
+		research: { allocated: 10_000, periodStartMs: 0 },
+		general: { allocated: 1_000, periodStartMs: 0 },
+	},
+});
+
+describe("fingerprintConfig", () => {
+	it("is a sha-256 hex digest, not the config JSON", () => {
+		expect(fingerprintConfig(BASE)).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it("never retains the proxyKey plaintext — the whole point of hashing it", () => {
+		const fp = fingerprintConfig(BASE, CC);
+		expect(fp).not.toContain(SECRET);
+		// Not even a prefix of it: a digest shares no substring with its input
+		// beyond coincidence, and `sk-ut-` would be a coincidence worth failing on.
+		expect(fp).not.toContain("sk-ut-");
+		// Nor any other config value that a heap dump would otherwise hand over.
+		expect(fp).not.toContain("proxy.usertrust.ai");
+		expect(fp).not.toContain("acme");
+	});
+
+	it("is key-order independent — the canonical-JSON guarantee survives hashing", () => {
+		const a: UsertrustPluginConfig = { budget: 100_000, dryRun: true, proxyKey: SECRET };
+		const b: UsertrustPluginConfig = { proxyKey: SECRET, dryRun: true, budget: 100_000 };
+
+		expect(fingerprintConfig(a)).toBe(fingerprintConfig(b));
+	});
+
+	it("is key-order independent through NESTED objects too", () => {
+		const a: UsertrustPluginConfig = {
+			budget: 1,
+			endpoint: { class: "local", runtime: "ollama", baseURL: "http://x" },
+		};
+		const b: UsertrustPluginConfig = {
+			endpoint: { baseURL: "http://x", runtime: "ollama", class: "local" },
+			budget: 1,
+		};
+
+		expect(fingerprintConfig(a)).toBe(fingerprintConfig(b));
+	});
+
+	it("separates configs that differ anywhere — budget, secret, or cost centers", () => {
+		const base = fingerprintConfig(BASE);
+
+		expect(fingerprintConfig({ ...BASE, budget: 200_000 })).not.toBe(base);
+		expect(fingerprintConfig({ ...BASE, proxyKey: `${SECRET}-rotated` })).not.toBe(base);
+		expect(fingerprintConfig(BASE, CC)).not.toBe(base);
+	});
+
+	it("is stable across calls for the same config (identity, not a nonce)", () => {
+		expect(fingerprintConfig(BASE, CC)).toBe(fingerprintConfig(BASE, CC));
+	});
+
+	it("separates configs that differ only DEEP inside a nested object", () => {
+		expect(
+			fingerprintConfig({ budget: 1, endpoint: { class: "local", runtime: "unknown" } }),
+		).not.toBe(fingerprintConfig({ budget: 1, endpoint: { class: "cloud", runtime: "unknown" } }));
+	});
+});

--- a/packages/openclaw/tests/host-fixtures.ts
+++ b/packages/openclaw/tests/host-fixtures.ts
@@ -84,6 +84,25 @@ export function toolResult(
 	};
 }
 
+/**
+ * The assistant turn that ISSUED `toolNames` — the message a trailing
+ * tool-result run correlates back to. Ids follow `toolResult`'s `call_<name>`
+ * convention, so a correlated pair is the default and every mismatch a test
+ * wants has to be written out explicitly.
+ */
+export function assistantToolCalls(...toolNames: string[]): Message {
+	return {
+		...makeAssistantMessage(),
+		content: toolNames.map((name) => ({
+			type: "toolCall" as const,
+			id: `call_${name}`,
+			name,
+			arguments: {},
+		})),
+		stopReason: "toolUse",
+	};
+}
+
 // ── events ──
 
 export function startEvent(): StreamEvent {

--- a/packages/openclaw/tests/host-fixtures.ts
+++ b/packages/openclaw/tests/host-fixtures.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * host-fixtures.ts — builders for the PINNED host shapes.
+ *
+ * Every openclaw test that fakes a stream builds its events here, so a
+ * contract correction lands in one place instead of eight test files. The
+ * shapes are pinned by `contract.test-d.ts`; these builders just fill them in.
+ */
+
+import type {
+	AssistantMessage,
+	AssistantMessageEventStreamLike,
+	Context,
+	Message,
+	Model,
+	StreamEvent,
+	ToolResultMessage,
+	Usage,
+} from "../src/types.js";
+
+export const TEST_MODEL_ID = "claude-sonnet-4-6";
+
+export function makeModel(id: string = TEST_MODEL_ID): Model {
+	return {
+		id,
+		name: id,
+		api: "anthropic-messages",
+		provider: "anthropic",
+		baseUrl: "https://api.anthropic.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	};
+}
+
+export function makeUsage(input = 0, output = 0, cacheRead = 0, cacheWrite = 0): Usage {
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output + cacheRead + cacheWrite,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+export function makeAssistantMessage(usage: Usage = makeUsage()): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: TEST_MODEL_ID,
+		usage,
+		stopReason: "stop",
+		timestamp: 0,
+	};
+}
+
+export function makeContext(messages: Message[] = [userMessage("hi")]): Context {
+	return { messages };
+}
+
+export function userMessage(text: string): Message {
+	return { role: "user", content: text, timestamp: 0 };
+}
+
+export function toolResult(
+	toolName: string,
+	overrides: Partial<ToolResultMessage> = {},
+): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: `call_${toolName}`,
+		toolName,
+		content: [{ type: "text", text: "ok" }],
+		isError: false,
+		timestamp: 0,
+		...overrides,
+	};
+}
+
+// ── events ──
+
+export function startEvent(): StreamEvent {
+	return { type: "start", partial: makeAssistantMessage() };
+}
+
+export function textDelta(delta: string, contentIndex = 0): StreamEvent {
+	return { type: "text_delta", contentIndex, delta };
+}
+
+export function doneEvent(usage: Usage = makeUsage()): StreamEvent {
+	return { type: "done", reason: "stop", message: makeAssistantMessage(usage) };
+}
+
+export function errorEvent(usage: Usage = makeUsage()): StreamEvent {
+	return {
+		type: "error",
+		reason: "error",
+		error: { ...makeAssistantMessage(usage), stopReason: "error", errorMessage: "boom" },
+	};
+}
+
+// ── streams ──
+
+/**
+ * Wrap an async iterable of events in the pinned stream surface. `result()`
+ * resolves with the terminal event's assistant message once the stream ends.
+ */
+export function asHostStream(
+	events: AsyncIterable<StreamEvent>,
+	final: AssistantMessage = makeAssistantMessage(),
+): AssistantMessageEventStreamLike {
+	return {
+		[Symbol.asyncIterator]: () => events[Symbol.asyncIterator](),
+		result: async () => final,
+	};
+}
+
+/** A host stream fn that replays a fixed event list. */
+export function streamOf(
+	events: StreamEvent[],
+): (model: Model, context: Context) => AssistantMessageEventStreamLike {
+	return () =>
+		asHostStream(
+			(async function* () {
+				for (const event of events) yield event;
+			})(),
+		);
+}

--- a/packages/openclaw/tests/host-fixtures.ts
+++ b/packages/openclaw/tests/host-fixtures.ts
@@ -22,6 +22,25 @@ import type {
 
 export const TEST_MODEL_ID = "claude-sonnet-4-6";
 
+/**
+ * Guard against a promise that never settles. A hung `result()` is the whole
+ * failure mode half these tests exist to catch, and it would otherwise surface
+ * as an opaque suite-level timeout instead of a named assertion failure.
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms = 500): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error("promise never settled")), ms);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
 export function makeModel(id: string = TEST_MODEL_ID): Model {
 	return {
 		id,
@@ -125,6 +144,37 @@ export function errorEvent(usage: Usage = makeUsage()): StreamEvent {
 	};
 }
 
+/**
+ * The OTHER terminal `error` event: `reason: "aborted"`.
+ *
+ * This is what the pinned providers emit when the CALLER's `AbortSignal` fires —
+ * not a provider failure. Evidence, verbatim from the pinned tarballs:
+ *
+ *   pi-ai `dist/providers/anthropic.js:515-517`
+ *     output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+ *     output.errorMessage = …;
+ *     stream.push({ type: "error", reason: output.stopReason, error: output });
+ *
+ *   openclaw `dist/proxy-BzhBz8iM.js:4380-4386` (`streamProxy`) and
+ *   `dist/openai-transport-stream-B0WkSqXp.js:758-768` (`failTransportStream`)
+ *     const reason = options.signal?.aborted ? "aborted" : "error";
+ *
+ * `error.usage` carries whatever the provider had accumulated before the abort
+ * (pi-ai `anthropic.js:480-497` mutates `output.usage` per SSE frame), which is
+ * why this path SETTLES the partial rather than voiding it.
+ */
+export function abortedEvent(usage: Usage = makeUsage()): StreamEvent {
+	return {
+		type: "error",
+		reason: "aborted",
+		error: {
+			...makeAssistantMessage(usage),
+			stopReason: "aborted",
+			errorMessage: "Request was aborted",
+		},
+	};
+}
+
 // ── streams ──
 
 /**
@@ -151,4 +201,149 @@ export function streamOf(
 				for (const event of events) yield event;
 			})(),
 		);
+}
+
+// ── the PINNED host's own stream class, ported ──
+
+/**
+ * A faithful port of the pinned `EventStream` / `AssistantMessageEventStream`.
+ *
+ * Sources, identical in both pinned tarballs:
+ *   `@mariozechner/pi-ai@0.73.1` `dist/utils/event-stream.js:2-80`
+ *   `openclaw@2026.7.1-2`        `dist/validation-DQFzVcBb.js:3-65`
+ *
+ * Three behaviours here are LOAD-BEARING and cannot be faked with a plain async
+ * generator, which is why this port exists instead of another `asHostStream`:
+ *
+ *  1. `push()` resolves the final-result promise BEFORE handing the terminal
+ *     event to the waiting consumer (`resolveFinalResult` precedes `waiter(…)`).
+ *     That single ordering is what lets the host `await response.result()` from
+ *     INSIDE its own loop body without deadlocking — and therefore what any
+ *     governed proxy has to preserve.
+ *  2. `result()` is PASSIVE. It returns the promise and consumes nothing, so a
+ *     `result()`-first consumer that later iterates still sees every event.
+ *  3. `end()` called with NO argument leaves the final-result promise pending
+ *     FOREVER while the iteration terminates normally — the "clean close with
+ *     no terminal event" case.
+ */
+export class PinnedEventStream implements AssistantMessageEventStreamLike {
+	private readonly queue: StreamEvent[] = [];
+	private readonly waiting: ((r: IteratorResult<StreamEvent>) => void)[] = [];
+	private closed = false;
+	private resolveFinal!: (message: AssistantMessage) => void;
+	private readonly finalResultPromise: Promise<AssistantMessage>;
+
+	constructor() {
+		this.finalResultPromise = new Promise<AssistantMessage>((resolve) => {
+			this.resolveFinal = resolve;
+		});
+	}
+
+	push(event: StreamEvent): void {
+		if (this.closed) return;
+		// Terminal events resolve the result FIRST — before the consumer is
+		// handed the event. See (1) above.
+		if (event.type === "done") {
+			this.closed = true;
+			this.resolveFinal(event.message);
+		} else if (event.type === "error") {
+			this.closed = true;
+			this.resolveFinal(event.error);
+		}
+		const waiter = this.waiting.shift();
+		if (waiter) waiter({ value: event, done: false });
+		else this.queue.push(event);
+	}
+
+	end(result?: AssistantMessage): void {
+		this.closed = true;
+		// NOTE the pinned asymmetry: no argument means the promise stays pending.
+		if (result !== undefined) this.resolveFinal(result);
+		while (this.waiting.length > 0) {
+			this.waiting.shift()?.({ value: undefined, done: true });
+		}
+	}
+
+	async *[Symbol.asyncIterator](): AsyncGenerator<StreamEvent> {
+		for (;;) {
+			const queued = this.queue.shift();
+			if (queued !== undefined) {
+				yield queued;
+				continue;
+			}
+			if (this.closed) return;
+			const next = await new Promise<IteratorResult<StreamEvent>>((resolve) =>
+				this.waiting.push(resolve),
+			);
+			if (next.done === true) return;
+			yield next.value;
+		}
+	}
+
+	result(): Promise<AssistantMessage> {
+		return this.finalResultPromise;
+	}
+}
+
+/**
+ * A host stream fn backed by {@link PinnedEventStream}, fed by a producer that
+ * runs EAGERLY — exactly as every pinned provider does (an async IIFE that
+ * starts pushing the moment the stream object is handed back).
+ */
+export function pinnedStreamOf(
+	events: StreamEvent[],
+	opts: { endWith?: AssistantMessage | undefined } = {},
+): (model: Model, context: Context) => AssistantMessageEventStreamLike {
+	return () => {
+		const stream = new PinnedEventStream();
+		void (async () => {
+			for (const event of events) {
+				await Promise.resolve();
+				stream.push(event);
+			}
+			if (opts.endWith !== undefined) stream.end(opts.endWith);
+			else stream.end();
+		})();
+		return stream;
+	};
+}
+
+// ── the PINNED host's consumption loop, ported ──
+
+/**
+ * The pinned OpenClaw agent loop's consumption of a stream, reproduced move for
+ * move — `openclaw@2026.7.1-2` `dist/proxy-BzhBz8iM.js:363-424`, region
+ * `packages/agent-core/src/agent-loop.ts`, function `streamAssistantResponse`.
+ *
+ * The two moves that matter, and that no other test in this package made:
+ *
+ *   case "done":
+ *   case "error": {
+ *     const finalMessage = removeNonExecutableToolCalls(await response.result());
+ *     …
+ *     return finalMessage;              // ← returns from INSIDE the for-await
+ *   }
+ *   }
+ *   const finalMessage = removeNonExecutableToolCalls(await response.result());
+ *
+ * So the host awaits `result()` **while it is suspended in the loop body
+ * handling the terminal event**, and then abandons the iterator instead of
+ * draining it. A proxy whose `result()` can only settle after its generator is
+ * resumed deadlocks right there. The post-loop `result()` at line 411 is the
+ * only path for a stream that ends with no terminal event at all.
+ *
+ * `observed` collects every event the host saw, so a test can assert the host
+ * loop's view of the stream is intact as well as unblocked.
+ */
+export async function consumeLikeOpenClawLoop(
+	stream: AssistantMessageEventStreamLike,
+	observed: StreamEvent[] = [],
+): Promise<AssistantMessage> {
+	for await (const event of stream) {
+		observed.push(event);
+		if (event.type === "done" || event.type === "error") {
+			return await stream.result();
+		}
+	}
+	return await stream.result();
 }

--- a/packages/openclaw/tests/host-loop.test.ts
+++ b/packages/openclaw/tests/host-loop.test.ts
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * host-loop.test.ts — the governed proxy as the PINNED OpenClaw loop consumes it.
+ *
+ * Every other suite in this package drives the wrapper the way a *test* finds
+ * convenient: `for await (…) { }` to exhaustion, then `await stream.result()`.
+ * The pinned host does neither. `openclaw@2026.7.1-2`
+ * `dist/proxy-BzhBz8iM.js:363-424` (`streamAssistantResponse`) awaits
+ * `response.result()` from INSIDE the loop body while handling the terminal
+ * event, and then returns without draining the iterator:
+ *
+ *     case "done":
+ *     case "error": {
+ *       const finalMessage = removeNonExecutableToolCalls(await response.result());
+ *       …
+ *       return finalMessage;
+ *     }
+ *
+ * That is legal against the pinned stream class only because
+ * `EventStream.push()` resolves the final-result promise BEFORE delivering the
+ * terminal event to the waiting consumer (`pi-ai/dist/utils/event-stream.js:20-31`,
+ * `openclaw/dist/validation-DQFzVcBb.js:16-28`). A proxy that settles its
+ * deferred only after its generator is RESUMED past the terminal `yield` cannot
+ * be resumed — the host is blocked on the very promise the resumption would
+ * settle — and the whole agent turn hangs.
+ *
+ * The absence of this consumption shape from the test suite is what let the
+ * Codex PR-82 findings through, so it is the shape every case here uses:
+ * `consumeLikeOpenClawLoop` + `PinnedEventStream` (both in `host-fixtures.ts`,
+ * both ported line-for-line from the pinned tarballs).
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Governor } from "usertrust";
+import { createGovernor } from "usertrust";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { wrapStreamWithGovernance } from "../src/stream-governor.js";
+import type { AssistantMessageEventStreamLike, StreamEvent, StreamFn } from "../src/types.js";
+import {
+	abortedEvent,
+	consumeLikeOpenClawLoop,
+	doneEvent,
+	errorEvent,
+	makeContext,
+	makeModel,
+	makeUsage,
+	PinnedEventStream,
+	pinnedStreamOf,
+	startEvent,
+	textDelta,
+	withTimeout,
+} from "./host-fixtures.js";
+
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+const model = makeModel();
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `openclaw-host-loop-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+describe("pinned OpenClaw host loop", () => {
+	let vaultBase: string;
+	let gov: Governor;
+	let settle: ReturnType<typeof vi.spyOn>;
+	let abort: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(async () => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+		gov = await createGovernor({ dryRun: true, budget: 100_000, vaultBase });
+		settle = vi.spyOn(gov, "settle");
+		abort = vi.spyOn(gov, "abort");
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		vi.restoreAllMocks();
+		await gov.destroy();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup
+		}
+	});
+
+	function terminalCount(): number {
+		return settle.mock.calls.length + abort.mock.calls.length;
+	}
+
+	function settleParams(): Record<string, unknown> {
+		return settle.mock.calls[0]?.[1] as Record<string, unknown>;
+	}
+
+	// ── [P1-1] the deadlock: result() awaited from inside the loop body ──
+
+	it("resolves result() awaited from inside the loop body on a `done` event", async () => {
+		const events = [startEvent(), textDelta("hi"), doneEvent(makeUsage(10, 5))];
+		const governed = wrapStreamWithGovernance(pinnedStreamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		const observed: StreamEvent[] = [];
+		const finalMessage = await withTimeout(consumeLikeOpenClawLoop(stream, observed));
+
+		// The host saw the whole stream and got its final message back.
+		expect(observed.map((e) => e.type)).toEqual(["start", "text_delta", "done"]);
+		expect(finalMessage.usage.input).toBe(10);
+		expect(finalMessage.usage.output).toBe(5);
+
+		// And governance had ALREADY finished by the time it did: the host never
+		// resumes the generator, so anything deferred past the terminal `yield`
+		// would simply never run.
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(settleParams()).toMatchObject({
+			inputTokens: 10,
+			outputTokens: 5,
+			usageSource: "provider",
+		});
+	});
+
+	it("settles the hold BEFORE the terminal event reaches the host", async () => {
+		// Ordering, not just eventual consistency: the host treats `result()`
+		// resolving as the turn being over, so a settle still in flight at that
+		// point is a hold the host believes is already closed.
+		const order: string[] = [];
+		settle.mockImplementation(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			order.push("settle");
+		});
+
+		const events = [startEvent(), doneEvent(makeUsage(10, 5))];
+		const governed = wrapStreamWithGovernance(pinnedStreamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		for await (const event of stream) {
+			if (event.type === "done") {
+				order.push("host-sees-done");
+				break;
+			}
+		}
+
+		expect(order).toEqual(["settle", "host-sees-done"]);
+	});
+
+	it("resolves result() awaited from inside the loop body on an `error` event", async () => {
+		// [P2-4] The pinned `AssistantMessageEventStream` RESOLVES its result with
+		// `event.error` for an in-band error event — `extractResult` returns
+		// `event.error`, it never rejects (`event-stream.js:66-74`). OpenClaw then
+		// uses that AssistantMessage as the terminal assistant turn and branches on
+		// `message.stopReason` (`proxy-BzhBz8iM.js:264`). Rejecting here would turn
+		// a normal failed turn into a thrown agent-loop error.
+		const events = [startEvent(), textDelta("partial"), errorEvent(makeUsage(9, 3))];
+		const governed = wrapStreamWithGovernance(pinnedStreamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		const observed: StreamEvent[] = [];
+		const finalMessage = await withTimeout(consumeLikeOpenClawLoop(stream, observed));
+
+		expect(observed.map((e) => e.type)).toEqual(["start", "text_delta", "error"]);
+		expect(finalMessage.stopReason).toBe("error");
+		expect(finalMessage.errorMessage).toBe("boom");
+
+		// A provider-reported failure still VOIDS the hold — resolving `result()`
+		// changes what the host is told, never what the ledger does.
+		expect(terminalCount()).toBe(1);
+		expect(abort).toHaveBeenCalledOnce();
+		expect(settle).not.toHaveBeenCalled();
+	});
+
+	// ── [P1-2] consumer abort is not a provider failure ──
+
+	it("settles the partial usage when the consumer aborts (reason: `aborted`)", async () => {
+		const events = [startEvent(), textDelta("partial"), abortedEvent(makeUsage(9, 3))];
+		const governed = wrapStreamWithGovernance(pinnedStreamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		const finalMessage = await withTimeout(consumeLikeOpenClawLoop(stream));
+
+		expect(finalMessage.stopReason).toBe("aborted");
+
+		// The caller cancelled a call the provider was serving honestly, and the
+		// partial usage is real spend. Settle it — do NOT void, and do not book it
+		// as a provider failure.
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(abort).not.toHaveBeenCalled();
+		expect(settleParams()).toMatchObject({
+			inputTokens: 9,
+			outputTokens: 3,
+			usageSource: "provider",
+		});
+	});
+
+	it("settles the partial when a real AbortSignal cancels the stream mid-flight", async () => {
+		// The end-to-end shape: the caller's signal fires, the provider catches it
+		// and pushes `{ type: "error", reason: "aborted", error: <partial> }` —
+		// `pi-ai/dist/providers/anthropic.js:500-517`.
+		const controller = new AbortController();
+		const streamFn: StreamFn = (_model, _context, options): AssistantMessageEventStreamLike => {
+			const stream = new PinnedEventStream();
+			void (async () => {
+				stream.push(startEvent());
+				await Promise.resolve();
+				stream.push(textDelta("half a sen"));
+				await new Promise((resolve) => setTimeout(resolve, 5));
+				if (options?.signal?.aborted === true) {
+					stream.push(abortedEvent(makeUsage(42, 7)));
+					stream.end();
+					return;
+				}
+				stream.push(doneEvent(makeUsage(42, 400)));
+				stream.end();
+			})();
+			return stream;
+		};
+
+		const governed = wrapStreamWithGovernance(streamFn, gov);
+		const stream = await governed(model, makeContext(), { signal: controller.signal });
+		controller.abort();
+
+		const finalMessage = await withTimeout(consumeLikeOpenClawLoop(stream));
+
+		expect(finalMessage.stopReason).toBe("aborted");
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(abort).not.toHaveBeenCalled();
+		expect(settleParams()).toMatchObject({ inputTokens: 42, outputTokens: 7 });
+	});
+
+	// ── [P2-5] clean close with no terminal event ──
+
+	it("terminates result() explicitly when the stream closes with no terminal event", async () => {
+		// `EventStream.end()` with no argument marks the iteration finished but
+		// leaves `finalResultPromise` pending FOREVER (`event-stream.js:33-43`).
+		// This is the host's post-loop `await response.result()` at
+		// `proxy-BzhBz8iM.js:411`, and adopting the provider's promise there marks
+		// our deferred settled while it hangs — the one state the wrapper's own
+		// "result() must never be left pending" guard cannot see.
+		const governed = wrapStreamWithGovernance(pinnedStreamOf([startEvent(), textDelta("x")]), gov);
+		const stream = await governed(model, makeContext());
+
+		await expect(withTimeout(consumeLikeOpenClawLoop(stream))).rejects.toThrow(
+			/closed without a terminal event/,
+		);
+
+		// The hold is still released, at the estimate, exactly as before.
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(settleParams().usageSource).toBe("estimated");
+	});
+
+	// ── [P2-3] result() is passive upstream; our drain must not eat the stream ──
+
+	it("replays every event to an iterator that arrives after a result()-only drain", async () => {
+		// The pinned `result()` consumes NOTHING (`event-stream.js:60-62`), so a
+		// consumer that calls it first and iterates afterwards still sees the whole
+		// stream. Our `result()` has to drain — nothing else pumps governance — so
+		// it must replay what that drain swallowed instead of silently eating it.
+		const events = [startEvent(), textDelta("a"), textDelta("b"), doneEvent(makeUsage(10, 5))];
+		const governed = wrapStreamWithGovernance(pinnedStreamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		const finalMessage = await withTimeout(stream.result());
+		expect(finalMessage.usage.input).toBe(10);
+
+		const seen: StreamEvent[] = [];
+		for await (const event of stream) seen.push(event);
+
+		expect(seen.map((e) => e.type)).toEqual(["start", "text_delta", "text_delta", "done"]);
+		expect(terminalCount()).toBe(1);
+	});
+
+	it("does not split the stream when result() and iteration race", async () => {
+		const events = [startEvent(), textDelta("a"), textDelta("b"), doneEvent(makeUsage(10, 5))];
+		const governed = wrapStreamWithGovernance(pinnedStreamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		// `result()` first, deliberately NOT awaited — its hidden drain is still
+		// running when the iterator arrives.
+		const resultPromise = stream.result();
+		const seen: StreamEvent[] = [];
+		for await (const event of stream) seen.push(event);
+
+		await withTimeout(resultPromise);
+		expect(seen.map((e) => e.type)).toEqual(["start", "text_delta", "text_delta", "done"]);
+		expect(terminalCount()).toBe(1);
+	});
+
+	it("replays a mid-stream provider throw to a late iterator", async () => {
+		const streamFn: StreamFn = () => ({
+			[Symbol.asyncIterator]: async function* () {
+				yield startEvent();
+				throw new Error("provider_exploded");
+			},
+			result: () => new Promise<never>(() => {}),
+		});
+		const governed = wrapStreamWithGovernance(streamFn, gov);
+		const stream = await governed(model, makeContext());
+
+		await expect(withTimeout(stream.result())).rejects.toThrow("provider_exploded");
+
+		const seen: StreamEvent[] = [];
+		await expect(async () => {
+			for await (const event of stream) seen.push(event);
+		}).rejects.toThrow("provider_exploded");
+		expect(seen.map((e) => e.type)).toEqual(["start"]);
+
+		expect(terminalCount()).toBe(1);
+		expect(abort).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/openclaw/tests/index.test.ts
+++ b/packages/openclaw/tests/index.test.ts
@@ -3,6 +3,16 @@ import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi, ProviderPlugin } from "../src/types.js";
+import {
+	doneEvent,
+	makeContext,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+	textDelta,
+} from "./host-fixtures.js";
 
 // Mock tigerbeetle-node
 vi.mock("tigerbeetle-node", () => ({
@@ -61,45 +71,42 @@ describe("openclaw plugin entry point", () => {
 			const registerFn = mod.default;
 
 			const registerProviderMock = vi.fn();
-			const api = {
-				registerTool: vi.fn(),
+			const api: OpenClawPluginApi = {
+				id: "usertrust",
+				name: "usertrust",
+				pluginConfig: { budget: 100_000, dryRun: true },
 				registerProvider: registerProviderMock,
-				registerChannel: vi.fn(),
-				registerHttpRoute: vi.fn(),
 			};
 
 			registerFn(api);
 
 			expect(registerProviderMock).toHaveBeenCalledOnce();
-			const plugin = registerProviderMock.mock.calls[0][0];
+			const plugin = registerProviderMock.mock.calls[0]?.[0] as ProviderPlugin;
 			expect(plugin.id).toBe("usertrust");
 			expect(plugin.label).toBe("usertrust Governance");
 			expect(typeof plugin.wrapStreamFn).toBe("function");
 		});
 
-		it("wrapStreamFn returns a function with the same arity", async () => {
+		it("wrapStreamFn returns a stream function from the hook context", async () => {
 			const mod = await import("../src/index.js");
 			const registerFn = mod.default;
 
-			let capturedPlugin: { wrapStreamFn: (fn: unknown, config: unknown) => unknown } | null = null;
-			const api = {
-				registerTool: vi.fn(),
-				registerProvider: vi.fn((p: unknown) => {
-					capturedPlugin = p as typeof capturedPlugin;
-				}),
-				registerChannel: vi.fn(),
-				registerHttpRoute: vi.fn(),
+			let capturedPlugin: ProviderPlugin | null = null;
+			const api: OpenClawPluginApi = {
+				id: "usertrust",
+				name: "usertrust",
+				pluginConfig: { budget: 100_000, dryRun: true },
+				registerProvider: (p) => {
+					capturedPlugin = p;
+				},
 			};
 
 			registerFn(api);
 
-			const mockStreamFn = async function* () {
-				yield { type: "start" as const };
-			};
-
-			const wrapped = capturedPlugin?.wrapStreamFn(mockStreamFn, {
-				budget: 100_000,
-				dryRun: true,
+			const wrapped = capturedPlugin?.wrapStreamFn?.({
+				provider: "anthropic",
+				modelId: "claude-sonnet-4-6",
+				streamFn: streamOf([startEvent()]),
 			});
 
 			expect(typeof wrapped).toBe("function");
@@ -110,26 +117,13 @@ describe("openclaw plugin entry point", () => {
 		it("returns a governed stream function and a governor", async () => {
 			const { createGovernedStreamFn } = await import("../src/index.js");
 
-			const events = [
-				{ type: "start" as const },
-				{ type: "text_delta" as const, text: "hello" },
+			const { governedStreamFn, governor } = await createGovernedStreamFn(
+				streamOf([startEvent(), doneEvent(makeUsage(50, 20))]),
 				{
-					type: "done" as const,
-					stopReason: "stop" as const,
-					usage: { inputTokens: 50, outputTokens: 20 },
+					budget: 100_000,
+					dryRun: true,
 				},
-			];
-
-			const mockStreamFn = async function* () {
-				for (const event of events) {
-					yield event;
-				}
-			};
-
-			const { governedStreamFn, governor } = await createGovernedStreamFn(mockStreamFn, {
-				budget: 100_000,
-				dryRun: true,
-			});
+			);
 
 			expect(typeof governedStreamFn).toBe("function");
 			expect(governor).toBeDefined();
@@ -152,9 +146,7 @@ describe("openclaw plugin entry point", () => {
 		it("returns governor after createGovernedStreamFn() initializes it", async () => {
 			const { createGovernedStreamFn, getGovernor } = await import("../src/index.js");
 
-			const mockStreamFn = async function* () {
-				yield { type: "start" as const };
-			};
+			const mockStreamFn = streamOf([startEvent()]);
 
 			const { governor } = await createGovernedStreamFn(mockStreamFn, {
 				budget: 100_000,
@@ -173,9 +165,7 @@ describe("openclaw plugin entry point", () => {
 		it("cleans up governor and sets it to null", async () => {
 			const { createGovernedStreamFn, getGovernor, shutdown } = await import("../src/index.js");
 
-			const mockStreamFn = async function* () {
-				yield { type: "start" as const };
-			};
+			const mockStreamFn = streamOf([startEvent()]);
 
 			await createGovernedStreamFn(mockStreamFn, {
 				budget: 100_000,
@@ -201,9 +191,7 @@ describe("openclaw plugin entry point", () => {
 		it("returns existing governor on second createGovernedStreamFn call", async () => {
 			const { createGovernedStreamFn, getGovernor } = await import("../src/index.js");
 
-			const mockStreamFn = async function* () {
-				yield { type: "start" as const };
-			};
+			const mockStreamFn = streamOf([startEvent()]);
 
 			// First call initializes
 			const { governor: gov1 } = await createGovernedStreamFn(mockStreamFn, {
@@ -229,51 +217,31 @@ describe("openclaw plugin entry point", () => {
 			const mod = await import("../src/index.js");
 			const registerFn = mod.default;
 
-			let capturedPlugin: {
-				wrapStreamFn: (
-					fn: (...args: unknown[]) => AsyncIterable<unknown>,
-					config: { budget: number; dryRun: boolean },
-				) => (...args: unknown[]) => AsyncIterable<unknown>;
-			} | null = null;
-			const api = {
-				registerTool: vi.fn(),
-				registerProvider: vi.fn((p: unknown) => {
-					capturedPlugin = p as typeof capturedPlugin;
-				}),
-				registerChannel: vi.fn(),
-				registerHttpRoute: vi.fn(),
+			let capturedPlugin: ProviderPlugin | null = null;
+			const api: OpenClawPluginApi = {
+				id: "usertrust",
+				name: "usertrust",
+				pluginConfig: { budget: 100_000, dryRun: true },
+				registerProvider: (p) => {
+					capturedPlugin = p;
+				},
 			};
 
 			registerFn(api);
 
-			const events = [
-				{ type: "start" as const },
-				{ type: "text_delta" as const, text: "hello" },
-				{
-					type: "done" as const,
-					stopReason: "stop" as const,
-					usage: { inputTokens: 50, outputTokens: 20 },
-				},
-			];
-
-			const mockStreamFn = async function* () {
-				for (const e of events) yield e;
-			};
-
-			const wrapped = capturedPlugin?.wrapStreamFn(mockStreamFn, {
-				budget: 100_000,
-				dryRun: true,
+			const wrapped = capturedPlugin?.wrapStreamFn?.({
+				provider: "anthropic",
+				modelId: "claude-sonnet-4-6",
+				streamFn: streamOf([startEvent(), textDelta("hello"), doneEvent(makeUsage(50, 20))]),
 			});
+
+			expect(wrapped).toBeTypeOf("function");
+			// biome-ignore lint/style/noNonNullAssertion: guarded by expect above
+			const stream = await wrapped!(makeModel(), makeContext());
 
 			const collected: unknown[] = [];
-			const stream = wrapped?.("claude-sonnet-4-6", {
-				messages: [{ role: "user", content: "hi" }],
-				model: "claude-sonnet-4-6",
-			});
-			if (stream) {
-				for await (const event of stream) {
-					collected.push(event);
-				}
+			for await (const event of stream) {
+				collected.push(event);
 			}
 
 			expect(collected).toHaveLength(3);

--- a/packages/openclaw/tests/index.test.ts
+++ b/packages/openclaw/tests/index.test.ts
@@ -188,22 +188,20 @@ describe("openclaw plugin entry point", () => {
 	});
 
 	describe("initGovernor early return", () => {
-		it("returns existing governor on second createGovernedStreamFn call", async () => {
+		it("returns existing governor on second createGovernedStreamFn call with the SAME config", async () => {
 			const { createGovernedStreamFn, getGovernor } = await import("../src/index.js");
 
 			const mockStreamFn = streamOf([startEvent()]);
+			const config = { budget: 100_000, dryRun: true };
 
 			// First call initializes
-			const { governor: gov1 } = await createGovernedStreamFn(mockStreamFn, {
-				budget: 100_000,
-				dryRun: true,
-			});
+			const { governor: gov1 } = await createGovernedStreamFn(mockStreamFn, config);
 
-			// Second call should return the same governor
-			const { governor: gov2 } = await createGovernedStreamFn(mockStreamFn, {
-				budget: 200_000,
-				dryRun: true,
-			});
+			// Second call, SAME config, should return the same governor — a
+			// DIFFERENT config now rejects instead of silently reusing the first
+			// instance's governor (Task 4, `tests/cost-centers-config.test.ts`'s
+			// "governor config-mismatch guard" suite).
+			const { governor: gov2 } = await createGovernedStreamFn(mockStreamFn, config);
 
 			expect(gov1).toBe(gov2);
 			expect(getGovernor()).toBe(gov1);

--- a/packages/openclaw/tests/integration.test.ts
+++ b/packages/openclaw/tests/integration.test.ts
@@ -37,7 +37,25 @@ vi.mock("tigerbeetle-node", () => ({
 }));
 
 import { createUsertrustPlugin } from "../src/index.js";
-import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+import type { Context, StreamEvent, StreamFn } from "../src/types.js";
+import {
+	asHostStream,
+	doneEvent,
+	makeAssistantMessage,
+	makeContext,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+	textDelta,
+} from "./host-fixtures.js";
+
+/** The hook context openclaw hands `wrapStreamFn`, with the inner fn on it. */
+function wrapCtx(streamFn: StreamFn) {
+	return { provider: "anthropic", modelId: "claude-sonnet-4-6", streamFn };
+}
+
+const MODEL = makeModel();
 
 function makeTmpVault(): string {
 	const dir = join(tmpdir(), `openclaw-integration-test-${randomUUID()}`);
@@ -73,48 +91,34 @@ describe("createUsertrustPlugin (factory)", () => {
 		expect(typeof plugin.wrapStreamFn).toBe("function");
 	});
 
-	it("wrapStreamFn(next) returns a callable stream function", () => {
+	it("wrapStreamFn(ctx) returns a callable stream function", () => {
 		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
 
-		const rawStreamFn: StreamFn = async function* () {
-			yield { type: "start" as const };
-		};
-
-		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		const wrapped = plugin.wrapStreamFn?.(wrapCtx(streamOf([startEvent()])));
 		expect(typeof wrapped).toBe("function");
 	});
 
 	it("wrapped stream forwards all events from the inner streamFn", async () => {
 		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
 
+		const partial = makeAssistantMessage();
 		const events: StreamEvent[] = [
-			{ type: "start" },
-			{ type: "text_start" },
-			{ type: "text_delta", text: "hello " },
-			{ type: "text_delta", text: "world" },
-			{ type: "text_end" },
-			{
-				type: "done",
-				stopReason: "stop",
-				usage: { inputTokens: 10, outputTokens: 5 },
-			},
+			startEvent(),
+			{ type: "text_start", contentIndex: 0, partial },
+			textDelta("hello "),
+			textDelta("world"),
+			{ type: "text_end", contentIndex: 0, content: "hello world", partial },
+			doneEvent(makeUsage(10, 5)),
 		];
 
-		const rawStreamFn: StreamFn = async function* () {
-			for (const e of events) yield e;
-		};
-
-		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
+		const wrapped = plugin.wrapStreamFn?.(wrapCtx(streamOf(events)));
 		expect(wrapped).toBeDefined();
 
-		const ctx: StreamContext = {
-			messages: [{ role: "user", content: "hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const ctx: Context = makeContext();
 
 		const collected: StreamEvent[] = [];
 		// biome-ignore lint/style/noNonNullAssertion: guarded by expect above
-		for await (const event of wrapped!("claude-sonnet-4-6", ctx)) {
+		for await (const event of await wrapped!(MODEL, ctx)) {
 			collected.push(event);
 		}
 
@@ -131,17 +135,11 @@ describe("createUsertrustPlugin (factory)", () => {
 		expect(getGovernor()).toBeNull();
 
 		// First call should trigger init
-		const rawStreamFn: StreamFn = async function* () {
-			yield { type: "start" as const };
-		};
-		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
-		const ctx: StreamContext = {
-			messages: [{ role: "user", content: "hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const wrapped = plugin.wrapStreamFn?.(wrapCtx(streamOf([startEvent()])));
+		const ctx: Context = makeContext();
 
 		// biome-ignore lint/style/noNonNullAssertion: guarded above
-		for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+		for await (const _e of await wrapped!(MODEL, ctx)) {
 			// drain
 		}
 
@@ -151,26 +149,26 @@ describe("createUsertrustPlugin (factory)", () => {
 	it("propagates errors from the inner streamFn and aborts the hold", async () => {
 		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
 
-		const rawStreamFn: StreamFn = async function* () {
-			yield { type: "start" as const };
-			throw new Error("upstream_failure");
-		};
+		const rawStreamFn: StreamFn = () =>
+			asHostStream(
+				(async function* () {
+					yield startEvent();
+					throw new Error("upstream_failure");
+				})(),
+			);
 
 		// Trigger lazy init by calling once with a successful no-op — but
 		// we can't, since first call may also be the failing one. Instead,
 		// snapshot budget AFTER first authorize completes by routing through
 		// a separate channel: just compare delta within this test.
-		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
-		const ctx: StreamContext = {
-			messages: [{ role: "user", content: "hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const wrapped = plugin.wrapStreamFn?.(wrapCtx(rawStreamFn));
+		const ctx: Context = makeContext();
 
 		const { getGovernor } = await import("../src/index.js");
 
 		await expect(async () => {
 			// biome-ignore lint/style/noNonNullAssertion: guarded above
-			for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+			for await (const _e of await wrapped!(MODEL, ctx)) {
 				// drain
 			}
 		}).rejects.toThrow("upstream_failure");
@@ -193,24 +191,14 @@ describe("createUsertrustPlugin (factory)", () => {
 		const SETTLED_PER_CALL = 240;
 		const plugin = createUsertrustPlugin({ budget: BUDGET, dryRun: true, vaultBase });
 
-		const rawStreamFn: StreamFn = async function* () {
-			yield { type: "start" as const };
-			yield {
-				type: "done" as const,
-				stopReason: "stop" as const,
-				usage: { inputTokens: 500, outputTokens: 1500 },
-			};
-		};
-
-		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
-		const ctx: StreamContext = {
-			messages: [{ role: "user", content: "hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const wrapped = plugin.wrapStreamFn?.(
+			wrapCtx(streamOf([startEvent(), doneEvent(makeUsage(500, 1500))])),
+		);
+		const ctx: Context = makeContext();
 
 		const drain = async () => {
 			// biome-ignore lint/style/noNonNullAssertion: guarded by the test setup
-			for await (const _e of wrapped!("claude-sonnet-4-6", ctx)) {
+			for await (const _e of await wrapped!(MODEL, ctx)) {
 				// drain
 			}
 		};
@@ -240,26 +228,22 @@ describe("createUsertrustPlugin (factory)", () => {
 		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
 
 		// A stream that produces many chunks and never gets to `done`
-		const rawStreamFn: StreamFn = async function* () {
-			yield { type: "start" as const };
-			for (let i = 0; i < 100; i++) {
-				yield { type: "text_delta" as const, text: `chunk-${i}` };
-			}
-			yield {
-				type: "done" as const,
-				stopReason: "stop" as const,
-				usage: { inputTokens: 10, outputTokens: 100 },
-			};
-		};
+		const rawStreamFn: StreamFn = () =>
+			asHostStream(
+				(async function* () {
+					yield startEvent();
+					for (let i = 0; i < 100; i++) {
+						yield textDelta(`chunk-${i}`);
+					}
+					yield doneEvent(makeUsage(10, 100));
+				})(),
+			);
 
-		const wrapped = plugin.wrapStreamFn?.(rawStreamFn);
-		const ctx: StreamContext = {
-			messages: [{ role: "user", content: "hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const wrapped = plugin.wrapStreamFn?.(wrapCtx(rawStreamFn));
+		const ctx: Context = makeContext();
 
 		// biome-ignore lint/style/noNonNullAssertion: guarded above
-		const iter = wrapped!("claude-sonnet-4-6", ctx)[Symbol.asyncIterator]();
+		const iter = (await wrapped!(MODEL, ctx))[Symbol.asyncIterator]();
 		await iter.next(); // consume one chunk
 		// Caller drops the iterator without consuming `done`. The async
 		// generator's `return()` will run the finally block — abort path.

--- a/packages/openclaw/tests/integration.test.ts
+++ b/packages/openclaw/tests/integration.test.ts
@@ -224,8 +224,9 @@ describe("createUsertrustPlugin (factory)", () => {
 		expect(succeeded * SETTLED_PER_CALL).toBeLessThanOrEqual(BUDGET);
 	});
 
-	it("settles the hold on early consumer-side termination (break)", async () => {
+	it("settles the hold at the estimate on early consumer-side termination (break)", async () => {
 		const plugin = createUsertrustPlugin({ budget: 100_000, dryRun: true, vaultBase });
+		const { getGovernor } = await import("../src/index.js");
 
 		// A stream that produces many chunks and never gets to `done`
 		const rawStreamFn: StreamFn = () =>
@@ -242,16 +243,35 @@ describe("createUsertrustPlugin (factory)", () => {
 		const wrapped = plugin.wrapStreamFn?.(wrapCtx(rawStreamFn));
 		const ctx: Context = makeContext();
 
-		// biome-ignore lint/style/noNonNullAssertion: guarded above
+		// Run one call to completion first: init is lazy, so this is what creates
+		// the governor the terminal-action spies below attach to.
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the test setup
+		for await (const _e of await wrapped!(MODEL, ctx)) {
+			// drain
+		}
+		const gov = getGovernor();
+		expect(gov).not.toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the expect above
+		const settle = vi.spyOn(gov!, "settle");
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the expect above
+		const abort = vi.spyOn(gov!, "abort");
+
+		// biome-ignore lint/style/noNonNullAssertion: guarded by the test setup
 		const iter = (await wrapped!(MODEL, ctx))[Symbol.asyncIterator]();
 		await iter.next(); // consume one chunk
-		// Caller drops the iterator without consuming `done`. The async
-		// generator's `return()` will run the finally block — abort path.
-		if (typeof iter.return === "function") {
-			await iter.return(undefined);
-		}
-		// We don't assert budget here — abort vs. settle on early-return is
-		// implementation-defined. We just assert it doesn't throw or hang.
-		expect(true).toBe(true);
+		// Caller drops the iterator without consuming `done`, unwinding the
+		// governed generator through its `finally`.
+		await iter.return?.(undefined);
+
+		// The hold must not leak. Early termination is clean, so it SETTLES the
+		// partial — at the estimate, since usage only arrives on a terminal event —
+		// and never voids. Exactly one terminal action, through the plugin seam.
+		expect(settle).toHaveBeenCalledOnce();
+		expect(abort).not.toHaveBeenCalled();
+		expect(settle.mock.calls[0]?.[1]).toMatchObject({
+			usageSource: "estimated",
+			chunksDelivered: 1,
+		});
+		vi.restoreAllMocks();
 	});
 });

--- a/packages/openclaw/tests/scarcity-block.test.ts
+++ b/packages/openclaw/tests/scarcity-block.test.ts
@@ -1,0 +1,551 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * scarcity-block.test.ts — Ship 2, Task 6.
+ *
+ * Three parts:
+ *  1. The pure helpers (`formatScarcityBlock`, `injectScarcityBlock`,
+ *     `estimationMessages`) — exact format, copy semantics, exactly-once
+ *     representation.
+ *  2. The injection wiring through `wrapStreamWithGovernance`: delivery on
+ *     `Context.systemPrompt` (contract-notes §4), estimation honesty
+ *     (`authorize()`'s messages), and every A8 failure leg (empty read,
+ *     rejected read, the injector's OWN formatter failure, `scarcityContext:
+ *     false`) degrading to no block rather than gating/delaying/throwing.
+ *  3. The receipt seam (`opts.onReceipt`): fires with the settle receipt,
+ *     isolates both a synchronous throw and a returned rejection, and never
+ *     delays stream termination.
+ *
+ * `formatScarcityBlock` is mocked (delegating to the real implementation by
+ * default) ONLY so the "injector's own failure" case can force it to throw
+ * from OUTSIDE `scarcity-block.ts` — `stream-governor.ts`'s cross-module
+ * import of it is what makes this interceptable; a same-module self-call
+ * would not be (see `scarcity-block.ts`'s module doc for why the try/catches
+ * are split the way they are).
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { EnvelopeStatus, Governor, TrustReceipt } from "usertrust";
+import { createGovernor } from "usertrust";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeCostCenters } from "../src/index.js";
+import {
+	envelopeDescriptorsFrom,
+	estimationMessages,
+	formatScarcityBlock,
+	injectScarcityBlock,
+} from "../src/scarcity-block.js";
+import { wrapStreamWithGovernance } from "../src/stream-governor.js";
+import type { Context, FrozenCostCenters, StreamEvent, StreamFn } from "../src/types.js";
+import {
+	asHostStream,
+	assistantToolCalls,
+	doneEvent,
+	makeModel,
+	makeUsage,
+	streamOf,
+	toolResult,
+	userMessage,
+} from "./host-fixtures.js";
+
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// `formatScarcityBlock` delegates to the real implementation by default, so
+// every OTHER test in this file (including Part 1's direct unit tests, which
+// import the same binding) is unaffected — only the one test that calls
+// `.mockImplementationOnce` on it observes a throw.
+vi.mock("../src/scarcity-block.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/scarcity-block.js")>();
+	return { ...actual, formatScarcityBlock: vi.fn(actual.formatScarcityBlock) };
+});
+
+const model = makeModel();
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `openclaw-scarcity-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+async function drain(stream: AsyncIterable<StreamEvent>): Promise<void> {
+	for await (const _event of stream) {
+		// consume
+	}
+}
+
+/** Guards against a promise that never settles, per `stream-governor.test.ts`. */
+async function withTimeout<T>(promise: Promise<T>, ms = 500): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error("promise never settled")), ms);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+function okStream(): StreamFn {
+	return streamOf([doneEvent(makeUsage(50, 20))]);
+}
+
+// ── Part 1: the pure helpers ──
+
+describe("formatScarcityBlock", () => {
+	it("formats percent, the runway clause, and the · join exactly per spec", () => {
+		const statuses: EnvelopeStatus[] = [
+			{
+				costCenter: "research",
+				allocated: 10_000,
+				spent: 6_600,
+				remaining: 3_400,
+				fraction: 0.34,
+				runwayHours: 2.1,
+			},
+			{
+				costCenter: "verification",
+				allocated: 5_000,
+				spent: 550,
+				remaining: 4_450,
+				fraction: 0.89,
+				runwayHours: null,
+			},
+		];
+		expect(formatScarcityBlock(statuses)).toBe(
+			"[usertrust scarcity] research: 34% left (~2.1h runway) · verification: 89% left",
+		);
+	});
+
+	it("percent is round(fraction·100), not floor/truncate", () => {
+		const statuses: EnvelopeStatus[] = [
+			{ costCenter: "x", allocated: 1, spent: 0, remaining: 1, fraction: 0.335, runwayHours: null },
+		];
+		expect(formatScarcityBlock(statuses)).toBe("[usertrust scarcity] x: 34% left");
+	});
+
+	it("omits the runway clause only when runwayHours is null, not when it's 0", () => {
+		const statuses: EnvelopeStatus[] = [
+			{ costCenter: "x", allocated: 1, spent: 1, remaining: 0, fraction: 0, runwayHours: 0 },
+		];
+		expect(formatScarcityBlock(statuses)).toBe("[usertrust scarcity] x: 0% left (~0.0h runway)");
+	});
+
+	it("returns null for an empty batch", () => {
+		expect(formatScarcityBlock([])).toBeNull();
+	});
+});
+
+describe("envelopeDescriptorsFrom", () => {
+	it("builds one descriptor per frozen envelope, carrying its metadata", () => {
+		const cc: FrozenCostCenters = normalizeCostCenters({
+			parentUserId: "acme",
+			tools: {},
+			envelopes: {
+				research: { allocated: 10_000, periodStartMs: 1000 },
+				verification: { allocated: 5_000, periodStartMs: 1000, periodEndMs: 2000 },
+			},
+		});
+		expect(envelopeDescriptorsFrom(cc)).toEqual([
+			{ costCenter: "research", allocated: 10_000, periodStartMs: 1000 },
+			{ costCenter: "verification", allocated: 5_000, periodStartMs: 1000, periodEndMs: 2000 },
+		]);
+	});
+});
+
+describe("injectScarcityBlock", () => {
+	it("returns the SAME context reference when there is no block to inject", () => {
+		const context: Context = { messages: [] };
+		expect(injectScarcityBlock(context, null)).toBe(context);
+	});
+
+	it("sets systemPrompt to the block alone when the context had none", () => {
+		const context: Context = { messages: [] };
+		const result = injectScarcityBlock(context, "[usertrust scarcity] x: 1% left");
+		expect(result.systemPrompt).toBe("[usertrust scarcity] x: 1% left");
+		expect(result).not.toBe(context);
+	});
+
+	it("treats an empty-string systemPrompt as absent", () => {
+		const context: Context = { messages: [], systemPrompt: "" };
+		expect(injectScarcityBlock(context, "block").systemPrompt).toBe("block");
+	});
+
+	it("appends the block onto an existing systemPrompt with a blank-line join", () => {
+		const context: Context = { messages: [], systemPrompt: "You are helpful." };
+		const result = injectScarcityBlock(context, "[usertrust scarcity] x: 1% left");
+		expect(result.systemPrompt).toBe("You are helpful.\n\n[usertrust scarcity] x: 1% left");
+	});
+
+	it("never mutates the caller's own context object — deep-untouched", () => {
+		const context: Context = {
+			messages: [userMessage("hi")],
+			systemPrompt: "sys",
+		};
+		const before = JSON.stringify(context);
+		injectScarcityBlock(context, "[usertrust scarcity] x: 1% left");
+		expect(JSON.stringify(context)).toBe(before);
+	});
+});
+
+describe("estimationMessages", () => {
+	it("returns the original messages array unchanged when there is no systemPrompt", () => {
+		const context: Context = { messages: [userMessage("hi")] };
+		expect(estimationMessages(context)).toBe(context.messages);
+	});
+
+	it("treats an empty-string systemPrompt as absent", () => {
+		const context: Context = { messages: [userMessage("hi")], systemPrompt: "" };
+		expect(estimationMessages(context)).toBe(context.messages);
+	});
+
+	it("prepends the full effective system prompt exactly once, ahead of the real messages", () => {
+		const context: Context = {
+			messages: [userMessage("hi")],
+			systemPrompt: "full effective prompt",
+		};
+		const result = estimationMessages(context);
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual({ role: "system", content: "full effective prompt" });
+		expect(result[1]).toBe(context.messages[0]);
+		// Exactly once: the text does not also appear a second time in the array.
+		const occurrences = JSON.stringify(result).split("full effective prompt").length - 1;
+		expect(occurrences).toBe(1);
+	});
+});
+
+// ── Part 2: injection wiring through the wrapper ──
+
+const PERIOD_START = Date.UTC(2026, 7, 3);
+
+const CC: FrozenCostCenters = normalizeCostCenters({
+	parentUserId: "acme",
+	tools: { web_search: "research" },
+	default: "general",
+	envelopes: {
+		research: { allocated: 10_000, periodStartMs: PERIOD_START },
+		general: { allocated: 1_000, periodStartMs: PERIOD_START },
+	},
+});
+
+const CC_NO_SCARCITY: FrozenCostCenters = normalizeCostCenters({
+	parentUserId: "acme",
+	tools: { web_search: "research" },
+	default: "general",
+	envelopes: {
+		research: { allocated: 10_000, periodStartMs: PERIOD_START },
+		general: { allocated: 1_000, periodStartMs: PERIOD_START },
+	},
+	scarcityContext: false,
+});
+
+const RESEARCH_STATUS: EnvelopeStatus = {
+	costCenter: "research",
+	allocated: 10_000,
+	spent: 6_600,
+	remaining: 3_400,
+	fraction: 0.34,
+	runwayHours: 2.1,
+};
+const RESEARCH_BLOCK = "[usertrust scarcity] research: 34% left (~2.1h runway)";
+
+describe("wrapStreamWithGovernance — scarcity injection", () => {
+	let vaultBase: string;
+	let gov: Governor;
+
+	beforeEach(async () => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+		gov = await createGovernor({ dryRun: true, budget: 100_000, vaultBase, parentUserId: "acme" });
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		vi.restoreAllMocks();
+		await gov.destroy();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup
+		}
+	});
+
+	it("delivers the block on Context.systemPrompt, into a COPIED context — the caller's own object untouched", async () => {
+		vi.spyOn(gov, "budgetContext").mockResolvedValue([RESEARCH_STATUS]);
+
+		let seenContext: Context | undefined;
+		const streamFn: StreamFn = (_model, context) => {
+			seenContext = context;
+			return asHostStream(
+				(async function* () {
+					yield doneEvent(makeUsage(10, 5));
+				})(),
+			);
+		};
+
+		const wrapped = wrapStreamWithGovernance(streamFn, gov, { costCenters: CC });
+		const original: Context = { messages: [userMessage("hi")] };
+		const before = JSON.stringify(original);
+
+		await drain(await wrapped(model, original));
+
+		expect(JSON.stringify(original)).toBe(before);
+		expect(seenContext).not.toBe(original);
+		expect(seenContext?.systemPrompt).toBe(RESEARCH_BLOCK);
+	});
+
+	it("represents the FULL effective system prompt exactly once in the messages authorize() receives", async () => {
+		vi.spyOn(gov, "budgetContext").mockResolvedValue([RESEARCH_STATUS]);
+		const authorize = vi.spyOn(gov, "authorize");
+
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC });
+		const context: Context = {
+			messages: [userMessage("hi")],
+			systemPrompt: "You are helpful.",
+		};
+
+		await drain(await wrapped(model, context));
+
+		const expectedFull = `You are helpful.\n\n${RESEARCH_BLOCK}`;
+		const messages = authorize.mock.calls[0]?.[0]?.messages as unknown[];
+		expect(messages).toHaveLength(2);
+		expect(messages[0]).toEqual({ role: "system", content: expectedFull });
+		// Exactly once — not duplicated elsewhere in the array.
+		const occurrences = JSON.stringify(messages).split(RESEARCH_BLOCK).length - 1;
+		expect(occurrences).toBe(1);
+	});
+
+	it("pins the no-scarcity case: a pre-existing systemPrompt alone still reaches estimation", async () => {
+		// No `costCenters` at all — scarcity is entirely off, but the pre-existing
+		// systemPrompt still has to reach `authorize()`'s messages (contract-notes
+		// §4: today `Context.systemPrompt` never reaches `authorize()` at all).
+		const authorize = vi.spyOn(gov, "authorize");
+		const wrapped = wrapStreamWithGovernance(okStream(), gov);
+		const context: Context = {
+			messages: [userMessage("hi")],
+			systemPrompt: "You are helpful.",
+		};
+
+		await drain(await wrapped(model, context));
+
+		const messages = authorize.mock.calls[0]?.[0]?.messages as unknown[];
+		expect(messages).toHaveLength(2);
+		expect(messages[0]).toEqual({ role: "system", content: "You are helpful." });
+	});
+
+	it("[] read → no block, call proceeds", async () => {
+		vi.spyOn(gov, "budgetContext").mockResolvedValue([]);
+		let seenContext: Context | undefined;
+		const streamFn: StreamFn = (_model, context) => {
+			seenContext = context;
+			return asHostStream(
+				(async function* () {
+					yield doneEvent(makeUsage(10, 5));
+				})(),
+			);
+		};
+
+		const wrapped = wrapStreamWithGovernance(streamFn, gov, { costCenters: CC });
+		await expect(
+			drain(await wrapped(model, { messages: [userMessage("hi")] })),
+		).resolves.toBeUndefined();
+		expect(seenContext?.systemPrompt).toBeUndefined();
+	});
+
+	it("a rejected budgetContext read → no block, call proceeds", async () => {
+		vi.spyOn(gov, "budgetContext").mockRejectedValue(new Error("ledger unreachable"));
+		let seenContext: Context | undefined;
+		const streamFn: StreamFn = (_model, context) => {
+			seenContext = context;
+			return asHostStream(
+				(async function* () {
+					yield doneEvent(makeUsage(10, 5));
+				})(),
+			);
+		};
+
+		const wrapped = wrapStreamWithGovernance(streamFn, gov, { costCenters: CC });
+		await expect(
+			drain(await wrapped(model, { messages: [userMessage("hi")] })),
+		).resolves.toBeUndefined();
+		expect(seenContext?.systemPrompt).toBeUndefined();
+	});
+
+	it("the injector's own failure (formatter throw injected) → no block, call proceeds", async () => {
+		vi.spyOn(gov, "budgetContext").mockResolvedValue([RESEARCH_STATUS]);
+		(formatScarcityBlock as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+			throw new Error("format_boom");
+		});
+
+		let seenContext: Context | undefined;
+		const streamFn: StreamFn = (_model, context) => {
+			seenContext = context;
+			return asHostStream(
+				(async function* () {
+					yield doneEvent(makeUsage(10, 5));
+				})(),
+			);
+		};
+
+		const wrapped = wrapStreamWithGovernance(streamFn, gov, { costCenters: CC });
+		await expect(
+			drain(await wrapped(model, { messages: [userMessage("hi")] })),
+		).resolves.toBeUndefined();
+		expect(seenContext?.systemPrompt).toBeUndefined();
+	});
+
+	it("scarcityContext: false → no read at all", async () => {
+		const budgetContext = vi.spyOn(gov, "budgetContext");
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, { costCenters: CC_NO_SCARCITY });
+
+		await drain(await wrapped(model, { messages: [userMessage("hi")] }));
+
+		expect(budgetContext).not.toHaveBeenCalled();
+	});
+});
+
+// ── Part 3: the receipt seam (opts.onReceipt) ──
+
+function makeMockEngine(balance: number) {
+	return {
+		spendPending: vi.fn(async (p: { transferId: string }) => ({ transferId: p.transferId })),
+		postPendingSpend: vi.fn(async () => {}),
+		voidPendingSpend: vi.fn(async () => {}),
+		voidAllPending: vi.fn(async () => {}),
+		destroy: vi.fn(),
+		lookupBalances: vi.fn(
+			async (ids: bigint[]) => new Map<bigint, number>(ids.map((id) => [id, balance])),
+		),
+	};
+}
+
+/** A context whose trailing run attributes to `research` via `CC_ONRECEIPT`'s map. */
+function attributedContext(): Context {
+	return {
+		messages: [userMessage("go"), assistantToolCalls("web_search"), toolResult("web_search")],
+	};
+}
+
+const CC_ONRECEIPT: FrozenCostCenters = normalizeCostCenters({
+	parentUserId: "acme",
+	tools: { web_search: "research" },
+	default: "general",
+	envelopes: {
+		research: { allocated: 10_000, periodStartMs: PERIOD_START },
+		general: { allocated: 1_000, periodStartMs: PERIOD_START },
+	},
+	// Isolates this describe block's concern (the receipt seam) from
+	// scarcity injection's own — both read the same mock engine, and mixing
+	// the two would leave it ambiguous which feature a given assertion pins.
+	scarcityContext: false,
+});
+
+describe("wrapStreamWithGovernance — onReceipt", () => {
+	let vaultBase: string;
+	let engine: ReturnType<typeof makeMockEngine>;
+	let gov: Governor;
+
+	beforeEach(async () => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+		engine = makeMockEngine(4_000);
+		gov = await createGovernor({
+			budget: 100_000,
+			vaultBase,
+			parentUserId: "acme",
+			_engine: engine,
+		});
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		vi.restoreAllMocks();
+		await gov.destroy();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup
+		}
+	});
+
+	it("fires with the settle receipt — attributed case, receipt.budget.costCenter matches", async () => {
+		const received: TrustReceipt[] = [];
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, {
+			costCenters: CC_ONRECEIPT,
+			onReceipt: (r) => {
+				received.push(r);
+			},
+		});
+
+		await drain(await wrapped(model, attributedContext()));
+
+		expect(received).toHaveLength(1);
+		expect(received[0]?.budget?.costCenter).toBe("research");
+	});
+
+	it("isolates a SYNCHRONOUS throw from the callback — the stream still completes", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, {
+			costCenters: CC_ONRECEIPT,
+			onReceipt: () => {
+				throw new Error("callback_boom");
+			},
+		});
+
+		const stream = await wrapped(model, attributedContext());
+		await expect(drain(stream)).resolves.toBeUndefined();
+		await expect(withTimeout(stream.result())).resolves.toBeDefined();
+	});
+
+	it("isolates a returned REJECTION from the callback — the stream still completes", async () => {
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, {
+			costCenters: CC_ONRECEIPT,
+			onReceipt: () => Promise.reject(new Error("callback_rejection")),
+		});
+
+		const stream = await wrapped(model, attributedContext());
+		await expect(drain(stream)).resolves.toBeUndefined();
+		await expect(withTimeout(stream.result())).resolves.toBeDefined();
+	});
+
+	it("never delays stream termination — settle/result finish before a slow callback does", async () => {
+		const order: string[] = [];
+		const wrapped = wrapStreamWithGovernance(okStream(), gov, {
+			costCenters: CC_ONRECEIPT,
+			onReceipt: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				order.push("callback");
+			},
+		});
+
+		const stream = await wrapped(model, attributedContext());
+		await drain(stream);
+		order.push("drained");
+		await withTimeout(stream.result());
+		order.push("result");
+
+		// The callback is still in flight — drain/result did not wait on it.
+		expect(order).toEqual(["drained", "result"]);
+
+		await new Promise((resolve) => setTimeout(resolve, 80));
+		expect(order).toEqual(["drained", "result", "callback"]);
+	});
+});

--- a/packages/openclaw/tests/stream-governor.test.ts
+++ b/packages/openclaw/tests/stream-governor.test.ts
@@ -6,7 +6,18 @@ import type { Governor } from "usertrust";
 import { createGovernor } from "usertrust";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { wrapCompleteWithGovernance, wrapStreamWithGovernance } from "../src/stream-governor.js";
-import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+import type { Context, StreamEvent, StreamFn, StreamOptions } from "../src/types.js";
+import {
+	asHostStream,
+	doneEvent,
+	makeAssistantMessage,
+	makeContext,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+	textDelta,
+} from "./host-fixtures.js";
 
 // Mock tigerbeetle-node
 vi.mock("tigerbeetle-node", () => ({
@@ -37,24 +48,23 @@ function makeTmpVault(): string {
 	return dir;
 }
 
-/** Create a mock pi-ai stream function that yields predefined events. */
-function mockStreamFn(events: StreamEvent[]): StreamFn {
-	return async function* (_model: string, _context: StreamContext) {
-		for (const event of events) {
-			yield event;
-		}
-	};
-}
+/** Create a mock host stream function that yields predefined events. */
+const mockStreamFn = streamOf;
 
 /** Create a mock stream that throws an error mid-stream. */
 function mockFailingStreamFn(errorAfter: number): StreamFn {
-	return async function* (_model: string, _context: StreamContext) {
-		for (let i = 0; i < errorAfter; i++) {
-			yield { type: "text_delta" as const, text: `chunk ${i}` };
-		}
-		throw new Error("stream_failed");
-	};
+	return () =>
+		asHostStream(
+			(async function* () {
+				for (let i = 0; i < errorAfter; i++) {
+					yield textDelta(`chunk ${i}`);
+				}
+				throw new Error("stream_failed");
+			})(),
+		);
 }
+
+const model = makeModel();
 
 // ── Tests ──
 
@@ -83,29 +93,23 @@ describe("wrapStreamWithGovernance", () => {
 	});
 
 	it("wraps a stream and forwards all events", async () => {
+		const partial = makeAssistantMessage();
 		const events: StreamEvent[] = [
-			{ type: "start" },
-			{ type: "text_start" },
-			{ type: "text_delta", text: "Hello" },
-			{ type: "text_delta", text: " world" },
-			{ type: "text_end" },
-			{
-				type: "done",
-				stopReason: "stop",
-				usage: { inputTokens: 50, outputTokens: 20 },
-			},
+			startEvent(),
+			{ type: "text_start", contentIndex: 0, partial },
+			textDelta("Hello"),
+			textDelta(" world"),
+			{ type: "text_end", contentIndex: 0, content: "Hello world", partial },
+			doneEvent(makeUsage(50, 20)),
 		];
 
 		const streamFn = mockStreamFn(events);
 		const governed = wrapStreamWithGovernance(streamFn, gov);
 
 		const collected: StreamEvent[] = [];
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const context: Context = makeContext();
 
-		for await (const event of governed("claude-sonnet-4-6", context)) {
+		for await (const event of await governed(model, context)) {
 			collected.push(event);
 		}
 
@@ -115,25 +119,14 @@ describe("wrapStreamWithGovernance", () => {
 	});
 
 	it("deducts budget after successful stream", async () => {
-		const events: StreamEvent[] = [
-			{ type: "start" },
-			{ type: "text_delta", text: "Hi" },
-			{
-				type: "done",
-				stopReason: "stop",
-				usage: { inputTokens: 100, outputTokens: 50 },
-			},
-		];
+		const events: StreamEvent[] = [startEvent(), textDelta("Hi"), doneEvent(makeUsage(100, 50))];
 
 		const governed = wrapStreamWithGovernance(mockStreamFn(events), gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hello" }],
-			model: "claude-sonnet-4-6",
-		};
+		const context: Context = makeContext();
 
 		const budgetBefore = gov.budgetRemaining();
 
-		for await (const _event of governed("claude-sonnet-4-6", context)) {
+		for await (const _event of await governed(model, context)) {
 			// consume stream
 		}
 
@@ -142,16 +135,13 @@ describe("wrapStreamWithGovernance", () => {
 
 	it("aborts governance on stream error", async () => {
 		const governed = wrapStreamWithGovernance(mockFailingStreamFn(3), gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hello" }],
-			model: "claude-sonnet-4-6",
-		};
+		const context: Context = makeContext();
 
 		const budgetBefore = gov.budgetRemaining();
 
 		const collected: StreamEvent[] = [];
 		await expect(async () => {
-			for await (const event of governed("claude-sonnet-4-6", context)) {
+			for await (const event of await governed(model, context)) {
 				collected.push(event);
 			}
 		}).rejects.toThrow("stream_failed");
@@ -165,25 +155,18 @@ describe("wrapStreamWithGovernance", () => {
 
 	it("handles multiple concurrent streams", async () => {
 		const events: StreamEvent[] = [
-			{ type: "start" },
-			{ type: "text_delta", text: "response" },
-			{
-				type: "done",
-				stopReason: "stop",
-				usage: { inputTokens: 30, outputTokens: 10 },
-			},
+			startEvent(),
+			textDelta("response"),
+			doneEvent(makeUsage(30, 10)),
 		];
 
 		const governed = wrapStreamWithGovernance(mockStreamFn(events), gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const context: Context = makeContext();
 
 		// Run two streams concurrently
 		const stream1 = (async () => {
 			const result: StreamEvent[] = [];
-			for await (const e of governed("claude-sonnet-4-6", context)) {
+			for await (const e of await governed(model, context)) {
 				result.push(e);
 			}
 			return result;
@@ -191,7 +174,7 @@ describe("wrapStreamWithGovernance", () => {
 
 		const stream2 = (async () => {
 			const result: StreamEvent[] = [];
-			for await (const e of governed("claude-sonnet-4-6", context)) {
+			for await (const e of await governed(model, context)) {
 				result.push(e);
 			}
 			return result;
@@ -233,16 +216,13 @@ describe("wrapCompleteWithGovernance", () => {
 	it("wraps a completion function with governance", async () => {
 		const completeFn = vi.fn(async () => ({
 			content: "Hello!",
-			usage: { inputTokens: 50, outputTokens: 10 },
+			usage: makeUsage(50, 10),
 		}));
 
 		const governed = wrapCompleteWithGovernance(completeFn, gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const context: Context = makeContext();
 
-		const result = await governed("claude-sonnet-4-6", context);
+		const result = await governed(model, context);
 
 		expect(result.content).toBe("Hello!");
 		expect(completeFn).toHaveBeenCalledOnce();
@@ -255,14 +235,11 @@ describe("wrapCompleteWithGovernance", () => {
 		});
 
 		const governed = wrapCompleteWithGovernance(completeFn, gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const context: Context = makeContext();
 
 		const budgetBefore = gov.budgetRemaining();
 
-		await expect(governed("claude-sonnet-4-6", context)).rejects.toThrow("completion_failed");
+		await expect(governed(model, context)).rejects.toThrow("completion_failed");
 
 		// Budget restored after abort
 		expect(gov.budgetRemaining()).toBe(budgetBefore);
@@ -274,14 +251,10 @@ describe("wrapCompleteWithGovernance", () => {
 		}));
 
 		const governed = wrapCompleteWithGovernance(completeFn, gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hi" }],
-			model: "claude-sonnet-4-6",
-			maxTokens: 2000,
-			temperature: 0.7,
-		};
+		const context: Context = makeContext();
+		const options: StreamOptions = { maxTokens: 2000, temperature: 0.7 };
 
-		const result = await governed("claude-sonnet-4-6", context);
+		const result = await governed(model, context, options);
 
 		expect(result.content).toBe("Hello!");
 		expect(gov.budgetRemaining()).toBeLessThan(100_000);
@@ -312,52 +285,44 @@ describe("wrapStreamWithGovernance with maxTokens/temperature", () => {
 		}
 	});
 
-	it("passes maxTokens and temperature through authorize params", async () => {
-		const events: StreamEvent[] = [
-			{ type: "start" },
-			{
-				type: "done",
-				stopReason: "stop",
-				usage: { inputTokens: 10, outputTokens: 5 },
-			},
-		];
+	it("reads maxTokens/temperature from options, not the context, and authorizes model.id", async () => {
+		const events: StreamEvent[] = [startEvent(), doneEvent(makeUsage(10, 5))];
 
 		const governed = wrapStreamWithGovernance(mockStreamFn(events), gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hi" }],
-			model: "claude-sonnet-4-6",
-			maxTokens: 1000,
-			temperature: 0.5,
-		};
+		const context: Context = makeContext();
+		const options: StreamOptions = { maxTokens: 1000, temperature: 0.5 };
+		const authorize = vi.spyOn(gov, "authorize");
 
 		const collected: StreamEvent[] = [];
-		for await (const event of governed("claude-sonnet-4-6", context)) {
+		for await (const event of await governed(model, context, options)) {
 			collected.push(event);
 		}
 
 		expect(collected).toHaveLength(2);
+		expect(authorize).toHaveBeenCalledOnce();
+		expect(authorize.mock.calls[0]?.[0]).toMatchObject({
+			model: model.id,
+			maxOutputTokens: 1000,
+			params: { temperature: 0.5 },
+		});
 		expect(gov.budgetRemaining()).toBeLessThan(100_000);
 	});
 
 	it("handles stream without usage reporting (falls back to estimated)", async () => {
+		const partial = makeAssistantMessage();
 		const events: StreamEvent[] = [
-			{ type: "start" },
-			{ type: "text_delta", text: "hello" },
-			{ type: "text_end" },
+			startEvent(),
+			textDelta("hello"),
+			{ type: "text_end", contentIndex: 0, content: "hello", partial },
 		];
 
 		// Stream ends without a done event that has usage
-		const noUsageStreamFn: StreamFn = async function* () {
-			for (const e of events) yield e;
-		};
+		const noUsageStreamFn: StreamFn = streamOf(events);
 
 		const governed = wrapStreamWithGovernance(noUsageStreamFn, gov);
-		const context: StreamContext = {
-			messages: [{ role: "user", content: "Hi" }],
-			model: "claude-sonnet-4-6",
-		};
+		const context: Context = makeContext();
 
-		for await (const _event of governed("claude-sonnet-4-6", context)) {
+		for await (const _event of await governed(model, context)) {
 			// consume
 		}
 

--- a/packages/openclaw/tests/stream-governor.test.ts
+++ b/packages/openclaw/tests/stream-governor.test.ts
@@ -66,6 +66,33 @@ function mockFailingStreamFn(errorAfter: number): StreamFn {
 
 const model = makeModel();
 
+/**
+ * Guard against a promise that never settles. A hung `result()` would otherwise
+ * show up as an opaque test-suite timeout instead of a named assertion failure.
+ */
+async function withTimeout<T>(promise: Promise<T>, ms = 500): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error("promise never settled")), ms);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+/** Iterate a governed stream to exhaustion, discarding the events. */
+function drain(stream: AsyncIterable<StreamEvent>): Promise<void> {
+	return (async () => {
+		for await (const _event of stream) {
+			// consume
+		}
+	})();
+}
+
 // ── Tests ──
 
 describe("wrapStreamWithGovernance", () => {
@@ -327,5 +354,134 @@ describe("wrapStreamWithGovernance with maxTokens/temperature", () => {
 		}
 
 		expect(gov.budgetRemaining()).toBeLessThan(100_000);
+	});
+});
+
+/**
+ * `result()` is backed by a deferred. It MUST settle on every terminal path of
+ * the governed run — otherwise the host's normal pattern (iterate for UI events,
+ * await `result()` for the final message) hangs forever, or worse, reports a
+ * successful assistant message for a call governance actually voided.
+ */
+describe("wrapStreamWithGovernance result() settlement", () => {
+	let vaultBase: string;
+	let gov: Governor;
+
+	beforeEach(async () => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+		gov = await createGovernor({ dryRun: true, budget: 100_000, vaultBase });
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		vi.restoreAllMocks();
+		await gov.destroy();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup
+		}
+	});
+
+	const okEvents: StreamEvent[] = [startEvent(), textDelta("hi"), doneEvent(makeUsage(10, 5))];
+
+	it("rejects result() on a policy DENY when the consumer also iterates", async () => {
+		vi.spyOn(gov, "authorize").mockRejectedValue(new Error("policy_denied"));
+
+		const governed = wrapStreamWithGovernance(mockStreamFn(okEvents), gov);
+		const stream = await governed(model, makeContext());
+
+		// Iterating first marks the stream consumed, so `result()` cannot fall
+		// back to its own drain — the governed run has to settle the deferred.
+		await expect(drain(stream)).rejects.toThrow("policy_denied");
+		await expect(withTimeout(stream.result())).rejects.toThrow("policy_denied");
+	});
+
+	it("rejects result() on a policy DENY for a result()-only consumer", async () => {
+		vi.spyOn(gov, "authorize").mockRejectedValue(new Error("policy_denied"));
+
+		const governed = wrapStreamWithGovernance(mockStreamFn(okEvents), gov);
+		const stream = await governed(model, makeContext());
+
+		await expect(withTimeout(stream.result())).rejects.toThrow("policy_denied");
+	});
+
+	it("rejects result() when the budget is exhausted and the consumer also iterates", async () => {
+		vi.spyOn(gov, "budgetRemaining").mockReturnValue(0);
+
+		const governed = wrapStreamWithGovernance(mockStreamFn(okEvents), gov);
+		const stream = await governed(model, makeContext());
+
+		await expect(drain(stream)).rejects.toThrow("budget exhausted");
+		await expect(withTimeout(stream.result())).rejects.toThrow("budget exhausted");
+	});
+
+	it("rejects result() when settle fails after the provider stream succeeded", async () => {
+		vi.spyOn(gov, "settle").mockRejectedValue(new Error("settle_failed"));
+
+		const governed = wrapStreamWithGovernance(mockStreamFn(okEvents), gov);
+		const stream = await governed(model, makeContext());
+
+		// The provider's own `result()` resolves as soon as its stream ends —
+		// well before settle runs. `result()` must not report that success.
+		await expect(drain(stream)).rejects.toThrow("settle_failed");
+		await expect(withTimeout(stream.result())).rejects.toThrow("settle_failed");
+	});
+
+	it("surfaces a settle failure to a result()-only consumer instead of swallowing it", async () => {
+		vi.spyOn(gov, "settle").mockRejectedValue(new Error("settle_failed"));
+
+		const governed = wrapStreamWithGovernance(mockStreamFn(okEvents), gov);
+		const stream = await governed(model, makeContext());
+
+		await expect(withTimeout(stream.result())).rejects.toThrow("settle_failed");
+	});
+
+	it("rejects result() when the provider stream itself fails mid-flight", async () => {
+		const governed = wrapStreamWithGovernance(mockFailingStreamFn(2), gov);
+		const stream = await governed(model, makeContext());
+
+		await expect(drain(stream)).rejects.toThrow("stream_failed");
+		await expect(withTimeout(stream.result())).rejects.toThrow("stream_failed");
+	});
+
+	it("rejects result() when the consumer abandons the stream early", async () => {
+		const governed = wrapStreamWithGovernance(mockStreamFn(okEvents), gov);
+		const stream = await governed(model, makeContext());
+
+		for await (const _event of stream) {
+			break; // caller walks away before `done`
+		}
+
+		await expect(withTimeout(stream.result())).rejects.toThrow("abandoned before completion");
+	});
+
+	it("resolves result() with the host's final message, and only after settle", async () => {
+		const order: string[] = [];
+		vi.spyOn(gov, "settle").mockImplementation(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			order.push("settle");
+		});
+
+		const finalMessage = makeAssistantMessage(makeUsage(10, 5));
+		const streamFn: StreamFn = () =>
+			asHostStream(
+				(async function* () {
+					for (const event of okEvents) yield event;
+				})(),
+				finalMessage,
+			);
+
+		const governed = wrapStreamWithGovernance(streamFn, gov);
+		const stream = await governed(model, makeContext());
+
+		const iteration = drain(stream);
+		const got = await withTimeout(stream.result());
+		order.push("result");
+		await iteration;
+
+		expect(got).toBe(finalMessage);
+		expect(order).toEqual(["settle", "result"]);
 	});
 });

--- a/packages/openclaw/tests/stream-governor.test.ts
+++ b/packages/openclaw/tests/stream-governor.test.ts
@@ -17,6 +17,7 @@ import {
 	startEvent,
 	streamOf,
 	textDelta,
+	withTimeout,
 } from "./host-fixtures.js";
 
 // Mock tigerbeetle-node
@@ -65,24 +66,6 @@ function mockFailingStreamFn(errorAfter: number): StreamFn {
 }
 
 const model = makeModel();
-
-/**
- * Guard against a promise that never settles. A hung `result()` would otherwise
- * show up as an opaque test-suite timeout instead of a named assertion failure.
- */
-async function withTimeout<T>(promise: Promise<T>, ms = 500): Promise<T> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		return await Promise.race([
-			promise,
-			new Promise<never>((_resolve, reject) => {
-				timer = setTimeout(() => reject(new Error("promise never settled")), ms);
-			}),
-		]);
-	} finally {
-		if (timer !== undefined) clearTimeout(timer);
-	}
-}
 
 /** Iterate a governed stream to exhaustion, discarding the events. */
 function drain(stream: AsyncIterable<StreamEvent>): Promise<void> {

--- a/packages/openclaw/tests/terminal-modes.test.ts
+++ b/packages/openclaw/tests/terminal-modes.test.ts
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * terminal-modes.test.ts — exactly one terminal ledger action per authorization.
+ *
+ * A stream can end six ways: normal completion, close-without-a-terminal-event,
+ * a terminal `error` event, a thrown provider error, a consumer `break`, and an
+ * explicit `iterator.return()`. Each must produce EXACTLY ONE of
+ * `governor.settle` / `governor.abort` — never zero (a leaked PENDING hold) and
+ * never two (AGENTS.md, "Exactly one ledger mutation per hold").
+ *
+ * The clean-but-early paths (break / return / close-without-done) settle at the
+ * ESTIMATE: the accumulator only learns tokens from terminal events
+ * (token-extractor.ts `extractUsageFromEvent`), so there is no provider usage to
+ * settle with. That asymmetry — settle the partial, do not void — is the
+ * documented one in AGENTS.md, "The settle/void asymmetry is deliberate."
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Governor } from "usertrust";
+import { createGovernor } from "usertrust";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { wrapStreamWithGovernance } from "../src/stream-governor.js";
+import type { StreamEvent, StreamFn } from "../src/types.js";
+import {
+	asHostStream,
+	doneEvent,
+	errorEvent,
+	makeContext,
+	makeModel,
+	makeUsage,
+	startEvent,
+	streamOf,
+	textDelta,
+} from "./host-fixtures.js";
+
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferError: { exists: 1, exceeds_credits: 34 },
+	CreateAccountError: { exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+const model = makeModel();
+
+function makeTmpVault(): string {
+	const dir = join(tmpdir(), `openclaw-terminal-test-${randomUUID()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+/** A long stream a consumer can walk away from long before the `done` event. */
+function longStreamFn(): StreamFn {
+	return () =>
+		asHostStream(
+			(async function* () {
+				yield startEvent();
+				for (let i = 0; i < 50; i++) yield textDelta(`chunk-${i}`);
+				yield doneEvent(makeUsage(10, 100));
+			})(),
+		);
+}
+
+/** A stream that throws mid-flight instead of reaching a terminal event. */
+function throwingStreamFn(): StreamFn {
+	return () =>
+		asHostStream(
+			(async function* () {
+				yield startEvent();
+				throw new Error("provider_exploded");
+			})(),
+		);
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms = 500): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_resolve, reject) => {
+				timer = setTimeout(() => reject(new Error("promise never settled")), ms);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+describe("stream terminal modes", () => {
+	let vaultBase: string;
+	let gov: Governor;
+	let settle: ReturnType<typeof vi.spyOn>;
+	let abort: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(async () => {
+		vaultBase = makeTmpVault();
+		process.env.USERTRUST_TEST = "1";
+		gov = await createGovernor({ dryRun: true, budget: 100_000, vaultBase });
+		settle = vi.spyOn(gov, "settle");
+		abort = vi.spyOn(gov, "abort");
+	});
+
+	afterEach(async () => {
+		process.env.USERTRUST_TEST = "";
+		vi.restoreAllMocks();
+		await gov.destroy();
+		try {
+			rmSync(vaultBase, { recursive: true, force: true });
+		} catch {
+			// cleanup
+		}
+	});
+
+	/** Total terminal ledger actions taken for the authorization. */
+	function terminalCount(): number {
+		return settle.mock.calls.length + abort.mock.calls.length;
+	}
+
+	/** The `SettleParams` the sole settle call was made with. */
+	function settleParams(): Record<string, unknown> {
+		return settle.mock.calls[0]?.[1] as Record<string, unknown>;
+	}
+
+	it("settles at the estimate when the consumer breaks mid-stream", async () => {
+		const governed = wrapStreamWithGovernance(longStreamFn(), gov);
+
+		for await (const _event of await governed(model, makeContext())) {
+			break; // caller walks away before `done`
+		}
+
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		const params = settleParams();
+		expect(params.usageSource).toBe("estimated");
+		expect(params).not.toHaveProperty("inputTokens");
+		expect(params).not.toHaveProperty("outputTokens");
+		expect(params.chunksDelivered).toBe(1);
+	});
+
+	it("settles at the estimate when the consumer calls iterator.return()", async () => {
+		const governed = wrapStreamWithGovernance(longStreamFn(), gov);
+
+		const iterator = (await governed(model, makeContext()))[Symbol.asyncIterator]();
+		await iterator.next();
+		await iterator.next();
+		await iterator.return?.(undefined);
+
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(settleParams().usageSource).toBe("estimated");
+		expect(settleParams().chunksDelivered).toBe(2);
+	});
+
+	it("aborts exactly once when the provider stream throws", async () => {
+		const governed = wrapStreamWithGovernance(throwingStreamFn(), gov);
+		const stream = await governed(model, makeContext());
+
+		await expect(async () => {
+			for await (const _event of stream) {
+				// drain
+			}
+		}).rejects.toThrow("provider_exploded");
+
+		expect(terminalCount()).toBe(1);
+		expect(abort).toHaveBeenCalledOnce();
+		expect(settle).not.toHaveBeenCalled();
+	});
+
+	it("aborts exactly once when the stream ends on a terminal error EVENT", async () => {
+		// Per contract-notes §3 the `error` event is terminal and carries an
+		// AssistantMessage, not a throw — the iteration simply ends after it.
+		const events: StreamEvent[] = [startEvent(), textDelta("partial"), errorEvent(makeUsage(9, 3))];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		const collected: StreamEvent[] = [];
+		for await (const event of stream) {
+			collected.push(event);
+		}
+
+		// The event itself is forwarded unchanged; only the hold treatment differs.
+		expect(collected).toHaveLength(3);
+		expect(collected[2]?.type).toBe("error");
+
+		expect(terminalCount()).toBe(1);
+		expect(abort).toHaveBeenCalledOnce();
+		expect(settle).not.toHaveBeenCalled();
+
+		// A voided call has no successful final message to report.
+		await expect(withTimeout(stream.result())).rejects.toThrow("boom");
+	});
+
+	it("settles at the estimate when the stream closes without any terminal event", async () => {
+		const events: StreamEvent[] = [startEvent(), textDelta("orphaned")];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+
+		for await (const _event of await governed(model, makeContext())) {
+			// drain to natural end — no `done`, no `error`
+		}
+
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(settleParams().usageSource).toBe("estimated");
+		expect(settleParams()).not.toHaveProperty("inputTokens");
+	});
+
+	it("settles exactly once at provider usage on normal completion", async () => {
+		const events: StreamEvent[] = [startEvent(), textDelta("hi"), doneEvent(makeUsage(120, 45))];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+
+		for await (const _event of await governed(model, makeContext())) {
+			// drain
+		}
+
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(settle.mock.calls[0]?.[1]).toMatchObject({
+			inputTokens: 120,
+			outputTokens: 45,
+			usageSource: "provider",
+			chunksDelivered: 3,
+		});
+	});
+
+	it("takes no ledger action when the pre-flight budget check denies the call", async () => {
+		vi.spyOn(gov, "budgetRemaining").mockReturnValue(0);
+		const governed = wrapStreamWithGovernance(longStreamFn(), gov);
+
+		await expect(async () => {
+			for await (const _event of await governed(model, makeContext())) {
+				// drain
+			}
+		}).rejects.toThrow("budget exhausted");
+
+		// No hold was ever created, so there is nothing to settle or abort.
+		expect(terminalCount()).toBe(0);
+	});
+
+	it("takes no ledger action when authorize() rejects", async () => {
+		vi.spyOn(gov, "authorize").mockRejectedValue(new Error("policy_denied"));
+		const governed = wrapStreamWithGovernance(longStreamFn(), gov);
+
+		await expect(async () => {
+			for await (const _event of await governed(model, makeContext())) {
+				// drain
+			}
+		}).rejects.toThrow("policy_denied");
+
+		expect(terminalCount()).toBe(0);
+	});
+
+	it("still releases the hold when the abandonment settle itself fails", async () => {
+		settle.mockRejectedValue(new Error("settle_unavailable"));
+		const governed = wrapStreamWithGovernance(longStreamFn(), gov);
+
+		for await (const _event of await governed(model, makeContext())) {
+			break;
+		}
+
+		// Settle failed, so the hold would dangle PENDING — abort is the fallback
+		// that returns the money, and it must not escape the `finally`.
+		expect(settle).toHaveBeenCalledOnce();
+		expect(abort).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/openclaw/tests/terminal-modes.test.ts
+++ b/packages/openclaw/tests/terminal-modes.test.ts
@@ -4,11 +4,12 @@
 /**
  * terminal-modes.test.ts — exactly one terminal ledger action per authorization.
  *
- * A stream can end six ways: normal completion, close-without-a-terminal-event,
- * a terminal `error` event, a thrown provider error, a consumer `break`, and an
- * explicit `iterator.return()`. Each must produce EXACTLY ONE of
- * `governor.settle` / `governor.abort` — never zero (a leaked PENDING hold) and
- * never two (AGENTS.md, "Exactly one ledger mutation per hold").
+ * A stream can end seven ways: normal completion, close-without-a-terminal-event,
+ * a terminal `error` event with `reason: "error"`, the SAME event with
+ * `reason: "aborted"`, a thrown provider error, a consumer `break`, and an
+ * explicit `iterator.return()`. Each must produce EXACTLY ONE ledger mutation —
+ * never zero (a leaked PENDING hold) and never two (AGENTS.md, "Exactly one
+ * ledger mutation per hold").
  *
  * The clean-but-early paths (break / return / close-without-done) settle at the
  * ESTIMATE: the accumulator only learns tokens from terminal events
@@ -16,11 +17,17 @@
  * settle with. That asymmetry — settle the partial, do not void — is the
  * documented one in AGENTS.md, "The settle/void asymmetry is deliberate."
  *
- * Where those two axes CROSS — the consumer breaks immediately after a terminal
- * event — the terminal event the loop observed wins, not the unwind: break after
- * `done` settles at the provider's usage (it was captured before the `yield`),
- * break after `error` aborts. Otherwise a failed call gets charged, and a fully
- * served one gets charged at the estimate.
+ * VOIDING IS NARROW. Only two things void a hold: a THROW, and an `error` event
+ * whose `reason` is `"error"`. `reason: "aborted"` is the caller's own
+ * AbortSignal, not a provider failure — the provider served real tokens up to
+ * the cancellation and attaches them to the event — so it settles the partial
+ * like every other clean-but-early path.
+ *
+ * Where the two axes CROSS — the consumer breaks immediately after a terminal
+ * event — the terminal event wins, not the unwind, and it wins STRUCTURALLY:
+ * governance runs before the terminal event is ever yielded, so by the time a
+ * consumer can break, the ledger action has already been taken. (It has to run
+ * there anyway; see `host-loop.test.ts` for the deadlock that forced it.)
  */
 
 import { randomUUID } from "node:crypto";
@@ -33,6 +40,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { wrapStreamWithGovernance } from "../src/stream-governor.js";
 import type { StreamEvent, StreamFn } from "../src/types.js";
 import {
+	abortedEvent,
 	asHostStream,
 	doneEvent,
 	errorEvent,
@@ -42,6 +50,7 @@ import {
 	startEvent,
 	streamOf,
 	textDelta,
+	withTimeout,
 } from "./host-fixtures.js";
 
 vi.mock("tigerbeetle-node", () => ({
@@ -88,20 +97,6 @@ function throwingStreamFn(): StreamFn {
 				throw new Error("provider_exploded");
 			})(),
 		);
-}
-
-async function withTimeout<T>(promise: Promise<T>, ms = 500): Promise<T> {
-	let timer: ReturnType<typeof setTimeout> | undefined;
-	try {
-		return await Promise.race([
-			promise,
-			new Promise<never>((_resolve, reject) => {
-				timer = setTimeout(() => reject(new Error("promise never settled")), ms);
-			}),
-		]);
-	} finally {
-		if (timer !== undefined) clearTimeout(timer);
-	}
 }
 
 describe("stream terminal modes", () => {
@@ -204,8 +199,15 @@ describe("stream terminal modes", () => {
 		expect(abort).toHaveBeenCalledOnce();
 		expect(settle).not.toHaveBeenCalled();
 
-		// A voided call has no successful final message to report.
-		await expect(withTimeout(stream.result())).rejects.toThrow("boom");
+		// …and `result()` RESOLVES with the terminal assistant message, because
+		// that is what the pinned stream class does: `extractResult` returns
+		// `event.error` for an error event (`pi-ai/dist/utils/event-stream.js:66-74`)
+		// and OpenClaw consumes it as the terminal assistant turn, branching on
+		// `message.stopReason` afterwards (`dist/proxy-BzhBz8iM.js:264`). The VOID
+		// is what protects the money; rejecting here would only misreport the turn.
+		const failed = await withTimeout(stream.result());
+		expect(failed.stopReason).toBe("error");
+		expect(failed.errorMessage).toBe("boom");
 	});
 
 	it("aborts exactly once when the consumer breaks right after the error event", async () => {
@@ -226,9 +228,11 @@ describe("stream terminal modes", () => {
 		expect(abort).toHaveBeenCalledOnce();
 		expect(settle).not.toHaveBeenCalled();
 
-		// Same rejection as the drain-to-end error path: there is no successful
-		// final message either way.
-		await expect(withTimeout(stream.result())).rejects.toThrow("boom");
+		// Same resolution as the drain-to-end error path — the break changes
+		// nothing, because governance now finishes BEFORE the terminal event is
+		// yielded rather than after the loop unwinds.
+		const failed = await withTimeout(stream.result());
+		expect(failed.stopReason).toBe("error");
 	});
 
 	it("settles at the provider usage when the consumer breaks right after `done`", async () => {
@@ -253,11 +257,64 @@ describe("stream terminal modes", () => {
 		});
 	});
 
+	it("settles the PARTIAL usage when the stream ends on a consumer-abort event", async () => {
+		// The seventh mode, and the one that used to be folded into "terminal
+		// error event". `reason: "aborted"` is not a provider failure — it is the
+		// CALLER's own AbortSignal, and every pinned provider derives the reason
+		// from `signal?.aborted` while attaching the usage accumulated so far
+		// (`pi-ai/dist/providers/anthropic.js:500-517`). Those tokens were really
+		// spent, so this SETTLES the partial. Voiding would let any consumer
+		// cancel its way out of paying for work the provider actually did.
+		const events: StreamEvent[] = [
+			startEvent(),
+			textDelta("partial"),
+			abortedEvent(makeUsage(9, 3)),
+		];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		const collected: StreamEvent[] = [];
+		for await (const event of stream) collected.push(event);
+
+		// The event is forwarded unchanged, exactly as the failure event is.
+		expect(collected).toHaveLength(3);
+		expect(collected[2]).toMatchObject({ type: "error", reason: "aborted" });
+
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(abort).not.toHaveBeenCalled();
+		expect(settleParams()).toMatchObject({
+			inputTokens: 9,
+			outputTokens: 3,
+			usageSource: "provider",
+			chunksDelivered: 3,
+		});
+
+		const aborted = await withTimeout(stream.result());
+		expect(aborted.stopReason).toBe("aborted");
+	});
+
+	it("settles the PARTIAL when the consumer breaks right after the abort event", async () => {
+		const events: StreamEvent[] = [startEvent(), abortedEvent(makeUsage(9, 3))];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		for await (const event of stream) {
+			if (event.type === "error") break;
+		}
+
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(abort).not.toHaveBeenCalled();
+		expect(settleParams()).toMatchObject({ inputTokens: 9, outputTokens: 3 });
+	});
+
 	it("settles at the estimate when the stream closes without any terminal event", async () => {
 		const events: StreamEvent[] = [startEvent(), textDelta("orphaned")];
 		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+		const stream = await governed(model, makeContext());
 
-		for await (const _event of await governed(model, makeContext())) {
+		for await (const _event of stream) {
 			// drain to natural end — no `done`, no `error`
 		}
 
@@ -265,6 +322,40 @@ describe("stream terminal modes", () => {
 		expect(settle).toHaveBeenCalledOnce();
 		expect(settleParams().usageSource).toBe("estimated");
 		expect(settleParams()).not.toHaveProperty("inputTokens");
+
+		// `result()` is TERMINATED explicitly rather than left adopting the
+		// provider's own promise, which on this path is never resolved at all:
+		// `EventStream.end()` resolves it only when handed an explicit result
+		// (`pi-ai/dist/utils/event-stream.js:33-43`). Adopting it would mark the
+		// deferred settled while it hung forever.
+		await expect(withTimeout(stream.result())).rejects.toThrow(/closed without a terminal event/);
+	});
+
+	it("still takes exactly one ledger action when the settle fails on a terminal event", async () => {
+		// The settle is the last thing that can throw on the `done` path, and it
+		// now runs BEFORE the terminal event is yielded — so its failure unwinds
+		// THROUGH the generator's own catch. That catch must not void a hold the
+		// terminal-event handler has already voided.
+		settle.mockRejectedValue(new Error("settle_unavailable"));
+		const events: StreamEvent[] = [startEvent(), doneEvent(makeUsage(120, 45))];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		const collected: StreamEvent[] = [];
+		await expect(async () => {
+			for await (const event of stream) collected.push(event);
+		}).rejects.toThrow("settle_unavailable");
+
+		// The consumer still saw the provider's terminal event — the failure is
+		// ours, not a reason to hide it — and then the iteration threw.
+		expect(collected.map((e) => e.type)).toEqual(["start", "done"]);
+
+		// Two CALLS, one MUTATION: the settle rejected and moved nothing, so the
+		// compensating void is the sole action the ledger actually took. Anything
+		// more than one abort would be the double-void this guard exists to catch.
+		expect(settle).toHaveBeenCalledOnce();
+		expect(abort).toHaveBeenCalledOnce();
+		await expect(withTimeout(stream.result())).rejects.toThrow("settle_unavailable");
 	});
 
 	it("settles exactly once at provider usage on normal completion", async () => {

--- a/packages/openclaw/tests/terminal-modes.test.ts
+++ b/packages/openclaw/tests/terminal-modes.test.ts
@@ -15,6 +15,12 @@
  * (token-extractor.ts `extractUsageFromEvent`), so there is no provider usage to
  * settle with. That asymmetry — settle the partial, do not void — is the
  * documented one in AGENTS.md, "The settle/void asymmetry is deliberate."
+ *
+ * Where those two axes CROSS — the consumer breaks immediately after a terminal
+ * event — the terminal event the loop observed wins, not the unwind: break after
+ * `done` settles at the provider's usage (it was captured before the `yield`),
+ * break after `error` aborts. Otherwise a failed call gets charged, and a fully
+ * served one gets charged at the estimate.
  */
 
 import { randomUUID } from "node:crypto";
@@ -200,6 +206,51 @@ describe("stream terminal modes", () => {
 
 		// A voided call has no successful final message to report.
 		await expect(withTimeout(stream.result())).rejects.toThrow("boom");
+	});
+
+	it("aborts exactly once when the consumer breaks right after the error event", async () => {
+		// The terminal event and the abandonment collide: the consumer sees the
+		// `error` event and leaves, so the generator unwinds at the `yield` and
+		// never reaches the post-loop branch. What the loop already OBSERVED still
+		// decides the hold — a call the provider reported as failed is voided, not
+		// charged at the estimate.
+		const events: StreamEvent[] = [startEvent(), textDelta("partial"), errorEvent(makeUsage(9, 3))];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+		const stream = await governed(model, makeContext());
+
+		for await (const event of stream) {
+			if (event.type === "error") break;
+		}
+
+		expect(terminalCount()).toBe(1);
+		expect(abort).toHaveBeenCalledOnce();
+		expect(settle).not.toHaveBeenCalled();
+
+		// Same rejection as the drain-to-end error path: there is no successful
+		// final message either way.
+		await expect(withTimeout(stream.result())).rejects.toThrow("boom");
+	});
+
+	it("settles at the provider usage when the consumer breaks right after `done`", async () => {
+		// `for await (…) { if (e.type === "done") break; }` is an ordinary consumer
+		// shape. The accumulator already captured the provider's tokens from that
+		// event, so settling at the ESTIMATE here would systematically overcharge a
+		// fully served call — holds are sized above expected actuals.
+		const events: StreamEvent[] = [startEvent(), textDelta("hi"), doneEvent(makeUsage(120, 45))];
+		const governed = wrapStreamWithGovernance(streamOf(events), gov);
+
+		for await (const event of await governed(model, makeContext())) {
+			if (event.type === "done") break;
+		}
+
+		expect(terminalCount()).toBe(1);
+		expect(settle).toHaveBeenCalledOnce();
+		expect(settleParams()).toMatchObject({
+			inputTokens: 120,
+			outputTokens: 45,
+			usageSource: "provider",
+			chunksDelivered: 3,
+		});
 	});
 
 	it("settles at the estimate when the stream closes without any terminal event", async () => {

--- a/packages/openclaw/tests/token-extractor.branches.test.ts
+++ b/packages/openclaw/tests/token-extractor.branches.test.ts
@@ -7,15 +7,11 @@ import {
 	extractUsageFromEvent,
 	extractUsageFromProviderChunk,
 } from "../src/token-extractor.js";
-import type { DoneEvent } from "../src/types.js";
+import { doneEvent, makeUsage } from "./host-fixtures.js";
 
 describe("token-extractor — remaining branch edges", () => {
 	it("clampTokens zeroes non-finite usage that bypasses readNum (event path)", () => {
-		const done: DoneEvent = {
-			type: "done",
-			stopReason: "stop",
-			usage: { inputTokens: Number.POSITIVE_INFINITY, outputTokens: Number.NaN },
-		};
+		const done = doneEvent(makeUsage(Number.POSITIVE_INFINITY, Number.NaN));
 		expect(extractUsageFromEvent(done)).toMatchObject({ inputTokens: 0, outputTokens: 0 });
 	});
 

--- a/packages/openclaw/tests/token-extractor.edge.test.ts
+++ b/packages/openclaw/tests/token-extractor.edge.test.ts
@@ -8,7 +8,7 @@ import {
 	extractUsageFromEvent,
 	extractUsageFromProviderChunk,
 } from "../src/token-extractor.js";
-import type { DoneEvent, ErrorEvent, StreamEvent } from "../src/types.js";
+import { doneEvent, errorEvent, makeUsage, textDelta } from "./host-fixtures.js";
 
 describe("extractUsageFromProviderChunk — clamping and cache tokens", () => {
 	it("clamps non-finite, negative, and over-max token counts", () => {
@@ -93,8 +93,8 @@ describe("extractUsageFromProviderChunk — message_delta / OpenAI / Gemini", ()
 });
 
 describe("extractTextDeltaLength — provider shapes", () => {
-	it("pi-ai text_delta", () => {
-		expect(extractTextDeltaLength({ type: "text_delta", text: "hello" })).toBe(5);
+	it("host text_delta carries the text on `delta`", () => {
+		expect(extractTextDeltaLength({ type: "text_delta", contentIndex: 0, delta: "hello" })).toBe(5);
 	});
 
 	it("Anthropic content_block_delta", () => {
@@ -124,27 +124,20 @@ describe("extractTextDeltaLength — provider shapes", () => {
 
 describe("extractUsageFromEvent + createAccumulator", () => {
 	it("extracts usage from an error event", () => {
-		const ev: ErrorEvent = {
-			type: "error",
-			error: new Error("boom"),
-			usage: { inputTokens: 3, outputTokens: 4 },
-		};
-		expect(extractUsageFromEvent(ev)).toMatchObject({ inputTokens: 3, outputTokens: 4 });
+		expect(extractUsageFromEvent(errorEvent(makeUsage(3, 4)))).toMatchObject({
+			inputTokens: 3,
+			outputTokens: 4,
+		});
 	});
 
 	it("returns null for a non-terminal event", () => {
-		expect(extractUsageFromEvent({ type: "text_delta", text: "hi" } as StreamEvent)).toBeNull();
+		expect(extractUsageFromEvent(textDelta("hi"))).toBeNull();
 	});
 
 	it("accumulator records usage only from terminal events and counts chunks", () => {
 		const acc = createAccumulator();
-		acc.update({ type: "text_delta", text: "hi" } as StreamEvent);
-		const done: DoneEvent = {
-			type: "done",
-			stopReason: "stop",
-			usage: { inputTokens: 11, outputTokens: 22 },
-		};
-		acc.update(done);
+		acc.update(textDelta("hi"));
+		acc.update(doneEvent(makeUsage(11, 22)));
 		expect(acc.result()).toEqual({
 			inputTokens: 11,
 			outputTokens: 22,

--- a/packages/openclaw/tests/token-extractor.ollama.test.ts
+++ b/packages/openclaw/tests/token-extractor.ollama.test.ts
@@ -22,7 +22,20 @@ import {
 	extractTextDeltaLength,
 	extractUsageFromProviderChunk,
 } from "../src/token-extractor.js";
-import type { StreamContext, StreamEvent, StreamFn } from "../src/types.js";
+import type {
+	AssistantMessageEventStreamLike,
+	Context,
+	StreamEvent,
+	StreamFn,
+} from "../src/types.js";
+import {
+	asHostStream,
+	doneEvent,
+	makeContext,
+	makeModel,
+	makeUsage,
+	textDelta,
+} from "./host-fixtures.js";
 
 /** A realistic Ollama /api/chat final chunk (values from a llama3.3 run). */
 const ollamaFinalChunk = {
@@ -205,10 +218,10 @@ describe("createAccumulator — Ollama-native capture", () => {
 		expect(result.computeMs).toBe(4709);
 	});
 
-	it("omits computeMs entirely for pi-ai event streams (A6 discipline)", () => {
+	it("omits computeMs entirely for host event streams (A6 discipline)", () => {
 		const acc = createAccumulator();
-		acc.update({ type: "text_delta", text: "hi" });
-		acc.update({ type: "done", stopReason: "stop", usage: { inputTokens: 10, outputTokens: 5 } });
+		acc.update(textDelta("hi"));
+		acc.update(doneEvent(makeUsage(10, 5)));
 
 		const result = acc.result();
 		expect(result.usageReported).toBe(true);
@@ -260,15 +273,17 @@ function fakeGovernor(): { governor: Governor; settle: ReturnType<typeof vi.fn> 
 }
 
 function streamOf(chunks: unknown[]): StreamFn {
-	return (_model: string, _context: StreamContext, _options?: Record<string, unknown>) =>
-		(async function* () {
-			for (const chunk of chunks) {
-				yield chunk as StreamEvent;
-			}
-		})();
+	return (): AssistantMessageEventStreamLike =>
+		asHostStream(
+			(async function* () {
+				for (const chunk of chunks) {
+					yield chunk as StreamEvent;
+				}
+			})(),
+		);
 }
 
-const context: StreamContext = { messages: [{ role: "user", content: "hi" }], model: "m" };
+const context: Context = makeContext();
 
 describe("stream-governor — computeMs forwarding", () => {
 	it("forwards accumulated computeMs into governor.settle()", async () => {
@@ -279,7 +294,7 @@ describe("stream-governor — computeMs forwarding", () => {
 		);
 
 		const events: StreamEvent[] = [];
-		for await (const event of governed("llama3.3:70b", context)) {
+		for await (const event of await governed(makeModel("llama3.3:70b"), context)) {
 			events.push(event);
 		}
 
@@ -297,14 +312,11 @@ describe("stream-governor — computeMs forwarding", () => {
 	it("omits computeMs from settle params when the stream never carried one", async () => {
 		const { governor, settle } = fakeGovernor();
 		const governed = wrapStreamWithGovernance(
-			streamOf([
-				{ type: "text_delta", text: "hi" },
-				{ type: "done", stopReason: "stop", usage: { inputTokens: 10, outputTokens: 5 } },
-			]),
+			streamOf([textDelta("hi"), doneEvent(makeUsage(10, 5))]),
 			governor,
 		);
 
-		for await (const _event of governed("claude-sonnet-4-6", context)) {
+		for await (const _event of await governed(makeModel(), context)) {
 			// drain
 		}
 

--- a/packages/openclaw/tests/token-extractor.test.ts
+++ b/packages/openclaw/tests/token-extractor.test.ts
@@ -5,94 +5,101 @@ import {
 	extractUsageFromEvent,
 	extractUsageFromProviderChunk,
 } from "../src/token-extractor.js";
-import type { DoneEvent, ErrorEvent, StreamEvent, TextDeltaEvent } from "../src/types.js";
+import type { ErrorEvent, StreamEvent } from "../src/types.js";
+import {
+	doneEvent,
+	errorEvent,
+	makeAssistantMessage,
+	makeUsage,
+	startEvent,
+	textDelta,
+} from "./host-fixtures.js";
 
 describe("extractUsageFromEvent", () => {
 	it("extracts usage from done event", () => {
-		const event: DoneEvent = {
-			type: "done",
-			stopReason: "stop",
-			usage: { inputTokens: 100, outputTokens: 50 },
-		};
-
-		const usage = extractUsageFromEvent(event);
-		expect(usage).toEqual({ inputTokens: 100, outputTokens: 50 });
+		const usage = extractUsageFromEvent(doneEvent(makeUsage(100, 50)));
+		expect(usage).toEqual({
+			inputTokens: 100,
+			outputTokens: 50,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+		});
 	});
 
-	it("extracts usage from error event with usage", () => {
-		const event: ErrorEvent = {
-			type: "error",
-			error: new Error("test"),
-			usage: { inputTokens: 80, outputTokens: 30 },
-		};
-
-		const usage = extractUsageFromEvent(event);
-		expect(usage).toEqual({ inputTokens: 80, outputTokens: 30 });
+	it("extracts usage from error event", () => {
+		const usage = extractUsageFromEvent(errorEvent(makeUsage(80, 30)));
+		expect(usage).toEqual({
+			inputTokens: 80,
+			outputTokens: 30,
+			cacheReadTokens: 0,
+			cacheWriteTokens: 0,
+		});
 	});
 
-	it("returns null for error event without usage", () => {
-		const event: ErrorEvent = {
-			type: "error",
-			error: new Error("test"),
-		};
-
+	it("returns null for a malformed error event carrying no assistant message", () => {
+		const event = { type: "error", reason: "error" } as unknown as ErrorEvent;
 		expect(extractUsageFromEvent(event)).toBeNull();
 	});
 
 	it("returns null for text delta events", () => {
-		const event: TextDeltaEvent = {
-			type: "text_delta",
-			text: "hello",
-		};
-
-		expect(extractUsageFromEvent(event)).toBeNull();
+		expect(extractUsageFromEvent(textDelta("hello"))).toBeNull();
 	});
 
 	it("returns null for start events", () => {
-		const event: StreamEvent = { type: "start" };
-		expect(extractUsageFromEvent(event)).toBeNull();
+		expect(extractUsageFromEvent(startEvent())).toBeNull();
 	});
 });
 
 describe("extractUsageFromEvent edge cases", () => {
+	const partial = makeAssistantMessage();
+
 	it("returns null for text_start events", () => {
-		const event: StreamEvent = { type: "text_start" };
+		const event: StreamEvent = { type: "text_start", contentIndex: 0, partial };
 		expect(extractUsageFromEvent(event)).toBeNull();
 	});
 
 	it("returns null for text_end events", () => {
-		const event: StreamEvent = { type: "text_end" };
+		const event: StreamEvent = { type: "text_end", contentIndex: 0, content: "hi", partial };
 		expect(extractUsageFromEvent(event)).toBeNull();
 	});
 
 	it("returns null for thinking_delta events", () => {
-		const event: StreamEvent = { type: "thinking_delta", text: "reasoning..." };
+		const event: StreamEvent = {
+			type: "thinking_delta",
+			contentIndex: 0,
+			delta: "reasoning...",
+			partial,
+		};
 		expect(extractUsageFromEvent(event)).toBeNull();
 	});
 
 	it("returns null for toolcall_start events", () => {
-		const event: StreamEvent = { type: "toolcall_start", name: "search", id: "tc_1" };
+		const event: StreamEvent = { type: "toolcall_start", contentIndex: 0, partial };
 		expect(extractUsageFromEvent(event)).toBeNull();
 	});
 
 	it("returns null for toolcall_delta events", () => {
-		const event: StreamEvent = { type: "toolcall_delta", args: '{"q":"test"}' };
+		const event: StreamEvent = {
+			type: "toolcall_delta",
+			contentIndex: 0,
+			delta: '{"q":"test"}',
+			partial,
+		};
 		expect(extractUsageFromEvent(event)).toBeNull();
 	});
 
 	it("returns null for toolcall_end events", () => {
-		const event: StreamEvent = { type: "toolcall_end" };
+		const event: StreamEvent = {
+			type: "toolcall_end",
+			contentIndex: 0,
+			toolCall: { type: "toolCall", id: "tc_1", name: "search", arguments: {} },
+			partial,
+		};
 		expect(extractUsageFromEvent(event)).toBeNull();
 	});
 
 	it("clamps excessively large token counts", () => {
-		const event: DoneEvent = {
-			type: "done",
-			stopReason: "stop",
-			usage: { inputTokens: 999_999_999, outputTokens: 999_999_999 },
-		};
-
-		const usage = extractUsageFromEvent(event);
+		const usage = extractUsageFromEvent(doneEvent(makeUsage(999_999_999, 999_999_999)));
 		expect(usage).not.toBeNull();
 		// MAX_TOKENS is 2_000_000, so these should be clamped
 		expect(usage?.inputTokens).toBeLessThanOrEqual(2_000_000);
@@ -100,31 +107,14 @@ describe("extractUsageFromEvent edge cases", () => {
 	});
 
 	it("clamps negative token counts to zero", () => {
-		const event: DoneEvent = {
-			type: "done",
-			stopReason: "stop",
-			usage: { inputTokens: -100, outputTokens: -50 },
-		};
-
-		const usage = extractUsageFromEvent(event);
+		const usage = extractUsageFromEvent(doneEvent(makeUsage(-100, -50)));
 		expect(usage).not.toBeNull();
 		expect(usage?.inputTokens).toBe(0);
 		expect(usage?.outputTokens).toBe(0);
 	});
 
 	it("preserves cache token fields from done events", () => {
-		const event: DoneEvent = {
-			type: "done",
-			stopReason: "stop",
-			usage: {
-				inputTokens: 100,
-				outputTokens: 50,
-				cacheReadTokens: 30,
-				cacheWriteTokens: 10,
-			},
-		};
-
-		const usage = extractUsageFromEvent(event);
+		const usage = extractUsageFromEvent(doneEvent(makeUsage(100, 50, 30, 10)));
 		expect(usage).not.toBeNull();
 		expect(usage?.cacheReadTokens).toBe(30);
 		expect(usage?.cacheWriteTokens).toBe(10);
@@ -132,19 +122,17 @@ describe("extractUsageFromEvent edge cases", () => {
 });
 
 describe("createAccumulator", () => {
+	const partial = makeAssistantMessage();
+
 	it("accumulates usage from a stream of events", () => {
 		const acc = createAccumulator();
 
-		acc.update({ type: "start" });
-		acc.update({ type: "text_start" });
-		acc.update({ type: "text_delta", text: "Hello" });
-		acc.update({ type: "text_delta", text: " world" });
-		acc.update({ type: "text_end" });
-		acc.update({
-			type: "done",
-			stopReason: "stop",
-			usage: { inputTokens: 120, outputTokens: 45 },
-		});
+		acc.update(startEvent());
+		acc.update({ type: "text_start", contentIndex: 0, partial });
+		acc.update(textDelta("Hello"));
+		acc.update(textDelta(" world"));
+		acc.update({ type: "text_end", contentIndex: 0, content: "Hello world", partial });
+		acc.update(doneEvent(makeUsage(120, 45)));
 
 		const result = acc.result();
 		expect(result.inputTokens).toBe(120);
@@ -156,8 +144,8 @@ describe("createAccumulator", () => {
 	it("reports usageReported = false when no done event", () => {
 		const acc = createAccumulator();
 
-		acc.update({ type: "start" });
-		acc.update({ type: "text_delta", text: "Hello" });
+		acc.update(startEvent());
+		acc.update(textDelta("Hello"));
 
 		const result = acc.result();
 		expect(result.inputTokens).toBe(0);
@@ -169,16 +157,7 @@ describe("createAccumulator", () => {
 	it("handles cache token fields", () => {
 		const acc = createAccumulator();
 
-		acc.update({
-			type: "done",
-			stopReason: "stop",
-			usage: {
-				inputTokens: 100,
-				outputTokens: 50,
-				cacheReadTokens: 30,
-				cacheWriteTokens: 10,
-			},
-		});
+		acc.update(doneEvent(makeUsage(100, 50, 30, 10)));
 
 		const result = acc.result();
 		expect(result.inputTokens).toBe(100);
@@ -196,12 +175,12 @@ describe("createAccumulator", () => {
 		expect(result.usageReported).toBe(false);
 	});
 
-	it("handles error event without usage field", () => {
+	it("handles a malformed error event with no assistant message", () => {
 		const acc = createAccumulator();
 
-		acc.update({ type: "start" });
-		acc.update({ type: "text_delta", text: "partial" });
-		acc.update({ type: "error", error: new Error("stream broke") } as ErrorEvent);
+		acc.update(startEvent());
+		acc.update(textDelta("partial"));
+		acc.update({ type: "error", reason: "error" } as unknown as ErrorEvent);
 
 		const result = acc.result();
 		expect(result.inputTokens).toBe(0);
@@ -213,12 +192,8 @@ describe("createAccumulator", () => {
 	it("handles error event with usage field", () => {
 		const acc = createAccumulator();
 
-		acc.update({ type: "start" });
-		acc.update({
-			type: "error",
-			error: new Error("partial failure"),
-			usage: { inputTokens: 60, outputTokens: 25 },
-		} as ErrorEvent);
+		acc.update(startEvent());
+		acc.update(errorEvent(makeUsage(60, 25)));
 
 		const result = acc.result();
 		expect(result.inputTokens).toBe(60);
@@ -376,8 +351,8 @@ describe("extractTextDeltaLength", () => {
 		expect(extractTextDeltaLength(undefined)).toBe(0);
 	});
 
-	it("counts pi-ai text_delta length", () => {
-		expect(extractTextDeltaLength({ type: "text_delta", text: "hello" })).toBe(5);
+	it("counts host text_delta length off `delta`", () => {
+		expect(extractTextDeltaLength({ type: "text_delta", contentIndex: 0, delta: "hello" })).toBe(5);
 	});
 
 	it("counts Anthropic content_block_delta length", () => {

--- a/packages/openclaw/tsconfig.contract-openclaw.json
+++ b/packages/openclaw/tsconfig.contract-openclaw.json
@@ -5,7 +5,12 @@
 		"declaration": false,
 		"declarationMap": false,
 		"sourceMap": false,
-		"composite": false
+		"composite": false,
+		"types": ["node"]
 	},
-	"include": ["tests/contract.test-d.ts", "tests/host-fixtures.ts"]
+	"include": [
+		"tests/contract-openclaw.test-d.ts",
+		"tests/contract.test.ts",
+		"tests/host-fixtures.ts"
+	]
 }

--- a/packages/openclaw/tsconfig.type-tests.json
+++ b/packages/openclaw/tsconfig.type-tests.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"declaration": false,
+		"declarationMap": false,
+		"sourceMap": false,
+		"composite": false
+	},
+	"include": ["tests/contract.test-d.ts", "tests/contract.test.ts", "tests/host-fixtures.ts"]
+}

--- a/packages/server/tests/helpers/fake-governor.ts
+++ b/packages/server/tests/helpers/fake-governor.ts
@@ -1,6 +1,7 @@
 import type {
 	Authorization,
 	AuthorizeParams,
+	EnvelopeStatus,
 	Governor,
 	SettleParams,
 	TrustReceipt,
@@ -73,6 +74,15 @@ export function createFakeGovernor(
 		},
 		budgetRemaining(): number {
 			return budget;
+		},
+		/**
+		 * No ledger and no `parentUserId`, so there are no envelopes to report on —
+		 * the same empty answer the real governor gives for a dry-run or identity-less
+		 * one. Faking scarcity numbers here would put invented percentages into a
+		 * server test's assertions as though they came from TigerBeetle.
+		 */
+		async budgetContext(): Promise<EnvelopeStatus[]> {
+			return [];
 		},
 		// biome-ignore lint/suspicious/noExplicitAny: minimal config for tests
 		config: {} as any,


### PR DESCRIPTION
## Summary

Completes budget-as-personality's open half — "the agent plans within its means" (envelope spec Ship 2):

- **Stateless tool→envelope attribution.** Operator declares `costCenters.tools` (toolName → cost center) in plugin config; each governed call derives its envelope from the TRAILING host-inserted tool-result run in the current context — correlated by `toolCallId` to the preceding assistant tool calls, `isError` results excluded, no cross-call state. `authorize()` runs inside `withCostCenter`; settle/abort ride the handle capture.
- **Security model (documented carve-out):** bounded operator-delegated selection — writing the map delegates access to the mapped, ledger-capped envelopes; activity selects among capped pools but can never author a cc, reach an unmapped envelope, or exceed any cap. Programmatic mode (`createGovernedStreamFn`) is caller-trusted labeling.
- **Per-turn scarcity injection.** One compact system block (`[usertrust scarcity] research: 34% left (~2.1h runway) · …`) — operator labels + numbers only, counted in the authorize estimate, omitted on any read failure. `scarcityContext: false` opts out.
- **Core seam:** `Governor.budgetContext(envelopes)` — reporting-only batched read (A8; validates pre-I/O, catches only the ledger lookup).
- **Contract pinned:** `openclaw@2026.7.1-2` + `@mariozechner/pi-ai@0.73.1`; local type mirrors corrected against the real shipped types; compile-time contract tests. pi-ai assertions gate every push (root typecheck); the 361 MB `openclaw` package is verified in a dedicated `openclaw-contract` CI job (ad-hoc `--no-save --ignore-scripts` install, pin in one file, hard-fail under `USERTRUST_OPENCLAW_CONTRACT=1`) — dual-review consensus.
- **Pre-existing money bug fixed:** consumer break/return leaked the PENDING hold (no settle, no abort). Exactly one terminal ledger action now runs per authorization; the observed terminal event decides the hold's fate.
- **Known limitation (documented):** upstream `wrapStreamFn` is provider-scoped — the plugin governs calls routed to the `usertrust` provider; there is no host-wide stream seam.

## Review trail
Three Codex plan reviews before execution (14 → 11 → 1 findings, all incorporated). SDD execution: 8 tasks, 6 task-level fix rounds, Fable whole-branch final review (one Important — peer-range semver — fixed + re-verified), split-pin restructure re-reviewed 5/5.

## Test plan
2826 tests green; coverage 93.5 / 86.5 / 95.1 / 95.0 over the 92/84/90/92 gate; real-TigerBeetle suites executed locally (3 files, 11 tests) against TB 0.17.9; contract gates proven in both dependency states; tb-integration CI job widened to the new real-TB suites.

**Post-merge action:** add the new `openclaw-contract` job to master's required-checks list (branch protection, not YAML).

🤖 Generated with [Claude Code](https://claude.com/claude-code)