### PR TITLE
fix(types): governed openai/google surfaces return the { response, receipt } envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   iterable with a settled-`.receipt` promise — not the SDK's raw `Stream`
   (which the runtime never returns from governed `create`; the envelope's own
   `receipt` is the pre-settlement estimate). Types-only; no runtime change.
+- `TrustedClient` types: the same envelope now covers the remaining governed
+  surfaces — OpenAI `chat.completions.create` and `responses.create`, and Google
+  `models.generateContent`. All three resolved to the provider SDK's raw return
+  type while the runtime had been returning `{ response, receipt }` since the
+  proxies were written, so an OpenAI or Google consumer had no typed path to
+  `.receipt` at all and had to cast through `as unknown as`. Streaming calls on
+  either OpenAI surface resolve `response` to `GovernedStream<T>`, matching the
+  generic async-iterable branch of `interceptCall` that actually wraps them.
+  `TrustedClient<T>` now mirrors `detectClientKind`'s ORDER and its
+  callable-method guards, as exclusive branches — Anthropic, else OpenAI, else
+  Google — so a hybrid client is typed as governed on exactly the one provider
+  surface `trust()` proxies at runtime. The ungoverned inventory stays raw and
+  is pinned by type tests: `chat.completions.parse` / `.stream` / `.runTools`,
+  `responses.stream` / `.parse` / `.retrieve` / `.cancel` / `.delete` /
+  `.compact`, the OpenAI `beta.*` namespace, legacy `completions.create`, and
+  Google `models.generateContentStream`. The OpenAI assertions run against the
+  real installed `openai@^7.3.0` types; the Google mapper is asserted against a
+  structural mock only — no `@google/genai` devDependency exists yet, so real
+  `@google/genai` compatibility is unverified. Types-only; no runtime change.
 - A policy rule with no `description` no longer renders its identifier twice
   in the denial reason (`[scarcity-brake] scarcity-brake` is now
   `[scarcity-brake]`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,10 +83,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.receipt` at all and had to cast through `as unknown as`. Streaming calls on
   either OpenAI surface resolve `response` to `GovernedStream<T>`, matching the
   generic async-iterable branch of `interceptCall` that actually wraps them.
-  `TrustedClient<T>` now mirrors `detectClientKind`'s ORDER and its
-  callable-method guards, as exclusive branches — Anthropic, else OpenAI, else
-  Google — so a hybrid client is typed as governed on exactly the one provider
-  surface `trust()` proxies at runtime. The ungoverned inventory stays raw and
+  `TrustedClient<T>` now mirrors `detectClientKind`'s ORDER and BOTH halves of
+  its shape test, as exclusive branches — Anthropic, else OpenAI, else Google —
+  so a hybrid client is typed as governed on exactly the one provider surface
+  `trust()` proxies at runtime. Both halves means the governed method must be
+  callable AND its namespace must be a non-callable object: every namespace walk
+  in the runtime is gated on `typeof ns === "object"`, which a function object
+  fails, so a client whose `chat`, `messages`, `models`, `responses` or `beta` is
+  a callable carrying properties is skipped by the runtime and is now skipped by
+  the type too (falling through to the next provider where one applies).
+  Namespaces are re-added through homomorphic mapped types rather than plain
+  intersections, so `readonly` — which real `@google/genai` declares on `models`
+  — and `?` both survive, and a namespace the client never declared does not
+  become a phantom property. The ungoverned inventory stays raw and
   is pinned by type tests: `chat.completions.parse` / `.stream` / `.runTools`,
   `responses.stream` / `.parse` / `.retrieve` / `.cancel` / `.delete` /
   `.compact`, the OpenAI `beta.*` namespace, legacy `completions.create`, and

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -209,7 +209,15 @@ export interface TrustEngine {
 // settled `.receipt`. These mapped types make the EXPORTED TrustedClient type
 // match that runtime contract, so a consumer using the old bare-`Message` or
 // sync `const s = client.messages.stream(...)` patterns gets a compile error.
-// Clients without a top-level `messages` (OpenAI/Google) pass through unchanged.
+//
+// The same envelope rewrite covers the other two providers' governed `create`
+// surfaces: OpenAI `chat.completions.create` and (feature-detected)
+// `responses.create` via buildOpenAIProxy, and Google `models.generateContent`
+// via buildGoogleProxy. Neither is a special case — both route through the same
+// interceptCall, and a streaming call on either reaches the GENERIC
+// `Symbol.asyncIterator` branch that returns createGovernedStream's wrapper, not
+// the Anthropic `stream-helper` graft. Everything else on those resources is
+// ungoverned (see detect.ts's boundary block) and passes through untouched.
 
 /** `stream` becomes `(...args) => Promise<MessageStream & { receipt: Promise<TrustReceipt> }>`. */
 type GovernedStreamMethod<F> = F extends (...args: infer A) => infer R
@@ -292,15 +300,91 @@ type GovernedBeta<B> = B extends { messages: infer BM }
 	: B;
 
 /**
- * Rewrite only the Anthropic `messages` / `beta.messages` surfaces. A client
- * without a `messages` resource (OpenAI, Google) is returned unchanged — its
- * governed `create`/`responses` shapes are unaffected by this rewrite.
+ * A callable member — a GUARD, never a value type. `detectClientKind` keys every
+ * provider branch on `typeof x === "function"`, not on the key merely being
+ * present, and these types must agree with it exactly. `never[]` parameters put
+ * this at the top of the function lattice, so every function matches and every
+ * non-function (a string stub, a nested object) does not.
  */
-type GovernedShape<T> = T extends { messages: infer M }
+type AnyMethod = (...args: never[]) => unknown;
+
+/**
+ * Rewrite `create` on an OpenAI `chat.completions` resource. `parse`, `stream`,
+ * `runTools`, `retrieve` / `update` / `list` / `delete` and the legacy top-level
+ * `completions` are all UNGOVERNED (detect.ts's boundary block) and survive the
+ * `Omit` untouched — they drive the SDK's raw client and never reach interceptCall.
+ */
+type GovernedChatCompletions<CC> = CC extends { create: infer C extends AnyMethod }
+	? Omit<CC, "create"> & { create: GovernedCreateMethod<C> }
+	: CC;
+
+/** Rewrite `chat.completions` when present; the rest of `chat` is left alone. */
+type GovernedChat<C> = C extends { completions: infer CC }
+	? Omit<C, "completions"> & { completions: GovernedChatCompletions<CC> }
+	: C;
+
+/**
+ * Rewrite ONLY `create` on an OpenAI `responses` resource. The guard is the
+ * type-level twin of buildOpenAIResponsesProxy's
+ * `typeof responsesObj.create !== "function"` bail-out: on that miss the runtime
+ * installs no proxy and the WHOLE resource stays a raw pass-through, so a
+ * non-callable `create` must leave `R` intact rather than rewrite the rest of it.
+ * `stream` / `parse` / `retrieve` / `cancel` / `delete` / `compact` are ungoverned.
+ */
+type GovernedResponses<R> = R extends { create: infer C extends AnyMethod }
+	? Omit<R, "create"> & { create: GovernedCreateMethod<C> }
+	: R;
+
+/**
+ * Re-add the rewritten `responses` ONLY when the client type declares one —
+ * written as a homomorphic mapped type over a key set derived from `keyof T`, so
+ * the `?` modifier survives verbatim.
+ * *Prevents:* two failures a hand-written `{ responses: … }` intersection causes.
+ * An OpenAI client older than the Responses API (~4.87 — the peer floor is
+ * `>=4.70.0`) has no `responses` key at all and buildOpenAIProxy installs no proxy
+ * for it, so a re-added property would advertise a surface that does not exist.
+ * And under `exactOptionalPropertyTypes`, re-adding an optional property as
+ * required — or as `X | undefined` — is a DIFFERENT type from `responses?: X`,
+ * which breaks assignability for every consumer holding the original client type.
+ */
+type GovernedResponsesPart<T, K extends keyof T = Extract<keyof T, "responses">> = {
+	[P in K]: GovernedResponses<T[P]>;
+};
+
+/**
+ * Rewrite ONLY `generateContent` on a Google `models` resource. `generateContentStream`
+ * stays raw: buildGoogleProxy traps the one method and lets everything else fall
+ * through `Reflect.get`, so a rewrite here would advertise a `.receipt` that never
+ * arrives on the streaming shortcut users actually reach for.
+ */
+type GovernedGoogleModels<G> = G extends { generateContent: infer C extends AnyMethod }
+	? Omit<G, "generateContent"> & { generateContent: GovernedCreateMethod<C> }
+	: G;
+
+/**
+ * Rewrite the governed surfaces of whichever provider `detectClientKind` would
+ * pick — and only that provider's. The branches are EXCLUSIVE and ordered exactly
+ * as detect.ts:61: Anthropic (callable `messages.create`), else OpenAI (callable
+ * `chat.completions.create`, carrying `responses` with it), else Google (callable
+ * `models.generateContent`). A client matching none passes through unchanged;
+ * detectClientKind throws on it at runtime.
+ * *Prevents:* a hybrid client — an in-house facade exposing both an Anthropic and
+ * an OpenAI shape — typed as if both were governed, when `trust()` installs exactly
+ * ONE provider proxy and the loser's `create` is never intercepted. A receipt
+ * advertised on a surface no proxy wraps is the one lie this type must not tell.
+ * The guards are on CALLABILITY rather than key presence for that same reason: a
+ * `messages` whose `create` is not a function does not make a client Anthropic,
+ * so it must not preempt the OpenAI branch here either.
+ */
+type GovernedShape<T> = T extends { messages: infer M extends { create: AnyMethod } }
 	? Omit<T, "messages" | "beta"> & { messages: GovernedMessages<M> } & (T extends { beta: infer B }
 				? { beta: GovernedBeta<B> }
 				: unknown)
-	: T;
+	: T extends { chat: infer C extends { completions: { create: AnyMethod } } }
+		? Omit<T, "chat" | "responses"> & { chat: GovernedChat<C> } & GovernedResponsesPart<T>
+		: T extends { models: infer G extends { generateContent: AnyMethod } }
+			? Omit<T, "models"> & { models: GovernedGoogleModels<G> }
+			: T;
 
 /** The trusted client: governed client shape (F5) + governance methods. */
 export type TrustedClient<T> = GovernedShape<T> & {

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -294,11 +294,6 @@ type GovernedMessages<M> = M extends object
 			("parse" extends keyof M ? { parse: GovernedParseMethod<M["parse"]> } : unknown)
 	: M;
 
-/** Rewrite `beta.messages` when present; otherwise leave `beta` untouched. */
-type GovernedBeta<B> = B extends { messages: infer BM }
-	? Omit<B, "messages"> & { messages: GovernedMessages<BM> }
-	: B;
-
 /**
  * A callable member — a GUARD, never a value type. `detectClientKind` keys every
  * provider branch on `typeof x === "function"`, not on the key merely being
@@ -307,6 +302,37 @@ type GovernedBeta<B> = B extends { messages: infer BM }
  * non-function (a string stub, a nested object) does not.
  */
 type AnyMethod = (...args: never[]) => unknown;
+
+/**
+ * True when `X` is callable. The bracket wrapping is load-bearing: it stops the
+ * conditional distributing, so a union answers once for the whole union.
+ *
+ * This is the NEGATIVE half of the runtime's shape tests, and it needs its own
+ * type because TypeScript has no "object but not callable" constraint to write
+ * positively. Every namespace the runtime walks is gated on
+ * `typeof x === "object"` — `detectClientKind`, `buildOpenAIResponsesProxy` and
+ * `buildAnthropicBetaProxy` all do it — and a FUNCTION OBJECT (a callable that
+ * also carries properties) answers `"function"` there, not `"object"`. Yet a
+ * function object with the right properties satisfies `X extends { create: … }`
+ * happily, so the positive structural guard alone selects surfaces the runtime
+ * skips entirely.
+ */
+type IsCallable<X> = [X] extends [AnyMethod] ? true : false;
+
+/**
+ * Rewrite `beta.messages` when present; otherwise leave `beta` untouched.
+ * Both levels are excluded when callable, mirroring buildAnthropicBetaProxy,
+ * which returns undefined — leaving `beta` a whole raw pass-through — unless
+ * `beta` AND `beta.messages` are both non-callable objects.
+ */
+type GovernedBeta<B> =
+	IsCallable<B> extends true
+		? B
+		: B extends { messages: infer BM }
+			? IsCallable<BM> extends true
+				? B
+				: Omit<B, "messages"> & { messages: GovernedMessages<BM> }
+			: B;
 
 /**
  * Rewrite `create` on an OpenAI `chat.completions` resource. `parse`, `stream`,
@@ -331,25 +357,12 @@ type GovernedChat<C> = C extends { completions: infer CC }
  * non-callable `create` must leave `R` intact rather than rewrite the rest of it.
  * `stream` / `parse` / `retrieve` / `cancel` / `delete` / `compact` are ungoverned.
  */
-type GovernedResponses<R> = R extends { create: infer C extends AnyMethod }
-	? Omit<R, "create"> & { create: GovernedCreateMethod<C> }
-	: R;
-
-/**
- * Re-add the rewritten `responses` ONLY when the client type declares one —
- * written as a homomorphic mapped type over a key set derived from `keyof T`, so
- * the `?` modifier survives verbatim.
- * *Prevents:* two failures a hand-written `{ responses: … }` intersection causes.
- * An OpenAI client older than the Responses API (~4.87 — the peer floor is
- * `>=4.70.0`) has no `responses` key at all and buildOpenAIProxy installs no proxy
- * for it, so a re-added property would advertise a surface that does not exist.
- * And under `exactOptionalPropertyTypes`, re-adding an optional property as
- * required — or as `X | undefined` — is a DIFFERENT type from `responses?: X`,
- * which breaks assignability for every consumer holding the original client type.
- */
-type GovernedResponsesPart<T, K extends keyof T = Extract<keyof T, "responses">> = {
-	[P in K]: GovernedResponses<T[P]>;
-};
+type GovernedResponses<R> =
+	IsCallable<R> extends true
+		? R
+		: R extends { create: infer C extends AnyMethod }
+			? Omit<R, "create"> & { create: GovernedCreateMethod<C> }
+			: R;
 
 /**
  * Rewrite ONLY `generateContent` on a Google `models` resource. `generateContentStream`
@@ -361,30 +374,102 @@ type GovernedGoogleModels<G> = G extends { generateContent: infer C extends AnyM
 	? Omit<G, "generateContent"> & { generateContent: GovernedCreateMethod<C> }
 	: G;
 
+// ── Provider selection: the type-level twin of detectClientKind ──
+// Each predicate is the full runtime test, both halves: the namespace is a
+// NON-CALLABLE object, and the governed method on it is callable. `detect.ts`
+// spells this `typeof ns === "object" && typeof ns.method === "function"`.
+
+/** detect.ts's Anthropic test: `messages` a non-callable object, `create` callable. */
+type IsAnthropicClient<T> = T extends { messages: infer M }
+	? IsCallable<M> extends true
+		? false
+		: M extends { create: AnyMethod }
+			? true
+			: false
+	: false;
+
+/** detect.ts's OpenAI test — `chat` AND `chat.completions` are both checked for object-ness. */
+type IsOpenAIClient<T> = T extends { chat: infer C }
+	? IsCallable<C> extends true
+		? false
+		: C extends { completions: infer CC }
+			? IsCallable<CC> extends true
+				? false
+				: CC extends { create: AnyMethod }
+					? true
+					: false
+			: false
+	: false;
+
+/** detect.ts's Google test: `models` a non-callable object, `generateContent` callable. */
+type IsGoogleClient<T> = T extends { models: infer G }
+	? IsCallable<G> extends true
+		? false
+		: G extends { generateContent: AnyMethod }
+			? true
+			: false
+	: false;
+
+// ── Namespace re-add parts ──
+// Every rewritten namespace is put back through a homomorphic mapped type over a
+// key set derived from `keyof T`, never a hand-written `{ ns: … }` intersection.
+// Three things that buys, all of which a literal intersection silently breaks:
+// a namespace the client does not declare stays ABSENT rather than becoming a
+// phantom property for a surface no proxy installs (an OpenAI client older than
+// the Responses API — ~4.87, under the `>=4.70.0` peer floor — has no `responses`
+// at all); an OPTIONAL namespace stays optional, where re-adding it as required,
+// or as `X | undefined`, is a different type under `exactOptionalPropertyTypes`
+// and breaks assignability for every consumer holding the original client type;
+// and `readonly` survives, which real `@google/genai` declares on `models`.
+
+type GovernedMessagesPart<T, K extends keyof T = Extract<keyof T, "messages">> = {
+	[P in K]: GovernedMessages<T[P]>;
+};
+type GovernedBetaPart<T, K extends keyof T = Extract<keyof T, "beta">> = {
+	[P in K]: GovernedBeta<T[P]>;
+};
+type GovernedChatPart<T, K extends keyof T = Extract<keyof T, "chat">> = {
+	[P in K]: GovernedChat<T[P]>;
+};
+type GovernedResponsesPart<T, K extends keyof T = Extract<keyof T, "responses">> = {
+	[P in K]: GovernedResponses<T[P]>;
+};
+type GovernedModelsPart<T, K extends keyof T = Extract<keyof T, "models">> = {
+	[P in K]: GovernedGoogleModels<T[P]>;
+};
+
 /**
  * Rewrite the governed surfaces of whichever provider `detectClientKind` would
  * pick — and only that provider's. The branches are EXCLUSIVE and ordered exactly
- * as detect.ts:61: Anthropic (callable `messages.create`), else OpenAI (callable
- * `chat.completions.create`, carrying `responses` with it), else Google (callable
- * `models.generateContent`). A client matching none passes through unchanged;
- * detectClientKind throws on it at runtime.
+ * as detect.ts:61: Anthropic, else OpenAI (carrying `responses` with it), else
+ * Google. A client matching none passes through unchanged; detectClientKind
+ * throws on it at runtime.
  * *Prevents:* a hybrid client — an in-house facade exposing both an Anthropic and
  * an OpenAI shape — typed as if both were governed, when `trust()` installs exactly
  * ONE provider proxy and the loser's `create` is never intercepted. A receipt
  * advertised on a surface no proxy wraps is the one lie this type must not tell.
- * The guards are on CALLABILITY rather than key presence for that same reason: a
- * `messages` whose `create` is not a function does not make a client Anthropic,
- * so it must not preempt the OpenAI branch here either.
+ * That is also why selection runs through the predicates above rather than a bare
+ * structural `extends`: a client whose `chat` is a function object is skipped by
+ * the runtime and falls through to Google, and the type must fall through with it.
  */
-type GovernedShape<T> = T extends { messages: infer M extends { create: AnyMethod } }
-	? Omit<T, "messages" | "beta"> & { messages: GovernedMessages<M> } & (T extends { beta: infer B }
-				? { beta: GovernedBeta<B> }
-				: unknown)
-	: T extends { chat: infer C extends { completions: { create: AnyMethod } } }
-		? Omit<T, "chat" | "responses"> & { chat: GovernedChat<C> } & GovernedResponsesPart<T>
-		: T extends { models: infer G extends { generateContent: AnyMethod } }
-			? Omit<T, "models"> & { models: GovernedGoogleModels<G> }
-			: T;
+type GovernedShapeOf<T> =
+	IsAnthropicClient<T> extends true
+		? Omit<T, "messages" | "beta"> & GovernedMessagesPart<T> & GovernedBetaPart<T>
+		: IsOpenAIClient<T> extends true
+			? Omit<T, "chat" | "responses"> & GovernedChatPart<T> & GovernedResponsesPart<T>
+			: IsGoogleClient<T> extends true
+				? Omit<T, "models"> & GovernedModelsPart<T>
+				: T;
+
+/**
+ * `T extends unknown` is a no-op for a single client type and DISTRIBUTES over a
+ * union one. It is required because the predicates above are not naked-`T`
+ * conditionals: `IsOpenAIClient<A | B>` would collapse to `boolean` and fail
+ * `extends true`, silently returning a union client unrewritten. Distributing
+ * first makes each member pick its own provider branch, which is what `trust()`
+ * does anyway — it detects one kind per actual client.
+ */
+type GovernedShape<T> = T extends unknown ? GovernedShapeOf<T> : never;
 
 /** The trusted client: governed client shape (F5) + governance methods. */
 export type TrustedClient<T> = GovernedShape<T> & {

--- a/packages/core/tests/govern/trusted-client-types.test-d.ts
+++ b/packages/core/tests/govern/trusted-client-types.test-d.ts
@@ -686,3 +686,186 @@ export type _NonCallableResponsesCreateStaysRaw = Assert<
 		{ create: string; retrieve(id: string): Promise<{ id: string }> }
 	>
 >;
+
+// ── CALLABLE namespaces: the runtime SKIPS them, so the type must too ──
+// Every namespace walk in the runtime is gated on `typeof ns === "object"` —
+// detectClientKind, buildOpenAIResponsesProxy and buildAnthropicBetaProxy alike —
+// and a function object (a callable carrying properties) answers `"function"`
+// there. It nonetheless satisfies a bare `extends { create: … }`, so without the
+// IsCallable exclusion these clients would be typed as governed on a surface no
+// proxy ever wraps, and — worse on the hybrid — typed as UNgoverned on the
+// surface that actually is.
+
+interface CallableChat {
+	(...args: never[]): void;
+	completions: { create(body: { model: string }): Promise<{ id: string }> };
+}
+
+// A callable `chat` with a valid Google `models`: detectClientKind's OpenAI test
+// fails on `typeof client.chat === "object"` and falls through to Google.
+interface CallableChatWithGoogle {
+	chat: CallableChat;
+	models: FakeGoogleModels;
+}
+type GovCallableChatWithGoogle = TrustedClient<CallableChatWithGoogle>;
+
+export type _CallableChatFallsThroughToGoogle = Assert<
+	IsExact<
+		ReturnType<GovCallableChatWithGoogle["models"]["generateContent"]>,
+		Promise<{ response: { text: string }; receipt: TrustReceipt }>
+	>
+>;
+export type _CallableChatStaysRaw = Assert<
+	IsExact<GovCallableChatWithGoogle["chat"], CallableChat>
+>;
+
+// Same for a callable `chat.completions`.
+interface CallableCompletions {
+	(...args: never[]): void;
+	create(body: { model: string }): Promise<{ id: string }>;
+}
+interface CallableCompletionsWithGoogle {
+	chat: { completions: CallableCompletions };
+	models: FakeGoogleModels;
+}
+type GovCallableCompletions = TrustedClient<CallableCompletionsWithGoogle>;
+
+export type _CallableCompletionsFallsThroughToGoogle = Assert<
+	IsExact<
+		ReturnType<GovCallableCompletions["models"]["generateContent"]>,
+		Promise<{ response: { text: string }; receipt: TrustReceipt }>
+	>
+>;
+export type _CallableCompletionsStaysRaw = Assert<
+	IsExact<GovCallableCompletions["chat"]["completions"], CallableCompletions>
+>;
+
+// A callable `messages` must not preempt the OpenAI branch.
+interface CallableMessages {
+	(...args: never[]): void;
+	create(body: { model: string }): Promise<{ id: string }>;
+}
+interface CallableMessagesWithOpenAI extends FakeOpenAI {
+	messages: CallableMessages;
+}
+type GovCallableMessages = TrustedClient<CallableMessagesWithOpenAI>;
+
+export type _CallableMessagesStaysRaw = Assert<
+	IsExact<GovCallableMessages["messages"], CallableMessages>
+>;
+export type _CallableMessagesFallsThroughToOpenAI = Assert<
+	IsExact<
+		ReturnType<GovCallableMessages["chat"]["completions"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+
+// A callable `models` is not a Google client either.
+interface CallableModels {
+	(...args: never[]): void;
+	generateContent(params: { model: string; contents: string }): Promise<{ text: string }>;
+}
+export type _CallableModelsStaysRaw = Assert<
+	IsExact<TrustedClient<{ models: CallableModels }>["models"], CallableModels>
+>;
+
+// A callable `responses` is left ENTIRELY raw by buildOpenAIResponsesProxy — it
+// bails on `typeof responses !== "object"`. The IsExact here is what pins the
+// call signature: `Omit` builds a plain object type and would silently drop it,
+// so a rewrite makes the resource uncallable at every existing call site.
+interface CallableResponses {
+	(...args: never[]): void;
+	create(body: { model: string }): Promise<{ id: string }>;
+}
+interface CallableResponsesOpenAI {
+	chat: { completions: { create(body: { model: string }): Promise<{ id: string }> } };
+	responses: CallableResponses;
+}
+type GovCallableResponses = TrustedClient<CallableResponsesOpenAI>;
+
+export type _CallableResponsesStaysFullyRaw = Assert<
+	IsExact<GovCallableResponses["responses"], CallableResponses>
+>;
+export type _CallableResponsesChatStillGoverned = Assert<
+	IsExact<
+		ReturnType<GovCallableResponses["chat"]["completions"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+
+// A callable `beta` — and a callable `beta.messages` — are both skipped by
+// buildAnthropicBetaProxy, which returns undefined and leaves `beta` a whole raw
+// pass-through.
+interface CallableBeta {
+	(...args: never[]): void;
+	messages: { create(body: { model: string }): Promise<{ id: string }> };
+}
+export type _CallableBetaStaysRaw = Assert<
+	IsExact<
+		TrustedClient<{
+			messages: { create(body: { model: string }): Promise<{ id: string }> };
+			beta: CallableBeta;
+		}>["beta"],
+		CallableBeta
+	>
+>;
+export type _CallableBetaMessagesStaysRaw = Assert<
+	IsExact<
+		TrustedClient<{
+			messages: { create(body: { model: string }): Promise<{ id: string }> };
+			beta: { messages: CallableMessages };
+		}>["beta"],
+		{ messages: CallableMessages }
+	>
+>;
+
+// ── namespace modifiers survive the rewrite ──
+// Real `@google/genai` declares `models` readonly. Rebuilding the namespace as a
+// plain property drops the modifier, so a consumer holding the original client
+// type could assign over a namespace the SDK declared immutable.
+interface ReadonlyModelsGoogle {
+	readonly models: FakeGoogleModels;
+}
+type GovReadonlyModels = TrustedClient<ReadonlyModelsGoogle>;
+export type _ReadonlyModelsStaysReadonly = Assert<
+	IsExact<
+		Pick<GovReadonlyModels, "models">,
+		{ readonly models: Pick<GovReadonlyModels, "models">["models"] }
+	>
+>;
+export type _ReadonlyModelsIsGoverned = Assert<
+	IsExact<
+		ReturnType<GovReadonlyModels["models"]["generateContent"]>,
+		Promise<{ response: { text: string }; receipt: TrustReceipt }>
+	>
+>;
+
+interface ReadonlyMessagesAnthropic {
+	readonly messages: { create(body: { model: string }): Promise<{ id: string }> };
+}
+export type _ReadonlyMessagesStaysReadonly = Assert<
+	IsExact<
+		Pick<TrustedClient<ReadonlyMessagesAnthropic>, "messages">,
+		{ readonly messages: TrustedClient<ReadonlyMessagesAnthropic>["messages"] }
+	>
+>;
+
+// ── a UNION client type still resolves per member ──
+// GovernedShape distributes before selecting a provider; without that, the
+// predicates collapse to `boolean` and the whole union comes back unrewritten.
+type GovUnion = TrustedClient<FakeAnthropic | FakeGoogle>;
+type GovUnionAnthropic = Extract<GovUnion, { messages: unknown }>;
+type GovUnionGoogle = Extract<GovUnion, { models: unknown }>;
+
+export type _UnionAnthropicMemberGoverned = Assert<
+	IsExact<
+		ReturnType<GovUnionAnthropic["messages"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+export type _UnionGoogleMemberGoverned = Assert<
+	IsExact<
+		ReturnType<GovUnionGoogle["models"]["generateContent"]>,
+		Promise<{ response: { text: string }; receipt: TrustReceipt }>
+	>
+>;

--- a/packages/core/tests/govern/trusted-client-types.test-d.ts
+++ b/packages/core/tests/govern/trusted-client-types.test-d.ts
@@ -25,6 +25,16 @@ import type {
 } from "@anthropic-ai/sdk/resources/beta/messages/messages";
 import type { Message, RawMessageStreamEvent } from "@anthropic-ai/sdk/resources/messages/messages";
 import type { Stream } from "@anthropic-ai/sdk/streaming";
+import type OpenAI from "openai";
+import type { Stream as OpenAIStream } from "openai/core/streaming";
+import type {
+	ChatCompletion,
+	ChatCompletionChunk,
+} from "openai/resources/chat/completions/completions";
+import type {
+	Response as OpenAIResponse,
+	ResponseStreamEvent,
+} from "openai/resources/responses/responses";
 import type { TrustedClient } from "../../src/govern.js";
 import type { TrustReceipt } from "../../src/shared/types.js";
 import type { GovernedStream } from "../../src/streaming.js";
@@ -282,12 +292,23 @@ export type _RealBetaStreamingEnvelope = Assert<
 
 export type _HasDestroy = Assert<Extends<GovAnthropic, { destroy(): Promise<void> }>>;
 
-// ── a client WITHOUT `messages` (OpenAI/Google) passes through unchanged ──
-// chat.completions.create stays RAW (no top-level `messages` → no rewrite), and
-// responses.stream stays RAW/sync (ungoverned per F7): not a Promise, no receipt.
+// ── OpenAI mocks: BOTH governed `create` surfaces carry the envelope ──
+// buildOpenAIProxy routes `chat.completions.create` and (feature-detected)
+// `responses.create` through interceptCall, so both resolve to
+// `{ response, receipt }`. `responses.stream()` stays RAW and SYNC: it drives the
+// SDK's own client internally and never reaches the governed `create` (F7).
 
-export type _OpenAICreateUnchanged = Assert<
-	IsExact<ReturnType<GovOpenAI["chat"]["completions"]["create"]>, Promise<{ id: string }>>
+export type _OpenAIChatCreateEnvelope = Assert<
+	IsExact<
+		ReturnType<GovOpenAI["chat"]["completions"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+export type _OpenAIResponsesCreateEnvelope = Assert<
+	IsExact<
+		ReturnType<GovOpenAI["responses"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
 >;
 export type _OpenAIResponsesStreamRaw = Assert<
 	IsExact<ReturnType<GovOpenAI["responses"]["stream"]>, { on(): void }>
@@ -298,3 +319,370 @@ export type _OpenAIResponsesStreamNotAsync = Assert<
 		: true
 >;
 export type _OpenAIHasDestroy = Assert<Extends<GovOpenAI, { destroy(): Promise<void> }>>;
+
+// ── REAL OpenAI SDK: the published surface, per call site ──
+// Same acceptance criterion as the Anthropic block above: every assertion is over
+// `typeof` an actual call expression, and the non-streaming `response` is compared
+// against the RAW client's own resolution so the SDK's `WithRequestID` graft
+// (`Awaited<APIPromise<T>>`) survives the rewrite rather than being replaced by a
+// bare nominal type. Streaming resolves to createGovernedStream's wrapper — the
+// generic AsyncIterable branch in interceptCall, NOT the `stream-helper` path —
+// so the raw `Stream` members (`tee()`, `controller`) are gone.
+// openai@7.3.0 declares exactly three `create` overloads on BOTH resources
+// (completions.d.ts:56-58, responses.d.ts:51-53). If upstream adds a fourth, or
+// reshapes either type, this block breaks loudly.
+
+type GovRealOpenAI = TrustedClient<OpenAI>;
+declare const rawOpenAI: OpenAI;
+declare const govRealOpenAI: GovRealOpenAI;
+
+const rawChatNonStreaming = () => rawOpenAI.chat.completions.create({ model: "m", messages: [] });
+const govChatNonStreaming = () =>
+	govRealOpenAI.chat.completions.create({ model: "m", messages: [] });
+export type _RealChatNonStreamingEnvelope = Assert<
+	IsExact<
+		Awaited<ReturnType<typeof govChatNonStreaming>>,
+		{ response: Awaited<ReturnType<typeof rawChatNonStreaming>>; receipt: TrustReceipt }
+	>
+>;
+export type _RealChatNonStreamingIsChatCompletion = Assert<
+	Extends<Awaited<ReturnType<typeof govChatNonStreaming>>["response"], ChatCompletion>
+>;
+
+// The second RequestOptions argument must survive the rewrite.
+const govChatStreaming = () =>
+	govRealOpenAI.chat.completions.create(
+		{ model: "m", messages: [], stream: true },
+		{ maxRetries: 0 },
+	);
+export type _RealChatStreamingEnvelope = Assert<
+	IsExact<
+		Awaited<ReturnType<typeof govChatStreaming>>,
+		{ response: GovernedStream<ChatCompletionChunk>; receipt: TrustReceipt }
+	>
+>;
+export type _RealChatStreamingIsNotRawStream = Assert<
+	Extends<
+		Awaited<ReturnType<typeof govChatStreaming>>["response"],
+		OpenAIStream<ChatCompletionChunk>
+	> extends true
+		? false
+		: true
+>;
+export type _RealChatStreamingIsNotChatCompletion = Assert<
+	Extends<Awaited<ReturnType<typeof govChatStreaming>>["response"], ChatCompletion> extends true
+		? false
+		: true
+>;
+
+const govChatWidened = () =>
+	govRealOpenAI.chat.completions.create({ model: "m", messages: [], stream: widenedFlag });
+export type _RealChatWidenedEnvelope = Assert<
+	IsExact<
+		Awaited<ReturnType<typeof govChatWidened>>,
+		{
+			response:
+				| GovernedStream<ChatCompletionChunk>
+				| Awaited<ReturnType<typeof rawChatNonStreaming>>;
+			receipt: TrustReceipt;
+		}
+	>
+>;
+
+// responses.create — the highest-risk overloaded path: `retrieve` is overloaded
+// three ways too and must stay raw, and the streaming overload sits between two
+// non-streaming ones.
+const rawResponsesNonStreaming = () => rawOpenAI.responses.create({ model: "m", input: "hi" });
+const govResponsesNonStreaming = () => govRealOpenAI.responses.create({ model: "m", input: "hi" });
+export type _RealResponsesNonStreamingEnvelope = Assert<
+	IsExact<
+		Awaited<ReturnType<typeof govResponsesNonStreaming>>,
+		{ response: Awaited<ReturnType<typeof rawResponsesNonStreaming>>; receipt: TrustReceipt }
+	>
+>;
+export type _RealResponsesNonStreamingIsResponse = Assert<
+	Extends<Awaited<ReturnType<typeof govResponsesNonStreaming>>["response"], OpenAIResponse>
+>;
+
+const govResponsesStreaming = () =>
+	govRealOpenAI.responses.create({ model: "m", input: "hi", stream: true });
+export type _RealResponsesStreamingEnvelope = Assert<
+	IsExact<
+		Awaited<ReturnType<typeof govResponsesStreaming>>,
+		{ response: GovernedStream<ResponseStreamEvent>; receipt: TrustReceipt }
+	>
+>;
+export type _RealResponsesStreamingIsNotRawStream = Assert<
+	Extends<
+		Awaited<ReturnType<typeof govResponsesStreaming>>["response"],
+		OpenAIStream<ResponseStreamEvent>
+	> extends true
+		? false
+		: true
+>;
+
+const govResponsesStreamingWithOptions = () =>
+	govRealOpenAI.responses.create({ model: "m", input: "hi", stream: true }, { maxRetries: 0 });
+export type _RealResponsesStreamingWithOptionsEnvelope = Assert<
+	IsExact<
+		Awaited<ReturnType<typeof govResponsesStreamingWithOptions>>,
+		{ response: GovernedStream<ResponseStreamEvent>; receipt: TrustReceipt }
+	>
+>;
+
+const govResponsesWidened = () =>
+	govRealOpenAI.responses.create({ model: "m", input: "hi", stream: widenedFlag });
+export type _RealResponsesWidenedEnvelope = Assert<
+	IsExact<
+		Awaited<ReturnType<typeof govResponsesWidened>>,
+		{
+			response:
+				| GovernedStream<ResponseStreamEvent>
+				| Awaited<ReturnType<typeof rawResponsesNonStreaming>>;
+			receipt: TrustReceipt;
+		}
+	>
+>;
+
+// ── UNGOVERNED OpenAI inventory: raw parity, per call site ──
+// These bypass governance, audit and budget enforcement (detect.ts's boundary
+// doc block). If any of them ever gained a receipt-bearing type, TrustedClient
+// would advertise a proof that the runtime never produces — and these are exactly
+// the streaming shortcuts users reach for.
+
+export type _RawChatParse = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["chat"]["completions"]["parse"]>,
+		ReturnType<OpenAI["chat"]["completions"]["parse"]>
+	>
+>;
+export type _RawChatStreamHelper = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["chat"]["completions"]["stream"]>,
+		ReturnType<OpenAI["chat"]["completions"]["stream"]>
+	>
+>;
+export type _RawChatRunTools = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["chat"]["completions"]["runTools"]>,
+		ReturnType<OpenAI["chat"]["completions"]["runTools"]>
+	>
+>;
+export type _RawChatRetrieve = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["chat"]["completions"]["retrieve"]>,
+		ReturnType<OpenAI["chat"]["completions"]["retrieve"]>
+	>
+>;
+export type _RawResponsesStreamHelper = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["responses"]["stream"]>,
+		ReturnType<OpenAI["responses"]["stream"]>
+	>
+>;
+export type _RawResponsesParse = Assert<
+	IsExact<ReturnType<GovRealOpenAI["responses"]["parse"]>, ReturnType<OpenAI["responses"]["parse"]>>
+>;
+export type _RawResponsesRetrieve = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["responses"]["retrieve"]>,
+		ReturnType<OpenAI["responses"]["retrieve"]>
+	>
+>;
+export type _RawResponsesCancel = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["responses"]["cancel"]>,
+		ReturnType<OpenAI["responses"]["cancel"]>
+	>
+>;
+export type _RawResponsesDelete = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["responses"]["delete"]>,
+		ReturnType<OpenAI["responses"]["delete"]>
+	>
+>;
+export type _RawResponsesCompact = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["responses"]["compact"]>,
+		ReturnType<OpenAI["responses"]["compact"]>
+	>
+>;
+export type _RawLegacyCompletionsCreate = Assert<
+	IsExact<
+		ReturnType<GovRealOpenAI["completions"]["create"]>,
+		ReturnType<OpenAI["completions"]["create"]>
+	>
+>;
+export type _RawOpenAIBeta = Assert<IsExact<GovRealOpenAI["beta"], OpenAI["beta"]>>;
+export type _RawOpenAIModels = Assert<IsExact<GovRealOpenAI["models"], OpenAI["models"]>>;
+
+// ── detectClientKind's ORDER and GUARDS, mirrored exactly (detect.ts:61) ──
+// The runtime picks ONE provider proxy: Anthropic (callable `messages.create`),
+// else OpenAI (callable `chat.completions.create`), else Google (callable
+// `models.generateContent`). A hybrid client must resolve the same way in the
+// type, or TrustedClient advertises receipts on a surface no proxy wraps.
+
+interface FakeGoogleModels {
+	generateContent(params: { model: string; contents: string }): Promise<{ text: string }>;
+	generateContentStream(params: {
+		model: string;
+		contents: string;
+	}): Promise<AsyncGenerator<{ text: string }>>;
+	countTokens(params: { model: string }): Promise<{ totalTokens: number }>;
+}
+
+interface FakeGoogle {
+	models: FakeGoogleModels;
+}
+
+type GovGoogle = TrustedClient<FakeGoogle>;
+
+export type _GoogleGenerateContentEnvelope = Assert<
+	IsExact<
+		ReturnType<GovGoogle["models"]["generateContent"]>,
+		Promise<{ response: { text: string }; receipt: TrustReceipt }>
+	>
+>;
+// generateContentStream is UNGOVERNED: buildGoogleProxy traps `generateContent`
+// only, everything else falls through Reflect.get. Its raw return is a promise of
+// an AsyncGenerator, so a rewrite here would be invisible at the call site until
+// a consumer reached for a `.receipt` that never arrives.
+export type _GoogleGenerateContentStreamRaw = Assert<
+	IsExact<
+		ReturnType<GovGoogle["models"]["generateContentStream"]>,
+		Promise<AsyncGenerator<{ text: string }>>
+	>
+>;
+export type _GoogleCountTokensRaw = Assert<
+	IsExact<ReturnType<GovGoogle["models"]["countTokens"]>, Promise<{ totalTokens: number }>>
+>;
+export type _GoogleHasDestroy = Assert<Extends<GovGoogle, { destroy(): Promise<void> }>>;
+
+// Anthropic + OpenAI on one client → Anthropic wins; the OpenAI surfaces stay raw.
+interface HybridAnthropicOpenAI extends FakeOpenAI {
+	messages: { create(body: { model: string }): Promise<{ id: string }> };
+}
+type GovHybridAnthropicOpenAI = TrustedClient<HybridAnthropicOpenAI>;
+
+export type _HybridAnthropicWins = Assert<
+	IsExact<
+		ReturnType<GovHybridAnthropicOpenAI["messages"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+export type _HybridOpenAIChatStaysRaw = Assert<
+	IsExact<
+		ReturnType<GovHybridAnthropicOpenAI["chat"]["completions"]["create"]>,
+		Promise<{ id: string }>
+	>
+>;
+export type _HybridOpenAIResponsesStaysRaw = Assert<
+	IsExact<ReturnType<GovHybridAnthropicOpenAI["responses"]["create"]>, Promise<{ id: string }>>
+>;
+
+// OpenAI + Google on one client → OpenAI wins; `models` stays raw.
+interface HybridOpenAIGoogle extends FakeOpenAI {
+	models: FakeGoogleModels;
+}
+type GovHybridOpenAIGoogle = TrustedClient<HybridOpenAIGoogle>;
+
+export type _HybridOpenAIWins = Assert<
+	IsExact<
+		ReturnType<GovHybridOpenAIGoogle["chat"]["completions"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+export type _HybridGoogleStaysRaw = Assert<
+	IsExact<ReturnType<GovHybridOpenAIGoogle["models"]["generateContent"]>, Promise<{ text: string }>>
+>;
+
+// `responses` WITHOUT `chat.completions.create` is NOT an OpenAI client:
+// detectClientKind keys on chat.completions.create alone, so nothing is rewritten
+// and `responses.create` must stay raw.
+interface ResponsesOnly {
+	responses: { create(body: { model: string }): Promise<{ id: string }> };
+}
+export type _ResponsesOnlyNotRewritten = Assert<
+	IsExact<ReturnType<TrustedClient<ResponsesOnly>["responses"]["create"]>, Promise<{ id: string }>>
+>;
+
+// A top-level `messages` whose `create` is NOT callable does not preempt:
+// detect.ts requires `typeof client.messages.create === "function"`, so this
+// client is detected as OpenAI and only the OpenAI surfaces are rewritten.
+interface NonCallableMessages extends FakeOpenAI {
+	messages: { create: string };
+}
+type GovNonCallableMessages = TrustedClient<NonCallableMessages>;
+export type _NonCallableMessagesStayRaw = Assert<
+	IsExact<GovNonCallableMessages["messages"], { create: string }>
+>;
+export type _NonCallableMessagesFallsToOpenAI = Assert<
+	IsExact<
+		ReturnType<GovNonCallableMessages["chat"]["completions"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+
+// …and with no other governed shape present, nothing is rewritten at all
+// (detectClientKind would throw on this client at runtime).
+export type _NonCallableMessagesAloneUnchanged = Assert<
+	IsExact<TrustedClient<{ messages: { create: string } }>["messages"], { create: string }>
+>;
+
+// An older OpenAI client predating the Responses API: no `responses` key at all.
+// The rewrite must not grow a phantom one — buildOpenAIResponsesProxy returns
+// undefined for that client and `responses` stays a raw Reflect.get miss.
+interface ChatOnlyOpenAI {
+	chat: { completions: { create(body: { model: string }): Promise<{ id: string }> } };
+}
+type GovChatOnlyOpenAI = TrustedClient<ChatOnlyOpenAI>;
+export type _ChatOnlyHasNoPhantomResponses = Assert<
+	"responses" extends keyof GovChatOnlyOpenAI ? false : true
+>;
+export type _ChatOnlyChatIsGoverned = Assert<
+	IsExact<
+		ReturnType<GovChatOnlyOpenAI["chat"]["completions"]["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+
+// An OPTIONAL `responses` must stay optional. Under exactOptionalPropertyTypes a
+// rewrite that dropped the `?` (or that widened it with `| undefined`) breaks
+// assignability across the package boundary for every consumer holding the
+// original client type.
+interface OptionalResponsesOpenAI {
+	chat: { completions: { create(body: { model: string }): Promise<{ id: string }> } };
+	responses?: { create(body: { model: string }): Promise<{ id: string }> };
+}
+type GovOptionalResponses = TrustedClient<OptionalResponsesOpenAI>;
+export type _OptionalResponsesIsStillOptional = Assert<
+	Pick<GovOptionalResponses, "responses"> extends Required<Pick<GovOptionalResponses, "responses">>
+		? false
+		: true
+>;
+// …and the `?` was not paid for by widening the value with `| undefined`, which
+// under exactOptionalPropertyTypes is a DIFFERENT type that accepts an explicit
+// `responses: undefined` the original rejects.
+export type _OptionalResponsesNotWidenedWithUndefined = Assert<
+	{ responses: undefined } extends Pick<GovOptionalResponses, "responses"> ? false : true
+>;
+export type _OptionalResponsesCreateGoverned = Assert<
+	IsExact<
+		ReturnType<NonNullable<GovOptionalResponses["responses"]>["create"]>,
+		Promise<{ response: { id: string }; receipt: TrustReceipt }>
+	>
+>;
+
+// A `responses` whose `create` is NOT callable stays raw in full — this mirrors
+// buildOpenAIResponsesProxy's `typeof responsesObj.create !== "function"` bail-out,
+// which leaves the whole resource a pass-through.
+interface NonCallableResponsesCreate {
+	chat: { completions: { create(body: { model: string }): Promise<{ id: string }> } };
+	responses: { create: string; retrieve(id: string): Promise<{ id: string }> };
+}
+export type _NonCallableResponsesCreateStaysRaw = Assert<
+	IsExact<
+		TrustedClient<NonCallableResponsesCreate>["responses"],
+		{ create: string; retrieve(id: string): Promise<{ id: string }> }
+	>
+>;


### PR DESCRIPTION
## Summary
- Sequel to #83, closing the mirror-image gap its security review found: governed OpenAI `chat.completions.create` / `responses.create` and Google `models.generateContent` return the `{ response, receipt }` envelope at runtime, but `TrustedClient<T>` left their types raw — `.receipt` unreachable on every non-Anthropic provider.
- `GovernedShape<T>` becomes three exclusive, callability-guarded branches mirroring `detectClientKind`'s order (Anthropic → OpenAI → Google), so hybrid client shapes type exactly as the runtime detects them; streaming responses map to `GovernedStream` per #83's established pattern.
- The deliberately ungoverned inventory stays raw and is now pinned by negatives: chat `parse`/`stream`/`runTools`, responses `stream`/`parse`/`retrieve`/`cancel`/`delete`/`compact`, `beta.*`, legacy `completions.create`, Google `generateContentStream`.
- Types-only: emitted runtime JS proven byte-identical (74/74 dist hashes, cold builds) — verified independently by implementer and security review.

## Test plan
- Real `openai@7.3.0` call-site assertions: both surfaces × non-streaming (raw-parity incl. `WithRequestID`) / streaming (`GovernedStream<...>` + no-raw-Stream negatives) / streaming+RequestOptions / widened `stream: boolean`.
- Detection-mirror mocks: both hybrid pairs, responses-without-chat, non-callable `messages.create` fallthrough, chat-only (no phantom `responses`), optional `responses?:` preserved un-widened under `exactOptionalPropertyTypes`, non-callable `responses.create` leaves the resource raw (twin of the runtime bail-out).
- Assertions mutation-tested (guard reorder and key-presence weakening each redden the suite).
- Local gate: typecheck ✓, lint ✓ (38 pre-existing warnings), tests 2836 passed / 1 known-flaky watcher test (passes isolated).
- Google is a structural mock only — real `@google/genai` compatibility unverified; adding the devDep as a drift alarm is a named follow-up.

## Files changed
- `packages/core/src/govern.ts` — F5 type block + `GovernedShape` (types + comments only)
- `packages/core/tests/govern/trusted-client-types.test-d.ts`
- `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)