### PR TITLE
fix(policy): caller params can no longer set the gate's clock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,9 +695,16 @@ not assume they are the same:
 
 | Call site | Re-asserted after the spread |
 |---|---|
-| `govern.ts` — LLM path | `model`, `tier`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `budgetFractionRemaining`, `budgetRunwayHours`, `cost_center` |
-| `govern.ts` — `governAction` | `action_kind`, `action_name`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `tier`, `budgetFractionRemaining`, `budgetRunwayHours`, `cost_center` (**no `model`**) |
+| `govern.ts` — LLM path | `model`, `tier`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `budgetFractionRemaining`, `budgetRunwayHours`, `timestamp`, `cost_center` |
+| `govern.ts` — `governAction` | `action_kind`, `action_name`, `estimated_cost`, `budget_remaining`, `budget_remaining_after`, `tier`, `budgetFractionRemaining`, `budgetRunwayHours`, `timestamp`, `cost_center` (**no `model`**) |
 | `headless.ts` — `authorize` | same set as the LLM path |
+
+`timestamp` is on that list because it is the gate's CLOCK: `ruleMatches` evaluates a rule's
+`timeWindows` against `context.timestamp ?? new Date()`, so a request body that sets it decides
+whether a curfew rule fires. All three sites assert it `undefined`, which sends the gate back to the
+real clock — read in LOCAL time by contract (`isWithinTimeWindow` uses `getDay`/`getHours`, and
+changing that would silently re-time every deployed window). A host calling `evaluatePolicy`
+directly may still supply its own timestamp; it owns its clock.
 
 The obligation runs in **both** directions. New governance field on `PolicyContext` → re-assert it
 at every one of the three sites, **including asserting `undefined` when the honest value is

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -1347,6 +1347,17 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						budget_remaining_after: gateRemaining - estimatedCost,
 						budgetFractionRemaining: tierFields.budgetFractionRemaining,
 						budgetRunwayHours: tierFields.budgetRunwayHours,
+						// P1-CLOCK-SHADOW: the gate's CLOCK is trusted-host input too.
+						// `ruleMatches` evaluates `timeWindows` against
+						// `context.timestamp ?? new Date()`, so a request body carrying
+						// `{"timestamp": "..."}` would otherwise choose whether a curfew rule
+						// fires — walking a call out of a live window, or into a dormant one.
+						// Asserted explicitly `undefined` for the same reason as the budget
+						// tier fields: absent is the honest value, and absent is what makes
+						// the gate read the REAL clock. Time windows are evaluated in LOCAL
+						// time by contract (`isWithinTimeWindow` uses getDay/getHours); this
+						// changes WHOSE clock the gate reads, never which zone it reads in.
+						timestamp: undefined,
 						// Structurally un-forgeable: this comes from the caller's own async
 						// execution context, which no request body can reach. Asserted after
 						// the spread like every other trusted field, `undefined` included.
@@ -2767,6 +2778,11 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 						// same assertion on the LLM path above.
 						budgetFractionRemaining: tierFields.budgetFractionRemaining,
 						budgetRunwayHours: tierFields.budgetRunwayHours,
+						// P1-CLOCK-SHADOW: same assertion, same reason as the LLM path above —
+						// `action.params` must not be able to pick the time a `timeWindows`
+						// rule is evaluated at. Explicit `undefined` sends the gate back to the
+						// real clock, which it reads in LOCAL time by contract.
+						timestamp: undefined,
 						// Structurally un-forgeable: it comes from this call's own async
 						// execution context, which `action.params` cannot reach.
 						cost_center: envelope?.attribution.costCenter,

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -1013,6 +1013,12 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 						budget_remaining_after: gateRemaining - estCost,
 						budgetFractionRemaining: tierFields.budgetFractionRemaining,
 						budgetRunwayHours: tierFields.budgetRunwayHours,
+						// P1-CLOCK-SHADOW: the third re-assertion site, same assertion and same
+						// reason as govern.ts — `params.params` must not be able to pick the
+						// time a `timeWindows` rule is evaluated at. Explicit `undefined` sends
+						// the gate back to the real clock, which it reads in LOCAL time by
+						// contract.
+						timestamp: undefined,
 						// Structurally un-forgeable: this comes from the caller's own async
 						// execution context, which no request body can reach. Asserted after
 						// the spread like every other trusted field, `undefined` included.

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -390,8 +390,23 @@ export interface PolicyContext extends Record<string, unknown> {
 	scope?: string[];
 	/** Optional time windows for temporal constraints */
 	timeWindows?: TimeWindow[];
-	/** Optional timestamp override (defaults to now) */
-	timestamp?: string;
+	/**
+	 * Optional evaluation-time override (defaults to now).
+	 *
+	 * TRUSTED HOST INPUT ONLY, exactly like the budget fields below: it is what
+	 * `ruleMatches` feeds to {@link isWithinTimeWindow}, so whoever writes it
+	 * decides whether a `timeWindows` rule fires at all. All three SDK call sites
+	 * spread the caller's params first and then re-assert this field as explicit
+	 * `undefined`, so a body carrying `{"timestamp": "..."}` cannot walk a call
+	 * out of a curfew window — or into one. A host driving `evaluatePolicy`
+	 * directly (a replay, a what-if, a backfilled audit) may still set it; that
+	 * host owns its own clock.
+	 *
+	 * Declared `| undefined` so a call site under `exactOptionalPropertyTypes`
+	 * can write the field explicitly as `undefined` to overwrite an untrusted
+	 * inbound value; the `??` fallback reads the result as absent either way.
+	 */
+	timestamp?: string | undefined;
 
 	/**
 	 * Budget telemetry for the cost center funding this call. Both fields are

--- a/packages/core/tests/harden/clock-shadow.test.ts
+++ b/packages/core/tests/harden/clock-shadow.test.ts
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * P1-PARAM-SHADOW, extended to the gate's CLOCK — a request body must never be
+ * able to choose which time a policy rule is evaluated at.
+ *
+ * `PolicyContext.timestamp` is a governance input like any other: `ruleMatches`
+ * reads `context.timestamp ?? new Date().toISOString()` and feeds it to
+ * `isWithinTimeWindow`, so whoever writes that field decides whether a
+ * `timeWindows` rule fires. Every `evaluatePolicy` call site spreads the
+ * caller's params FIRST precisely so trusted fields can be re-asserted after it
+ * (AGENTS.md, "Trusted policy-context fields are re-asserted AFTER the
+ * request-body spread"), and `timestamp` must be re-asserted `undefined` there
+ * for the same reason the budget-tier fields are: absent is the honest value,
+ * and absent means the gate falls back to the REAL clock.
+ *
+ * The two directions are both tested at all three sites, because they fail
+ * differently:
+ *
+ *  - **Escaping a live window** (the security case): a hard deny scoped to a
+ *    window the real clock is INSIDE must still fire when the body claims a
+ *    time outside it.
+ *  - **Inflicting a dormant window**: a hard deny scoped to a window the real
+ *    clock is OUTSIDE must NOT fire just because the body claims a time inside
+ *    it. This is the direction that proves the real clock actually wins rather
+ *    than the caller's field merely being ignored in one direction.
+ *
+ * TIME WINDOWS ARE LOCAL TIME BY CONTRACT — `isWithinTimeWindow` uses
+ * `getDay()`/`getHours()`, not their UTC counterparts. These fixtures therefore
+ * derive their windows from the LOCAL day of a real `Date`, never from a
+ * hard-coded UTC weekday, and read the forged timestamp's local day back off
+ * the `Date` object instead of assuming `(today + 3) % 7` (a DST transition can
+ * move a near-midnight instant onto a different local day).
+ *
+ * SECURITY (mirrors cost-center-spoof.test.ts): never log or snapshot a whole
+ * PolicyContext — it carries request-shaped data. Assert on individual fields.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { trust } from "../../src/govern.js";
+import { createGovernor } from "../../src/headless.js";
+import { evaluatePolicy, type PolicyContext } from "../../src/policy/gate.js";
+
+// tigerbeetle-node is a native module and is never loaded in unit tests.
+vi.mock("tigerbeetle-node", () => ({
+	createClient: vi.fn(() => ({
+		createAccounts: vi.fn(async () => []),
+		createTransfers: vi.fn(async () => []),
+		lookupAccounts: vi.fn(async () => []),
+		lookupTransfers: vi.fn(async () => []),
+		destroy: vi.fn(),
+	})),
+	AccountFlags: { linked: 1, debits_must_not_exceed_credits: 2, history: 4 },
+	TransferFlags: { linked: 1, pending: 2, post_pending_transfer: 4, void_pending_transfer: 8 },
+	CreateTransferStatus: { created: 4294967295, exists: 1, exceeds_credits: 34 },
+	CreateAccountStatus: { created: 4294967295, exists: 1 },
+	amount_max: 0xffffffffffffffffffffffffffffffffn,
+}));
+
+// The evaluator itself stays REAL — this only records the context each call
+// site hands it, so the assertions are about what the gate actually saw.
+vi.mock("../../src/policy/gate.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../src/policy/gate.js")>();
+	return { ...actual, evaluatePolicy: vi.fn(actual.evaluatePolicy) };
+});
+
+const VAULT_DIR = ".usertrust";
+const POLICY_REL = "policies/default.yml";
+
+// ── Time fixtures (LOCAL time, per the contract above) ──
+
+const NOW = new Date();
+/** The local weekday the real clock is on right now. */
+const TODAY = NOW.getDay();
+/**
+ * Included in the "live" window alongside TODAY so a run that crosses local
+ * midnight mid-test still has the real clock inside the window it is supposed
+ * to be inside.
+ */
+const TOMORROW = (TODAY + 1) % 7;
+/** What a forged body claims instead: three days out, so never TODAY/TOMORROW. */
+const FORGED_DATE = new Date(NOW.getTime() + 3 * 86_400_000);
+const FORGED_TS = FORGED_DATE.toISOString();
+/** Read back off the Date rather than computed, so DST cannot desynchronise it. */
+const FORGED_DAY = FORGED_DATE.getDay();
+
+/** A hard deny that fires whenever it matches, restricted to `days`. */
+function denyDuring(days: number[]): Record<string, unknown> {
+	return {
+		id: "window-deny",
+		name: "window-deny",
+		effect: "deny",
+		enforcement: "hard",
+		// `tier` is re-asserted at every call site, so this condition is true on
+		// every governed call and the time window is the only thing gating the rule.
+		conditions: [{ field: "tier", operator: "exists" }],
+		timeWindows: [{ daysOfWeek: days }],
+	};
+}
+
+/** Window the real clock is INSIDE — the body tries to escape it. */
+const LIVE_WINDOW = [TODAY, TOMORROW];
+/** Window the real clock is OUTSIDE — the body tries to walk into it. */
+const DORMANT_WINDOW = [FORGED_DAY];
+
+function makeTmpVault(rules: unknown[]): string {
+	const base = join(tmpdir(), `harden-clock-${randomUUID()}`);
+	const dir = join(base, VAULT_DIR);
+	mkdirSync(join(dir, "policies"), { recursive: true });
+	writeFileSync(
+		join(dir, "usertrust.config.json"),
+		JSON.stringify({ budget: 1_000_000, tier: "pro", policies: `./${POLICY_REL}` }),
+	);
+	writeFileSync(join(dir, POLICY_REL), JSON.stringify({ rules }));
+	return base;
+}
+
+/** The context the (real) evaluator saw for the most recent gate call. */
+function lastPolicyContext(): PolicyContext {
+	const calls = vi.mocked(evaluatePolicy).mock.calls;
+	const last = calls[calls.length - 1];
+	if (last === undefined) throw new Error("the policy evaluator was never called");
+	return last[1];
+}
+
+const PARAMS = {
+	model: "claude-sonnet-4-6",
+	max_tokens: 64,
+	messages: [{ role: "user", content: "hi" }],
+};
+
+const vaults: string[] = [];
+function vault(rules: unknown[]): string {
+	const base = makeTmpVault(rules);
+	vaults.push(base);
+	return base;
+}
+
+beforeEach(() => {
+	vi.mocked(evaluatePolicy).mockClear();
+});
+
+afterEach(() => {
+	for (const base of vaults.splice(0)) {
+		try {
+			rmSync(base, { recursive: true, force: true });
+		} catch {
+			// best-effort
+		}
+	}
+});
+
+// A VACUITY GUARD, not a hole detector — it is the one case in this file that
+// passes with or without the fix, deliberately. If the forged day ever collided
+// with the live window, the forged timestamp and the real clock would agree and
+// every "escape"/"inflict" assertion below would pass for the wrong reason.
+it("vacuity guard (passes pre- and post-fix): the forged local day is outside the live window", () => {
+	expect(LIVE_WINDOW).not.toContain(FORGED_DAY);
+});
+
+// ---------------------------------------------------------------------------
+// Site 1 — govern.ts's LLM path (interceptCall)
+// ---------------------------------------------------------------------------
+
+describe("LLM path (trust()) — request-body clock forgery", () => {
+	it("a caller-supplied timestamp cannot escape a deny window the REAL clock is inside", async () => {
+		const createSpy = vi.fn(async () => ({
+			id: "x",
+			usage: { input_tokens: 1, output_tokens: 1 },
+		}));
+		const governed = await trust(
+			{ messages: { create: createSpy } },
+			{ dryRun: true, vaultBase: vault([denyDuring(LIVE_WINDOW)]) },
+		);
+
+		await expect(
+			governed.messages.create({ ...PARAMS, timestamp: FORGED_TS } as Record<string, unknown>),
+			// The rule ID, not just "Policy denied" — this must be THE window rule
+			// firing, not some unrelated default deny standing in for it.
+		).rejects.toThrow(/\[window-deny\]/);
+		expect(createSpy).not.toHaveBeenCalled();
+		// The gate never saw the caller's clock; it fell back to the real one.
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await governed.destroy();
+	});
+
+	it("a caller-supplied timestamp cannot inflict a deny window the REAL clock is outside", async () => {
+		const createSpy = vi.fn(async () => ({
+			id: "x",
+			usage: { input_tokens: 1, output_tokens: 1 },
+		}));
+		const governed = await trust(
+			{ messages: { create: createSpy } },
+			{ dryRun: true, vaultBase: vault([denyDuring(DORMANT_WINDOW)]) },
+		);
+
+		await expect(
+			governed.messages.create({ ...PARAMS, timestamp: FORGED_TS } as Record<string, unknown>),
+		).resolves.toBeDefined();
+		// The call really was forwarded — an "allow" that quietly swallowed the
+		// request would satisfy a rejects-free assertion just as well.
+		expect(createSpy).toHaveBeenCalledTimes(1);
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Site 2 — govern.ts's governAction
+// ---------------------------------------------------------------------------
+
+describe("governAction — action.params clock forgery", () => {
+	const ACTION = { kind: "tool_use" as const, name: "search", cost: 25 };
+
+	it("action.params cannot escape a deny window the REAL clock is inside", async () => {
+		const governed = await trust(
+			{ messages: { create: vi.fn() } },
+			{ dryRun: true, vaultBase: vault([denyDuring(LIVE_WINDOW)]) },
+		);
+		const run = vi.fn(async () => "ok");
+
+		await expect(
+			governed.governAction({ ...ACTION, params: { timestamp: FORGED_TS } }, run),
+		).rejects.toThrow(/\[window-deny\]/);
+		expect(run).not.toHaveBeenCalled();
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await governed.destroy();
+	});
+
+	it("action.params cannot inflict a deny window the REAL clock is outside", async () => {
+		const governed = await trust(
+			{ messages: { create: vi.fn() } },
+			{ dryRun: true, vaultBase: vault([denyDuring(DORMANT_WINDOW)]) },
+		);
+		const run = vi.fn(async () => "ok");
+
+		await expect(
+			governed.governAction({ ...ACTION, params: { timestamp: FORGED_TS } }, run),
+		).resolves.toBeDefined();
+		expect(run).toHaveBeenCalled();
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await governed.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Site 3 — headless.ts's authorize (the third re-assertion site, AGENTS.md)
+// ---------------------------------------------------------------------------
+
+describe("headless authorize — params.params clock forgery", () => {
+	const AUTHORIZE = { model: "claude-sonnet-4-6", estimatedInputTokens: 100, maxOutputTokens: 500 };
+
+	it("params.params cannot escape a deny window the REAL clock is inside", async () => {
+		const gov = await createGovernor({ dryRun: true, vaultBase: vault([denyDuring(LIVE_WINDOW)]) });
+
+		await expect(gov.authorize({ ...AUTHORIZE, params: { timestamp: FORGED_TS } })).rejects.toThrow(
+			/\[window-deny\]/,
+		);
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await gov.destroy();
+	});
+
+	it("params.params cannot inflict a deny window the REAL clock is outside", async () => {
+		const gov = await createGovernor({
+			dryRun: true,
+			vaultBase: vault([denyDuring(DORMANT_WINDOW)]),
+		});
+
+		const auth = await gov.authorize({ ...AUTHORIZE, params: { timestamp: FORGED_TS } });
+		expect(auth.transferId).toEqual(expect.any(String));
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await gov.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The HOUR half of the window predicate, on a DETERMINISTIC clock
+//
+// The three site pairs above move the `daysOfWeek` half of `isWithinTimeWindow`
+// and take the real clock as they find it. This pair pins the OTHER half —
+// `startHour`/`endHour`, the shape a real after-hours freeze is written in —
+// and fakes only `Date` (`toFake: ["Date"]`, so the governor's real timers and
+// async plumbing are untouched) to put the machine clock on a chosen side of
+// the window. Both instants are built from LOCAL components, so the fixture
+// means the same thing in every timezone.
+//
+// It runs on `headless.authorize` because that is the highest-blast-radius
+// site: `packages/server` hands `governor.authorize(parsed.data)` a request
+// body straight off the wire, so the "caller" there is a REMOTE tenant.
+// ---------------------------------------------------------------------------
+
+describe("headless authorize — hour-window freeze on a faked machine clock", () => {
+	const FREEZE = {
+		id: "after-hours-freeze",
+		name: "after-hours-freeze",
+		effect: "deny",
+		enforcement: "hard",
+		severity: "high",
+		conditions: [{ field: "estimated_cost", operator: "exists" }],
+		timeWindows: [{ startHour: 9, endHour: 12 }],
+	};
+	const AUTHORIZE = { model: "claude-sonnet-4-6", estimatedInputTokens: 100, maxOutputTokens: 500 };
+	const INSIDE = new Date(2026, 7, 12, 10, 30, 0); // local 10:30 → inside 9–12
+	const OUTSIDE = new Date(2026, 7, 12, 3, 30, 0); // local 03:30 → outside 9–12
+
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ["Date"] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("a body claiming 03:30 cannot dodge the freeze while the machine clock says 10:30", async () => {
+		vi.setSystemTime(INSIDE);
+		const gov = await createGovernor({ dryRun: true, vaultBase: vault([FREEZE]) });
+
+		await expect(
+			gov.authorize({ ...AUTHORIZE, params: { timestamp: OUTSIDE.toISOString() } }),
+		).rejects.toThrow(/\[after-hours-freeze\]/);
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await gov.destroy();
+	});
+
+	it("a body claiming 10:30 cannot manufacture the freeze while the machine clock says 03:30", async () => {
+		vi.setSystemTime(OUTSIDE);
+		const gov = await createGovernor({ dryRun: true, vaultBase: vault([FREEZE]) });
+
+		const auth = await gov.authorize({
+			...AUTHORIZE,
+			params: { timestamp: INSIDE.toISOString() },
+		});
+		expect(auth.transferId).toEqual(expect.any(String));
+		expect(lastPolicyContext().timestamp).toBeUndefined();
+
+		await gov.destroy();
+	});
+});


### PR DESCRIPTION
**Security fix, isolated deliberately** so adopters do not wait on unrelated feature work and so it is not buried in a feature changelog.

## What was wrong

`evaluatePolicy` resolves the clock as `context.timestamp ?? new Date().toISOString()` (both `ruleMatches` and the evaluator entry). All three governor call sites spread caller-supplied params into the `PolicyContext` and then re-assert the trusted fields — model, tier, budget tiers, `cost_center` — but **`timestamp` was missing from that list at every site**.

So a caller could supply the clock that policy **time-window** rules are matched against: escape a live curfew rule, or inflict a dormant one.

**Highest blast radius: `headless.ts`.** `packages/server` wraps it, so the caller there is a remote tenant over HTTP and the value arrives in a request body.

`AGENTS.md` already documented this as a three-site invariant for `cost_center` — *"re-assert it at every one of the three sites"*. `timestamp` was simply omitted from the table. The table now lists it.

## What this does and does not change

- **Closes** the request-body route through all three governors (`govern.ts` ×2, `headless.ts`).
- **Does not retire** `PolicyContext.timestamp`, which remains a legitimate trusted-host input for a host that builds its own context and calls `evaluatePolicy` directly — exactly as the `gate.ts` docblock example shows.
- **Leaves time windows in LOCAL time**, by contract (`isWithinTimeWindow` reads `getDay`/`getHours`). Moving them to UTC would silently alter deny behavior for every deployed policy carrying a time window; explicitly out of scope.

## Evidence

`clock-shadow.test.ts` — **9 tests**: four decision-level pairs (escape a live window / inflict a dormant one) covering all three call sites, including a pair against a `startHour`/`endHour` freeze with the clock faked, plus one explicitly-declared vacuity guard that passes pre- and post-fix by design and says so in its title. Deny assertions match on the rule ID; allow assertions prove the call was really forwarded.

Verified **failing-first** two independent ways:
1. TDD order during implementation — the test file was written and run RED before any source edit.
2. Re-confirmed from a clean revert: the three source files restored via `git show HEAD:<path>` into an isolated sandbox replica (the shared worktree was never reverted) → **8 failed / 1 passed**, the single pass being the vacuity guard.

Post-fix 9/9; full core suite green (see CI on this PR).

A separately authored test file using a different harness (fake timers, `startHour`/`endHour` windows) also passed against this implementation before being dropped as a duplicate.

## Known exposure

`usertools-stealth` is **not** affected — verified three ways: `apps/api` imports `usertrust` type-only, its own governance builds timestamps server-side at every site, and it defines no time-window rules.

Beyond that we cannot survey adopters of the published package. Anyone using policy `timeWindows` on `usertrust-server`, or calling the headless governor with caller-supplied params, should take this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)