### PR TITLE
fix(audit): validate inclusion-proof topology against leafIndex and treeSize

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,17 @@ it; a genuine leaf-0 proof verified at a forged `leafIndex` of 2 through that ga
 Not reachable through JSON-parsed input or any shipped caller — a parsed proof carries plain data
 properties — but `verifyInclusionProof` is an **exported** function whose contract says "untrusted
 input", so it must hold against objects a caller built by hand.
+
+*The `proof` argument itself is inside that contract.* It is guarded for object-ness (`null`,
+`undefined` and primitives return false), and **both** groups of extraction reads — the five
+top-level fields, and the per-level sibling index/`hash`/`position` reads — sit inside a
+`try`/`catch` that returns false. The catch spans only the reads; the hashing is deliberately left
+outside every catch, so a genuine crypto fault can never be swallowed into a silent verdict.
+*Prevents:* `verifyInclusionProof(null, …)`, a throwing accessor, or a revoked `Proxy` throwing out
+of a function this same section documents as never throwing — the contract contradicting itself.
+This is not a hypothetical tidy-up: the first two rounds of this work shipped the "never throws"
+wording while a bare `null` still threw on `proof.treeSize`, and wrapping only the top-level reads
+still let a hand-built array's throwing index getter escape.
 *Prevents:* a forged `leafIndex` riding an otherwise-valid fold, which is what lets a tampered
 receipt claim a different event's position in an anchored tree; padded, truncated or reordered
 sibling paths; and — the case no amount of hashing can catch — the **equal-hash flip**, where two

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -463,6 +463,42 @@ pre-image.
 `SHA-256(0x01 ‖ left ‖ right)`. **Odd nodes are promoted, not duplicated** — this avoids
 CVE-2012-2459.
 
+**An inclusion proof is validated for PATH TOPOLOGY before it is folded.** The fold alone proves
+only that *some* path of these siblings reaches the root; it says nothing about *where* the leaf
+sits. `verifyInclusionProof` therefore derives the expected per-level sibling orientation from
+`(leafIndex, treeSize)` — walking the levels under the promotion semantics above, never a
+`ceil(log2(treeSize))` shortcut, because a promoted node has **no** sibling at its level and its
+path is correspondingly shorter — and requires the supplied sibling count and every `position` to
+match that sequence exactly. `leafIndex` is zero-based, both it and `treeSize` must be
+`Number.isSafeInteger` (`2**53` passes `Number.isInteger`; a non-finite size never leaves the
+derivation loop, since `ceil(Infinity / 2)` is `Infinity`), and `0 ≤ leafIndex < treeSize`. The
+proof is untrusted input, so every structural defect returns `false` and the function never throws.
+The two copies — `core/src/audit/merkle.ts` and `verify/src/verify.ts` — carry byte-identical
+validation blocks and identical early-return order (treeSize, root, then topology).
+
+*Every field of the proof is read EXACTLY ONCE, into a local, and the fold walks a materialized
+array of checked hashes plus the **derived** orientation — never `proof.siblings` a second time, and
+never `sibling.position`, which the loop above already proved equal to `expected[level]`. Do not
+"simplify" the fold back onto `for (const sibling of proof.siblings)`.
+*Prevents:* a hostile in-memory proof — a `get position()` that answers differently on its second
+read, or an array with an overridden `Symbol.iterator` — passing validation on one path and then
+folding a different one. The first cut of this fix validated by index and re-read the object to fold
+it; a genuine leaf-0 proof verified at a forged `leafIndex` of 2 through that gap, by both routes.
+Not reachable through JSON-parsed input or any shipped caller — a parsed proof carries plain data
+properties — but `verifyInclusionProof` is an **exported** function whose contract says "untrusted
+input", so it must hold against objects a caller built by hand.
+*Prevents:* a forged `leafIndex` riding an otherwise-valid fold, which is what lets a tampered
+receipt claim a different event's position in an anchored tree; padded, truncated or reordered
+sibling paths; and — the case no amount of hashing can catch — the **equal-hash flip**, where two
+identical leaves make `hashInternal(sibling, self)` and `hashInternal(self, sibling)` the same
+value, so swapping a sibling's side refolds to the very same published root. Strict position
+matching is load-bearing on its own: the fold reads every non-`"left"` value as `"right"`, so an
+unvalidated `position` field is a free right-hand step.
+*What this function still does NOT authenticate,* deliberately: `version` and `segmentId` (changing
+either still verifies), and the binding of `leafHash` to an externally expected event — that is the
+caller's job. Hash-string *encoding* is likewise unvalidated beyond `typeof === "string"`; Node's
+hex decoder is permissive, and tightening it needs its own compatibility analysis.
+
 **Audit-write failure degrades; it never unwinds committed money.** The writer dead-letters to
 `.usertrust/dlq/dead-letters.jsonl` (dir `0700`, file `0600`, fsync'd) and **re-throws**; governance
 call sites catch it and mark the call audit-degraded. A failed append must not unwind the transfer,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in the denial reason (`[scarcity-brake] scarcity-brake` is now
   `[scarcity-brake]`).
 
+### Security
+
+- **Merkle inclusion proofs now validate PATH TOPOLOGY against
+  `(leafIndex, treeSize)`.** `verifyInclusionProof` previously folded whatever
+  siblings it was handed and compared the result to the published root. It
+  never derived what the path *should* look like for the claimed position, so
+  a proof could assert any `leafIndex` it liked and still verify — a forged
+  index rode an otherwise-valid fold, and where two sibling hashes are equal
+  (identical leaves) flipping a sibling's side refolded to the very same root,
+  which no amount of hashing can catch. The verifier now derives the expected
+  per-level orientation from `(leafIndex, treeSize)` under the tree's
+  odd-node-promotion semantics, requires the supplied sibling count and every
+  `position` to match it exactly, and rejects non-safe-integer or
+  out-of-range indices and sizes before hashing. `packages/core` and
+  `usertrust-verify` changed in lockstep and are covered by a differential
+  suite that drives both verifiers directly. Every field of the proof is read
+  exactly once and the fold walks a materialized array plus the derived
+  orientation, so a hand-built object with a re-reading `position` getter or an
+  overridden array iterator cannot pass validation on one path and fold
+  another.
+
+  **Compatibility.** Every proof `generateInclusionProof` produces still
+  verifies — exhaustively pinned for all leaves of every tree sized 1..33.
+  `leafIndex` is ZERO-BASED and is now authenticated: a caller that treated
+  it as informational, dropped it during (de)serialization, or stored a
+  one-based sequence number will start failing verification. That is the fix
+  working, not a regression.
+
 ## [3.0.0] - 2026-08-03
 
 **Loopback/local endpoints now settle at nominal local rates instead of silently

--- a/packages/core/src/audit/merkle.ts
+++ b/packages/core/src/audit/merkle.ts
@@ -244,52 +244,81 @@ function expectedPathTopology(leafIndex: number, treeSize: number): ("left" | "r
  * of 2 through exactly that gap. Unreachable through JSON-parsed input, but
  * this is an exported function whose contract is "untrusted input", so the
  * contract has to hold against objects the caller built by hand.
+ *
+ * The `proof` argument itself is part of that contract: it is guarded for
+ * object-ness, and the extraction below is wrapped so a throwing accessor or
+ * a revoked proxy answers `false` like any other structural defect. The catch
+ * spans ONLY the reads — never the hashing — so it can never turn a genuine
+ * crypto fault into a silent verdict.
  */
 export function verifyInclusionProof(
 	proof: MerkleInclusionProof,
 	publishedRoot: string,
 	publishedTreeSize: number,
 ): boolean {
-	const treeSize = proof.treeSize;
+	const candidate: unknown = proof;
+	if (typeof candidate !== "object" || candidate === null) {
+		return false;
+	}
+
+	let treeSize: number;
+	let root: string;
+	let leafIndex: number;
+	let leafHash: unknown;
+	let siblings: unknown;
+	try {
+		treeSize = proof.treeSize;
+		root = proof.root;
+		leafIndex = proof.leafIndex;
+		leafHash = proof.leafHash;
+		siblings = proof.siblings;
+	} catch {
+		return false;
+	}
+
 	if (treeSize !== publishedTreeSize) {
 		return false;
 	}
 
-	const root = proof.root;
 	if (root !== publishedRoot) {
 		return false;
 	}
 
-	const expected = expectedPathTopology(proof.leafIndex, treeSize);
+	const expected = expectedPathTopology(leafIndex, treeSize);
 	if (expected === null) {
 		return false;
 	}
 
-	const leafHash = proof.leafHash;
 	if (typeof leafHash !== "string") {
 		return false;
 	}
 
-	const siblings: unknown = proof.siblings;
 	if (!Array.isArray(siblings) || siblings.length !== expected.length) {
 		return false;
 	}
 
-	// Materialize the checked hashes; nothing below re-reads `proof`.
+	// Materialize the checked hashes; nothing below re-reads `proof`. These are
+	// extraction reads too — an index or accessor on a hand-built array can
+	// throw — so they carry the same catch, and it still stops short of the
+	// hashing.
 	const path: string[] = [];
-	for (const [level, expectedPosition] of expected.entries()) {
-		const sibling = siblings[level] as Partial<MerkleSibling> | null | undefined;
-		if (typeof sibling !== "object" || sibling === null) {
-			return false;
+	try {
+		for (const [level, expectedPosition] of expected.entries()) {
+			const sibling = siblings[level] as Partial<MerkleSibling> | null | undefined;
+			if (typeof sibling !== "object" || sibling === null) {
+				return false;
+			}
+			const hash = sibling.hash;
+			if (typeof hash !== "string") {
+				return false;
+			}
+			if (sibling.position !== expectedPosition) {
+				return false;
+			}
+			path.push(hash);
 		}
-		const hash = sibling.hash;
-		if (typeof hash !== "string") {
-			return false;
-		}
-		if (sibling.position !== expectedPosition) {
-			return false;
-		}
-		path.push(hash);
+	} catch {
+		return false;
 	}
 
 	let currentHash = hashLeaf(leafHash);

--- a/packages/core/src/audit/merkle.ts
+++ b/packages/core/src/audit/merkle.ts
@@ -177,34 +177,134 @@ export function generateInclusionProof(
 }
 
 /**
+ * Derive the sibling orientation a proof for `leafIndex` in a tree of
+ * `treeSize` leaves MUST have, level by level, under this tree's
+ * odd-node-PROMOTION variant of RFC 6962 (see buildMerkleTree).
+ *
+ * Returns null when (leafIndex, treeSize) cannot describe a real position.
+ * `Number.isSafeInteger` rather than `Number.isInteger`: 2**53 passes the
+ * latter, and a non-finite size never leaves the loop — ceil(Infinity / 2)
+ * is Infinity.
+ *
+ * A promoted node has NO sibling at its level, so the path is shorter than
+ * ceil(log2(treeSize)) — deriving the length arithmetically instead of
+ * walking the levels gets every promotion-shaped tree wrong.
+ */
+function expectedPathTopology(leafIndex: number, treeSize: number): ("left" | "right")[] | null {
+	if (!Number.isSafeInteger(leafIndex) || !Number.isSafeInteger(treeSize)) {
+		return null;
+	}
+
+	if (leafIndex < 0 || leafIndex >= treeSize) {
+		return null;
+	}
+
+	const positions: ("left" | "right")[] = [];
+	let index = leafIndex;
+	let levelSize = treeSize;
+
+	while (levelSize > 1) {
+		const promoted = index === levelSize - 1 && levelSize % 2 === 1;
+		if (!promoted) {
+			positions.push(index % 2 === 0 ? "right" : "left");
+		}
+		index = Math.floor(index / 2);
+		levelSize = Math.ceil(levelSize / 2);
+	}
+
+	return positions;
+}
+
+/**
  * Verify an inclusion proof against a published root and tree size.
  *
  * Pure function — no I/O, only crypto.createHash.
+ *
+ * The fold alone proves only that SOME path of these siblings reaches the
+ * root; it says nothing about WHERE the leaf sits. The topology check below
+ * is what binds the proof to its claimed position: without it a forged
+ * `leafIndex` rides an otherwise-valid fold unchallenged, and — where two
+ * sibling hashes are equal — flipping a sibling's side refolds to the very
+ * same root, so no amount of hashing can catch it.
+ *
+ * Positions are matched STRICTLY against the derived orientation. The fold
+ * treats every non-"left" value as "right", so an unvalidated "position"
+ * field is a free right-hand step.
+ *
+ * The proof is untrusted input: every structural defect returns false, and
+ * this function never throws.
+ *
+ * Every field of the proof is read EXACTLY ONCE, into a local, and the fold
+ * walks only those locals and the DERIVED orientation.
+ * *Prevents:* a hostile in-memory object — a `get position()` that answers
+ * differently on its second read, or an array with an overridden
+ * `Symbol.iterator` — passing validation on one path and then folding a
+ * different one. Validating a value and re-reading it to use it is the
+ * check-then-use gap; a genuine leaf-0 proof verified at a forged leafIndex
+ * of 2 through exactly that gap. Unreachable through JSON-parsed input, but
+ * this is an exported function whose contract is "untrusted input", so the
+ * contract has to hold against objects the caller built by hand.
  */
 export function verifyInclusionProof(
 	proof: MerkleInclusionProof,
 	publishedRoot: string,
 	publishedTreeSize: number,
 ): boolean {
-	if (proof.treeSize !== publishedTreeSize) {
+	const treeSize = proof.treeSize;
+	if (treeSize !== publishedTreeSize) {
 		return false;
 	}
 
-	if (proof.root !== publishedRoot) {
+	const root = proof.root;
+	if (root !== publishedRoot) {
 		return false;
 	}
 
-	let currentHash = hashLeaf(proof.leafHash);
+	const expected = expectedPathTopology(proof.leafIndex, treeSize);
+	if (expected === null) {
+		return false;
+	}
 
-	for (const sibling of proof.siblings) {
-		if (sibling.position === "left") {
-			currentHash = hashInternal(sibling.hash, currentHash);
-		} else {
-			currentHash = hashInternal(currentHash, sibling.hash);
+	const leafHash = proof.leafHash;
+	if (typeof leafHash !== "string") {
+		return false;
+	}
+
+	const siblings: unknown = proof.siblings;
+	if (!Array.isArray(siblings) || siblings.length !== expected.length) {
+		return false;
+	}
+
+	// Materialize the checked hashes; nothing below re-reads `proof`.
+	const path: string[] = [];
+	for (const [level, expectedPosition] of expected.entries()) {
+		const sibling = siblings[level] as Partial<MerkleSibling> | null | undefined;
+		if (typeof sibling !== "object" || sibling === null) {
+			return false;
 		}
+		const hash = sibling.hash;
+		if (typeof hash !== "string") {
+			return false;
+		}
+		if (sibling.position !== expectedPosition) {
+			return false;
+		}
+		path.push(hash);
 	}
 
-	return currentHash === proof.root;
+	let currentHash = hashLeaf(leafHash);
+
+	// Orientation comes from `expected`, never from the sibling: it was already
+	// proven equal, and re-reading it is what the gap above was made of.
+	for (const [level, expectedPosition] of expected.entries()) {
+		const hash = path[level] as string;
+		currentHash =
+			expectedPosition === "left"
+				? hashInternal(hash, currentHash)
+				: hashInternal(currentHash, hash);
+	}
+
+	return currentHash === root;
 }
 
 // ── Consistency proofs ──

--- a/packages/core/tests/audit/merkle.test.ts
+++ b/packages/core/tests/audit/merkle.test.ts
@@ -473,6 +473,64 @@ describe("Merkle — inclusion proof read discipline (hostile objects)", () => {
 
 		expect(verifyInclusionProof(forged, root, 4)).toBe(false);
 	});
+
+	it("returns false for a proof that is not an object at all", () => {
+		const root = rootOf(4);
+		for (const bad of [null, undefined, 42, "proof", true, Symbol("p")]) {
+			expect(() => verifyInclusionProof(malformed(bad), root, 4)).not.toThrow();
+			expect(verifyInclusionProof(malformed(bad), root, 4)).toBe(false);
+		}
+	});
+
+	it("returns false when any field accessor throws", () => {
+		const { root, proof } = fourLeaf();
+		for (const field of ["treeSize", "root", "leafIndex", "leafHash", "siblings"]) {
+			const hostile = { ...proof };
+			Object.defineProperty(hostile, field, {
+				get(): never {
+					throw new Error(`hostile ${field}`);
+				},
+			});
+			expect(() => verifyInclusionProof(malformed(hostile), root, 4)).not.toThrow();
+			expect(verifyInclusionProof(malformed(hostile), root, 4)).toBe(false);
+		}
+	});
+
+	it("returns false when a sibling's index or accessor throws", () => {
+		const { root, proof } = fourLeaf();
+
+		const throwingIndex: unknown[] = [proof.siblings[0], proof.siblings[1]];
+		Object.defineProperty(throwingIndex, "1", {
+			get(): never {
+				throw new Error("hostile index");
+			},
+			configurable: true,
+		});
+		const byIndex = malformed({ ...proof, siblings: throwingIndex });
+		expect(() => verifyInclusionProof(byIndex, root, 4)).not.toThrow();
+		expect(verifyInclusionProof(byIndex, root, 4)).toBe(false);
+
+		for (const field of ["hash", "position"]) {
+			const sibling = { ...(proof.siblings[1] as MerkleSibling) };
+			Object.defineProperty(sibling, field, {
+				get(): never {
+					throw new Error(`hostile ${field}`);
+				},
+			});
+			const forged = malformed({ ...proof, siblings: [proof.siblings[0], sibling] });
+			expect(() => verifyInclusionProof(forged, root, 4)).not.toThrow();
+			expect(verifyInclusionProof(forged, root, 4)).toBe(false);
+		}
+	});
+
+	it("returns false for a revoked proxy", () => {
+		const { root, proof } = fourLeaf();
+		const { proxy, revoke } = Proxy.revocable({ ...proof }, {});
+		revoke();
+
+		expect(() => verifyInclusionProof(malformed(proxy), root, 4)).not.toThrow();
+		expect(verifyInclusionProof(malformed(proxy), root, 4)).toBe(false);
+	});
 });
 
 describe("Merkle — inclusion proof round-trip and position uniqueness", () => {

--- a/packages/core/tests/audit/merkle.test.ts
+++ b/packages/core/tests/audit/merkle.test.ts
@@ -6,6 +6,8 @@ import {
 	generateInclusionProof,
 	hashInternal,
 	hashLeaf,
+	type MerkleInclusionProof,
+	type MerkleSibling,
 	verifyConsistencyProof,
 	verifyInclusionProof,
 } from "../../src/audit/merkle.js";
@@ -262,5 +264,244 @@ describe("Merkle — inclusion proof for promoted odd leaf", () => {
 		const proof = generateInclusionProof(6, leaves, "seg-7");
 		const valid = verifyInclusionProof(proof, root as string, leaves.length);
 		expect(valid).toBe(true);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Inclusion-proof PATH TOPOLOGY validation
+//
+// Before this suite existed, verifyInclusionProof folded whatever
+// siblings it was handed and compared the result to proof.root. It
+// never derived what the path SHOULD look like for (leafIndex,
+// treeSize), so a proof could claim any position it liked and still
+// verify. These are the attacks that buys.
+// ═══════════════════════════════════════════════════════════════
+
+function leaves(n: number): string[] {
+	return Array.from({ length: n }, (_, i) => makeLeaf(i));
+}
+
+function rootOf(n: number): string {
+	return buildMerkleTree(leaves(n)).root as string;
+}
+
+/** Cast an intentionally malformed proof to the declared shape. */
+function malformed(value: unknown): MerkleInclusionProof {
+	return value as MerkleInclusionProof;
+}
+
+describe("Merkle — inclusion proof topology (attack matrix)", () => {
+	it("rejects a forged leafIndex riding an otherwise-valid fold", () => {
+		const eight = leaves(8);
+		const proof = generateInclusionProof(3, eight, "seg-test");
+		const forged = { ...proof, leafIndex: 5 };
+
+		expect(verifyInclusionProof(forged, rootOf(8), 8)).toBe(false);
+	});
+
+	it("rejects padded siblings", () => {
+		const proof = generateInclusionProof(3, leaves(8), "seg-pad");
+		const padded = {
+			...proof,
+			siblings: [...proof.siblings, { hash: "0".repeat(64), position: "right" as const }],
+		};
+
+		expect(verifyInclusionProof(padded, rootOf(8), 8)).toBe(false);
+	});
+
+	it("rejects truncated siblings", () => {
+		const proof = generateInclusionProof(3, leaves(8), "seg-trunc");
+		const truncated = { ...proof, siblings: proof.siblings.slice(0, 2) };
+
+		expect(verifyInclusionProof(truncated, rootOf(8), 8)).toBe(false);
+	});
+
+	it("rejects a flipped position on one level of an otherwise-valid proof", () => {
+		const proof = generateInclusionProof(3, leaves(8), "seg-flip");
+		const flipped = {
+			...proof,
+			siblings: proof.siblings.map((s, i) =>
+				i === 1
+					? { ...s, position: s.position === "left" ? ("right" as const) : ("left" as const) }
+					: s,
+			),
+		};
+
+		expect(verifyInclusionProof(flipped, rootOf(8), 8)).toBe(false);
+	});
+
+	it("rejects a non-'left'/'right' position rather than treating it as right", () => {
+		const proof = generateInclusionProof(1, leaves(8), "seg-bogus");
+		// The pre-fix fold read every non-"left" value as "right", so "bogus" on
+		// a level whose real orientation is right verified cleanly.
+		const bogus = malformed({
+			...proof,
+			siblings: proof.siblings.map((s, i) => (i === 1 ? { ...s, position: "bogus" } : s)),
+		});
+
+		expect(verifyInclusionProof(bogus, rootOf(8), 8)).toBe(false);
+	});
+
+	it("rejects the equal-hash flip: identical leaves refold to the same root", () => {
+		// Two IDENTICAL leaves. hashInternal(sibling, self) === hashInternal(self, sibling)
+		// here, so flipping the orientation still lands on the published root — only
+		// topology validation can catch this one.
+		const twin = makeLeaf(0);
+		const pair = [twin, twin];
+		const root = buildMerkleTree(pair).root as string;
+		const proof = generateInclusionProof(0, pair, "seg-twin");
+		expect(proof.siblings[0]?.position).toBe("right");
+
+		const flipped = {
+			...proof,
+			siblings: [{ hash: proof.siblings[0]?.hash as string, position: "left" as const }],
+		};
+		expect(verifyInclusionProof(flipped, root, 2)).toBe(false);
+
+		// Same fold, relabelled as the other leaf: also rejected.
+		const relabelled = { ...proof, leafIndex: 1 };
+		expect(verifyInclusionProof(relabelled, root, 2)).toBe(false);
+	});
+
+	it("rejects out-of-range and non-integral leafIndex values", () => {
+		const proof = generateInclusionProof(3, leaves(8), "seg-idx");
+		for (const leafIndex of [-1, 8, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(verifyInclusionProof({ ...proof, leafIndex }, rootOf(8), 8)).toBe(false);
+		}
+	});
+
+	it("rejects non-safe-integer tree sizes even when proof and published agree", () => {
+		const proof = generateInclusionProof(3, leaves(8), "seg-size");
+		// 2**53 passes Number.isInteger; Number.isSafeInteger is what refuses it.
+		// Infinity must be refused BEFORE the derivation loop — ceil(Infinity/2)
+		// is Infinity, so the loop would never terminate.
+		for (const treeSize of [0, -1, 8.5, Number.POSITIVE_INFINITY, 2 ** 53]) {
+			expect(verifyInclusionProof({ ...proof, treeSize }, rootOf(8), treeSize)).toBe(false);
+		}
+	});
+
+	it("returns false — never throws — for structurally malformed proofs", () => {
+		const proof = generateInclusionProof(3, leaves(8), "seg-malformed");
+		const root = rootOf(8);
+
+		const cases: MerkleInclusionProof[] = [
+			malformed({ ...proof, siblings: null }),
+			malformed({ ...proof, siblings: "not-an-array" }),
+			malformed({ ...proof, siblings: [proof.siblings[0], undefined, proof.siblings[2]] }),
+			malformed({ ...proof, siblings: [proof.siblings[0], null, proof.siblings[2]] }),
+			malformed({ ...proof, siblings: proof.siblings.map(({ hash }) => ({ hash })) }),
+			malformed({
+				...proof,
+				siblings: proof.siblings.map((s) => ({ ...s, hash: Buffer.from(s.hash, "hex") })),
+			}),
+			malformed({ ...proof, leafHash: undefined }),
+			malformed({ ...proof, leafHash: 42 }),
+		];
+
+		for (const bad of cases) {
+			expect(() => verifyInclusionProof(bad, root, 8)).not.toThrow();
+			expect(verifyInclusionProof(bad, root, 8)).toBe(false);
+		}
+	});
+
+	it("still verifies the final leaf of promotion-shaped trees", () => {
+		// Odd leaf counts promote at level 0; 6 and 10 are EVEN yet still promote
+		// at an internal level, which a ceil(log2(n)) path length gets wrong.
+		for (const size of [3, 5, 6, 7, 9, 10, 11, 17]) {
+			const proof = generateInclusionProof(size - 1, leaves(size), `seg-${size}`);
+			expect(verifyInclusionProof(proof, rootOf(size), size)).toBe(true);
+		}
+	});
+
+	it("pins the promotion-shortened orientation sequences", () => {
+		const finalLeafPath = (size: number): string[] =>
+			generateInclusionProof(size - 1, leaves(size), `seg-${size}`).siblings.map((s) => s.position);
+
+		expect(finalLeafPath(6)).toEqual(["left", "left"]);
+		expect(finalLeafPath(7)).toEqual(["left", "left"]);
+		expect(finalLeafPath(10)).toEqual(["left", "left"]);
+		expect(finalLeafPath(17)).toEqual(["left"]);
+	});
+});
+
+describe("Merkle — inclusion proof read discipline (hostile objects)", () => {
+	// These defend the EXPORTED function's "untrusted input" contract against
+	// objects a caller built by hand. No vault ingestion path can reach them —
+	// a JSON-parsed proof carries plain data properties — but verifyInclusionProof
+	// is a public export and its contract makes no such assumption.
+	//
+	// A valid leaf-0 proof in a 4-leaf tree has orientations [right, right];
+	// leafIndex 2 derives [right, left]. Each fixture below shows one face to
+	// the validation pass and the other to a fold that re-reads.
+
+	function fourLeaf(): { root: string; proof: MerkleInclusionProof } {
+		return { root: rootOf(4), proof: generateInclusionProof(0, leaves(4), "seg-hostile") };
+	}
+
+	it("rejects a `position` getter that flips between validation and the fold", () => {
+		const { root, proof } = fourLeaf();
+		let reads = 0;
+		const hostile = {
+			hash: (proof.siblings[1] as MerkleSibling).hash,
+			get position(): string {
+				reads += 1;
+				return reads === 1 ? "left" : "right";
+			},
+		};
+		const forged = malformed({
+			...proof,
+			leafIndex: 2,
+			siblings: [proof.siblings[0], hostile],
+		});
+
+		expect(verifyInclusionProof(forged, root, 4)).toBe(false);
+		// One read per property, total — the fold must never come back for more.
+		expect(reads).toBe(1);
+	});
+
+	it("rejects an array whose Symbol.iterator yields a different path", () => {
+		const { root, proof } = fourLeaf();
+		const real = proof.siblings[1] as MerkleSibling;
+		const indexed: unknown[] = [proof.siblings[0], { ...real, position: "left" }];
+		Object.defineProperty(indexed, Symbol.iterator, {
+			value: function* () {
+				yield proof.siblings[0];
+				yield real;
+			},
+		});
+		const forged = malformed({ ...proof, leafIndex: 2, siblings: indexed });
+
+		expect(verifyInclusionProof(forged, root, 4)).toBe(false);
+	});
+});
+
+describe("Merkle — inclusion proof round-trip and position uniqueness", () => {
+	it("every generated proof verifies, for every leaf of trees sized 1..33", () => {
+		for (let size = 1; size <= 33; size++) {
+			const set = leaves(size);
+			const root = buildMerkleTree(set).root as string;
+			for (let i = 0; i < size; i++) {
+				const proof = generateInclusionProof(i, set, `seg-${size}`);
+				expect(verifyInclusionProof(proof, root, size)).toBe(true);
+			}
+		}
+	});
+
+	it("no valid proof verifies at any other leaf index, for trees sized 2..17", () => {
+		// The theorem the fix establishes: within one tree the orientation
+		// sequence uniquely identifies the leaf position. A pair of distinct
+		// indices sharing a sequence AND folding to the root would be a real
+		// hole — investigate rather than weakening this.
+		for (let size = 2; size <= 17; size++) {
+			const set = leaves(size);
+			const root = buildMerkleTree(set).root as string;
+			for (let i = 0; i < size; i++) {
+				const proof = generateInclusionProof(i, set, `seg-${size}`);
+				for (let claimed = 0; claimed < size; claimed++) {
+					if (claimed === i) continue;
+					expect(verifyInclusionProof({ ...proof, leafIndex: claimed }, root, size)).toBe(false);
+				}
+			}
+		}
 	});
 });

--- a/packages/core/tests/harden/differential.test.ts
+++ b/packages/core/tests/harden/differential.test.ts
@@ -332,4 +332,60 @@ describe("HARDEN: core vs verify pkg agree on inclusion-proof topology", () => {
 			expect(core).toBe(false);
 		}
 	});
+
+	it("13. neither throws on a non-object, throwing-accessor or revoked proof", () => {
+		const leaves = merkleLeaves(4);
+		const root = coreBuildMerkleTree(leaves).root as string;
+		const source = coreGenerateInclusionProof(0, leaves, "seg-hostile-proof");
+		const as = (v: unknown): MerkleInclusionProof => v as MerkleInclusionProof;
+
+		const makers: (() => MerkleInclusionProof)[] = [
+			() => as(null),
+			() => as(undefined),
+			() => as(42),
+			() => as("proof"),
+		];
+
+		for (const field of ["treeSize", "root", "leafIndex", "leafHash", "siblings"]) {
+			makers.push(() => {
+				const hostile = { ...source };
+				Object.defineProperty(hostile, field, {
+					get(): never {
+						throw new Error(`hostile ${field}`);
+					},
+				});
+				return as(hostile);
+			});
+		}
+
+		makers.push(() => {
+			const throwingIndex: unknown[] = [source.siblings[0], source.siblings[1]];
+			Object.defineProperty(throwingIndex, "1", {
+				get(): never {
+					throw new Error("hostile index");
+				},
+				configurable: true,
+			});
+			return as({ ...source, siblings: throwingIndex });
+		});
+
+		makers.push(() => {
+			const { proxy, revoke } = Proxy.revocable({ ...source }, {});
+			revoke();
+			return as(proxy);
+		});
+
+		for (const make of makers) {
+			let core: boolean | undefined;
+			let pkg: boolean | undefined;
+			expect(() => {
+				core = coreVerifyInclusionProof(make(), root, 4);
+			}).not.toThrow();
+			expect(() => {
+				pkg = pkgVerifyInclusionProof(make(), root, 4);
+			}).not.toThrow();
+			expect(core).toBe(pkg);
+			expect(core).toBe(false);
+		}
+	});
 });

--- a/packages/core/tests/harden/differential.test.ts
+++ b/packages/core/tests/harden/differential.test.ts
@@ -15,8 +15,20 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 // Zero-dep verify package, imported by relative path across the workspace.
 import { verifyVault as pkgVerifyVault } from "../../../verify/src/index.js";
+import {
+	buildMerkleTree as pkgBuildMerkleTree,
+	generateInclusionProof as pkgGenerateInclusionProof,
+	verifyInclusionProof as pkgVerifyInclusionProof,
+} from "../../../verify/src/verify.js";
 import { canonicalize } from "../../src/audit/canonical.js";
 import { createAuditWriter } from "../../src/audit/chain.js";
+import {
+	buildMerkleTree as coreBuildMerkleTree,
+	generateInclusionProof as coreGenerateInclusionProof,
+	verifyInclusionProof as coreVerifyInclusionProof,
+	type MerkleInclusionProof,
+	type MerkleSibling,
+} from "../../src/audit/merkle.js";
 import { verifyVault as coreVerifyVault } from "../../src/audit/verify.js";
 import { GENESIS_HASH, VAULT_DIR } from "../../src/shared/constants.js";
 
@@ -154,5 +166,170 @@ describe("HARDEN: core vs verify pkg produce identical verdicts", () => {
 		lines[0] = JSON.stringify(ev);
 		writeFileSync(logPath, `${lines.join("\n")}\n`);
 		assertAgree(join(root, VAULT_DIR), false);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Inclusion proofs are driven DIRECTLY, not through a vault. No
+// vault format carries an attacker-supplied inclusion proof — core
+// builds roots, and verify generates its own proof immediately
+// before checking it (verify/src/index.ts) — so a forged proof
+// smuggled into vault data would have both packages "agree" for a
+// reason that has nothing to do with this function.
+// ═══════════════════════════════════════════════════════════════
+
+function merkleLeaves(n: number): string[] {
+	return Array.from({ length: n }, (_, i) =>
+		createHash("sha256").update(`leaf-${i}`).digest("hex"),
+	);
+}
+
+/**
+ * Both implementations must return the same boolean, and neither may throw.
+ * Cross-fed as well: core's generator against verify's verifier and back, so
+ * a drift in either the generator or the topology derivation surfaces here.
+ */
+function assertInclusionAgree(
+	proof: MerkleInclusionProof,
+	root: string,
+	treeSize: number,
+	expected: boolean,
+): void {
+	let core: boolean | undefined;
+	let pkg: boolean | undefined;
+	expect(() => {
+		core = coreVerifyInclusionProof(proof, root, treeSize);
+	}).not.toThrow();
+	expect(() => {
+		pkg = pkgVerifyInclusionProof(proof, root, treeSize);
+	}).not.toThrow();
+	expect(core).toBe(pkg);
+	expect(core).toBe(expected);
+}
+
+describe("HARDEN: core vs verify pkg agree on inclusion-proof topology", () => {
+	it("7. both generators produce proofs both verifiers accept (sizes 1..17)", () => {
+		for (let size = 1; size <= 17; size++) {
+			const leaves = merkleLeaves(size);
+			const coreRoot = coreBuildMerkleTree(leaves).root as string;
+			const pkgRoot = pkgBuildMerkleTree(leaves).root as string;
+			expect(coreRoot).toBe(pkgRoot);
+
+			for (let i = 0; i < size; i++) {
+				assertInclusionAgree(coreGenerateInclusionProof(i, leaves, "seg"), coreRoot, size, true);
+				assertInclusionAgree(pkgGenerateInclusionProof(i, leaves, "seg"), coreRoot, size, true);
+			}
+		}
+	});
+
+	it("8. both reject a forged leafIndex on an otherwise-valid fold", () => {
+		const leaves = merkleLeaves(8);
+		const root = coreBuildMerkleTree(leaves).root as string;
+		const proof = coreGenerateInclusionProof(3, leaves, "seg-forged");
+
+		assertInclusionAgree(proof, root, 8, true);
+		for (const leafIndex of [0, 1, 2, 4, 5, 6, 7]) {
+			assertInclusionAgree({ ...proof, leafIndex }, root, 8, false);
+		}
+	});
+
+	it("9. both reject the equal-hash position flip", () => {
+		const twin = createHash("sha256").update("twin").digest("hex");
+		const pair = [twin, twin];
+		const root = coreBuildMerkleTree(pair).root as string;
+		const proof = coreGenerateInclusionProof(0, pair, "seg-twin");
+
+		assertInclusionAgree(proof, root, 2, true);
+		assertInclusionAgree(
+			{ ...proof, siblings: [{ hash: proof.siblings[0]?.hash as string, position: "left" }] },
+			root,
+			2,
+			false,
+		);
+	});
+
+	it("10. both reject malformed proofs identically, neither throws", () => {
+		const leaves = merkleLeaves(8);
+		const root = coreBuildMerkleTree(leaves).root as string;
+		const proof = coreGenerateInclusionProof(3, leaves, "seg-malformed");
+		const bad = (v: unknown): MerkleInclusionProof => v as MerkleInclusionProof;
+
+		const cases: MerkleInclusionProof[] = [
+			bad({ ...proof, siblings: null }),
+			bad({ ...proof, siblings: [...proof.siblings, proof.siblings[0]] }),
+			bad({ ...proof, siblings: proof.siblings.slice(0, 1) }),
+			bad({ ...proof, siblings: [proof.siblings[0], null, proof.siblings[2]] }),
+			bad({ ...proof, siblings: proof.siblings.map((s) => ({ ...s, position: "bogus" })) }),
+			bad({ ...proof, siblings: proof.siblings.map(({ position }) => ({ position })) }),
+			bad({ ...proof, leafHash: undefined }),
+			bad({ ...proof, leafIndex: Number.NaN }),
+			bad({ ...proof, leafIndex: -1 }),
+			bad({ ...proof, leafIndex: 1.5 }),
+		];
+
+		for (const c of cases) {
+			assertInclusionAgree(c, root, 8, false);
+		}
+	});
+
+	it("11. both reject non-safe-integer tree sizes", () => {
+		const leaves = merkleLeaves(8);
+		const root = coreBuildMerkleTree(leaves).root as string;
+		const proof = coreGenerateInclusionProof(3, leaves, "seg-size");
+
+		for (const treeSize of [0, -1, 8.5, Number.POSITIVE_INFINITY, 2 ** 53]) {
+			assertInclusionAgree({ ...proof, treeSize }, root, treeSize, false);
+		}
+	});
+
+	it("12. both reject hostile objects that answer differently on a second read", () => {
+		// A fresh fixture per verifier: a one-shot getter is consumed by the
+		// first call. Defends the exported contract, not a vault path.
+		const leaves = merkleLeaves(4);
+		const root = coreBuildMerkleTree(leaves).root as string;
+		const source = coreGenerateInclusionProof(0, leaves, "seg-hostile");
+
+		const flippingGetter = (): MerkleInclusionProof => {
+			let reads = 0;
+			return {
+				...source,
+				leafIndex: 2,
+				siblings: [
+					source.siblings[0],
+					{
+						hash: (source.siblings[1] as MerkleSibling).hash,
+						get position(): string {
+							reads += 1;
+							return reads === 1 ? "left" : "right";
+						},
+					},
+				],
+			} as unknown as MerkleInclusionProof;
+		};
+
+		const hostileIterator = (): MerkleInclusionProof => {
+			const real = source.siblings[1] as MerkleSibling;
+			const indexed: unknown[] = [source.siblings[0], { ...real, position: "left" }];
+			Object.defineProperty(indexed, Symbol.iterator, {
+				value: function* () {
+					yield source.siblings[0];
+					yield real;
+				},
+			});
+			return { ...source, leafIndex: 2, siblings: indexed } as unknown as MerkleInclusionProof;
+		};
+
+		for (const make of [flippingGetter, hostileIterator]) {
+			let core: boolean | undefined;
+			let pkg: boolean | undefined;
+			expect(() => {
+				core = coreVerifyInclusionProof(make(), root, 4);
+			}).not.toThrow();
+			expect(() => {
+				pkg = pkgVerifyInclusionProof(make(), root, 4);
+			}).not.toThrow();
+			expect(core).toBe(pkg);
+			expect(core).toBe(false);
+		}
 	});
 });

--- a/packages/verify/src/verify.ts
+++ b/packages/verify/src/verify.ts
@@ -283,30 +283,135 @@ export function generateInclusionProof(
 	};
 }
 
+/**
+ * Derive the sibling orientation a proof for `leafIndex` in a tree of
+ * `treeSize` leaves MUST have, level by level, under this tree's
+ * odd-node-PROMOTION variant of RFC 6962 (see buildMerkleTree).
+ *
+ * Returns null when (leafIndex, treeSize) cannot describe a real position.
+ * `Number.isSafeInteger` rather than `Number.isInteger`: 2**53 passes the
+ * latter, and a non-finite size never leaves the loop — ceil(Infinity / 2)
+ * is Infinity.
+ *
+ * A promoted node has NO sibling at its level, so the path is shorter than
+ * ceil(log2(treeSize)) — deriving the length arithmetically instead of
+ * walking the levels gets every promotion-shaped tree wrong.
+ */
+function expectedPathTopology(leafIndex: number, treeSize: number): ("left" | "right")[] | null {
+	if (!Number.isSafeInteger(leafIndex) || !Number.isSafeInteger(treeSize)) {
+		return null;
+	}
+
+	if (leafIndex < 0 || leafIndex >= treeSize) {
+		return null;
+	}
+
+	const positions: ("left" | "right")[] = [];
+	let index = leafIndex;
+	let levelSize = treeSize;
+
+	while (levelSize > 1) {
+		const promoted = index === levelSize - 1 && levelSize % 2 === 1;
+		if (!promoted) {
+			positions.push(index % 2 === 0 ? "right" : "left");
+		}
+		index = Math.floor(index / 2);
+		levelSize = Math.ceil(levelSize / 2);
+	}
+
+	return positions;
+}
+
+/**
+ * Verify an inclusion proof against a published root and tree size.
+ *
+ * Pure function — no I/O, only crypto.createHash.
+ *
+ * The fold alone proves only that SOME path of these siblings reaches the
+ * root; it says nothing about WHERE the leaf sits. The topology check below
+ * is what binds the proof to its claimed position: without it a forged
+ * `leafIndex` rides an otherwise-valid fold unchallenged, and — where two
+ * sibling hashes are equal — flipping a sibling's side refolds to the very
+ * same root, so no amount of hashing can catch it.
+ *
+ * Positions are matched STRICTLY against the derived orientation. The fold
+ * treats every non-"left" value as "right", so an unvalidated "position"
+ * field is a free right-hand step.
+ *
+ * The proof is untrusted input: every structural defect returns false, and
+ * this function never throws.
+ *
+ * Every field of the proof is read EXACTLY ONCE, into a local, and the fold
+ * walks only those locals and the DERIVED orientation.
+ * *Prevents:* a hostile in-memory object — a `get position()` that answers
+ * differently on its second read, or an array with an overridden
+ * `Symbol.iterator` — passing validation on one path and then folding a
+ * different one. Validating a value and re-reading it to use it is the
+ * check-then-use gap; a genuine leaf-0 proof verified at a forged leafIndex
+ * of 2 through exactly that gap. Unreachable through JSON-parsed input, but
+ * this is an exported function whose contract is "untrusted input", so the
+ * contract has to hold against objects the caller built by hand.
+ */
 export function verifyInclusionProof(
 	proof: MerkleInclusionProof,
 	publishedRoot: string,
 	publishedTreeSize: number,
 ): boolean {
-	if (proof.treeSize !== publishedTreeSize) {
+	const treeSize = proof.treeSize;
+	if (treeSize !== publishedTreeSize) {
 		return false;
 	}
 
-	if (proof.root !== publishedRoot) {
+	const root = proof.root;
+	if (root !== publishedRoot) {
 		return false;
 	}
 
-	let currentHash = hashLeaf(proof.leafHash);
+	const expected = expectedPathTopology(proof.leafIndex, treeSize);
+	if (expected === null) {
+		return false;
+	}
 
-	for (const sibling of proof.siblings) {
-		if (sibling.position === "left") {
-			currentHash = hashInternal(sibling.hash, currentHash);
-		} else {
-			currentHash = hashInternal(currentHash, sibling.hash);
+	const leafHash = proof.leafHash;
+	if (typeof leafHash !== "string") {
+		return false;
+	}
+
+	const siblings: unknown = proof.siblings;
+	if (!Array.isArray(siblings) || siblings.length !== expected.length) {
+		return false;
+	}
+
+	// Materialize the checked hashes; nothing below re-reads `proof`.
+	const path: string[] = [];
+	for (const [level, expectedPosition] of expected.entries()) {
+		const sibling = siblings[level] as Partial<MerkleSibling> | null | undefined;
+		if (typeof sibling !== "object" || sibling === null) {
+			return false;
 		}
+		const hash = sibling.hash;
+		if (typeof hash !== "string") {
+			return false;
+		}
+		if (sibling.position !== expectedPosition) {
+			return false;
+		}
+		path.push(hash);
 	}
 
-	return currentHash === proof.root;
+	let currentHash = hashLeaf(leafHash);
+
+	// Orientation comes from `expected`, never from the sibling: it was already
+	// proven equal, and re-reading it is what the gap above was made of.
+	for (const [level, expectedPosition] of expected.entries()) {
+		const hash = path[level] as string;
+		currentHash =
+			expectedPosition === "left"
+				? hashInternal(hash, currentHash)
+				: hashInternal(currentHash, hash);
+	}
+
+	return currentHash === root;
 }
 
 function largestPowerOf2LessThan(n: number): number {

--- a/packages/verify/src/verify.ts
+++ b/packages/verify/src/verify.ts
@@ -351,52 +351,81 @@ function expectedPathTopology(leafIndex: number, treeSize: number): ("left" | "r
  * of 2 through exactly that gap. Unreachable through JSON-parsed input, but
  * this is an exported function whose contract is "untrusted input", so the
  * contract has to hold against objects the caller built by hand.
+ *
+ * The `proof` argument itself is part of that contract: it is guarded for
+ * object-ness, and the extraction below is wrapped so a throwing accessor or
+ * a revoked proxy answers `false` like any other structural defect. The catch
+ * spans ONLY the reads — never the hashing — so it can never turn a genuine
+ * crypto fault into a silent verdict.
  */
 export function verifyInclusionProof(
 	proof: MerkleInclusionProof,
 	publishedRoot: string,
 	publishedTreeSize: number,
 ): boolean {
-	const treeSize = proof.treeSize;
+	const candidate: unknown = proof;
+	if (typeof candidate !== "object" || candidate === null) {
+		return false;
+	}
+
+	let treeSize: number;
+	let root: string;
+	let leafIndex: number;
+	let leafHash: unknown;
+	let siblings: unknown;
+	try {
+		treeSize = proof.treeSize;
+		root = proof.root;
+		leafIndex = proof.leafIndex;
+		leafHash = proof.leafHash;
+		siblings = proof.siblings;
+	} catch {
+		return false;
+	}
+
 	if (treeSize !== publishedTreeSize) {
 		return false;
 	}
 
-	const root = proof.root;
 	if (root !== publishedRoot) {
 		return false;
 	}
 
-	const expected = expectedPathTopology(proof.leafIndex, treeSize);
+	const expected = expectedPathTopology(leafIndex, treeSize);
 	if (expected === null) {
 		return false;
 	}
 
-	const leafHash = proof.leafHash;
 	if (typeof leafHash !== "string") {
 		return false;
 	}
 
-	const siblings: unknown = proof.siblings;
 	if (!Array.isArray(siblings) || siblings.length !== expected.length) {
 		return false;
 	}
 
-	// Materialize the checked hashes; nothing below re-reads `proof`.
+	// Materialize the checked hashes; nothing below re-reads `proof`. These are
+	// extraction reads too — an index or accessor on a hand-built array can
+	// throw — so they carry the same catch, and it still stops short of the
+	// hashing.
 	const path: string[] = [];
-	for (const [level, expectedPosition] of expected.entries()) {
-		const sibling = siblings[level] as Partial<MerkleSibling> | null | undefined;
-		if (typeof sibling !== "object" || sibling === null) {
-			return false;
+	try {
+		for (const [level, expectedPosition] of expected.entries()) {
+			const sibling = siblings[level] as Partial<MerkleSibling> | null | undefined;
+			if (typeof sibling !== "object" || sibling === null) {
+				return false;
+			}
+			const hash = sibling.hash;
+			if (typeof hash !== "string") {
+				return false;
+			}
+			if (sibling.position !== expectedPosition) {
+				return false;
+			}
+			path.push(hash);
 		}
-		const hash = sibling.hash;
-		if (typeof hash !== "string") {
-			return false;
-		}
-		if (sibling.position !== expectedPosition) {
-			return false;
-		}
-		path.push(hash);
+	} catch {
+		return false;
 	}
 
 	let currentHash = hashLeaf(leafHash);

--- a/packages/verify/tests/verify.test.ts
+++ b/packages/verify/tests/verify.test.ts
@@ -11,6 +11,8 @@ import {
 	generateInclusionProof,
 	hashInternal,
 	hashLeaf,
+	type MerkleInclusionProof,
+	type MerkleSibling,
 	verifyChain,
 	verifyConsistencyProof,
 	verifyInclusionProof,
@@ -611,6 +613,179 @@ describe("verifyInclusionProof", () => {
 		for (let i = 0; i < 16; i++) {
 			const proof = generateInclusionProof(i, leaves, "seg-16");
 			expect(verifyInclusionProof(proof, rootOf(tree), 16)).toBe(true);
+		}
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Path topology. Mirrors packages/core/tests/audit/merkle.test.ts —
+// the fold alone proves a path exists, never that the leaf sits
+// where the proof claims it does.
+// ═══════════════════════════════════════════════════════════════
+
+describe("verifyInclusionProof — path topology", () => {
+	/** Cast an intentionally malformed proof to the declared shape. */
+	function malformed(value: unknown): MerkleInclusionProof {
+		return value as MerkleInclusionProof;
+	}
+
+	it("rejects a forged leafIndex riding an otherwise-valid fold", () => {
+		const leaves = makeLeaves(8);
+		const tree = buildMerkleTree(leaves);
+		const proof = generateInclusionProof(3, leaves, "seg-forged");
+
+		expect(verifyInclusionProof({ ...proof, leafIndex: 5 }, rootOf(tree), 8)).toBe(false);
+	});
+
+	it("rejects padded, truncated and flipped sibling paths", () => {
+		const leaves = makeLeaves(8);
+		const tree = buildMerkleTree(leaves);
+		const root = rootOf(tree);
+		const proof = generateInclusionProof(3, leaves, "seg-path");
+
+		const padded = { ...proof, siblings: [...proof.siblings, at(proof.siblings, 0)] };
+		expect(verifyInclusionProof(padded, root, 8)).toBe(false);
+
+		const truncated = { ...proof, siblings: proof.siblings.slice(0, 2) };
+		expect(verifyInclusionProof(truncated, root, 8)).toBe(false);
+
+		const flipped = {
+			...proof,
+			siblings: proof.siblings.map((s, i) =>
+				i === 1 ? { ...s, position: s.position === "left" ? "right" : "left" } : s,
+			),
+		};
+		expect(verifyInclusionProof(malformed(flipped), root, 8)).toBe(false);
+	});
+
+	it("rejects a non-'left'/'right' position rather than treating it as right", () => {
+		const leaves = makeLeaves(8);
+		const tree = buildMerkleTree(leaves);
+		const proof = generateInclusionProof(1, leaves, "seg-bogus");
+		const bogus = malformed({
+			...proof,
+			siblings: proof.siblings.map((s, i) => (i === 1 ? { ...s, position: "bogus" } : s)),
+		});
+
+		expect(verifyInclusionProof(bogus, rootOf(tree), 8)).toBe(false);
+	});
+
+	it("rejects the equal-hash flip: identical leaves refold to the same root", () => {
+		const twin = createHash("sha256").update("twin").digest("hex");
+		const pair = [twin, twin];
+		const root = rootOf(buildMerkleTree(pair));
+		const proof = generateInclusionProof(0, pair, "seg-twin");
+		expect(at(proof.siblings, 0).position).toBe("right");
+
+		const flipped: MerkleSibling[] = [{ hash: at(proof.siblings, 0).hash, position: "left" }];
+		expect(verifyInclusionProof({ ...proof, siblings: flipped }, root, 2)).toBe(false);
+		expect(verifyInclusionProof({ ...proof, leafIndex: 1 }, root, 2)).toBe(false);
+	});
+
+	it("rejects out-of-range leafIndex and non-safe-integer sizes", () => {
+		const leaves = makeLeaves(8);
+		const tree = buildMerkleTree(leaves);
+		const root = rootOf(tree);
+		const proof = generateInclusionProof(3, leaves, "seg-bounds");
+
+		for (const leafIndex of [-1, 8, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+			expect(verifyInclusionProof({ ...proof, leafIndex }, root, 8)).toBe(false);
+		}
+		// Number.isInteger(2**53) is true — Number.isSafeInteger is what refuses it.
+		for (const treeSize of [0, -1, 8.5, Number.POSITIVE_INFINITY, 2 ** 53]) {
+			expect(verifyInclusionProof({ ...proof, treeSize }, root, treeSize)).toBe(false);
+		}
+	});
+
+	it("returns false — never throws — for structurally malformed proofs", () => {
+		const leaves = makeLeaves(8);
+		const root = rootOf(buildMerkleTree(leaves));
+		const proof = generateInclusionProof(3, leaves, "seg-malformed");
+
+		const cases: MerkleInclusionProof[] = [
+			malformed({ ...proof, siblings: null }),
+			malformed({ ...proof, siblings: "not-an-array" }),
+			malformed({ ...proof, siblings: [proof.siblings[0], undefined, proof.siblings[2]] }),
+			malformed({ ...proof, siblings: [proof.siblings[0], null, proof.siblings[2]] }),
+			malformed({ ...proof, siblings: proof.siblings.map(({ hash }) => ({ hash })) }),
+			malformed({ ...proof, leafHash: undefined }),
+		];
+
+		for (const bad of cases) {
+			expect(() => verifyInclusionProof(bad, root, 8)).not.toThrow();
+			expect(verifyInclusionProof(bad, root, 8)).toBe(false);
+		}
+	});
+
+	// Hostile in-memory objects. These defend the EXPORTED function's
+	// "untrusted input" contract, not any vault ingestion path — a JSON-parsed
+	// proof carries plain data properties. A valid leaf-0 proof in a 4-leaf
+	// tree has orientations [right, right]; leafIndex 2 derives [right, left],
+	// so each fixture shows one face to validation and the other to a fold
+	// that re-reads.
+
+	it("rejects a `position` getter that flips between validation and the fold", () => {
+		const leaves = makeLeaves(4);
+		const root = rootOf(buildMerkleTree(leaves));
+		const proof = generateInclusionProof(0, leaves, "seg-hostile");
+		let reads = 0;
+		const hostile = {
+			hash: at(proof.siblings, 1).hash,
+			get position(): string {
+				reads += 1;
+				return reads === 1 ? "left" : "right";
+			},
+		};
+		const forged = malformed({
+			...proof,
+			leafIndex: 2,
+			siblings: [at(proof.siblings, 0), hostile],
+		});
+
+		expect(verifyInclusionProof(forged, root, 4)).toBe(false);
+		// One read per property, total — the fold must never come back for more.
+		expect(reads).toBe(1);
+	});
+
+	it("rejects an array whose Symbol.iterator yields a different path", () => {
+		const leaves = makeLeaves(4);
+		const root = rootOf(buildMerkleTree(leaves));
+		const proof = generateInclusionProof(0, leaves, "seg-hostile-iter");
+		const real = at(proof.siblings, 1);
+		const indexed: unknown[] = [at(proof.siblings, 0), { ...real, position: "left" }];
+		Object.defineProperty(indexed, Symbol.iterator, {
+			value: function* () {
+				yield at(proof.siblings, 0);
+				yield real;
+			},
+		});
+		const forged = malformed({ ...proof, leafIndex: 2, siblings: indexed });
+
+		expect(verifyInclusionProof(forged, root, 4)).toBe(false);
+	});
+
+	it("round-trips every leaf of trees sized 1..33, including promotion shapes", () => {
+		for (let size = 1; size <= 33; size++) {
+			const leaves = makeLeaves(size);
+			const root = rootOf(buildMerkleTree(leaves));
+			for (let i = 0; i < size; i++) {
+				const proof = generateInclusionProof(i, leaves, `seg-${size}`);
+				expect(verifyInclusionProof(proof, root, size)).toBe(true);
+			}
+		}
+	});
+
+	it("no valid proof verifies at any other leaf index, for trees sized 2..17", () => {
+		for (let size = 2; size <= 17; size++) {
+			const leaves = makeLeaves(size);
+			const root = rootOf(buildMerkleTree(leaves));
+			for (let i = 0; i < size; i++) {
+				const proof = generateInclusionProof(i, leaves, `seg-${size}`);
+				for (let claimed = 0; claimed < size; claimed++) {
+					if (claimed === i) continue;
+					expect(verifyInclusionProof({ ...proof, leafIndex: claimed }, root, size)).toBe(false);
+				}
+			}
 		}
 	});
 });

--- a/packages/verify/tests/verify.test.ts
+++ b/packages/verify/tests/verify.test.ts
@@ -764,6 +764,71 @@ describe("verifyInclusionProof — path topology", () => {
 		expect(verifyInclusionProof(forged, root, 4)).toBe(false);
 	});
 
+	it("returns false for a proof that is not an object at all", () => {
+		const root = rootOf(buildMerkleTree(makeLeaves(4)));
+		for (const bad of [null, undefined, 42, "proof", true, Symbol("p")]) {
+			expect(() => verifyInclusionProof(malformed(bad), root, 4)).not.toThrow();
+			expect(verifyInclusionProof(malformed(bad), root, 4)).toBe(false);
+		}
+	});
+
+	it("returns false when any field accessor throws", () => {
+		const leaves = makeLeaves(4);
+		const root = rootOf(buildMerkleTree(leaves));
+		const proof = generateInclusionProof(0, leaves, "seg-throwing");
+
+		for (const field of ["treeSize", "root", "leafIndex", "leafHash", "siblings"]) {
+			const hostile = { ...proof };
+			Object.defineProperty(hostile, field, {
+				get(): never {
+					throw new Error(`hostile ${field}`);
+				},
+			});
+			expect(() => verifyInclusionProof(malformed(hostile), root, 4)).not.toThrow();
+			expect(verifyInclusionProof(malformed(hostile), root, 4)).toBe(false);
+		}
+	});
+
+	it("returns false when a sibling's index or accessor throws", () => {
+		const leaves = makeLeaves(4);
+		const root = rootOf(buildMerkleTree(leaves));
+		const proof = generateInclusionProof(0, leaves, "seg-throwing-sib");
+
+		const throwingIndex: unknown[] = [at(proof.siblings, 0), at(proof.siblings, 1)];
+		Object.defineProperty(throwingIndex, "1", {
+			get(): never {
+				throw new Error("hostile index");
+			},
+			configurable: true,
+		});
+		const byIndex = malformed({ ...proof, siblings: throwingIndex });
+		expect(() => verifyInclusionProof(byIndex, root, 4)).not.toThrow();
+		expect(verifyInclusionProof(byIndex, root, 4)).toBe(false);
+
+		for (const field of ["hash", "position"]) {
+			const sibling = { ...at(proof.siblings, 1) };
+			Object.defineProperty(sibling, field, {
+				get(): never {
+					throw new Error(`hostile ${field}`);
+				},
+			});
+			const forged = malformed({ ...proof, siblings: [at(proof.siblings, 0), sibling] });
+			expect(() => verifyInclusionProof(forged, root, 4)).not.toThrow();
+			expect(verifyInclusionProof(forged, root, 4)).toBe(false);
+		}
+	});
+
+	it("returns false for a revoked proxy", () => {
+		const leaves = makeLeaves(4);
+		const root = rootOf(buildMerkleTree(leaves));
+		const proof = generateInclusionProof(0, leaves, "seg-revoked");
+		const { proxy, revoke } = Proxy.revocable({ ...proof }, {});
+		revoke();
+
+		expect(() => verifyInclusionProof(malformed(proxy), root, 4)).not.toThrow();
+		expect(verifyInclusionProof(malformed(proxy), root, 4)).toBe(false);
+	});
+
 	it("round-trips every leaf of trees sized 1..33, including promotion shapes", () => {
 		for (let size = 1; size <= 33; size++) {
 			const leaves = makeLeaves(size);

--- a/site/content/docs/concepts/merkle-proofs.mdx
+++ b/site/content/docs/concepts/merkle-proofs.mdx
@@ -54,7 +54,7 @@ Returns the Merkle root and all intermediate layers. If the input is empty, `roo
 
 ## Inclusion Proofs
 
-An inclusion proof demonstrates that a specific audit event (identified by its leaf index) is part of the Merkle tree with a known root.
+An inclusion proof demonstrates that a specific audit event (identified by its zero-based leaf index) is part of the Merkle tree with a known root.
 
 ```typescript
 generateInclusionProof(
@@ -71,6 +71,8 @@ verifyInclusionProof(
 ```
 
 The proof contains the sibling hashes needed to recompute the path from the leaf to the root. A verifier walks the path, hashing at each level, and checks that the result matches the published root.
+
+Verification also checks the path's **topology**: the expected number of siblings and each one's left/right orientation are derived from `leafIndex` and `treeSize`, and a proof whose siblings do not match that sequence is rejected before any hashing. Recomputing to the right root is not enough on its own — without this check a proof could claim any position it liked, and where two sibling hashes are equal, flipping a sibling's side folds to the same root.
 
 ### MerkleInclusionProof
 


### PR DESCRIPTION
## Summary
- **Security fix.** `verifyInclusionProof` — in core AND its deliberate zero-dep mirror in `usertrust-verify` — folded the supplied siblings to the root without ever validating the path's topology against `(leafIndex, treeSize)`. A forged `leafIndex` rode a valid fold; flipped positions on equal-hash siblings verified; `position: "bogus"` was treated as "right". Found by adversarial review during the receipt-spec work (the spec now makes topology validation normative).
- Fix derives the expected orientation sequence under the tree's odd-node-promotion semantics (level-by-level, matching `buildMerkleTree` exactly) and validates path length + per-level position strictly before any hashing. Safe-integer bounds on `leafIndex`/`treeSize`; structurally malformed proofs return `false`, never throw.
- Hardened against hostile in-memory objects: every proof field is read exactly once into locals; the fold runs over a materialized validated array using the derived orientations (a flip-flopping getter or overridden iterator can no longer pass validation then fold a different path). A test pins reads === 1.
- Core and verify blocks are byte-identical (parity contract); differential tests call BOTH verifiers directly with shared forged fixtures.

## Test plan
- 7 attack tests proven red against master's verifier, green on the branch (independently reproduced by the coordinator): forged leafIndex, `position: "bogus"`, the equal-hash flip attack, out-of-range/non-integer/non-finite indices and sizes incl. `2**53`, malformed structures.
- Exhaustive round-trip: every leaf of every tree size 1..33 verifies before AND after; all-pairs re-claim for sizes 2..17 — no orientation-sequence collisions (position uniqueness holds under promotion).
- Hostile-object regressions: flipping getter + overridden iterator, mirrored in both packages + differential agreement.
- Coverage up, not down: merkle.ts branches 87.18→90.74, verify.ts 84.91→88.24; all four CI thresholds pass.
- Behavior note: callers who treated `leafIndex` as informational (or one-based) now fail verification — that is the fix working; `leafIndex` is zero-based (site doc updated).

## Known pre-existing (not in this PR)
- Top-level `proof` argument is not null-checked (`verifyInclusionProof(null, …)` throws; predates this change).
- `version`/`segmentId` remain unauthenticated by this function; hex-decoding permissiveness unchanged (needs its own compatibility analysis).

## Files changed
- `packages/core/src/audit/merkle.ts`, `packages/verify/src/verify.ts` (byte-identical blocks)
- Tests: `packages/core/tests/audit/merkle.test.ts`, `packages/core/tests/harden/differential.test.ts`, `packages/verify/tests/verify.test.ts`
- `AGENTS.md` (new Audit invariant + read-once clause), `CHANGELOG.md` (Security), `site/content/docs/concepts/merkle-proofs.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)