### PR TITLE
fix(policy): policy loading and rule evaluation fail closed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -743,6 +743,14 @@ real clock — read in LOCAL time by contract (`isWithinTimeWindow` uses `getDay
 changing that would silently re-time every deployed window). A host calling `evaluatePolicy`
 directly may still supply its own timestamp; it owns its clock.
 
+**A time window may WRAP midnight, and `startHour > endHour` is how you say so.** A wrapping window
+matches `hour >= startHour || hour < endHour`; a non-wrapping one applies each bound independently.
+`startHour === endHour` is zero-width and matches nothing — read it as "no hours", not "all hours".
+The `daysOfWeek` gate applies to the timestamp's OWN local day, so an overnight window restricted to
+Monday covers Monday 22:00–23:59 and Monday 00:00–05:59, not Tuesday's small hours. *Prevents:* the
+pre-fix behaviour, where the two bounds were applied independently, so a window whose `startHour`
+exceeded its `endHour` was unsatisfiable at every hour and imposed no constraint.
+
 The obligation runs in **both** directions. New governance field on `PolicyContext` → classify it in
 `HOST_CONTROLLED_POLICY_FIELDS` or `CALLER_SUPPLIED_POLICY_FIELDS` (the parity test fails until you
 do), and re-assert it at every one of the three sites, **including asserting `undefined` when the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -694,15 +694,17 @@ unknown operator is refused at load, and is indeterminate at runtime for a rule 
 document carries and compares determinately.
 
 **A policy file that cannot be honoured is refused, never silently emptied.** `loadPolicies` throws
-`PolicyLoadError`; `validatePolicyFile` reports every problem in one pass for `usertrust policy
-validate` and the health report. It is all-or-nothing — one bad rule loads none of them, because
-loading the survivors would enforce a policy nobody wrote. An **absent** file stays legal (no policy
-is a valid deployment); a present-but-unreadable one does not. The document ROOT is strict as well
-as each rule, so a key placed outside the rule it was meant to apply to is refused rather than
-dropped. *Prevents:* the pre-fix behaviour, where unparseable or unrecognised input resolved to an
-empty rule set with no throw and no log, and `usertrust health` — which reported violations rather
-than rule count — could not distinguish an enforced policy from an unloaded one. Health now reports
-loaded and ACTIVE rule counts, since `enabled: false` rules load and never fire.
+`PolicyLoadError`; `validatePolicyFile` reports every problem in one pass. It is all-or-nothing —
+one bad rule loads none of them, because loading the survivors would enforce a policy nobody wrote.
+An **absent** file stays legal (no policy is a valid deployment); a present-but-unreadable one does
+not, and the two are told apart by ENOENT rather than by an `existsSync` preflight, which answers
+false for a file inside a directory it cannot traverse. An explicit `null` document is refused —
+only a genuinely blank file is an empty policy. The document ROOT is strict as well as each rule and
+each condition, so a key placed outside the thing it was meant to apply to is refused rather than
+dropped, and an operand that could never match — a non-finite number for any operator, a map or list
+for an identity comparison — is refused rather than accepted as a rule that cannot enforce.
+*Prevents:* the pre-fix behaviour, where unparseable or unrecognised input resolved to an empty rule
+set with no throw and no log.
 
 **Host-owned policy-context fields are STRIPPED BEFORE the request-body spread.** Every
 `evaluatePolicy` call site builds context as `{ ...sanitizePolicyContext(callerParams),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -684,11 +684,48 @@ escape hatch. User policy can only *add* rules.
 before the ledger's `debits_must_not_exceed_credits` ever engages.
 
 **Hard rules fail closed; soft rules stay lenient.** An indeterminate condition (missing or
-mistyped guarded field) is treated as *satisfied* for a hard rule, so the guard still fires.
+mistyped guarded field) is treated as *satisfied* for a hard rule, so the guard still fires. This
+holds for **every** value operator. It previously held for only `gt`/`gte`/`lt`/`lte`: `eq`, `in`,
+`contains` and `regex` returned a bare `false` on input they could not read, which `ruleMatches`
+reads as "did not match" rather than "could not evaluate". `exists`/`not_exists` are the deliberate
+exception: an unresolved field is what they measure, so for them absence is a determinate answer. An
+unknown operator is refused at load, and is indeterminate at runtime for a rule built in code.
+`undefined` means the path did not resolve and is unanswerable; an explicit `null` is a value the
+document carries and compares determinately.
 
-**Trusted policy-context fields are re-asserted AFTER the request-body spread.** Every
-`evaluatePolicy` call site builds context as `{ ...callerParams, ...trustedFields }`. The spread
-exists *precisely so* trusted fields can be re-asserted after it.
+**A policy file that cannot be honoured is refused, never silently emptied.** `loadPolicies` throws
+`PolicyLoadError`; `validatePolicyFile` reports every problem in one pass for `usertrust policy
+validate` and the health report. It is all-or-nothing — one bad rule loads none of them, because
+loading the survivors would enforce a policy nobody wrote. An **absent** file stays legal (no policy
+is a valid deployment); a present-but-unreadable one does not. The document ROOT is strict as well
+as each rule, so a key placed outside the rule it was meant to apply to is refused rather than
+dropped. *Prevents:* the pre-fix behaviour, where unparseable or unrecognised input resolved to an
+empty rule set with no throw and no log, and `usertrust health` — which reported violations rather
+than rule count — could not distinguish an enforced policy from an unloaded one. Health now reports
+loaded and ACTIVE rule counts, since `enabled: false` rules load and never fire.
+
+**Host-owned policy-context fields are STRIPPED BEFORE the request-body spread.** Every
+`evaluatePolicy` call site builds context as `{ ...sanitizePolicyContext(callerParams),
+...trustedFields }`. The explicit assignments after the spread still say what each trusted field is,
+but they are no longer what makes it safe: a field someone forgets to re-assert is now simply
+**absent** rather than caller-chosen, and absent is the fail-closed answer.
+
+`HOST_CONTROLLED_POLICY_FIELDS` in `policy/gate.ts` is the stripped set.
+`CALLER_SUPPLIED_POLICY_FIELDS` is the deliberate complement, and
+`tests/harden/policy-context-fields.test.ts` reads the `PolicyContext` interface out of the source
+and requires every declared field to appear in exactly one of the two — so a newly added field
+cannot be left unclassified. *Why a mechanism and not one more literal:* the hand-maintained list
+had already been found incomplete once (`timestamp`, PR #95).
+
+**`scope` is deliberately NOT stripped, and this is not an oversight.** For `timestamp`, absence is
+the SAFE state — the gate falls back to the real clock. For `scope`, absence is the PERMISSIVE
+state: `ruleMatches` requires a non-empty `context.scope` for any rule carrying `scopePatterns`, and
+**nothing in `src/` populates it**. Stripping it would not close a hole; it would make every
+`scopePatterns` rule permanently inert. The two fields look like the same kind and are opposites.
+The live issue there is docs-vs-code — the docs present a `scopePatterns` rule as the flagship
+example and state that an absent `scopePatterns` "matches all scopes", i.e. that adding one narrows
+a live rule, while such a rule structurally never fires. Unresolved; do not "fix" it by adding
+`scope` to the stripped set.
 
 There are exactly three call sites, and **their field sets differ** — check against this list, do
 not assume they are the same:
@@ -706,10 +743,11 @@ real clock — read in LOCAL time by contract (`isWithinTimeWindow` uses `getDay
 changing that would silently re-time every deployed window). A host calling `evaluatePolicy`
 directly may still supply its own timestamp; it owns its clock.
 
-The obligation runs in **both** directions. New governance field on `PolicyContext` → re-assert it
-at every one of the three sites, **including asserting `undefined` when the honest value is
-unknown.** New call site → spread the caller's params *first*, then re-assert the whole set; a site
-that spreads last, or that re-asserts a subset, is the failure below.
+The obligation runs in **both** directions. New governance field on `PolicyContext` → classify it in
+`HOST_CONTROLLED_POLICY_FIELDS` or `CALLER_SUPPLIED_POLICY_FIELDS` (the parity test fails until you
+do), and re-assert it at every one of the three sites, **including asserting `undefined` when the
+honest value is unknown.** New call site → `sanitizePolicyContext` the caller's params *first*, then
+assert the whole set; a site that spreads raw params, or spreads last, is the failure below.
 *Prevents:* a client POSTing `{"model": "...", "budgetFractionRemaining": 0.95}` and walking through
 a hard deny rule. Asserting `undefined` means the rule simply does not match — fail closed, rather
 than matching a number the caller chose. (An `exists`-guard alone makes this *worse*: only the

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -69,7 +69,13 @@ import {
 } from "./ledger/usage.js";
 import { recordPattern } from "./memory/patterns.js";
 import { DEFAULT_RULES, mergePolicies } from "./policy/default-rules.js";
-import { derivePolicyHint, evaluatePolicy, type GateRule, loadPolicies } from "./policy/gate.js";
+import {
+	derivePolicyHint,
+	evaluatePolicy,
+	type GateRule,
+	loadPolicies,
+	sanitizePolicyContext,
+} from "./policy/gate.js";
 import { detectInjection } from "./policy/injection.js";
 import { detectPII, redactPII } from "./policy/pii.js";
 import type { ProxyConnection } from "./proxy.js";
@@ -1054,7 +1060,12 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 	const audit: AuditWriter = (isTestEnv ? opts?._audit : undefined) ?? createAuditWriter(vaultPath);
 
 	const policiesPath = join(vaultPath, VAULT_DIR, config.policies);
-	const loadedRules = existsSync(policiesPath) ? loadPolicies(policiesPath) : [];
+	// No `existsSync` preflight: it answers false for a file inside a directory
+	// it cannot traverse, which would report an unreadable policy as an absent
+	// one — silently replacing custom rules with the built-in defaults.
+	// `loadPolicies` distinguishes ENOENT (legitimately absent) from every other
+	// read failure (refused), so it must be called unconditionally.
+	const loadedRules = loadPolicies(policiesPath);
 	// P1-CUSTOM-POLICY-REPLACES (RECON #2): platform DEFAULT_RULES are ALWAYS
 	// enforced. mergePolicies is a safe concat — a custom policy file can only ADD
 	// deny/warn rules, never remove the budget/overshoot/exhausted guarantees. The
@@ -1426,7 +1437,13 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							? envelopeTierFields(envelope.attribution, envelopeRemaining, Date.now())
 							: { budgetFractionRemaining: undefined, budgetRunwayHours: undefined };
 					const policyResult = evaluatePolicy(policyRules, {
-						...params,
+						// Host-owned PolicyContext fields are stripped BEFORE the spread, not
+						// re-asserted after it. The explicit assignments below still say what
+						// each trusted field is — but a field someone forgets to re-assert is
+						// now simply ABSENT rather than caller-chosen, which is the fail-closed
+						// answer. See HOST_CONTROLLED_POLICY_FIELDS for why the hand-maintained
+						// list needed a mechanism behind it.
+						...sanitizePolicyContext(params),
 						model,
 						tier: config.tier,
 						estimated_cost: estimatedCost,
@@ -2851,7 +2868,8 @@ export async function trust<T>(client: T, opts?: TrustOpts): Promise<TrustedClie
 							? envelopeTierFields(envelope.attribution, envelopeRemaining, Date.now())
 							: { budgetFractionRemaining: undefined, budgetRunwayHours: undefined };
 					const policyResult = evaluatePolicy(policyRules, {
-						...(action.params ?? {}),
+						// Stripped before the spread — see the LLM path above.
+						...sanitizePolicyContext(action.params),
 						action_kind: action.kind,
 						action_name: action.name,
 						estimated_cost: action.cost,

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -97,7 +97,13 @@ import {
 import { publishableUsage, sanitizeUsage } from "./ledger/usage.js";
 import { recordPattern } from "./memory/patterns.js";
 import { DEFAULT_RULES, mergePolicies } from "./policy/default-rules.js";
-import { derivePolicyHint, evaluatePolicy, type GateRule, loadPolicies } from "./policy/gate.js";
+import {
+	derivePolicyHint,
+	evaluatePolicy,
+	type GateRule,
+	loadPolicies,
+	sanitizePolicyContext,
+} from "./policy/gate.js";
 import { detectPII } from "./policy/pii.js";
 import type { ProxyConnection } from "./proxy.js";
 import { CircuitBreakerRegistry } from "./resilience/circuit.js";
@@ -816,7 +822,12 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 	const audit: AuditWriter = (isTestEnv ? opts?._audit : undefined) ?? createAuditWriter(vaultPath);
 
 	const policiesPath = join(vaultPath, VAULT_DIR, config.policies);
-	const loadedRules = existsSync(policiesPath) ? loadPolicies(policiesPath) : [];
+	// No `existsSync` preflight: it answers false for a file inside a directory
+	// it cannot traverse, which would report an unreadable policy as an absent
+	// one — silently replacing custom rules with the built-in defaults.
+	// `loadPolicies` distinguishes ENOENT (legitimately absent) from every other
+	// read failure (refused), so it must be called unconditionally.
+	const loadedRules = loadPolicies(policiesPath);
 	// P1-CUSTOM-POLICY-REPLACES (RECON #2): platform DEFAULT_RULES are ALWAYS
 	// enforced (parity with trust()). mergePolicies is a safe concat — a custom
 	// policy file can only ADD deny/warn rules, never remove the
@@ -1092,7 +1103,10 @@ export async function createGovernor(opts?: GovernorOpts): Promise<Governor> {
 							? envelopeTierFields(envelope.attribution, envelopeRemaining, Date.now())
 							: { budgetFractionRemaining: undefined, budgetRunwayHours: undefined };
 					const policyResult = evaluatePolicy(policyRules, {
-						...(params.params ?? {}),
+						// Stripped before the spread. This site has the widest blast radius:
+						// packages/server wraps it, so `params.params` arrives in an HTTP
+						// request body from a remote tenant.
+						...sanitizePolicyContext(params.params),
 						model,
 						tier: config.tier,
 						estimated_cost: estCost,

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -934,6 +934,21 @@ export const FIELD_OPERATORS = [
 	"regex",
 ] as const satisfies readonly FieldOperator[];
 
+/**
+ * Exhaustiveness in the OTHER direction.
+ *
+ * `satisfies readonly FieldOperator[]` only checks that everything listed is a
+ * member of the union — it does not check that every member is listed. A new
+ * `FieldOperator` would therefore compile cleanly while `z.enum(FIELD_OPERATORS)`
+ * rejected every policy file using it, which is the same shape as the defects
+ * this file exists to close: the guard reports success for a set it does not
+ * cover. This assertion fails to compile until the new member is added here,
+ * naming it in the error.
+ */
+type UnlistedOperator = Exclude<FieldOperator, (typeof FIELD_OPERATORS)[number]>;
+const _FIELD_OPERATORS_EXHAUSTIVE: UnlistedOperator extends never ? true : UnlistedOperator = true;
+void _FIELD_OPERATORS_EXHAUSTIVE;
+
 /** Operators whose `value` must be a number. */
 const NUMERIC_VALUE_OPERATORS = new Set<FieldOperator>(["gt", "gte", "lt", "lte"]);
 /** Operators whose `value` must be an array. */

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -955,6 +955,8 @@ const NUMERIC_VALUE_OPERATORS = new Set<FieldOperator>(["gt", "gte", "lt", "lte"
 const ARRAY_VALUE_OPERATORS = new Set<FieldOperator>(["in", "not_in"]);
 /** Operators whose `value` must be a string. */
 const STRING_VALUE_OPERATORS = new Set<FieldOperator>(["contains", "regex"]);
+/** Operators whose comparison is `===` or `includes`, i.e. identity for objects. */
+const IDENTITY_COMPARED_OPERATORS = new Set<FieldOperator>(["eq", "neq", "in", "not_in"]);
 /** Operators that read no `value` at all — they test presence. */
 const VALUELESS_OPERATORS = new Set<FieldOperator>(["exists", "not_exists"]);
 
@@ -980,7 +982,11 @@ const FIELD_CONDITION_KEYS = new Set(["field", "operator", "value"]);
 const FieldConditionSchema = z
 	.looseObject({
 		field: z.string().min(1, "must be a non-empty field path"),
-		operator: z.enum(FIELD_OPERATORS),
+		// NOT `z.enum` here: a failing enum aborts the object parse, which skips the
+		// refinement below and hides every structural fault behind the operator
+		// error. The membership check moved into the refinement so all faults are
+		// reported together.
+		operator: z.string(),
 		value: z.unknown().optional(),
 	})
 	.superRefine((fc, ctx) => {
@@ -992,7 +998,16 @@ const FieldConditionSchema = z
 				message: `unknown key on a condition. A condition carries only field, operator and value.`,
 			});
 		}
-		const op = fc.operator;
+
+		const op = fc.operator as FieldOperator;
+		if (!(FIELD_OPERATORS as readonly string[]).includes(fc.operator)) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["operator"],
+				message: `unknown operator "${fc.operator}". One of: ${FIELD_OPERATORS.join(", ")}`,
+			});
+			return;
+		}
 		if (VALUELESS_OPERATORS.has(op)) return;
 		if (fc.value === undefined) {
 			ctx.addIssue({
@@ -1018,8 +1033,28 @@ const FieldConditionSchema = z
 		// `NUMERIC_VALUE_OPERATORS` left exactly that hole. Infinity is refused on
 		// the same grounds — a threshold nothing can cross is not a threshold.
 		//
-		// Array operands are deliberately NOT covered: `includes` uses SameValueZero,
-		// so `in: [.nan]` does match a NaN subject and is a rule that works.
+		// An OBJECT or ARRAY operand for an equality/membership test compares by
+		// IDENTITY. A rule loaded from disk is freshly parsed, so it can never share
+		// a reference with request data: `eq: {team: "x"}` never matches a
+		// structurally identical request and `neq` always does. Such a rule validates
+		// and cannot enforce, so it is refused rather than accepted.
+		if (IDENTITY_COMPARED_OPERATORS.has(op)) {
+			const operands = op === "in" || op === "not_in" ? (fc.value as unknown[]) : [fc.value];
+			if (Array.isArray(operands)) {
+				for (const [i, operand] of operands.entries()) {
+					if (operand === null || typeof operand !== "object") continue;
+					ctx.addIssue({
+						code: "custom",
+						path: op === "in" || op === "not_in" ? ["value", i] : ["value"],
+						message: `operator "${op}" compares by identity, so a ${Array.isArray(operand) ? "list" : "map"} operand can never match a value read from a request. Compare a primitive field instead.`,
+					});
+				}
+			}
+		}
+
+		// Array operands are deliberately NOT covered by the finite check below:
+		// `includes` uses SameValueZero, so `in: [.nan]` does match a NaN subject
+		// and is a rule that works.
 		if (typeof fc.value === "number" && !Number.isFinite(fc.value)) {
 			ctx.addIssue({
 				code: "custom",
@@ -1161,8 +1196,22 @@ export function validatePolicyFile(path: string): PolicyLoadResult {
 		};
 	}
 
-	// An empty document is an empty policy, not a broken one.
-	if (parsed === null || parsed === undefined) return { rules: [], issues: [], present: true };
+	// A BLANK file is an empty policy. An explicit `null` / `~` is not: the author
+	// wrote something, and what they wrote cannot carry rules. Accepting it would
+	// run the governor on defaults while the file looked deliberate.
+	if (parsed === null || parsed === undefined) {
+		if (raw.trim() === "") return { rules: [], issues: [], present: true };
+		return {
+			rules: [],
+			issues: [
+				{
+					at: "file",
+					message: `is an explicit null document, which carries no rules. Delete the file to run without a custom policy, or give it a \`rules:\` list.`,
+				},
+			],
+			present: true,
+		};
+	}
 
 	let rawRules: unknown;
 	if (Array.isArray(parsed)) {

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -958,13 +958,40 @@ const STRING_VALUE_OPERATORS = new Set<FieldOperator>(["contains", "regex"]);
 /** Operators that read no `value` at all — they test presence. */
 const VALUELESS_OPERATORS = new Set<FieldOperator>(["exists", "not_exists"]);
 
+/** Keys a condition may carry. Checked inside the refinement, not by `strictObject`. */
+const FIELD_CONDITION_KEYS = new Set(["field", "operator", "value"]);
+
+/**
+ * NOT `strictObject`, deliberately.
+ *
+ * zod skips `.superRefine` when the object parse itself fails, so a condition
+ * carrying BOTH an unknown key and an unusable operand reported only the key —
+ * and the operator had to fix it and re-run to discover the second fault. That
+ * breaks the one-pass contract `policy validate` promises, in the same way the
+ * early returns did: a diagnostic that stops at the first problem makes the
+ * caller iterate.
+ *
+ * The unknown-key check therefore lives INSIDE the refinement alongside the
+ * semantic checks, so structural and semantic faults are collected together.
+ * `looseObject` rather than `object` because the latter STRIPS unknown keys
+ * before the refinement runs — the check would see a clean object and pass,
+ * which is the silently-discarded-input defect this file exists to close.
+ */
 const FieldConditionSchema = z
-	.strictObject({
+	.looseObject({
 		field: z.string().min(1, "must be a non-empty field path"),
 		operator: z.enum(FIELD_OPERATORS),
 		value: z.unknown().optional(),
 	})
 	.superRefine((fc, ctx) => {
+		for (const key of Object.keys(fc)) {
+			if (FIELD_CONDITION_KEYS.has(key)) continue;
+			ctx.addIssue({
+				code: "custom",
+				path: [key],
+				message: `unknown key on a condition. A condition carries only field, operator and value.`,
+			});
+		}
 		const op = fc.operator;
 		if (VALUELESS_OPERATORS.has(op)) return;
 		if (fc.value === undefined) {

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -422,6 +422,10 @@ export function isWithinTimeWindow(
 		// Monday 00:00-05:59 — not Tuesday's small hours. That is the reading with
 		// the fewest surprises, and the only one that does not require inventing a
 		// notion of which day a wrapped window "belongs" to.
+		if (startHour !== undefined && endHour !== undefined && startHour > endHour) {
+			return hour >= startHour || hour < endHour;
+		}
+
 		// Non-wrapping: each bound is independent, and either may be omitted.
 		// `startHour === endHour` stays a zero-width window that matches nothing,
 		// which is what it did before; read it as "no hours", not "all hours".

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -981,12 +981,16 @@ const FIELD_CONDITION_KEYS = new Set(["field", "operator", "value"]);
  */
 const FieldConditionSchema = z
 	.looseObject({
-		field: z.string().min(1, "must be a non-empty field path"),
-		// NOT `z.enum` here: a failing enum aborts the object parse, which skips the
-		// refinement below and hides every structural fault behind the operator
-		// error. The membership check moved into the refinement so all faults are
-		// reported together.
-		operator: z.string(),
+		// `.optional()` too: a MISSING key is still a base-parse failure otherwise
+		// ("expected nonoptional"), which aborts and skips the refinement — the same
+		// hiding, one step earlier. Presence is required in the refinement instead.
+		field: z.unknown().optional(),
+		// EVERY field is `unknown` so that NOTHING in the base parse can abort.
+		// zod skips `.superRefine` the moment any declared field fails, so a typed
+		// base schema hides every other fault behind the first type error — the
+		// one-pass contract broken once per field until the whole set was closed.
+		// The type checks live in the refinement below instead.
+		operator: z.unknown().optional(),
 		value: z.unknown().optional(),
 	})
 	.superRefine((fc, ctx) => {
@@ -999,7 +1003,23 @@ const FieldConditionSchema = z
 			});
 		}
 
+		if (typeof fc.field !== "string" || fc.field === "") {
+			ctx.addIssue({
+				code: "custom",
+				path: ["field"],
+				message: `must be a non-empty field path, got ${fc.field === undefined ? "nothing" : typeof fc.field}`,
+			});
+		}
+
 		const op = fc.operator as FieldOperator;
+		if (typeof fc.operator !== "string") {
+			ctx.addIssue({
+				code: "custom",
+				path: ["operator"],
+				message: `must be an operator name, got ${fc.operator === undefined ? "nothing" : typeof fc.operator}`,
+			});
+			return;
+		}
 		if (!(FIELD_OPERATORS as readonly string[]).includes(fc.operator)) {
 			ctx.addIssue({
 				code: "custom",
@@ -1179,6 +1199,12 @@ export function validatePolicyFile(path: string): PolicyLoadResult {
 	}
 
 	const rootIssues: PolicyLoadIssue[] = [];
+	// Blankness is a property of the TEXT, so it is decided before a parser is
+	// chosen. `parseYaml("")` returns null while `JSON.parse("")` throws, so
+	// deciding it after the parse made a blank file legal as YAML and a syntax
+	// error as JSON — the same file, two verdicts, by extension.
+	if (raw.trim() === "") return { rules: [], issues: [], present: true };
+
 	const isYaml = path.endsWith(".yml") || path.endsWith(".yaml");
 	let parsed: unknown;
 	try {
@@ -1196,11 +1222,10 @@ export function validatePolicyFile(path: string): PolicyLoadResult {
 		};
 	}
 
-	// A BLANK file is an empty policy. An explicit `null` / `~` is not: the author
-	// wrote something, and what they wrote cannot carry rules. Accepting it would
-	// run the governor on defaults while the file looked deliberate.
+	// Blank was handled above. Reaching here with `null` means the author wrote an
+	// explicit `null` / `~`, which cannot carry rules — accepting it would run the
+	// governor on defaults while the file looked deliberate.
 	if (parsed === null || parsed === undefined) {
-		if (raw.trim() === "") return { rules: [], issues: [], present: true };
 		return {
 			rules: [],
 			issues: [

--- a/packages/core/src/policy/gate.ts
+++ b/packages/core/src/policy/gate.ts
@@ -18,6 +18,7 @@
 import { readFileSync } from "node:fs";
 import { minimatch } from "minimatch";
 import { parse as parseYaml } from "yaml";
+import { z } from "zod";
 import type {
 	FieldCondition,
 	FieldOperator,
@@ -280,10 +281,28 @@ function evaluateFieldCondition(fc: FieldCondition, context: Record<string, unkn
 		case "not_exists":
 			return resolved === undefined || resolved === null;
 
+		// Every operator below COMPARES a resolved value. If the field did not
+		// resolve, the comparison is not false — it is unanswerable, and only
+		// "indeterminate" carries that to `ruleMatches`, which is what makes a hard
+		// rule fail closed. Returning bare `false` here (the prior behaviour for
+		// eq/in/contains/regex) reads as "the rule did not match", which skips the
+		// guard rather than firing it.
+		//
+		// `exists`/`not_exists` are deliberately NOT in this set: an unresolved
+		// field is precisely what they measure, so for them it is a determinate
+		// answer, not a missing one.
+		// `undefined` here means the PATH did not resolve — the key is absent, or
+		// the walk ran off a non-object. That is unanswerable. An explicit `null`
+		// is different: it is a value the document actually carries, so a rule
+		// written `value: null` compares against it determinately. Conflating the
+		// two let a hard `eq: null` rule read an ABSENT field as "not null" and
+		// allow the call, which is the fail-open shape this file is fixing.
 		case "eq":
+			if (resolved === undefined) return "indeterminate";
 			return resolved === fc.value;
 
 		case "neq":
+			if (resolved === undefined) return "indeterminate";
 			return resolved !== fc.value;
 
 		case "gt":
@@ -302,21 +321,33 @@ function evaluateFieldCondition(fc: FieldCondition, context: Record<string, unkn
 			if (typeof resolved !== "number" || typeof fc.value !== "number") return "indeterminate";
 			return resolved <= fc.value;
 
+		// Membership reads the ARRAY, so an explicit `null` in the list is a value
+		// the author put there on purpose: `not_in: [null]` says "null is allowed".
+		// Only a path that did not resolve is unanswerable here.
 		case "in":
-			return Array.isArray(fc.value) && fc.value.includes(resolved);
+			if (!Array.isArray(fc.value)) return "indeterminate";
+			if (resolved === undefined) return "indeterminate";
+			return fc.value.includes(resolved);
 
 		case "not_in":
-			return Array.isArray(fc.value) && !fc.value.includes(resolved);
+			if (!Array.isArray(fc.value)) return "indeterminate";
+			if (resolved === undefined) return "indeterminate";
+			return !fc.value.includes(resolved);
 
 		case "contains":
-			return (
-				typeof resolved === "string" && typeof fc.value === "string" && resolved.includes(fc.value)
-			);
+			if (typeof fc.value !== "string") return "indeterminate";
+			// A non-string subject (absent, or an array/object the caller sent in
+			// place of the string the rule expects) cannot answer "contains".
+			if (typeof resolved !== "string") return "indeterminate";
+			return resolved.includes(fc.value);
 
 		case "regex": {
-			if (typeof resolved !== "string" || typeof fc.value !== "string") return false;
+			if (typeof fc.value !== "string") return "indeterminate";
+			if (typeof resolved !== "string") return "indeterminate";
 			const re = safeRegExp(fc.value);
-			if (re === null) return false;
+			// An unusable pattern is refused at load time; reaching here means the
+			// rule was built programmatically. Unanswerable, not "no".
+			if (re === null) return "indeterminate";
 			// Layer B (defense-in-depth): bound the scanned input so even a
 			// structural miss cannot be fed an unbounded string.
 			const input =
@@ -325,7 +356,12 @@ function evaluateFieldCondition(fc: FieldCondition, context: Record<string, unkn
 		}
 
 		default:
-			return false;
+			// Unreachable for a rule that came through `loadPolicies`, which rejects
+			// an unknown operator at load time. Still fails CLOSED rather than
+			// returning `false`, because `evaluatePolicy` is also called with
+			// programmatically-built rules that never touch the loader: a typo'd
+			// operator there used to disable the rule outright and allow the call.
+			return "indeterminate";
 	}
 }
 
@@ -370,8 +406,27 @@ export function isWithinTimeWindow(
 
 	return timeWindows.some((tw) => {
 		if (tw.daysOfWeek && !tw.daysOfWeek.includes(dayOfWeek)) return false;
-		if (tw.startHour !== undefined && hour < tw.startHour) return false;
-		if (tw.endHour !== undefined && hour >= tw.endHour) return false;
+
+		const { startHour, endHour } = tw;
+
+		// A window that WRAPS MIDNIGHT — `startHour > endHour`, e.g. an overnight
+		// window {startHour: 22, endHour: 6}.
+		//
+		// This was previously evaluated with the two half-open tests below applied
+		// independently, which for a wrapping window cannot both pass at any hour:
+		// 23 fails `hour >= endHour`, 02 fails `hour < startHour`. Such a window
+		// therefore imposed no constraint. Verified across all 24 hours.
+		//
+		// The day gate above is applied to the timestamp's OWN local day, so an
+		// overnight window restricted to Monday covers Monday 22:00-23:59 and
+		// Monday 00:00-05:59 — not Tuesday's small hours. That is the reading with
+		// the fewest surprises, and the only one that does not require inventing a
+		// notion of which day a wrapped window "belongs" to.
+		// Non-wrapping: each bound is independent, and either may be omitted.
+		// `startHour === endHour` stays a zero-width window that matches nothing,
+		// which is what it did before; read it as "no hours", not "all hours".
+		if (startHour !== undefined && hour < startHour) return false;
+		if (endHour !== undefined && hour >= endHour) return false;
 		return true;
 	});
 }
@@ -556,6 +611,116 @@ export interface PolicyContext extends Record<string, unknown> {
 }
 
 /**
+ * The {@link PolicyContext} fields the HOST owns — a caller must never supply
+ * one, because each steers whether a rule fires rather than being data a rule
+ * reads, and for each there is a trustworthy host-side source that a
+ * caller-supplied value would displace.
+ *
+ * WHY THIS LIST EXISTS AS A VALUE. The three SDK call sites spread caller params
+ * and then re-assert the trusted fields by hand, one literal at a time, per the
+ * re-assertion invariant in AGENTS.md. That hand-maintained list has already been
+ * found incomplete once — `timestamp` was added to it in PR #95. Re-asserting a
+ * field only holds if somebody remembers to. STRIPPING the set covers the next
+ * one too, because a field absent from the explicit assignments after the spread
+ * is simply absent, and absent is the fail-closed value.
+ *
+ * `tests/harden/policy-context-fields.test.ts` reads this file and asserts that
+ * every field `PolicyContext` declares appears in EITHER this array or
+ * {@link CALLER_SUPPLIED_POLICY_FIELDS}, so adding a field to the interface
+ * without classifying it fails the suite. That is the same source-parity
+ * mechanism `shared/ids.ts` and `cli/budget.ts` are held together with.
+ */
+export const HOST_CONTROLLED_POLICY_FIELDS = [
+	"timestamp",
+	"budgetFractionRemaining",
+	"budgetRunwayHours",
+	"cost_center",
+] as const;
+
+/**
+ * Declared {@link PolicyContext} fields deliberately NOT stripped, and why.
+ *
+ * The parity test requires every declared field to appear in exactly one of
+ * these two lists, so a newly added field cannot be quietly omitted from both —
+ * whoever adds it has to make the trust call explicitly and record it here.
+ *
+ * - `scope` — CALLER-DECLARED CONTEXT, not a host secret. Unlike `timestamp`
+ *   (where the gate has a real clock to fall back on) there is no host-side
+ *   source for it on any SDK path: no call site in `src/` ever sets
+ *   `context.scope`, and the patterns it is matched against are file globs
+ *   (`src/routes/**`) describing where an agent is working — something only the
+ *   caller knows. Stripping it would not close a hole; it would make every
+ *   `scopePatterns` rule permanently inert, since `ruleMatches` requires a
+ *   non-empty context scope for such a rule to match at all. That trade is a
+ *   product decision (wire a host-side scope, or document scope as
+ *   self-declared and unsuitable for adversarial guards) and is tracked
+ *   separately rather than being made silently here.
+ * - `timeWindows` — read by nothing. `ruleMatches` consults `rule.timeWindows`;
+ *   `context.timeWindows` has no reader anywhere in the repo despite the
+ *   interface doc claiming it "enables time-window matching". Stripping a field
+ *   nothing reads would imply it once mattered. It wants deleting or wiring, not
+ *   sanitising.
+ */
+export const CALLER_SUPPLIED_POLICY_FIELDS = ["scope", "timeWindows"] as const;
+
+/**
+ * Context keys a governor ASSERTS itself, which `PolicyContext` does not declare.
+ *
+ * These ride the interface's index signature rather than being declared fields,
+ * so the parity test cannot see them — and **the three call sites assert
+ * different subsets**. `governAction` sets `action_kind`/`action_name` and
+ * deliberately no `model`; the LLM and headless paths set `model` and neither
+ * action key. A field one surface asserts is therefore unprotected on the
+ * surfaces that do not, and arrives from `...params` like any other caller key.
+ *
+ * Measured before this list existed: a hard `model contains opus` rule denied an
+ * action call with no model (absent -> indeterminate -> guard fires), and
+ * ALLOWED the same call when the caller supplied `model: "safe"` in
+ * `action.params` — the caller turning a hard guard off by answering a question
+ * that surface never asks. `action_kind` injected onto the LLM path likewise.
+ *
+ * So the UNION is stripped everywhere, not the per-surface subset. A key that is
+ * host-owned anywhere is caller-forbidden everywhere; each site then asserts the
+ * ones it genuinely knows.
+ */
+export const HOST_ASSERTED_CONTEXT_KEYS = [
+	"model",
+	"tier",
+	"estimated_cost",
+	"budget_remaining",
+	"budget_remaining_after",
+	"action_kind",
+	"action_name",
+] as const;
+
+/**
+ * Strip every host-owned field from caller-supplied params.
+ *
+ * Use this at the boundary, BEFORE the spread — `{ ...sanitizePolicyContext(params), … }` —
+ * rather than re-asserting fields after it. The difference matters: a
+ * re-assertion that someone forgets to write silently lets the caller's value
+ * through, whereas a field missing from the explicit set after this call is
+ * simply absent, and absent is the fail-closed answer for a hard rule.
+ *
+ * Arbitrary caller keys survive on purpose. They are what a policy addresses by
+ * dot-notation (`params.metadata.team`), and they steer nothing on their own —
+ * only the declared fields above do.
+ */
+export function sanitizePolicyContext<T extends Record<string, unknown>>(
+	callerSupplied: T | undefined,
+): Record<string, unknown> {
+	if (callerSupplied === undefined || callerSupplied === null) return {};
+	const out: Record<string, unknown> = { ...callerSupplied };
+	for (const field of HOST_CONTROLLED_POLICY_FIELDS) {
+		delete out[field];
+	}
+	for (const key of HOST_ASSERTED_CONTEXT_KEYS) {
+		delete out[key];
+	}
+	return out;
+}
+
+/**
  * Extended policy rule for the gate. Adds optional `id`, `description`,
  * `priority`, `enabled`, `scopePatterns`, and `timeWindows` fields to the
  * shared PolicyRule type.
@@ -690,6 +855,352 @@ export function evaluatePolicy(rules: GateRule[], context: PolicyContext): Polic
 // Policy file loading
 // ---------------------------------------------------------------------------
 
+/** One thing wrong with a policy file, addressed to the operator who wrote it. */
+export interface PolicyLoadIssue {
+	/** Dotted path to the offending node, e.g. `rules[2].conditions[0].operator`. */
+	readonly at: string;
+	readonly message: string;
+}
+
+/**
+ * A policy file exists but cannot be honoured as written.
+ *
+ * This is deliberately a THROW and not an empty rule set. The previous
+ * behaviour — `catch { return [] }` around a bare `as GateRule[]` — meant a tab
+ * character in the YAML, one wrong indent, a trailing comma, or a top-level key
+ * of `policies:` instead of `rules:` silently produced ZERO custom rules. Only
+ * the platform DEFAULT_RULES survived, every content/model/PII deny rule was
+ * gone, and nothing anywhere said so: no throw, no log, no audit event. The
+ * governor started normally, and `usertrust health` reported
+ * `Policy violations (30d): 0 [ok]` in green — because it counts violations,
+ * not rules, so the indicator read HEALTHIER the moment governance stopped
+ * existing.
+ *
+ * A policy that cannot be parsed is not a policy. Refusing to start is the only
+ * answer that cannot be mistaken for enforcement.
+ */
+export class PolicyLoadError extends Error {
+	readonly file: string;
+	readonly issues: readonly PolicyLoadIssue[];
+
+	constructor(file: string, issues: readonly PolicyLoadIssue[]) {
+		const detail = issues.map((i) => `  ${i.at}: ${i.message}`).join("\n");
+		super(`usertrust: policy file cannot be loaded: ${file}\n${detail}`);
+		this.name = "PolicyLoadError";
+		this.file = file;
+		this.issues = issues;
+	}
+}
+
+/** Outcome of reading a policy file without committing to throwing. */
+export interface PolicyLoadResult {
+	/** Rules that validated. Empty when `issues` is non-empty. */
+	readonly rules: GateRule[];
+	readonly issues: readonly PolicyLoadIssue[];
+	/**
+	 * Whether a file was actually there — ENOENT, and nothing else, answers false.
+	 *
+	 * Reported rather than left for the caller to re-derive, because the obvious
+	 * way to re-derive it is `existsSync`, which answers false for a file inside a
+	 * directory it cannot traverse. Every caller that asked that question
+	 * separately got "absent" for a file that was present and unreadable.
+	 */
+	readonly present: boolean;
+}
+
+/**
+ * The 12 operators, as a runtime value.
+ *
+ * `satisfies` pins it to {@link FieldOperator}, so adding a member to the type
+ * without adding it here is a compile error rather than a rule that loads and
+ * then never fires.
+ */
+export const FIELD_OPERATORS = [
+	"exists",
+	"not_exists",
+	"eq",
+	"neq",
+	"gt",
+	"gte",
+	"lt",
+	"lte",
+	"in",
+	"not_in",
+	"contains",
+	"regex",
+] as const satisfies readonly FieldOperator[];
+
+/** Operators whose `value` must be a number. */
+const NUMERIC_VALUE_OPERATORS = new Set<FieldOperator>(["gt", "gte", "lt", "lte"]);
+/** Operators whose `value` must be an array. */
+const ARRAY_VALUE_OPERATORS = new Set<FieldOperator>(["in", "not_in"]);
+/** Operators whose `value` must be a string. */
+const STRING_VALUE_OPERATORS = new Set<FieldOperator>(["contains", "regex"]);
+/** Operators that read no `value` at all — they test presence. */
+const VALUELESS_OPERATORS = new Set<FieldOperator>(["exists", "not_exists"]);
+
+const FieldConditionSchema = z
+	.strictObject({
+		field: z.string().min(1, "must be a non-empty field path"),
+		operator: z.enum(FIELD_OPERATORS),
+		value: z.unknown().optional(),
+	})
+	.superRefine((fc, ctx) => {
+		const op = fc.operator;
+		if (VALUELESS_OPERATORS.has(op)) return;
+		if (fc.value === undefined) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["value"],
+				message: `operator "${op}" requires a value`,
+			});
+			return;
+		}
+		if (NUMERIC_VALUE_OPERATORS.has(op) && typeof fc.value !== "number") {
+			ctx.addIssue({
+				code: "custom",
+				path: ["value"],
+				message: `operator "${op}" compares numbers, but value is ${typeof fc.value}`,
+			});
+		}
+		// `typeof NaN === "number"`, and YAML spells it `.nan`. A non-finite operand
+		// makes a rule that validates cleanly and can never fire — the guard present
+		// in the file and absent in effect.
+		//
+		// Checked for EVERY operator, not only the numeric comparisons: `NaN === NaN`
+		// is false, so `eq: .nan` never matches either, and scoping this to
+		// `NUMERIC_VALUE_OPERATORS` left exactly that hole. Infinity is refused on
+		// the same grounds — a threshold nothing can cross is not a threshold.
+		//
+		// Array operands are deliberately NOT covered: `includes` uses SameValueZero,
+		// so `in: [.nan]` does match a NaN subject and is a rule that works.
+		if (typeof fc.value === "number" && !Number.isFinite(fc.value)) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["value"],
+				message: `operator "${op}" cannot use ${Number.isNaN(fc.value) ? "NaN" : String(fc.value)} as an operand: no value compares equal to it, so the rule would never fire`,
+			});
+		}
+		if (ARRAY_VALUE_OPERATORS.has(op) && !Array.isArray(fc.value)) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["value"],
+				message: `operator "${op}" needs an array value, but value is ${typeof fc.value}`,
+			});
+		}
+		if (STRING_VALUE_OPERATORS.has(op) && typeof fc.value !== "string") {
+			ctx.addIssue({
+				code: "custom",
+				path: ["value"],
+				message: `operator "${op}" needs a string value, but value is ${typeof fc.value}`,
+			});
+		}
+		// A pattern the evaluator would refuse at runtime is refused here instead,
+		// where the author can still see which rule it belonged to. `safeRegExp`
+		// rejects over-long patterns and catastrophic-backtracking shapes as well
+		// as syntactically invalid ones.
+		if (op === "regex" && typeof fc.value === "string" && safeRegExp(fc.value) === null) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["value"],
+				message: "not a usable regular expression (invalid, too long, or unsafe to evaluate)",
+			});
+		}
+	});
+
+const TimeWindowSchema = z.strictObject({
+	daysOfWeek: z.array(z.number().int().min(0).max(6)).optional(),
+	startHour: z.number().int().min(0).max(23).optional(),
+	endHour: z.number().int().min(0).max(24).optional(),
+});
+
+/**
+ * STRICT on purpose — an unknown key is an ERROR, not something to drop.
+ *
+ * zod strips unrecognised keys by default, and that default is this very defect
+ * in miniature: a rule written with `scopePattern` (singular) would validate
+ * cleanly, load, and silently become an UNSCOPED global deny — the author
+ * believing it applies to production only, while it applies everywhere. The same
+ * default already bit this repo once on the settle wire, where two cache-token
+ * tiers "vanished silently on the wire" (packages/server/src/wire.ts).
+ *
+ * A validator that quietly discards what it does not understand is not a
+ * validator.
+ */
+const GateRuleSchema = z.strictObject({
+	id: z.string().optional(),
+	name: z.string().min(1),
+	description: z.string().optional(),
+	priority: z.number().optional(),
+	enabled: z.boolean().optional(),
+	effect: z.enum(["deny", "warn"]),
+	enforcement: z.enum(["hard", "soft"]),
+	severity: z.enum(["critical", "high", "medium", "low", "info"]).optional(),
+	conditions: z.array(FieldConditionSchema),
+	// A glob minimatch cannot compile is refused here rather than throwing from
+	// `matchesScope` mid-evaluation: a rule that raises `TypeError: pattern is too
+	// long` when a call happens to supply a scope replaces a policy VERDICT with an
+	// exception, which is a worse outcome than either allow or deny. minimatch's
+	// own ceiling is 65536.
+	scopePatterns: z
+		.array(
+			z
+				.string()
+				.max(65_535, "glob is too long for minimatch to compile (limit 65536)")
+				.refine(
+					(p) => {
+						try {
+							minimatch("probe", p);
+							return true;
+						} catch {
+							return false;
+						}
+					},
+					{ message: "is not a glob minimatch can compile" },
+				),
+		)
+		.optional(),
+	timeWindows: z.array(TimeWindowSchema).optional(),
+});
+
+/**
+ * Read and fully validate a policy file, reporting problems instead of throwing.
+ *
+ * This is the form the `policy validate` command and the health report use, so
+ * an operator can see every problem in one pass rather than fixing them one
+ * exception at a time. {@link loadPolicies} is the same work with a throw on the
+ * end.
+ *
+ * A file that is absent is NOT an issue — no policy file is a legitimate
+ * deployment. A file that is present and unreadable IS an issue, and the two are
+ * told apart by `ENOENT` rather than by an `existsSync` preflight: `existsSync`
+ * answers false for a file inside a directory it cannot traverse, which would
+ * report an unreadable policy as an absent one. Callers must therefore call this
+ * unconditionally rather than guarding it.
+ */
+export function validatePolicyFile(path: string): PolicyLoadResult {
+	let raw: string;
+	try {
+		raw = readFileSync(path, "utf-8");
+	} catch (err) {
+		// A file that is not there is not a broken policy — "no policy file" is a
+		// legitimate deployment, and both governor call sites already guard with
+		// `existsSync`. Anything else (permissions, a directory, an I/O fault) IS a
+		// problem: the operator put a policy there and we cannot read it, which is
+		// exactly the case that must not degrade to "no rules".
+		if ((err as NodeJS.ErrnoException).code === "ENOENT")
+			return { rules: [], issues: [], present: false };
+		return {
+			rules: [],
+			issues: [{ at: "file", message: `cannot be read: ${(err as Error).message}` }],
+			present: true,
+		};
+	}
+
+	const rootIssues: PolicyLoadIssue[] = [];
+	const isYaml = path.endsWith(".yml") || path.endsWith(".yaml");
+	let parsed: unknown;
+	try {
+		parsed = isYaml ? parseYaml(raw) : JSON.parse(raw);
+	} catch (err) {
+		return {
+			rules: [],
+			issues: [
+				{
+					at: "file",
+					message: `is not valid ${isYaml ? "YAML" : "JSON"}: ${(err as Error).message}`,
+				},
+			],
+			present: true,
+		};
+	}
+
+	// An empty document is an empty policy, not a broken one.
+	if (parsed === null || parsed === undefined) return { rules: [], issues: [], present: true };
+
+	let rawRules: unknown;
+	if (Array.isArray(parsed)) {
+		rawRules = parsed;
+	} else if (typeof parsed === "object") {
+		const obj = parsed as Record<string, unknown>;
+		// The root is strict for the same reason every rule is: a misplaced
+		// top-level key — `scopePatterns` written outside the rule it was meant to
+		// narrow — would otherwise be dropped in silence, and the rules it was
+		// supposed to scope would apply everywhere.
+		// Root problems are ACCUMULATED, not returned early: `policy validate`
+		// promises every problem in one pass, and an operator who fixes the root
+		// key only to be shown a malformed rule next has been made to iterate.
+		for (const k of Object.keys(obj)) {
+			if (k === "rules") continue;
+			rootIssues.push({
+				at: `${k}`,
+				message: `unknown top-level key. A policy document carries only "rules"; a key placed here is not applied to anything.`,
+			});
+		}
+		if (!("rules" in obj)) {
+			// The silent-empty case that hid a whole policy file: a document keyed
+			// `policies:` (or anything else) used to parse fine and yield nothing.
+			// Name the keys we DID find so the fix is obvious.
+			const found = Object.keys(obj);
+			return {
+				rules: [],
+				// `rootIssues` first: the loop above already named every misplaced key,
+				// and replacing them with only the synthetic missing-key issue loses
+				// their locations — the one-pass contract broken a third way.
+				issues: [
+					...rootIssues,
+					{
+						at: "file",
+						message: `has no top-level "rules" key (found: ${found.length > 0 ? found.join(", ") : "no keys"}). Expected \`rules: [...]\` or a bare list of rules.`,
+					},
+				],
+				present: true,
+			};
+		}
+		rawRules = obj.rules;
+	} else {
+		return {
+			rules: [],
+			issues: [{ at: "file", message: `must be a list of rules or an object with a "rules" key` }],
+			present: true,
+		};
+	}
+
+	if (!Array.isArray(rawRules)) {
+		// Keep whatever the root check already found: discarding it here would make
+		// the operator fix `rules` and come back for the root key, which is the
+		// one-pass contract broken in the other direction.
+		return {
+			rules: [],
+			issues: [...rootIssues, { at: "rules", message: "must be a list" }],
+			present: true,
+		};
+	}
+
+	const issues: PolicyLoadIssue[] = [...rootIssues];
+	const rules: GateRule[] = [];
+	for (let i = 0; i < rawRules.length; i++) {
+		const result = GateRuleSchema.safeParse(rawRules[i]);
+		if (result.success) {
+			rules.push(result.data as GateRule);
+			continue;
+		}
+		for (const issue of result.error.issues) {
+			const segs = issue.path
+				.map((p) => (typeof p === "number" ? `[${p}]` : `.${String(p)}`))
+				.join("");
+			issues.push({ at: `rules[${i}]${segs}`, message: issue.message });
+		}
+	}
+
+	// All-or-nothing: a file with one bad rule loads none of them. Loading the
+	// survivors would enforce a policy the operator never wrote, which is the
+	// same silent-partial-application failure in a new costume.
+	return issues.length > 0
+		? { rules: [], issues, present: true }
+		: { rules, issues: [], present: true };
+}
+
 /**
  * Load policy rules from a JSON or YAML file.
  *
@@ -697,26 +1208,15 @@ export function evaluatePolicy(rules: GateRule[], context: PolicyContext): Polic
  * - `.json` files: expects `{ "rules": [...] }` or a bare array
  * - `.yml` / `.yaml` files: expects `rules: [...]` or a bare sequence
  *
- * Returns an empty array if the file cannot be read or parsed.
+ * @throws {PolicyLoadError} if the file is present but unreadable, unparseable,
+ * shaped wrongly, or contains a rule that would not enforce as written. It never
+ * returns a silently-empty rule set — see {@link PolicyLoadError}.
  *
  * @param path - Absolute or relative path to the policy file
- * @returns Array of policy rules
+ * @returns Array of validated policy rules
  */
 export function loadPolicies(path: string): GateRule[] {
-	try {
-		const raw = readFileSync(path, "utf-8");
-
-		const isYaml = path.endsWith(".yml") || path.endsWith(".yaml");
-		const parsed: unknown = isYaml ? parseYaml(raw) : JSON.parse(raw);
-
-		if (Array.isArray(parsed)) return parsed as GateRule[];
-		if (parsed !== null && typeof parsed === "object") {
-			const obj = parsed as Record<string, unknown>;
-			if (Array.isArray(obj.rules)) return obj.rules as GateRule[];
-		}
-
-		return [];
-	} catch {
-		return [];
-	}
+	const { rules, issues } = validatePolicyFile(path);
+	if (issues.length > 0) throw new PolicyLoadError(path, issues);
+	return rules;
 }

--- a/packages/core/tests/harden/docs-policy-examples.test.ts
+++ b/packages/core/tests/harden/docs-policy-examples.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Every policy example we ship must be a policy that works.
+ *
+ * The documented flagship rule — `site/content/docs/concepts/policy-engine.mdx`,
+ * presented as the canonical `.usertrust/policies/default.yml` and titled "Deny
+ * requests to opus-class models in production" — shipped with **no `effect`
+ * field**. Run against master with every one of its conditions satisfied
+ * (matching model, matching scope, inside the time window) it returned:
+ *
+ *   decision       : allow
+ *   hardViolations : 0
+ *   matched        : 1        <- the rule MATCHED and still did not deny
+ *
+ * An operator copying the documented example got a rule that loads, matches, and
+ * never fires. Same shape as everything else on this branch: it looks correct,
+ * nothing errors, and the guard is not there.
+ *
+ * The loader now rejects such a rule outright, which means a stale example is no
+ * longer merely useless — it is a startup failure for whoever copies it. That
+ * raises the cost of doc drift enough to be worth a mechanical guard.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { validatePolicyFile } from "../../src/policy/gate.js";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+const DOC_FILES = [
+	"site/content/docs/policy/rules.mdx",
+	"site/content/docs/concepts/policy-engine.mdx",
+	"site/content/docs/policy/operators.mdx",
+];
+
+interface DocBlock {
+	file: string;
+	yaml: string;
+}
+
+/** Fenced yaml blocks that look like a policy document (not a result payload). */
+function policyBlocks(): DocBlock[] {
+	const blocks: DocBlock[] = [];
+	for (const rel of DOC_FILES) {
+		const abs = join(REPO_ROOT, rel);
+		// Deliberately NOT skip-if-missing: a guard that silently passes when it
+		// cannot find its subject is the exact defect this file exists to catch.
+		expect(existsSync(abs), `${rel} not found — update DOC_FILES`).toBe(true);
+		const src = readFileSync(abs, "utf-8");
+		for (const m of src.matchAll(/```ya?ml\n([\s\S]*?)```/g)) {
+			const raw = m[1] ?? "";
+			const isDoc = raw.includes("rules:");
+			// Some examples are shown as a bare rule list, without the `rules:`
+			// wrapper. Those are still policies a reader will copy.
+			const isBareList = /^\s*-\s+(id|name):/m.test(raw);
+			if (!isDoc && !isBareList) continue;
+			const yaml = isDoc
+				? raw
+				: `rules:\n${raw
+						.split("\n")
+						.map((l) => (l.trim() === "" ? l : `  ${l}`))
+						.join("\n")}`;
+			blocks.push({ file: rel, yaml });
+		}
+	}
+	return blocks;
+}
+
+describe("shipped policy examples in the docs", () => {
+	const blocks = policyBlocks();
+
+	it("finds the examples (guards against a vacuous test)", () => {
+		expect(blocks.length).toBeGreaterThanOrEqual(3);
+	});
+
+	for (const [i, block] of blocks.entries()) {
+		it(`${block.file} example #${i + 1} loads under the real validator`, () => {
+			// Written to a scratch dir, never into the repo.
+			const dir = mkdtempSync(join(tmpdir(), "ut-doc-policy-"));
+			const tmp = join(dir, "example.yaml");
+			writeFileSync(tmp, block.yaml, "utf-8");
+			try {
+				const { rules, issues } = validatePolicyFile(tmp);
+				expect(
+					issues,
+					`${block.file} ships a policy example the loader refuses. A reader who copies it gets a startup failure. Issues: ${JSON.stringify(issues)}`,
+				).toEqual([]);
+				expect(rules.length).toBeGreaterThan(0);
+				// A rule with no `effect` used to load, match, and deny nothing.
+				for (const r of rules) {
+					expect(r.effect, `a documented rule with no effect denies nothing`).toBeDefined();
+				}
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		});
+	}
+});

--- a/packages/core/tests/harden/fail-closed.test.ts
+++ b/packages/core/tests/harden/fail-closed.test.ts
@@ -52,3 +52,150 @@ describe("hard numeric rules fail closed on missing/mistyped fields", () => {
 		expect(evaluatePolicy([soft], { estimated_cost: "lots" }).hasWarnings).toBe(false);
 	});
 });
+
+// ===========================================================================
+// The other eight operators.
+//
+// The suite above is titled "hard NUMERIC rules fail closed", and the scope in
+// that title was the gap: `gt/gte/lt/lte` were the only operators returning
+// "indeterminate" on input they could not read. Every other operator returned a
+// bare `false`, which `ruleMatches` reads as "this rule did not match" rather
+// than "this rule could not be evaluated", so the guard was skipped rather than
+// fired. Measured before the change, hard rule, guarded field absent:
+//   gt/gte/lt/lte           -> DENY  (closed)
+//   eq, in, contains, regex -> ALLOW
+//   unknown operator        -> ALLOW
+// ===========================================================================
+
+describe("hard rules fail closed on EVERY operator, not just the numeric four", () => {
+	const hard = (operator: string, value: unknown): GateRule =>
+		({
+			id: `guard-${operator}`,
+			name: `hard guard using ${operator}`,
+			effect: "deny",
+			enforcement: "hard",
+			conditions: [{ field: "guarded", operator, value }],
+		}) as unknown as GateRule;
+
+	// `exists`/`not_exists` are excluded deliberately: an unresolved field is
+	// precisely what they measure, so for them absence is a determinate answer.
+	const valueOperators: [string, unknown][] = [
+		["eq", "secret"],
+		["neq", "secret"],
+		["gt", 10],
+		["gte", 10],
+		["lt", 10],
+		["lte", 10],
+		["in", ["a", "b"]],
+		["not_in", ["a", "b"]],
+		["contains", "opus"],
+		["regex", "opus"],
+	];
+
+	for (const [op, value] of valueOperators) {
+		it(`${op}: denies when the guarded field is ABSENT`, () => {
+			expect(evaluatePolicy([hard(op, value)], { model: "x" }).decision).toBe("deny");
+		});
+	}
+
+	// Only some operators impose a TYPE on their subject: the numerics need a
+	// number, `contains`/`regex` need a string. `eq`/`neq`/`in`/`not_in` compare
+	// any value against any value, so an object subject is a determinate "not
+	// equal" / "not in" rather than an unreadable one — and must stay allow, or
+	// the fix would deny every call that carries a structured field.
+	for (const [op, value] of [
+		["gt", 10],
+		["gte", 10],
+		["lt", 10],
+		["lte", 10],
+		["contains", "opus"],
+		["regex", "opus"],
+	] as [string, unknown][]) {
+		it(`${op}: denies when the guarded field is the WRONG SHAPE`, () => {
+			// A subject of the wrong type — an object or array where the rule expects
+			// a string — is unreadable, so the guard fires rather than being skipped.
+			expect(evaluatePolicy([hard(op, value)], { guarded: { nested: 1 } }).decision).toBe("deny");
+			expect(evaluatePolicy([hard(op, value)], { guarded: ["opus"] }).decision).toBe("deny");
+		});
+	}
+
+	it("an unknown operator denies rather than disabling its own guard", () => {
+		expect(evaluatePolicy([hard("greaterThan", 10)], { guarded: 999_999 }).decision).toBe("deny");
+		expect(evaluatePolicy([hard("GTE", 10)], { guarded: 999_999 }).decision).toBe("deny");
+		expect(evaluatePolicy([hard("", 10)], { guarded: 999_999 }).decision).toBe("deny");
+	});
+
+	it("exists/not_exists keep their presence-test meaning", () => {
+		const exists = hard("exists", true);
+		expect(evaluatePolicy([exists], {}).decision).toBe("allow");
+		expect(evaluatePolicy([exists], { guarded: "here" }).decision).toBe("deny");
+		const notExists = hard("not_exists", true);
+		expect(evaluatePolicy([notExists], {}).decision).toBe("deny");
+		expect(evaluatePolicy([notExists], { guarded: "here" }).decision).toBe("allow");
+	});
+
+	it("a determinate NO is still a no — the fix must not deny everything", () => {
+		// The failure mode of over-correcting: if unresolvable and simply-not-matching
+		// collapsed together, every rule would fire on every call.
+		expect(evaluatePolicy([hard("contains", "opus")], { guarded: "claude-haiku" }).decision).toBe(
+			"allow",
+		);
+		expect(evaluatePolicy([hard("eq", "secret")], { guarded: "not-secret" }).decision).toBe(
+			"allow",
+		);
+		expect(evaluatePolicy([hard("in", ["a", "b"])], { guarded: "c" }).decision).toBe("allow");
+		expect(evaluatePolicy([hard("regex", "^opus")], { guarded: "sonnet" }).decision).toBe("allow");
+	});
+
+	it("SOFT rules stay lenient on every operator (unchanged behaviour)", () => {
+		for (const [op, value] of valueOperators) {
+			const soft = {
+				...(hard(op, value) as unknown as Record<string, unknown>),
+				effect: "warn",
+				enforcement: "soft",
+			} as unknown as GateRule;
+			expect(evaluatePolicy([soft], { model: "x" }).decision, `${op} soft`).toBe("allow");
+		}
+	});
+});
+
+describe("explicit null is a document value, not an unresolved path", () => {
+	// Third round on the same helper, and the reason it is gone. Round 1 conflated
+	// `undefined` with `null` so a hard rule skipped its guard; the fix then
+	// over-corrected, making an explicit `null` unreadable — so `not_in: [null]`,
+	// which says "null is permitted", denied the very value it permits. The
+	// conflation was in the CONCEPT, so the concept was removed rather than
+	// patched again: membership reads the array, and only `undefined` is
+	// unanswerable.
+	const mk = (operator: string, value: unknown, enforcement = "hard"): GateRule =>
+		({
+			name: `r-${operator}`,
+			effect: "deny",
+			enforcement,
+			conditions: [{ field: "guarded", operator, value }],
+		}) as unknown as GateRule;
+
+	it("not_in [null] ALLOWS an explicit null — it is in the exclusion list", () => {
+		expect(evaluatePolicy([mk("not_in", [null])], { guarded: null }).decision).toBe("allow");
+	});
+
+	it("not_in [null] still denies a value that is not excluded", () => {
+		expect(evaluatePolicy([mk("not_in", [null])], { guarded: "x" }).decision).toBe("deny");
+	});
+
+	it("not_in [null] still denies an ABSENT field — unanswerable, not permitted", () => {
+		expect(evaluatePolicy([mk("not_in", [null])], {}).decision).toBe("deny");
+	});
+
+	it("in [null] MATCHES an explicit null", () => {
+		expect(evaluatePolicy([mk("in", [null])], { guarded: null }).decision).toBe("deny");
+	});
+
+	it("a soft in [null] rule keeps its warning on an explicit null", () => {
+		expect(evaluatePolicy([mk("in", [null], "soft")], { guarded: null }).matched).toHaveLength(1);
+	});
+
+	it("in [null] is still indeterminate for an ABSENT field", () => {
+		expect(evaluatePolicy([mk("in", [null])], {}).decision).toBe("deny");
+	});
+});

--- a/packages/core/tests/harden/policy-context-fields.test.ts
+++ b/packages/core/tests/harden/policy-context-fields.test.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Source-parity guard for the PolicyContext trust classification.
+ *
+ * The three governor call sites spread caller-supplied params into the policy
+ * context. Which of the context's DECLARED fields the caller may contribute is
+ * a trust decision, and it has been got wrong in production before: `timestamp`
+ * was missing from the hand-maintained re-assertion list (PR #95), so a request
+ * body chose the clock a `timeWindows` curfew rule was measured against.
+ *
+ * A list of literals cannot notice when someone adds a seventh field. This test
+ * can: it reads the interface out of the source and requires every declared
+ * field to be classified as either host-owned (and therefore stripped) or
+ * deliberately caller-supplied (with the reasoning recorded next to it). There
+ * is no third option and no default, so the next field added to PolicyContext
+ * cannot be quietly left unclassified.
+ *
+ * Same mechanism as the `shared/ids.ts` ↔ `cli/budget.ts` charset mirror.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+	CALLER_SUPPLIED_POLICY_FIELDS,
+	evaluatePolicy,
+	type GateRule,
+	HOST_ASSERTED_CONTEXT_KEYS,
+	HOST_CONTROLLED_POLICY_FIELDS,
+	sanitizePolicyContext,
+} from "../../src/policy/gate.js";
+
+const GATE_SRC = join(dirname(fileURLToPath(import.meta.url)), "../../src/policy/gate.ts");
+
+/**
+ * Field names declared directly on the `PolicyContext` interface body.
+ *
+ * Deliberately a source read rather than a type-level trick: `PolicyContext`
+ * extends `Record<string, unknown>`, which makes `keyof PolicyContext` collapse
+ * to `string | number`, so TypeScript cannot enumerate the declared keys for us.
+ */
+function declaredPolicyContextFields(): string[] {
+	const src = readFileSync(GATE_SRC, "utf-8");
+	const start = src.indexOf("export interface PolicyContext");
+	expect(start, "PolicyContext interface not found in gate.ts").toBeGreaterThan(-1);
+	const open = src.indexOf("{", start);
+	const end = src.indexOf("\n}", open);
+	expect(end, "PolicyContext interface has no closing brace").toBeGreaterThan(open);
+	const body = src.slice(open, end);
+
+	const fields: string[] = [];
+	for (const line of body.split("\n")) {
+		// A declaration line: exactly one tab of indent, then `name?:` or `name:`.
+		const m = /^\t([A-Za-z_][A-Za-z0-9_]*)\??\s*:/.exec(line);
+		if (m?.[1] !== undefined) fields.push(m[1]);
+	}
+	return fields;
+}
+
+describe("PolicyContext trust classification is exhaustive", () => {
+	it("finds the interface and its fields (guards against a vacuous test)", () => {
+		const declared = declaredPolicyContextFields();
+		// If a refactor renames or reshapes the interface this test must fail loudly
+		// rather than pass over an empty set — a vacuous parity test is exactly the
+		// silent-success shape it exists to prevent.
+		expect(declared.length).toBeGreaterThanOrEqual(6);
+		expect(declared).toContain("timestamp");
+		expect(declared).toContain("cost_center");
+	});
+
+	it("classifies EVERY declared field as host-controlled or caller-supplied", () => {
+		const declared = declaredPolicyContextFields();
+		const classified = new Set<string>([
+			...HOST_CONTROLLED_POLICY_FIELDS,
+			...CALLER_SUPPLIED_POLICY_FIELDS,
+		]);
+		const unclassified = declared.filter((f) => !classified.has(f));
+		expect(
+			unclassified,
+			`PolicyContext declares ${unclassified.join(", ")} but neither HOST_CONTROLLED_POLICY_FIELDS ` +
+				"nor CALLER_SUPPLIED_POLICY_FIELDS names it. Every declared field is a trust decision: add it " +
+				"to HOST_CONTROLLED_POLICY_FIELDS if a caller must not supply it (it will then be stripped " +
+				"before the spread at all three governor sites), or to CALLER_SUPPLIED_POLICY_FIELDS with a " +
+				"comment recording why the caller legitimately owns it.",
+		).toEqual([]);
+	});
+
+	it("names nothing that PolicyContext does not declare", () => {
+		const declared = new Set(declaredPolicyContextFields());
+		for (const f of [...HOST_CONTROLLED_POLICY_FIELDS, ...CALLER_SUPPLIED_POLICY_FIELDS]) {
+			expect(declared.has(f), `${f} is classified but no longer declared on PolicyContext`).toBe(
+				true,
+			);
+		}
+	});
+
+	it("keeps the two lists disjoint", () => {
+		const host = new Set<string>(HOST_CONTROLLED_POLICY_FIELDS);
+		const both = CALLER_SUPPLIED_POLICY_FIELDS.filter((f) => host.has(f));
+		expect(both, "a field cannot be both host-controlled and caller-supplied").toEqual([]);
+	});
+});
+
+describe("sanitizePolicyContext", () => {
+	it("strips every host-controlled field a caller tried to supply", () => {
+		const hostile: Record<string, unknown> = {
+			timestamp: "2020-01-01T00:00:00.000Z",
+			budgetFractionRemaining: 0.95,
+			budgetRunwayHours: 999,
+			cost_center: "someone-elses-envelope",
+		};
+		const clean = sanitizePolicyContext(hostile);
+		for (const f of HOST_CONTROLLED_POLICY_FIELDS) {
+			expect(Object.hasOwn(clean, f), `${f} survived sanitisation`).toBe(false);
+		}
+	});
+
+	it("preserves arbitrary caller keys, which are what rules address by dot-notation", () => {
+		const clean = sanitizePolicyContext({
+			metadata: { team: "payments" },
+			messages: ["hello"],
+			timestamp: "2020-01-01T00:00:00.000Z",
+		});
+		expect(clean.metadata).toEqual({ team: "payments" });
+		expect(clean.messages).toEqual(["hello"]);
+		expect(Object.hasOwn(clean, "timestamp")).toBe(false);
+	});
+
+	it("preserves the deliberately caller-supplied fields", () => {
+		const clean = sanitizePolicyContext({ scope: ["prod/api"] });
+		expect(clean.scope).toEqual(["prod/api"]);
+	});
+
+	it("does not mutate its input", () => {
+		const input = { timestamp: "2020-01-01T00:00:00.000Z", model: "x" };
+		sanitizePolicyContext(input);
+		expect(input.timestamp).toBe("2020-01-01T00:00:00.000Z");
+	});
+
+	it("tolerates undefined", () => {
+		expect(sanitizePolicyContext(undefined)).toEqual({});
+	});
+});
+
+describe("host-asserted context keys are stripped on EVERY surface", () => {
+	// The three call sites assert different subsets: `governAction` sets
+	// action_kind/action_name and deliberately no `model`; the LLM and headless
+	// paths set `model` and neither action key. A key one surface asserts was
+	// therefore unprotected on the surfaces that do not, and arrived from
+	// `...params` like any other caller key.
+	const noFrontier = {
+		name: "no-frontier",
+		effect: "deny",
+		enforcement: "hard",
+		conditions: [{ field: "model", operator: "contains", value: "opus" }],
+	} as unknown as GateRule;
+
+	it("a caller cannot answer a question its surface never asks", () => {
+		// The action surface sets no `model`, so a hard model rule must stay
+		// indeterminate — fail closed — no matter what the caller sends.
+		const honest = { ...sanitizePolicyContext(undefined), action_kind: "tool" };
+		const injected = { ...sanitizePolicyContext({ model: "safe" }), action_kind: "tool" };
+		expect(evaluatePolicy([noFrontier], honest as never).decision).toBe("deny");
+		expect(evaluatePolicy([noFrontier], injected as never).decision).toBe("deny");
+	});
+
+	it("strips every host-asserted key regardless of surface", () => {
+		const hostile: Record<string, unknown> = {};
+		for (const k of HOST_ASSERTED_CONTEXT_KEYS) hostile[k] = "forged";
+		const clean = sanitizePolicyContext(hostile);
+		for (const k of HOST_ASSERTED_CONTEXT_KEYS) {
+			expect(Object.hasOwn(clean, k), `${k} survived sanitisation`).toBe(false);
+		}
+	});
+
+	it("still preserves arbitrary caller keys a policy may address", () => {
+		const clean = sanitizePolicyContext({ metadata: { team: "payments" }, model: "forged" });
+		expect(clean.metadata).toEqual({ team: "payments" });
+		expect(Object.hasOwn(clean, "model")).toBe(false);
+	});
+});

--- a/packages/core/tests/harden/policy-load-integrity.test.ts
+++ b/packages/core/tests/harden/policy-load-integrity.test.ts
@@ -504,3 +504,86 @@ describe("one-pass reporting holds for structural AND semantic faults together",
 		expect(Object.keys(rules[0]?.conditions[0] ?? {})).toEqual(["field", "operator", "value"]);
 	});
 });
+
+describe("round-10 findings", () => {
+	it("an explicit null document is refused; a blank one is an empty policy", () => {
+		for (const [name, body] of [
+			["null.json", "null"],
+			["null.yaml", "null\n"],
+			["tilde.yaml", "~\n"],
+		] as [string, string][]) {
+			expect(() => loadPolicies(write(`r10-${name}`, body)), name).toThrow(
+				/explicit null document/,
+			);
+		}
+		expect(loadPolicies(write("r10-blank.yaml", ""))).toEqual([]);
+		expect(loadPolicies(write("r10-whitespace.yaml", "\n  \n"))).toEqual([]);
+	});
+
+	it("an operand that can only compare by identity is refused", () => {
+		// A rule loaded from disk is freshly parsed, so an object operand can never
+		// share a reference with request data: `eq` never matches a structurally
+		// identical value and `neq` always does. The rule validates and cannot
+		// enforce, which is the shape this file exists to close.
+		const mk = (operator: string, value: unknown) =>
+			JSON.stringify({
+				rules: [
+					{
+						name: "r",
+						effect: "deny",
+						enforcement: "hard",
+						conditions: [{ field: "meta", operator, value }],
+					},
+				],
+			});
+		expect(() => loadPolicies(write("r10-eq-obj.json", mk("eq", { team: "x" })))).toThrow(
+			/compares by identity/,
+		);
+		expect(() => loadPolicies(write("r10-neq-arr.json", mk("neq", [1, 2])))).toThrow(
+			/compares by identity/,
+		);
+		expect(() => loadPolicies(write("r10-in-obj.json", mk("in", [{ a: 1 }, "ok"])))).toThrow(
+			/compares by identity/,
+		);
+	});
+
+	it("primitive operands are unaffected, including inside in/not_in", () => {
+		const mk = (operator: string, value: unknown) =>
+			JSON.stringify({
+				rules: [
+					{
+						name: "r",
+						effect: "deny",
+						enforcement: "hard",
+						conditions: [{ field: "m", operator, value }],
+					},
+				],
+			});
+		expect(loadPolicies(write("r10-eq-str.json", mk("eq", "opus")))).toHaveLength(1);
+		expect(loadPolicies(write("r10-in-prims.json", mk("in", ["a", 1, true, null])))).toHaveLength(
+			1,
+		);
+	});
+
+	it("an unknown operator and an unknown key are reported together", () => {
+		// `z.enum` aborted the object parse, skipping the refinement, so the key was
+		// hidden until the operator was fixed. Operator membership is checked in the
+		// refinement now, so nothing aborts ahead of the structural checks.
+		const p = write(
+			"r10-op-and-key.json",
+			JSON.stringify({
+				rules: [
+					{
+						name: "r",
+						effect: "deny",
+						enforcement: "hard",
+						conditions: [{ field: "x", operator: "contain", value: "y", typo: 1 }],
+					},
+				],
+			}),
+		);
+		const { issues } = validatePolicyFile(p);
+		expect(issues.some((i) => i.at.endsWith(".operator"))).toBe(true);
+		expect(issues.some((i) => i.at.endsWith(".typo"))).toBe(true);
+	});
+});

--- a/packages/core/tests/harden/policy-load-integrity.test.ts
+++ b/packages/core/tests/harden/policy-load-integrity.test.ts
@@ -1,0 +1,457 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * A policy that cannot be honoured must never be mistaken for a policy.
+ *
+ * `loadPolicies` previously resolved unparseable or unrecognised input to an
+ * empty rule set, via two mechanisms: `catch { return [] }` absorbed parse
+ * failures, and a bare `as GateRule[]` cast admitted a rule whose `operator`,
+ * `effect` or `enforcement` was outside its union, which then never matched.
+ * Neither reported anything.
+ *
+ * The cases below are the input classes that produced those outcomes, each now
+ * asserted to be refused. They are the harness the fix was developed against,
+ * ported rather than rewritten.
+ */
+
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { DEFAULT_RULES, mergePolicies } from "../../src/policy/default-rules.js";
+import {
+	evaluatePolicy,
+	type GateRule,
+	loadPolicies,
+	PolicyLoadError,
+	validatePolicyFile,
+} from "../../src/policy/gate.js";
+
+const dir = mkdtempSync(join(tmpdir(), "ut-policy-integrity-"));
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+/** The operator's intent: block frontier models outright. */
+const GOOD_YAML = `rules:
+  - id: no-frontier
+    name: Block frontier models
+    priority: 1
+    enabled: true
+    effect: deny
+    enforcement: hard
+    severity: critical
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+`;
+
+function write(name: string, content: string): string {
+	const p = join(dir, name);
+	writeFileSync(p, content);
+	return p;
+}
+
+/** Exactly what a governor does: platform defaults + whatever the file yields. */
+function verdictFor(rules: GateRule[]): string {
+	return evaluatePolicy(mergePolicies(DEFAULT_RULES, rules), {
+		model: "claude-opus-5",
+		budget_remaining: 1_000_000,
+		budget_remaining_after: 999_000,
+		estimated_cost: 1000,
+	} as never).decision;
+}
+
+describe("a malformed policy file is refused, never silently emptied", () => {
+	it("the intended policy loads and DENIES (the control case)", () => {
+		const rules = loadPolicies(write("policy-good.yaml", GOOD_YAML));
+		expect(rules).toHaveLength(1);
+		expect(verdictFor(rules)).toBe("deny");
+	});
+
+	const parseFailures: [string, string, string][] = [
+		[
+			"policy-tab.yaml",
+			GOOD_YAML.replace("  - id: no-frontier", "\t- id: no-frontier"),
+			"a TAB (YAML forbids tabs)",
+		],
+		[
+			"policy-badindent.yaml",
+			GOOD_YAML.replace("    name: Block frontier models", "  name: Block frontier models"),
+			"one wrong indent level",
+		],
+		[
+			"policy-badjson.json",
+			'{"rules":[{"id":"no-frontier","effect":"deny",}]}',
+			"a trailing comma in JSON",
+		],
+	];
+	for (const [name, content, what] of parseFailures) {
+		it(`THROWS on ${what} — was: 0 rules, call ALLOWED`, () => {
+			const p = write(name, content);
+			expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+			expect(validatePolicyFile(p).rules).toHaveLength(0);
+			expect(validatePolicyFile(p).issues.length).toBeGreaterThan(0);
+		});
+	}
+
+	it("THROWS on a top-level key that is not `rules` — was: 0 rules, call ALLOWED", () => {
+		const p = write("policy-wrongkey.yaml", GOOD_YAML.replace("rules:", "policies:"));
+		expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+		// The message must name the keys that WERE found — this is the case an
+		// operator is least likely to spot unaided.
+		expect(() => loadPolicies(p)).toThrow(/no top-level "rules" key.*policies/s);
+	});
+
+	const shapeFailures: [string, string, string][] = [
+		[
+			"policy-typo-op.yaml",
+			GOOD_YAML.replace("operator: contains", "operator: contain"),
+			"a misspelled operator",
+		],
+		[
+			"policy-typo-enf.yaml",
+			GOOD_YAML.replace("enforcement: hard", "enforcement: HARD"),
+			"a wrong-cased enforcement",
+		],
+		[
+			"policy-typo-effect.yaml",
+			GOOD_YAML.replace("effect: deny", "effect: block"),
+			"an effect that is not deny/warn",
+		],
+		[
+			"policy-missing-effect.yaml",
+			GOOD_YAML.replace("    effect: deny\n", ""),
+			"a rule with no effect at all",
+		],
+	];
+	for (const [name, content, what] of shapeFailures) {
+		it(`THROWS on ${what} — was: rule LOADED but never fired, call ALLOWED`, () => {
+			const p = write(name, content);
+			// The nastier half of the original defect: these files parse fine. The
+			// rule arrived, looked real in the file, and simply never matched.
+			expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+		});
+	}
+
+	it("names the offending rule and field, so the fix is locatable", () => {
+		const p = write(
+			"policy-locate.yaml",
+			GOOD_YAML.replace("operator: contains", "operator: contain"),
+		);
+		const { issues } = validatePolicyFile(p);
+		expect(issues).toHaveLength(1);
+		expect(issues[0]?.at).toBe("rules[0].conditions[0].operator");
+	});
+
+	it("refuses ALL rules when only one is bad — no silent partial policy", () => {
+		// Loading the survivors would enforce a policy the operator never wrote,
+		// which is the same silent-partial-application failure in a new costume.
+		const twoRules = `rules:
+  - name: good rule
+    effect: deny
+    enforcement: hard
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+  - name: bad rule
+    effect: deny
+    enforcement: hard
+    conditions:
+      - field: model
+        operator: contain
+        value: sonnet
+`;
+		const p = write("policy-one-bad.yaml", twoRules);
+		expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+		expect(validatePolicyFile(p).rules).toHaveLength(0);
+	});
+
+	it("a value that the operator cannot use is refused at load", () => {
+		const p = write(
+			"policy-badvalue.yaml",
+			GOOD_YAML.replace(
+				"operator: contains\n        value: opus",
+				"operator: gt\n        value: opus",
+			),
+		);
+		expect(() => loadPolicies(p)).toThrow(/compares numbers/);
+	});
+
+	it("an absent file is NOT an error — running with no policy is legitimate", () => {
+		const p = join(dir, "definitely-not-here.yaml");
+		expect(loadPolicies(p)).toEqual([]);
+		expect(validatePolicyFile(p).issues).toEqual([]);
+	});
+
+	it("an empty document is an empty policy, not a broken one", () => {
+		expect(loadPolicies(write("policy-empty.yaml", ""))).toEqual([]);
+	});
+
+	it("a bare list of rules (no `rules:` wrapper) still loads", () => {
+		const bare = GOOD_YAML.replace("rules:\n", "").replace(/^ {2}/gm, "");
+		expect(loadPolicies(write("policy-bare.yaml", bare))).toHaveLength(1);
+	});
+});
+
+describe("the validator does not itself discard what it cannot understand", () => {
+	// The defect this whole branch is about, in miniature, inside the fix: zod
+	// strips unrecognised keys by DEFAULT. A first cut of `GateRuleSchema` used
+	// `z.object`, and a rule written with `scopePattern` (singular) validated
+	// cleanly, loaded, and silently became an UNSCOPED GLOBAL DENY — the author
+	// believing it applied to production only. Strict schemas make an unknown key
+	// an error. Caught by probing the fix for the shape it was fixing.
+	const MISSPELLED = `rules:
+  - name: prod only
+    effect: deny
+    enforcement: hard
+    scopePattern: ["production/*"]
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+`;
+
+	it("refuses a rule whose scoping key is misspelled, rather than globalising it", () => {
+		const p = write("policy-misspelled-key.yaml", MISSPELLED);
+		expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+		const { rules, issues } = validatePolicyFile(p);
+		expect(rules).toHaveLength(0);
+		expect(issues.length).toBeGreaterThan(0);
+		expect(issues[0]?.at).toContain("rules[0]");
+	});
+
+	it("refuses an unknown key on a condition", () => {
+		const p = write(
+			"policy-unknown-cond-key.yaml",
+			`rules:
+  - name: r
+    effect: deny
+    enforcement: hard
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+        caseSensitive: false
+`,
+		);
+		expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+	});
+
+	it("refuses an unknown key on a time window", () => {
+		const p = write(
+			"policy-unknown-tw-key.yaml",
+			`rules:
+  - name: r
+    effect: deny
+    enforcement: hard
+    timeWindows:
+      - startHour: 22
+        endHour: 6
+        timezone: UTC
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+`,
+		);
+		// `timezone` is especially worth refusing: windows are LOCAL by contract,
+		// so accepting-and-ignoring it would promise a guarantee we do not honour.
+		expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+	});
+});
+
+describe("findings from the Codex gate on this branch", () => {
+	// Each of these was the branch's own defect class reappearing inside the fix.
+
+	it("P1 — an absent path cannot answer `eq: null` for a HARD rule", () => {
+		// `isUnresolved` treated undefined and null alike, so the exemption meant
+		// to keep an explicit `value: null` determinate also let an ABSENT field
+		// answer it: `undefined === null` is false, the guard was skipped, and the
+		// call was allowed.
+		const r = {
+			name: "deny when unset",
+			effect: "deny",
+			enforcement: "hard",
+			conditions: [{ field: "guarded", operator: "eq", value: null }],
+		} as unknown as GateRule;
+		expect(evaluatePolicy([r], {}).decision).toBe("deny");
+		expect(evaluatePolicy([r], { guarded: null }).decision).toBe("deny");
+		expect(evaluatePolicy([r], { guarded: "set" }).decision).toBe("allow");
+	});
+
+	it("P1 — an unknown key on the policy ROOT is refused, not dropped", () => {
+		// `scopePatterns` written at the document root instead of on the rule it
+		// was meant to narrow: the key was silently discarded and the rules it was
+		// supposed to scope applied everywhere.
+		const p = write(
+			"policy-root-key.yaml",
+			`scopePatterns: ["production/*"]
+rules:
+  - name: r
+    effect: deny
+    enforcement: hard
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+`,
+		);
+		expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+		expect(() => loadPolicies(p)).toThrow(/unknown top-level key/);
+	});
+
+	it("the root check does not reject a legitimate document", () => {
+		expect(loadPolicies(write("policy-root-ok.yaml", GOOD_YAML))).toHaveLength(1);
+	});
+});
+
+describe("round-2 findings from the Codex gate", () => {
+	it("P1 — a non-finite threshold is refused; NaN would silence the guard", () => {
+		// `typeof NaN === "number"` and YAML spells it `.nan`, so the rule validated
+		// and then never fired: every comparison against NaN is false, so a hard
+		// budget guard let an overspend through while `policy validate` said ok.
+		const p = write(
+			"policy-nan.yaml",
+			`rules:
+  - name: budget guard
+    effect: deny
+    enforcement: hard
+    conditions:
+      - field: budget_remaining_after
+        operator: lt
+        value: .nan
+`,
+		);
+		expect(() => loadPolicies(p)).toThrow(/cannot use NaN as an operand/);
+	});
+
+	it("P1 — an unreadable policy file is refused, not treated as absent", () => {
+		// The call sites used to guard with `existsSync`, which answers false for a
+		// file inside a directory it cannot traverse — reporting an unreadable
+		// policy as no policy and falling back to the built-in defaults.
+		const locked = join(dir, "locked");
+		mkdirSync(locked, { recursive: true });
+		const p = join(locked, "default.yml");
+		writeFileSync(p, GOOD_YAML);
+		chmodSync(locked, 0o000);
+		try {
+			expect(existsSync(p), "existsSync cannot see it, which is the trap").toBe(false);
+			expect(() => loadPolicies(p)).toThrow(PolicyLoadError);
+		} finally {
+			chmodSync(locked, 0o755);
+		}
+	});
+
+	it("an ABSENT file is still legitimately absent", () => {
+		expect(loadPolicies(join(dir, "not-here-at-all.yaml"))).toEqual([]);
+	});
+
+	it("P2 — a root-key problem does not hide a malformed rule", () => {
+		// `policy validate` promises every problem in one pass; returning early on
+		// the root key made the operator fix it and come back for the next one.
+		const p = write(
+			"policy-root-and-rule.yaml",
+			`scopePatterns: ["production/*"]
+rules:
+  - name: r
+    effect: deny
+    enforcement: hard
+    conditions:
+      - field: model
+        operator: contain
+        value: opus
+`,
+		);
+		const { issues } = validatePolicyFile(p);
+		expect(issues.length).toBeGreaterThanOrEqual(2);
+		expect(issues.some((i) => i.at === "scopePatterns")).toBe(true);
+		expect(issues.some((i) => i.at.startsWith("rules[0]"))).toBe(true);
+	});
+});
+
+describe("round-4 findings", () => {
+	it("C1 controls are neutralised, not just C0", () => {
+		// U+009B is the 8-bit CSI introducer: a terminal honouring it can be
+		// repainted by a string the common C0-only regex passes untouched.
+		// AGENTS.md records why budget.ts's sanitizer is deliberately stronger.
+		const p = write(
+			"policy-c1.yaml",
+			`rules:\n  - name: "r\u009b[2Jok"\n    effect: deny\n    enforcement: hard\n    conditions: []\n`,
+		);
+		const { rules } = validatePolicyFile(p);
+		expect(rules).toHaveLength(1);
+		// The scrubbing happens at render; assert the raw value still carries it so
+		// this test fails loudly if the fixture ever stops exercising the case.
+		expect(rules[0]?.name).toContain("\u009b");
+	});
+
+	it("root issues survive a wrong-typed rules value", () => {
+		const p = write(
+			"policy-root-and-badrules.yaml",
+			`scopePatterns: ["production/*"]\nrules: {}\n`,
+		);
+		const { issues } = validatePolicyFile(p);
+		expect(issues.some((i) => i.at === "scopePatterns")).toBe(true);
+		expect(issues.some((i) => i.at === "rules")).toBe(true);
+	});
+
+	it("reports presence explicitly, so no caller re-derives it with existsSync", () => {
+		expect(validatePolicyFile(join(dir, "nope.yaml")).present).toBe(false);
+		expect(validatePolicyFile(write("policy-present.yaml", GOOD_YAML)).present).toBe(true);
+		const locked = join(dir, "locked2");
+		mkdirSync(locked, { recursive: true });
+		const p = join(locked, "default.yml");
+		writeFileSync(p, GOOD_YAML);
+		chmodSync(locked, 0o000);
+		try {
+			// Present but unreadable: present=true and an issue, NOT absent.
+			const r = validatePolicyFile(p);
+			expect(r.present).toBe(true);
+			expect(r.issues.length).toBeGreaterThan(0);
+		} finally {
+			chmodSync(locked, 0o755);
+		}
+	});
+});
+
+describe("round-7 findings", () => {
+	it("a non-finite operand is refused for EVERY operator, not just the numeric four", () => {
+		// The finite guard was scoped to gt/gte/lt/lte, so `eq: .nan` still loaded —
+		// and `NaN === NaN` is false, so that rule can never match either. Scoping a
+		// check to the operators it was written for left exactly that hole.
+		for (const op of ["eq", "neq", "gt", "gte", "lt", "lte"]) {
+			const p = write(
+				`policy-nan-${op}.yaml`,
+				`rules:\n  - name: guard\n    effect: deny\n    enforcement: hard\n    conditions:\n      - field: risk_score\n        operator: ${op}\n        value: .nan\n`,
+			);
+			expect(() => loadPolicies(p), `${op} must refuse NaN`).toThrow(
+				/cannot use NaN as an operand/,
+			);
+		}
+	});
+
+	it("an array operand containing NaN is still allowed — includes() matches it", () => {
+		// SameValueZero: [NaN].includes(NaN) is true, so `in: [.nan]` is a rule that
+		// works and must not be refused alongside the ones that cannot.
+		const p = write(
+			"policy-nan-in.yaml",
+			`rules:\n  - name: guard\n    effect: deny\n    enforcement: hard\n    conditions:\n      - field: risk_score\n        operator: in\n        value: [.nan]\n`,
+		);
+		expect(loadPolicies(p)).toHaveLength(1);
+		expect(evaluatePolicy(loadPolicies(p), { risk_score: Number.NaN } as never).decision).toBe(
+			"deny",
+		);
+	});
+
+	it("root issues survive a document with no rules key at all", () => {
+		const p = write("policy-root-no-rules.yaml", `scopePatterns: ["p/*"]\ntimeWindows: []\n`);
+		const { issues } = validatePolicyFile(p);
+		expect(issues.some((i) => i.at === "scopePatterns")).toBe(true);
+		expect(issues.some((i) => i.at === "timeWindows")).toBe(true);
+		expect(issues.some((i) => i.at === "file")).toBe(true);
+	});
+});

--- a/packages/core/tests/harden/policy-load-integrity.test.ts
+++ b/packages/core/tests/harden/policy-load-integrity.test.ts
@@ -455,3 +455,52 @@ describe("round-7 findings", () => {
 		expect(issues.some((i) => i.at === "file")).toBe(true);
 	});
 });
+
+describe("one-pass reporting holds for structural AND semantic faults together", () => {
+	it("reports an unknown key and a bad operand on the same condition", () => {
+		// zod skips `.superRefine` when the object parse fails, so a strict schema
+		// reported only the unknown key and the operator had to fix it and re-run to
+		// discover the second fault. The key check now lives inside the refinement,
+		// over a `looseObject` — `object` would strip the unknown key before the
+		// check could see it, which is the same silently-discarded-input shape.
+		const p = write(
+			"policy-both-faults.json",
+			JSON.stringify({
+				rules: [
+					{
+						name: "r",
+						effect: "deny",
+						enforcement: "hard",
+						conditions: [{ field: "x", operator: "gt", value: "not-a-number", typo: 1 }],
+					},
+				],
+			}),
+		);
+		const { issues } = validatePolicyFile(p);
+		expect(issues.some((i) => i.at.endsWith(".typo"))).toBe(true);
+		expect(issues.some((i) => i.at.endsWith(".value"))).toBe(true);
+		expect(issues.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("still refuses an unknown key on its own", () => {
+		const p = write(
+			"policy-unknown-key-alone.json",
+			JSON.stringify({
+				rules: [
+					{
+						name: "r",
+						effect: "deny",
+						enforcement: "hard",
+						conditions: [{ field: "x", operator: "eq", value: 1, caseSensitive: false }],
+					},
+				],
+			}),
+		);
+		expect(() => loadPolicies(p)).toThrow(/unknown key on a condition/);
+	});
+
+	it("a valid condition still loads carrying only its own keys", () => {
+		const rules = loadPolicies(write("policy-clean-cond.yaml", GOOD_YAML));
+		expect(Object.keys(rules[0]?.conditions[0] ?? {})).toEqual(["field", "operator", "value"]);
+	});
+});

--- a/packages/core/tests/harden/policy-load-integrity.test.ts
+++ b/packages/core/tests/harden/policy-load-integrity.test.ts
@@ -587,3 +587,62 @@ describe("round-10 findings", () => {
 		expect(issues.some((i) => i.at.endsWith(".typo"))).toBe(true);
 	});
 });
+
+describe("round-11 findings", () => {
+	it("a blank file is an empty policy in BOTH formats", () => {
+		// `parseYaml("")` returns null while `JSON.parse("")` throws, so deciding
+		// blankness after the parse made the same empty file legal as YAML and a
+		// syntax error as JSON. Blankness is a property of the text.
+		for (const name of ["r11-blank.json", "r11-blank.yaml"]) {
+			expect(loadPolicies(write(name, "")), name).toEqual([]);
+			expect(loadPolicies(write(`ws-${name}`, "  \n\t ")), `ws-${name}`).toEqual([]);
+		}
+	});
+
+	it("reports every fault on a condition in ONE pass", () => {
+		// zod skips `.superRefine` the moment any declared field fails, so a typed
+		// base schema hid every other fault behind the first type error. Every base
+		// field is `unknown` now and the type checks live in the refinement, so the
+		// set is closed rather than one more field being added to it.
+		const p = write(
+			"r11-four-faults.json",
+			JSON.stringify({
+				rules: [
+					{
+						name: "r",
+						effect: "deny",
+						enforcement: "hard",
+						conditions: [{ field: 42, operator: "gt", value: "bad", typo: 1 }],
+					},
+				],
+			}),
+		);
+		const { issues } = validatePolicyFile(p);
+		expect(issues.some((i) => i.at.endsWith(".field"))).toBe(true);
+		expect(issues.some((i) => i.at.endsWith(".value"))).toBe(true);
+		expect(issues.some((i) => i.at.endsWith(".typo"))).toBe(true);
+	});
+
+	it("a missing or non-string operator is named, not crashed on", () => {
+		const mk = (cond: Record<string, unknown>) =>
+			JSON.stringify({
+				rules: [{ name: "r", effect: "deny", enforcement: "hard", conditions: [cond] }],
+			});
+		expect(() => loadPolicies(write("r11-no-op.json", mk({ field: "x", value: 1 })))).toThrow(
+			/must be an operator name, got nothing/,
+		);
+		expect(() =>
+			loadPolicies(write("r11-num-op.json", mk({ field: "x", operator: 7, value: 1 }))),
+		).toThrow(/must be an operator name, got number/);
+	});
+
+	it("a well-formed condition still loads unchanged", () => {
+		const rules = loadPolicies(write("r11-good.yaml", GOOD_YAML));
+		expect(rules).toHaveLength(1);
+		expect(rules[0]?.conditions[0]).toEqual({
+			field: "model",
+			operator: "contains",
+			value: "opus",
+		});
+	});
+});

--- a/packages/core/tests/harden/redos.test.ts
+++ b/packages/core/tests/harden/redos.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Usertools, Inc.
 
+import { unlinkSync, writeFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
-import { evaluatePolicy, type GateRule } from "../../src/policy/gate.js";
+import { evaluatePolicy, type GateRule, loadPolicies } from "../../src/policy/gate.js";
 
 const CATASTROPHIC = ["(a+)+$", "(.*)*$", "(\\d+)+$", "(a|a)*$", "(a|ab)*$"];
 
@@ -22,11 +23,46 @@ describe("safeRegExp structural ReDoS guard", () => {
 			const start = Date.now();
 			const result = evaluatePolicy(rules, { text: evil });
 			const elapsed = Date.now() - start;
-			// Pattern is rejected as unsafe → condition never matches → allow, fast.
+			// The ReDoS property is the TIME BOUND, and it is unchanged: safeRegExp
+			// still refuses the pattern structurally, without ever handing it to the
+			// engine.
 			expect(elapsed).toBeLessThan(1000);
-			expect(result.decision).toBe("allow");
+			// The DECISION changed, deliberately. This used to assert "allow": a hard
+			// rule whose pattern could not be compiled evaluated to "did not match"
+			// rather than "could not evaluate". An unusable guard is now
+			// indeterminate, and a hard rule fails closed on it.
+			expect(result.decision).toBe("deny");
 		});
 	}
+
+	it("refuses a catastrophic pattern at LOAD time, before it can be relied on", () => {
+		// The better outcome than either verdict: the operator is told while they
+		// still have the rule in front of them, rather than shipping a guard that
+		// cannot run.
+		const path = `/tmp/trust-redos-policy-${Date.now()}.json`;
+		try {
+			writeFileSync(
+				path,
+				JSON.stringify({
+					rules: [
+						{
+							name: "redos",
+							effect: "deny",
+							enforcement: "hard",
+							conditions: [{ field: "text", operator: "regex", value: "(a+)+$" }],
+						},
+					],
+				}),
+			);
+			expect(() => loadPolicies(path)).toThrow(/not a usable regular expression/);
+		} finally {
+			try {
+				unlinkSync(path);
+			} catch {
+				/* best effort */
+			}
+		}
+	});
 
 	it("still allows a safe regex to match", () => {
 		const rules: GateRule[] = [

--- a/packages/core/tests/harden/time-window-wrap.test.ts
+++ b/packages/core/tests/harden/time-window-wrap.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * A time window may wrap midnight.
+ *
+ * `isWithinTimeWindow` applied its two half-open bounds independently:
+ *
+ *   if (hour < startHour) return false;
+ *   if (hour >= endHour)  return false;
+ *
+ * For a window whose `startHour` exceeds its `endHour` those cannot both pass at
+ * any hour — 23:00 fails the second, 02:00 fails the first — so such a window
+ * imposed no constraint. Measured across all 24 hours before the change:
+ *
+ *   {startHour:22, endHour:6} matched at: no hour
+ *   {startHour:9,  endHour:17} matched at: 9..16
+ */
+
+import { describe, expect, it } from "vitest";
+import { evaluatePolicy, type GateRule, isWithinTimeWindow } from "../../src/policy/gate.js";
+
+/** Local-time ISO stamp for a given hour on Wed 12 Aug 2026. Windows are LOCAL by contract. */
+function atHour(hour: number, day = 12): string {
+	return new Date(2026, 7, day, hour, 30, 0).toISOString();
+}
+
+function matchingHours(tw: {
+	startHour?: number;
+	endHour?: number;
+	daysOfWeek?: number[];
+}): number[] {
+	const hits: number[] = [];
+	for (let h = 0; h < 24; h++) {
+		if (isWithinTimeWindow([tw], atHour(h))) hits.push(h);
+	}
+	return hits;
+}
+
+describe("midnight-spanning time windows", () => {
+	it("an overnight window {22, 6} covers 22,23,0..5", () => {
+		expect(matchingHours({ startHour: 22, endHour: 6 })).toEqual([0, 1, 2, 3, 4, 5, 22, 23]);
+	});
+
+	it("excludes every hour outside the wrap", () => {
+		const hits = new Set(matchingHours({ startHour: 22, endHour: 6 }));
+		for (const h of [6, 7, 12, 17, 21]) {
+			expect(hits.has(h), `hour ${h} must be outside a 22:00-06:00 curfew`).toBe(false);
+		}
+	});
+
+	it("a one-hour wrap {23, 0} covers exactly 23:00", () => {
+		expect(matchingHours({ startHour: 23, endHour: 0 })).toEqual([23]);
+	});
+
+	it("non-wrapping windows are unchanged", () => {
+		expect(matchingHours({ startHour: 9, endHour: 17 })).toEqual([9, 10, 11, 12, 13, 14, 15, 16]);
+	});
+
+	it("open-ended bounds are unchanged", () => {
+		expect(matchingHours({ startHour: 20 })).toEqual([20, 21, 22, 23]);
+		expect(matchingHours({ endHour: 4 })).toEqual([0, 1, 2, 3]);
+	});
+
+	it("a zero-width window {9, 9} still matches nothing", () => {
+		expect(matchingHours({ startHour: 9, endHour: 9 })).toEqual([]);
+	});
+
+	it("no window at all means no constraint", () => {
+		expect(isWithinTimeWindow(undefined, atHour(3))).toBe(true);
+		expect(isWithinTimeWindow([], atHour(3))).toBe(true);
+	});
+
+	it("the day gate applies to the timestamp's OWN local day", () => {
+		// Wed 12 Aug 2026 is a Wednesday (3); Thu 13th is 4.
+		const wedOnly = { startHour: 22, endHour: 6, daysOfWeek: [3] };
+		expect(isWithinTimeWindow([wedOnly], atHour(23, 12))).toBe(true); // Wed 23:00
+		expect(isWithinTimeWindow([wedOnly], atHour(2, 12))).toBe(true); // Wed 02:00
+		expect(isWithinTimeWindow([wedOnly], atHour(2, 13))).toBe(false); // Thu 02:00
+	});
+
+	it("an overnight HARD rule actually denies overnight and allows midday", () => {
+		const curfew: GateRule = {
+			id: "no-frontier-overnight",
+			name: "No frontier models overnight",
+			effect: "deny",
+			enforcement: "hard",
+			timeWindows: [{ startHour: 22, endHour: 6 }],
+			conditions: [{ field: "model", operator: "contains", value: "opus" }],
+		};
+		// `timestamp` is trusted-host input (#95); a host driving evaluatePolicy
+		// directly owns its own clock, which is what lets this be deterministic.
+		expect(
+			evaluatePolicy([curfew], { model: "claude-opus-5", timestamp: atHour(23) } as never).decision,
+		).toBe("deny");
+		expect(
+			evaluatePolicy([curfew], { model: "claude-opus-5", timestamp: atHour(2) } as never).decision,
+		).toBe("deny");
+		expect(
+			evaluatePolicy([curfew], { model: "claude-opus-5", timestamp: atHour(13) } as never).decision,
+		).toBe("allow");
+	});
+});

--- a/packages/core/tests/policy/gate.test.ts
+++ b/packages/core/tests/policy/gate.test.ts
@@ -845,12 +845,15 @@ describe("loadPolicies", () => {
 		}
 	});
 
-	it("returns empty for null parsed value (line 382)", () => {
+	it("THROWS for an explicit null document — blank is empty, `null` is not", () => {
+		// Was: returned []. A file whose entire content is `null` (or YAML `~`) is
+		// something the author wrote, and it cannot carry rules — accepting it ran
+		// the governor on defaults while the file looked deliberate. A genuinely
+		// blank file is still a legitimate empty policy.
 		const path = `/tmp/trust-test-null-${Date.now()}.json`;
 		try {
 			writeFileSync(path, "null");
-			const rules = loadPolicies(path);
-			expect(rules).toEqual([]);
+			expect(() => loadPolicies(path)).toThrow(/explicit null document/);
 		} finally {
 			try {
 				unlinkSync(path);

--- a/packages/core/tests/policy/gate.test.ts
+++ b/packages/core/tests/policy/gate.test.ts
@@ -16,6 +16,7 @@ import {
 	loadPolicies,
 	matchesScope,
 	type PolicyContext,
+	PolicyLoadError,
 } from "../../src/policy/gate.js";
 import type { FieldOperator, PolicyEffect } from "../../src/shared/types.js";
 
@@ -268,12 +269,21 @@ describe("operators", () => {
 			expect(result.matched).toHaveLength(0);
 		});
 
-		it("does not match non-string fields", () => {
+		it("a non-string subject is indeterminate, so a HARD rule still fires", () => {
+			// Was: matched 0. A number subject made `contains` return bare `false`,
+			// which ruleMatches reads as "rule did not match", skipping the guard.
+			// An unreadable subject is now "indeterminate", which is what
+			// fail-closed is built on.
 			const r = rule({
 				conditions: [{ field: "count", operator: "contains", value: "5" }],
 			});
-			const result = evaluatePolicy([r], { count: 5 });
-			expect(result.matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { count: 5 }).matched).toHaveLength(1);
+			// A soft rule stays lenient, exactly as before.
+			const soft = rule({
+				enforcement: "soft",
+				conditions: [{ field: "count", operator: "contains", value: "5" }],
+			});
+			expect(evaluatePolicy([soft], { count: 5 }).matched).toHaveLength(0);
 		});
 	});
 
@@ -294,20 +304,22 @@ describe("operators", () => {
 			expect(result.matched).toHaveLength(0);
 		});
 
-		it("handles invalid regex gracefully", () => {
+		it("an unusable pattern is indeterminate, not a free pass", () => {
+			// Was: matched 0. `loadPolicies` now refuses such a rule outright; a
+			// programmatically-built one reaching the evaluator must not silently
+			// disable its own guard.
 			const r = rule({
 				conditions: [{ field: "text", operator: "regex", value: "[invalid" }],
 			});
-			const result = evaluatePolicy([r], { text: "anything" });
-			expect(result.matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { text: "anything" }).matched).toHaveLength(1);
 		});
 
-		it("does not match non-string fields", () => {
+		it("a non-string subject is indeterminate, so a HARD rule still fires", () => {
+			// Was: matched 0 — a non-string subject skipped a hard regex guard.
 			const r = rule({
 				conditions: [{ field: "count", operator: "regex", value: "\\d+" }],
 			});
-			const result = evaluatePolicy([r], { count: 42 });
-			expect(result.matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { count: 42 }).matched).toHaveLength(1);
 		});
 	});
 });
@@ -712,13 +724,15 @@ describe("loadPolicies", () => {
 		expect(rules).toEqual([]);
 	});
 
-	it("returns empty array for file with non-array, non-rules-object content (line 382)", () => {
+	it("THROWS for an object with no top-level rules key", () => {
 		const path = `/tmp/trust-test-no-rules-${Date.now()}.json`;
 		try {
-			// Object without "rules" key → should hit line 382
+			// Was: silently []. A document keyed anything-but-`rules` parsed fine and
+			// produced zero rules, so a whole policy file vanished without a word.
 			writeFileSync(path, JSON.stringify({ name: "not-rules", version: 1 }));
-			const rules = loadPolicies(path);
-			expect(rules).toEqual([]);
+			expect(() => loadPolicies(path)).toThrow(PolicyLoadError);
+			// The message names the keys that WERE found, so the fix is obvious.
+			expect(() => loadPolicies(path)).toThrow(/no top-level "rules" key.*name, version/s);
 		} finally {
 			try {
 				unlinkSync(path);
@@ -782,12 +796,11 @@ describe("loadPolicies", () => {
 		}
 	});
 
-	it("returns empty array for YAML with scalar content (line 382)", () => {
+	it("THROWS for YAML with scalar content", () => {
 		const path = `/tmp/trust-test-scalar-${Date.now()}.yml`;
 		try {
 			writeFileSync(path, "just-a-string\n");
-			const rules = loadPolicies(path);
-			expect(rules).toEqual([]);
+			expect(() => loadPolicies(path)).toThrow(PolicyLoadError);
 		} finally {
 			try {
 				unlinkSync(path);
@@ -797,12 +810,13 @@ describe("loadPolicies", () => {
 		}
 	});
 
-	it("returns empty array for invalid JSON (catch block)", () => {
+	it("THROWS for invalid JSON instead of silently disabling the policy", () => {
 		const path = `/tmp/trust-test-invalid-${Date.now()}.json`;
 		try {
+			// The headline case: a trailing comma or a stray character used to
+			// disable every custom rule in the file, silently.
 			writeFileSync(path, "{ broken json <<<");
-			const rules = loadPolicies(path);
-			expect(rules).toEqual([]);
+			expect(() => loadPolicies(path)).toThrow(/is not valid JSON/);
 		} finally {
 			try {
 				unlinkSync(path);
@@ -922,12 +936,23 @@ describe("operator edge cases", () => {
 			expect(evaluatePolicy([r], { active: "true" }).matched).toHaveLength(0);
 		});
 
-		it("matches null value", () => {
+		it("distinguishes an explicit null from a path that did not resolve", () => {
 			const r = rule({
 				conditions: [{ field: "value", operator: "eq", value: null }],
 			});
+			// Present and null: the document carries the value the rule asks about,
+			// so the comparison is determinate and matches. Unchanged.
 			expect(evaluatePolicy([r], { value: null }).matched).toHaveLength(1);
-			expect(evaluatePolicy([r], {}).matched).toHaveLength(0);
+			// ABSENT: was 0 — an unresolved path answered "not null", skipping the
+			// guard. Absence and an explicit null are different facts; only the
+			// latter can answer this comparison.
+			expect(evaluatePolicy([r], {}).matched).toHaveLength(1);
+			// And a soft rule still stays lenient on the same input.
+			const soft = rule({
+				enforcement: "soft",
+				conditions: [{ field: "value", operator: "eq", value: null }],
+			});
+			expect(evaluatePolicy([soft], {}).matched).toHaveLength(0);
 		});
 	});
 
@@ -1048,15 +1073,20 @@ describe("operator edge cases", () => {
 			const r = rule({
 				conditions: [{ field: "role", operator: "in", value: [] }],
 			});
+			// A PRESENT value genuinely is not in an empty list — determinate "no".
 			expect(evaluatePolicy([r], { role: "admin" }).matched).toHaveLength(0);
-			expect(evaluatePolicy([r], { role: undefined }).matched).toHaveLength(0);
+			// An ABSENT value cannot be compared at all. Was 0 (silent allow); a
+			// HARD rule now fails closed.
+			expect(evaluatePolicy([r], { role: undefined }).matched).toHaveLength(1);
 		});
 
-		it("returns false when value is not an array", () => {
+		it("a non-array value is indeterminate, so a HARD rule fires", () => {
+			// Was 0. `loadPolicies` now rejects this rule at load; built by hand it
+			// must not silently disable its own guard.
 			const r = rule({
 				conditions: [{ field: "role", operator: "in", value: "admin" }],
 			});
-			expect(evaluatePolicy([r], { role: "admin" }).matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { role: "admin" }).matched).toHaveLength(1);
 		});
 
 		it("matches undefined in array containing undefined", () => {
@@ -1075,11 +1105,11 @@ describe("operator edge cases", () => {
 			expect(evaluatePolicy([r], { provider: "anything" }).matched).toHaveLength(1);
 		});
 
-		it("returns false when value is not an array", () => {
+		it("a non-array value is indeterminate, so a HARD rule fires", () => {
 			const r = rule({
 				conditions: [{ field: "provider", operator: "not_in", value: "blocked" }],
 			});
-			expect(evaluatePolicy([r], { provider: "openai" }).matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { provider: "openai" }).matched).toHaveLength(1);
 		});
 	});
 
@@ -1099,42 +1129,43 @@ describe("operator edge cases", () => {
 			expect(evaluatePolicy([r], { prompt: "this is Secret" }).matched).toHaveLength(1);
 		});
 
-		it("does not match when resolved is not a string", () => {
+		it("a non-string subject is indeterminate, so a HARD rule fires", () => {
+			// A number or null subject previously skipped a hard `contains` guard.
 			const r = rule({
 				conditions: [{ field: "data", operator: "contains", value: "x" }],
 			});
-			expect(evaluatePolicy([r], { data: 123 }).matched).toHaveLength(0);
-			expect(evaluatePolicy([r], { data: null }).matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { data: 123 }).matched).toHaveLength(1);
+			expect(evaluatePolicy([r], { data: null }).matched).toHaveLength(1);
 		});
 
-		it("does not match when value is not a string", () => {
+		it("a non-string value is indeterminate, so a HARD rule fires", () => {
 			const r = rule({
 				conditions: [{ field: "prompt", operator: "contains", value: 123 as unknown as string }],
 			});
-			expect(evaluatePolicy([r], { prompt: "123" }).matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { prompt: "123" }).matched).toHaveLength(1);
 		});
 	});
 
 	describe("regex — edge cases", () => {
-		it("handles invalid regex without crashing (returns false)", () => {
+		it("an unusable pattern is indeterminate without crashing", () => {
 			const r = rule({
 				conditions: [{ field: "text", operator: "regex", value: "(?P<invalid>" }],
 			});
-			expect(evaluatePolicy([r], { text: "test" }).matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { text: "test" }).matched).toHaveLength(1);
 		});
 
-		it("does not match when resolved is not a string", () => {
+		it("a non-string subject is indeterminate, so a HARD rule fires", () => {
 			const r = rule({
 				conditions: [{ field: "count", operator: "regex", value: "\\d+" }],
 			});
-			expect(evaluatePolicy([r], { count: 42 }).matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { count: 42 }).matched).toHaveLength(1);
 		});
 
-		it("does not match when value is not a string", () => {
+		it("a non-string value is indeterminate, so a HARD rule fires", () => {
 			const r = rule({
 				conditions: [{ field: "text", operator: "regex", value: 42 as unknown as string }],
 			});
-			expect(evaluatePolicy([r], { text: "42" }).matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { text: "42" }).matched).toHaveLength(1);
 		});
 
 		it("matches complex regex patterns", () => {
@@ -1149,12 +1180,14 @@ describe("operator edge cases", () => {
 	});
 
 	describe("default/unknown operator (line 156)", () => {
-		it("returns false for unknown operator", () => {
+		it("an unknown operator is indeterminate — it must not disable its own guard", () => {
+			// Was: matched 0. An operator outside the union fell to `default:` and
+			// the rule never matched, with nothing reported. Such a rule is now
+			// refused by loadPolicies; one built in code fails closed.
 			const r = rule({
 				conditions: [{ field: "x", operator: "unknown_op" as unknown as FieldOperator, value: 1 }],
 			});
-			const result = evaluatePolicy([r], { x: 1 });
-			expect(result.matched).toHaveLength(0);
+			expect(evaluatePolicy([r], { x: 1 }).matched).toHaveLength(1);
 		});
 	});
 });

--- a/site/content/docs/concepts/policy-engine.mdx
+++ b/site/content/docs/concepts/policy-engine.mdx
@@ -39,6 +39,7 @@ A policy rule specifies conditions, scope, enforcement, and optional time window
 rules:
   - name: block-expensive-models
     description: Deny requests to opus-class models in production
+    effect: deny
     enforcement: hard
     priority: 10
     scopePatterns: ["production/*"]


### PR DESCRIPTION
## Policy enforcement integrity

Policy loading, operator evaluation, the trusted-field boundary, and time-window matching each treated input they could not interpret as input that imposed no constraint. All four now fail closed, and every condition that produced the permissive result is covered by a test.

**Split from the original bundle.** The CLI diagnostics (`usertrust policy validate`, the health rule-count line) are on `ship/policy-diagnostics` — a bounded, decision-free change should not be gated on the convergence of one that alters enforcement for every adopter. This PR carries the activation decision; that one carries none.

> ### ⚠️ Merge order is not optional
>
> The review of this branch in isolation raised exactly the right objection: **this PR makes a deployment refuse to start on an unparseable policy, and the tool for finding out why is on the other branch.** `usertrust policy validate` does not exist until `ship/policy-diagnostics` lands, and `usertrust health` reports only historical violations until then.
>
> That is a split artifact rather than a defect here — the diagnostics branch *consumes* `validatePolicyFile` and its `present` flag, so it cannot land first. The mitigation is at the release boundary, not the merge boundary:
>
> **Merge this, then merge diagnostics, then cut the release. No released version may contain the enforcement change without the diagnostic.** An adopter who upgrades into a refuse-to-start with no way to ask which line of their policy is wrong is a worse outcome than the defect being fixed.

---

## ⚠️ Behaviour changes — controls that are inert today become active

Two commits, independently revertable.

### 1. `dc8b5b8` — a policy file that does not parse will refuse to start

**Today:** a deployment whose policy file cannot be parsed starts and applies only the built-in budget rules.
**After:** it refuses to start.

`usertrust policy validate` (in the diagnostics PR) is the pre-flight that makes this survivable.

### 2. `bc3f562` — windows that wrap midnight begin matching

**Today:** `{startHour: 22, endHour: 6}` matches no hour and imposes no constraint. Verified across all 24.
**After:** it matches 22, 23, 0–5.

Any deployed policy carrying a midnight-spanning window is inert now and becomes active on upgrade. This commit touches only `isWithinTimeWindow`, its AGENTS.md paragraph, and its own test file.

---

## What changed

### Loading

`loadPolicies` was a bare `as GateRule[]` cast inside `catch { return [] }`. `validatePolicyFile` now reports every problem in one pass and `loadPolicies` throws `PolicyLoadError`. All-or-nothing: one invalid rule loads none of them.

Schemas are **strict at every level including the document root**, so a key placed outside the rule it was meant to apply to is refused rather than dropped — zod strips unrecognised keys by default, which is how two cache-token tiers were once dropped on the settle path. Non-finite operands are refused for **every** operator (`NaN` compares false against everything, so `eq: .nan` would validate and never fire). Globs minimatch cannot compile are refused at load rather than throwing mid-evaluation.

**Absence is decided by ENOENT and reported as `present`, never re-derived by a caller.** `existsSync` answers false for a file inside a directory it cannot traverse, so every caller that asked separately reported an unreadable policy as an absent one.

### Operators

`evaluateFieldCondition` returned `"indeterminate"` only for `gt/gte/lt/lte`. `eq`, `in`, `contains` and `regex` returned a bare `false` on a field that was absent or of an unusable type — which `ruleMatches` reads as "did not match" rather than "could not evaluate", skipping the guard rather than firing it.

Every value operator is now indeterminate on unreadable input. `exists`/`not_exists` are unchanged. `undefined` (path did not resolve) is distinguished from an explicit `null` (a value the document carries), so `not_in: [null]` still permits the value it names.

### Trusted fields

Two sets are stripped **before** the spread by `sanitizePolicyContext`: the declared `PolicyContext` fields the host owns, and the union of keys the governors assert themselves.

The union matters because the three sites assert **different subsets** — `governAction` sets `action_kind` and no `model`, the others set `model` and no action keys — so a key one surface asserted arrived from `...params` on the surfaces that did not.

**`scope` is deliberately not stripped.** For `timestamp` absence is the safe state (the gate falls back to the real clock); for `scope` absence is the permissive state, and nothing in `src/` populates it, so stripping it would make every `scopePatterns` rule inert. A source-parity test requires every declared field to be classified as one or the other.

**Filed, not resolved here:** the docs describe `scopePatterns` as narrowing a live rule, while such a rule requires a caller-supplied scope to match at all.

---

## Verification

- **Full suite: 3259 passed, 0 failed** (under `FORCE_COLOR=1 CI=true`)
- **Biome `check .`: exit 0**, matching CI
- **Every guard mutation-verified** — break it, watch its own test fail
- The strongest: **deleting the hand-written `timestamp: undefined` from all three sites leaves `clock-shadow` at 9/9**, because the strip alone now holds the line #95 established

**22 existing tests changed expectations** because they asserted the permissive result — including `redos.test.ts`, where a pattern rejected by the ReDoS guard made a hard rule allow. Each is annotated in place with its previous expectation and why it changed; the ReDoS *timing* assertion is untouched.

`AGENTS.md` is updated: three invariants it stated are no longer accurate as written.

### Gate history

Eight review rounds, 27 findings, every round non-empty until the split. Two recurring shapes, both worth more than the individual fixes:

- **A check narrower than the property it protects.** The finite-operand check scoped to the four numeric operators; the strip list derived from the interface while some keys ride the index signature; and `satisfies readonly FieldOperator[]`, which verifies that everything listed is a member without requiring every member to be listed.
- **The abstraction introduced to fix a defect class is where the class reappears.** `isUnresolved()` was written to close this class and conflated `undefined` with `null` twice in opposite directions before being deleted rather than patched a third time.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZCkyMkaEi2hRwhkVLa6TS
