### PR TITLE
fix(budget): distinguish an absent spend ledger from an unreadable one

### DIFF
--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -728,8 +728,22 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 			} finally {
 				await dirHandle.close();
 			}
-		} catch {
-			// Platform does not support directory fsync — the rename still landed.
+		} catch (dirErr) {
+			// DISTINGUISH unsupported from failed. A blanket catch here read EIO,
+			// ENOSPC and EACCES as "this platform has no directory fsync" and
+			// reported success — so a real durability failure left the rename
+			// non-durable in silence, and a crash could restore an older ledger, or
+			// none at all on a first write, which reseeds a LARGER budget. Same
+			// conflation as the read path this branch exists to fix: "cannot" and
+			// "did not" are different facts.
+			const code = (dirErr as NodeJS.ErrnoException)?.code;
+			const unsupported =
+				code === "EINVAL" || code === "ENOTSUP" || code === "EPERM" || code === "EBADF";
+			if (!unsupported) {
+				process.stderr.write(
+					`[usertrust] spend ledger directory not fsynced (${dirErr instanceof Error ? dirErr.message : String(dirErr)}) — the rename may not survive a power loss\n`,
+				);
+			}
 		}
 	} catch (err) {
 		// Still best-effort — a settled call must not fail over ledger persistence,

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -30,7 +30,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { open, readFile, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { CreateTransferStatus } from "tigerbeetle-node";
 import { type AuditWriter, createAuditWriter } from "./audit/chain.js";
@@ -86,6 +86,7 @@ import {
 	InsufficientBalanceError,
 	LedgerUnavailableError,
 	PolicyDeniedError,
+	SpendLedgerUnreadableError,
 } from "./shared/errors.js";
 import { trustId } from "./shared/ids.js";
 import type {
@@ -617,24 +618,47 @@ interface SpendLedger {
 
 async function loadSpendLedger(vaultBase: string): Promise<number> {
 	const ledgerPath = join(vaultBase, VAULT_DIR, "spend-ledger.json");
+	let raw: string;
 	try {
-		const raw = await readFile(ledgerPath, "utf-8");
-		const parsed: unknown = JSON.parse(raw);
-		if (
-			parsed != null &&
-			typeof parsed === "object" &&
-			"budgetSpent" in parsed &&
-			typeof (parsed as SpendLedger).budgetSpent === "number"
-		) {
-			const value = (parsed as SpendLedger).budgetSpent;
-			if (Number.isFinite(value) && value >= 0) {
-				return value;
-			}
-		}
-	} catch {
-		// No ledger file or corrupt — start from zero
+		raw = await readFile(ledgerPath, "utf-8");
+	} catch (err) {
+		// ENOENT is the ONE honest zero: no ledger means nothing has been spent,
+		// which is exactly true on a first run. Every OTHER read failure (EACCES,
+		// EIO, EISDIR) means a ledger that exists and could not be read, and
+		// answering that with zero is not a conservative default — it re-grants the
+		// whole budget in-process AND re-seeds the TigerBeetle enforcing wallet with
+		// it, because the seed is `max(0, budget - budgetSpent)`. Absent and
+		// unreadable are different facts and must not share an answer.
+		if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return 0;
+		throw new SpendLedgerUnreadableError(
+			`${ledgerPath}: ${err instanceof Error ? err.message : String(err)}`,
+		);
 	}
-	return 0;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new SpendLedgerUnreadableError(`${ledgerPath}: not valid JSON`);
+	}
+
+	if (
+		parsed == null ||
+		typeof parsed !== "object" ||
+		!("budgetSpent" in parsed) ||
+		typeof (parsed as SpendLedger).budgetSpent !== "number"
+	) {
+		throw new SpendLedgerUnreadableError(`${ledgerPath}: no numeric "budgetSpent" field`);
+	}
+
+	const value = (parsed as SpendLedger).budgetSpent;
+	// A negative or non-finite cumulative spend is not a smaller number than we
+	// expected — it is a file we cannot reason about, and rounding it to zero is
+	// the same re-grant as an unreadable one.
+	if (!Number.isFinite(value) || value < 0) {
+		throw new SpendLedgerUnreadableError(`${ledgerPath}: budgetSpent is ${value}`);
+	}
+	return value;
 }
 
 async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promise<void> {
@@ -662,9 +686,36 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 			budgetSpent,
 			updatedAt: new Date().toISOString(),
 		};
-		// Atomic write: write UNIQUE tmp then rename over the target.
-		await writeFile(tmpPath, JSON.stringify(data), "utf-8");
+		// Atomic write: write UNIQUE tmp, FSYNC it, then rename over the target.
+		// The rename was already atomic, so no ordinary crash or restart could tear
+		// the target — but without the fsync, a power loss can make the rename
+		// durable while the bytes it points at are not, leaving a zero-length or
+		// partially-zeroed ledger. That file then reads as unreadable rather than
+		// as a smaller number, which loadSpendLedger now refuses rather than
+		// silently treating as zero spend. Durability here is what keeps that
+		// refusal rare instead of routine.
+		const handle = await open(tmpPath, "w");
+		try {
+			await handle.writeFile(JSON.stringify(data), "utf-8");
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
 		await rename(tmpPath, ledgerPath);
+		// Fsync the DIRECTORY so the rename itself survives a power loss. Best
+		// effort: some platforms and filesystems refuse an O_RDONLY directory
+		// fsync, and failing the write over that would be worse than the residual
+		// risk it protects against.
+		try {
+			const dirHandle = await open(dir, "r");
+			try {
+				await dirHandle.sync();
+			} finally {
+				await dirHandle.close();
+			}
+		} catch {
+			// Platform does not support directory fsync — the rename still landed.
+		}
 	} catch {
 		// Best-effort — do not fail the LLM call over ledger persistence. Clean up
 		// our unique staging file if the rename never happened.

--- a/packages/core/src/govern.ts
+++ b/packages/core/src/govern.ts
@@ -697,7 +697,22 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 		const handle = await open(tmpPath, "w");
 		try {
 			await handle.writeFile(JSON.stringify(data), "utf-8");
-			await handle.sync();
+			// FSYNC FAILURE IS NOT WRITE FAILURE. `sync()` is unsupported on some
+			// filesystems (EINVAL/ENOTSUP) and can fail transiently on others, and
+			// letting it escape sent the whole write into the outer catch — which
+			// unlinks the staging file and returns as if the spend had persisted.
+			// On a platform without fsync that silently discarded EVERY ledger
+			// write, and a first write discarded that way leaves NO ledger at all,
+			// which the loader correctly reads as zero and re-grants the whole
+			// budget. A durable-but-unsynced ledger is strictly better than none:
+			// degrade, record it, and still rename.
+			try {
+				await handle.sync();
+			} catch (syncErr) {
+				process.stderr.write(
+					`[usertrust] spend ledger not fsynced (${syncErr instanceof Error ? syncErr.message : String(syncErr)}) — the record is written but a power loss may lose it\n`,
+				);
+			}
 		} finally {
 			await handle.close();
 		}
@@ -716,9 +731,16 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 		} catch {
 			// Platform does not support directory fsync — the rename still landed.
 		}
-	} catch {
-		// Best-effort — do not fail the LLM call over ledger persistence. Clean up
-		// our unique staging file if the rename never happened.
+	} catch (err) {
+		// Still best-effort — a settled call must not fail over ledger persistence,
+		// because the money has already moved. But SILENT is the part that was
+		// wrong: cleaning up and returning made a lost cumulative-spend write
+		// indistinguishable from a successful one, and the loss is invisible until
+		// the next startup seeds a budget that is too large. The operator gets a
+		// line on stderr, matching how audit degradation is already surfaced.
+		process.stderr.write(
+			`[usertrust] spend ledger write FAILED (${err instanceof Error ? err.message : String(err)}) — cumulative spend ${budgetSpent} was not persisted; the next start may under-count prior spend\n`,
+		);
 		await unlink(tmpPath).catch(() => {});
 	}
 }

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -39,7 +39,7 @@
 
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { open, readFile, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { CreateTransferStatus } from "tigerbeetle-node";
 import { type AuditWriter, createAuditWriter } from "./audit/chain.js";
@@ -106,6 +106,7 @@ import {
 	InsufficientBalanceError,
 	LedgerUnavailableError,
 	PolicyDeniedError,
+	SpendLedgerUnreadableError,
 } from "./shared/errors.js";
 import { trustId } from "./shared/ids.js";
 import type { EndpointInfo, TrustConfig, TrustReceipt } from "./shared/types.js";
@@ -429,24 +430,47 @@ interface SpendLedger {
 
 async function loadSpendLedger(vaultBase: string): Promise<number> {
 	const ledgerPath = join(vaultBase, VAULT_DIR, "spend-ledger.json");
+	let raw: string;
 	try {
-		const raw = await readFile(ledgerPath, "utf-8");
-		const parsed: unknown = JSON.parse(raw);
-		if (
-			parsed != null &&
-			typeof parsed === "object" &&
-			"budgetSpent" in parsed &&
-			typeof (parsed as SpendLedger).budgetSpent === "number"
-		) {
-			const value = (parsed as SpendLedger).budgetSpent;
-			if (Number.isFinite(value) && value >= 0) {
-				return value;
-			}
-		}
-	} catch {
-		// No ledger file or corrupt — start from zero
+		raw = await readFile(ledgerPath, "utf-8");
+	} catch (err) {
+		// ENOENT is the ONE honest zero: no ledger means nothing has been spent,
+		// which is exactly true on a first run. Every OTHER read failure (EACCES,
+		// EIO, EISDIR) means a ledger that exists and could not be read, and
+		// answering that with zero is not a conservative default — it re-grants the
+		// whole budget in-process AND re-seeds the TigerBeetle enforcing wallet with
+		// it, because the seed is `max(0, budget - budgetSpent)`. Absent and
+		// unreadable are different facts and must not share an answer.
+		if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return 0;
+		throw new SpendLedgerUnreadableError(
+			`${ledgerPath}: ${err instanceof Error ? err.message : String(err)}`,
+		);
 	}
-	return 0;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new SpendLedgerUnreadableError(`${ledgerPath}: not valid JSON`);
+	}
+
+	if (
+		parsed == null ||
+		typeof parsed !== "object" ||
+		!("budgetSpent" in parsed) ||
+		typeof (parsed as SpendLedger).budgetSpent !== "number"
+	) {
+		throw new SpendLedgerUnreadableError(`${ledgerPath}: no numeric "budgetSpent" field`);
+	}
+
+	const value = (parsed as SpendLedger).budgetSpent;
+	// A negative or non-finite cumulative spend is not a smaller number than we
+	// expected — it is a file we cannot reason about, and rounding it to zero is
+	// the same re-grant as an unreadable one.
+	if (!Number.isFinite(value) || value < 0) {
+		throw new SpendLedgerUnreadableError(`${ledgerPath}: budgetSpent is ${value}`);
+	}
+	return value;
 }
 
 async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promise<void> {
@@ -475,9 +499,36 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 			budgetSpent,
 			updatedAt: new Date().toISOString(),
 		};
-		// Atomic write: write UNIQUE tmp then rename over the target.
-		await writeFile(tmpPath, JSON.stringify(data), "utf-8");
+		// Atomic write: write UNIQUE tmp, FSYNC it, then rename over the target.
+		// The rename was already atomic, so no ordinary crash or restart could tear
+		// the target — but without the fsync, a power loss can make the rename
+		// durable while the bytes it points at are not, leaving a zero-length or
+		// partially-zeroed ledger. That file then reads as unreadable rather than
+		// as a smaller number, which loadSpendLedger now refuses rather than
+		// silently treating as zero spend. Durability here is what keeps that
+		// refusal rare instead of routine.
+		const handle = await open(tmpPath, "w");
+		try {
+			await handle.writeFile(JSON.stringify(data), "utf-8");
+			await handle.sync();
+		} finally {
+			await handle.close();
+		}
 		await rename(tmpPath, ledgerPath);
+		// Fsync the DIRECTORY so the rename itself survives a power loss. Best
+		// effort: some platforms and filesystems refuse an O_RDONLY directory
+		// fsync, and failing the write over that would be worse than the residual
+		// risk it protects against.
+		try {
+			const dirHandle = await open(dir, "r");
+			try {
+				await dirHandle.sync();
+			} finally {
+				await dirHandle.close();
+			}
+		} catch {
+			// Platform does not support directory fsync — the rename still landed.
+		}
 	} catch {
 		// Best-effort — do not fail the LLM call over ledger persistence. Clean up
 		// our unique staging file if the rename never happened.

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -541,8 +541,22 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 			} finally {
 				await dirHandle.close();
 			}
-		} catch {
-			// Platform does not support directory fsync — the rename still landed.
+		} catch (dirErr) {
+			// DISTINGUISH unsupported from failed. A blanket catch here read EIO,
+			// ENOSPC and EACCES as "this platform has no directory fsync" and
+			// reported success — so a real durability failure left the rename
+			// non-durable in silence, and a crash could restore an older ledger, or
+			// none at all on a first write, which reseeds a LARGER budget. Same
+			// conflation as the read path this branch exists to fix: "cannot" and
+			// "did not" are different facts.
+			const code = (dirErr as NodeJS.ErrnoException)?.code;
+			const unsupported =
+				code === "EINVAL" || code === "ENOTSUP" || code === "EPERM" || code === "EBADF";
+			if (!unsupported) {
+				process.stderr.write(
+					`[usertrust] spend ledger directory not fsynced (${dirErr instanceof Error ? dirErr.message : String(dirErr)}) — the rename may not survive a power loss\n`,
+				);
+			}
 		}
 	} catch (err) {
 		// Still best-effort — a settled call must not fail over ledger persistence,

--- a/packages/core/src/headless.ts
+++ b/packages/core/src/headless.ts
@@ -510,7 +510,22 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 		const handle = await open(tmpPath, "w");
 		try {
 			await handle.writeFile(JSON.stringify(data), "utf-8");
-			await handle.sync();
+			// FSYNC FAILURE IS NOT WRITE FAILURE. `sync()` is unsupported on some
+			// filesystems (EINVAL/ENOTSUP) and can fail transiently on others, and
+			// letting it escape sent the whole write into the outer catch — which
+			// unlinks the staging file and returns as if the spend had persisted.
+			// On a platform without fsync that silently discarded EVERY ledger
+			// write, and a first write discarded that way leaves NO ledger at all,
+			// which the loader correctly reads as zero and re-grants the whole
+			// budget. A durable-but-unsynced ledger is strictly better than none:
+			// degrade, record it, and still rename.
+			try {
+				await handle.sync();
+			} catch (syncErr) {
+				process.stderr.write(
+					`[usertrust] spend ledger not fsynced (${syncErr instanceof Error ? syncErr.message : String(syncErr)}) — the record is written but a power loss may lose it\n`,
+				);
+			}
 		} finally {
 			await handle.close();
 		}
@@ -529,9 +544,16 @@ async function persistSpendLedger(vaultBase: string, budgetSpent: number): Promi
 		} catch {
 			// Platform does not support directory fsync — the rename still landed.
 		}
-	} catch {
-		// Best-effort — do not fail the LLM call over ledger persistence. Clean up
-		// our unique staging file if the rename never happened.
+	} catch (err) {
+		// Still best-effort — a settled call must not fail over ledger persistence,
+		// because the money has already moved. But SILENT is the part that was
+		// wrong: cleaning up and returning made a lost cumulative-spend write
+		// indistinguishable from a successful one, and the loss is invisible until
+		// the next startup seeds a budget that is too large. The operator gets a
+		// line on stderr, matching how audit degradation is already surfaced.
+		process.stderr.write(
+			`[usertrust] spend ledger write FAILED (${err instanceof Error ? err.message : String(err)}) — cumulative spend ${budgetSpent} was not persisted; the next start may under-count prior spend\n`,
+		);
 		await unlink(tmpPath).catch(() => {});
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,7 @@ export {
 	LedgerUnavailableError,
 	PolicyDeniedError,
 	SkillVerificationError,
+	SpendLedgerUnreadableError,
 	VaultKeyMissingError,
 	VaultNotInitializedError,
 } from "./shared/errors.js";

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -163,6 +163,38 @@ export class LedgerUnavailableError extends Error {
 	}
 }
 
+/**
+ * The persisted spend ledger exists but could not be interpreted.
+ *
+ * `spend-ledger.json` carries cumulative spend ACROSS restarts, and its value
+ * seeds two things at startup: the in-process `budgetSpent`, and — via
+ * `max(0, budget - budgetSpent)` — the TigerBeetle enforcing wallet. A ledger
+ * that cannot be read is therefore not the same fact as a ledger that is not
+ * there. Absent means "nothing has been spent yet", which is true on a first
+ * run. Unreadable means "an unknown amount has been spent", and answering that
+ * with zero re-grants the full budget in both places at once.
+ *
+ * So this is thrown rather than defaulted. It is a startup error by design: the
+ * operator can delete the file to deliberately reset the ledger, or fix its
+ * permissions, and either way makes the choice knowingly.
+ */
+export class SpendLedgerUnreadableError extends Error {
+	public readonly cause_message: string;
+	public readonly hint: string;
+	public readonly docsUrl: string;
+
+	constructor(reason: string) {
+		const hint =
+			"Fix permissions on .usertrust/spend-ledger.json, restore it from a snapshot, or delete it to reset cumulative spend to zero.";
+		const docsUrl = "https://usertrust.ai/docs/errors/spend-ledger-unreadable";
+		super(`Spend ledger unreadable: ${reason}\n\n  Hint: ${hint}\n  Docs: ${docsUrl}`);
+		this.name = "SpendLedgerUnreadableError";
+		this.cause_message = reason;
+		this.hint = hint;
+		this.docsUrl = docsUrl;
+	}
+}
+
 export class AuditDegradedError extends Error {
 	public readonly cause_message: string;
 	public readonly hint: string;

--- a/packages/core/tests/govern/anthropic-surfaces.test.ts
+++ b/packages/core/tests/govern/anthropic-surfaces.test.ts
@@ -216,8 +216,24 @@ const PROVIDER_EVENTS = [
 ];
 const PROVIDER_FINAL = { id: "msg_1", usage: { input_tokens: 100, output_tokens: 30 } };
 
-/** Let the self-driven stream + async governance settlement fully complete. */
-async function flush(ms = 40): Promise<void> {
+/**
+ * Let the self-driven stream + async governance settlement fully complete.
+ *
+ * This is a WALL-CLOCK budget, not a tick count, and these cases run with
+ * `dryRun: false` against a real temp vault — so the settle path does real disk
+ * I/O (`persistSpendLedger`) BEFORE it calls `postPendingSpend`, which is what
+ * the assertions here count. The budget therefore has to cover an fsync, and
+ * fsync latency spikes by an order of magnitude on a loaded machine.
+ *
+ * Measured on APFS/SSD: the settle-path write costs ~0.2ms without fsync and
+ * ~5.6ms with the file + directory fsync that durability requires. The old 40ms
+ * default cleared that by a hair when idle and failed intermittently under
+ * parallel load, surfacing as "never-consume → settle exactly once" seeing zero
+ * calls. Raised to 400ms for real headroom: these are timing floors, not
+ * timing assertions, so a generous budget costs a few seconds of suite time and
+ * buys determinism.
+ */
+async function flush(ms = 400): Promise<void> {
 	await new Promise<void>((r) => setTimeout(r, ms));
 }
 

--- a/packages/core/tests/harden/spend-ledger-fsync.test.ts
+++ b/packages/core/tests/harden/spend-ledger-fsync.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * An fsync that fails must not discard the spend.
+ *
+ * `sync()` is unsupported on some filesystems (EINVAL/ENOTSUP) and can fail
+ * transiently on others (ENOSPC/EIO). Letting it escape sent the entire write
+ * into `persistSpendLedger`'s broad catch, which unlinks the staging file and
+ * returns as if the spend had persisted. On a platform without fsync that
+ * silently discarded EVERY ledger write — and a FIRST write discarded that way
+ * leaves no ledger at all, which the loader correctly reads as zero and
+ * re-grants the whole session budget.
+ *
+ * The two halves of this branch combined into the exact defect the branch
+ * exists to remove: the read was taught to distinguish absent from unreadable,
+ * and the write was given a path that manufactures "absent".
+ *
+ * `node:fs/promises` is mocked here rather than in the sibling suite so the
+ * mock cannot leak into tests that do real filesystem work.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Set per-test to make the mocked `FileHandle.sync()` reject. */
+let syncFails: Error | null = null;
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return {
+		...actual,
+		open: async (path: string, flags: string) => {
+			const handle = await actual.open(path, flags);
+			return new Proxy(handle, {
+				get(target, prop, receiver) {
+					if (prop === "sync") {
+						return async () => {
+							if (syncFails !== null) throw syncFails;
+							return await target.sync();
+						};
+					}
+					const v = Reflect.get(target, prop, receiver);
+					return typeof v === "function" ? v.bind(target) : v;
+				},
+			});
+		},
+	};
+});
+
+const { createGovernor } = await import("../../src/headless.js");
+
+let root: string;
+
+beforeEach(async () => {
+	root = mkdtempSync(join(tmpdir(), "usertrust-fsync-"));
+	const { mkdir } = await import("node:fs/promises");
+	await mkdir(join(root, ".usertrust"), { recursive: true });
+	syncFails = null;
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	try {
+		rmSync(root, { recursive: true, force: true });
+	} catch {
+		// Best-effort; the OS reclaims the temp dir regardless.
+	}
+});
+
+describe("spend ledger — a failing fsync must not discard the write", () => {
+	const opts = () => ({ budget: 100_000, dryRun: true, vaultBase: root }) as never;
+
+	/**
+	 * Assert on the LEDGER FILE, not on whether some rename happened. An earlier
+	 * cut of this test flagged any `rename` through the mocked module and passed
+	 * with the fix reverted, because the audit writer renames too — a global flag
+	 * measuring the wrong subject, which is the same mistake this whole branch is
+	 * about. The file and its contents are the only honest evidence.
+	 */
+	async function ledgerSpend(): Promise<number | null> {
+		const { readFile } = await import("node:fs/promises");
+		try {
+			const raw = await readFile(join(root, ".usertrust", "spend-ledger.json"), "utf-8");
+			return (JSON.parse(raw) as { budgetSpent: number }).budgetSpent;
+		} catch {
+			return null;
+		}
+	}
+
+	it("still PERSISTS the ledger when sync() is unsupported", async () => {
+		// EINVAL is what a filesystem without fsync support answers. Before the fix
+		// this threw past the rename into the broad catch, which unlinked the
+		// staging file and returned as though the spend had been recorded — leaving
+		// NO ledger, which the loader reads as zero and re-grants the whole budget.
+		syncFails = Object.assign(new Error("EINVAL: invalid argument, fsync"), { code: "EINVAL" });
+
+		const governor = await createGovernor(opts());
+		const auth = await governor.authorize({ model: "claude-sonnet-4-6", messages: [] } as never);
+		await governor.settle(auth, { inputTokens: 10, outputTokens: 10 } as never);
+
+		expect(await ledgerSpend()).not.toBeNull();
+	});
+
+	it("warns on stderr rather than degrading in silence", async () => {
+		syncFails = Object.assign(new Error("EIO: i/o error, fsync"), { code: "EIO" });
+		const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+		const governor = await createGovernor(opts());
+		const auth = await governor.authorize({ model: "claude-sonnet-4-6", messages: [] } as never);
+		await governor.settle(auth, { inputTokens: 10, outputTokens: 10 } as never);
+
+		const said = stderr.mock.calls.map((c) => String(c[0])).join("\n");
+		expect(said).toMatch(/spend ledger not fsynced/i);
+	});
+
+	it("persists normally when sync() succeeds", async () => {
+		const governor = await createGovernor(opts());
+		const auth = await governor.authorize({ model: "claude-sonnet-4-6", messages: [] } as never);
+		await governor.settle(auth, { inputTokens: 10, outputTokens: 10 } as never);
+		expect(await ledgerSpend()).not.toBeNull();
+	});
+});

--- a/packages/core/tests/harden/spend-ledger-integrity.test.ts
+++ b/packages/core/tests/harden/spend-ledger-integrity.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * `spend-ledger.json` — absent is not the same fact as unreadable.
+ *
+ * This file carries cumulative spend ACROSS restarts, and its value seeds two
+ * things at startup: the in-process `budgetSpent`, and — via
+ * `max(0, budget - budgetSpent)` — the TigerBeetle enforcing wallet. So the
+ * answer "0" is load-bearing in two places at once.
+ *
+ * "0" is the correct answer to *no ledger* (a first run has spent nothing) and
+ * the wrong answer to *a ledger we could not read* (an unknown amount has been
+ * spent). Collapsing the two re-grants the full budget in-process and re-seeds
+ * the enforcing wallet with it.
+ *
+ * These tests drive the two governors through their PUBLIC entry points rather
+ * than the module-private loader, because the loader being correct is not the
+ * property that matters — the property that matters is that a governor refuses
+ * to start on a ledger it cannot interpret.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmod, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { trust } from "../../src/govern.js";
+import { createGovernor } from "../../src/headless.js";
+import { SpendLedgerUnreadableError } from "../../src/shared/errors.js";
+
+let root: string;
+let vault: string;
+
+const ledgerPath = () => join(vault, "spend-ledger.json");
+
+/** dryRun keeps TigerBeetle out of it — the ledger read happens before any engine. */
+const opts = () => ({ budget: 100_000, dryRun: true, vaultBase: root }) as never;
+
+beforeEach(async () => {
+	root = mkdtempSync(join(tmpdir(), "usertrust-spend-ledger-"));
+	vault = join(root, ".usertrust");
+	await mkdir(vault, { recursive: true });
+});
+
+afterEach(() => {
+	try {
+		rmSync(root, { recursive: true, force: true });
+	} catch {
+		// Best-effort; the OS reclaims the temp dir regardless.
+	}
+});
+
+describe("spend ledger — absent means zero", () => {
+	it("starts clean when there is no ledger at all", async () => {
+		// A first run has genuinely spent nothing. This is the one honest zero and
+		// it must keep working, or every new vault fails to start.
+		await expect(createGovernor(opts())).resolves.toBeDefined();
+	});
+
+	it("reads a well-formed ledger", async () => {
+		writeFileSync(
+			ledgerPath(),
+			JSON.stringify({ budgetSpent: 4200, updatedAt: new Date(0).toISOString() }),
+			"utf-8",
+		);
+		await expect(createGovernor(opts())).resolves.toBeDefined();
+	});
+
+	it("accepts a zero-spend ledger, which is distinct from an absent one", async () => {
+		writeFileSync(
+			ledgerPath(),
+			JSON.stringify({ budgetSpent: 0, updatedAt: new Date(0).toISOString() }),
+			"utf-8",
+		);
+		await expect(createGovernor(opts())).resolves.toBeDefined();
+	});
+});
+
+describe("spend ledger — unreadable must not read as zero", () => {
+	const corrupt: ReadonlyArray<readonly [string, string]> = [
+		["truncated mid-write", '{"budgetSpent": 42'],
+		["zero-length (the post-power-loss shape)", ""],
+		["all NUL bytes (the other post-power-loss shape)", "\0\0\0\0\0\0\0\0"],
+		["valid JSON, wrong shape", '{"spent": 42}'],
+		["valid JSON, not an object", "[1,2,3]"],
+		["budgetSpent not a number", '{"budgetSpent": "42"}'],
+		["negative cumulative spend", '{"budgetSpent": -1}'],
+		["non-finite cumulative spend", '{"budgetSpent": 1e999}'],
+	];
+
+	for (const [label, body] of corrupt) {
+		it(`REFUSES to start on ${label}`, async () => {
+			writeFileSync(ledgerPath(), body, "utf-8");
+			await expect(createGovernor(opts())).rejects.toThrow(SpendLedgerUnreadableError);
+		});
+	}
+
+	it("REFUSES to start on a ledger it lacks permission to read", async () => {
+		writeFileSync(ledgerPath(), JSON.stringify({ budgetSpent: 7 }), "utf-8");
+		await chmod(ledgerPath(), 0o000);
+		try {
+			await createGovernor(opts());
+			// Root ignores the permission bits; the setup cannot hold there.
+		} catch (err) {
+			expect(err).toBeInstanceOf(SpendLedgerUnreadableError);
+		} finally {
+			await chmod(ledgerPath(), 0o600);
+		}
+	});
+
+	it("names the file and the reason, so the operator can act", async () => {
+		writeFileSync(ledgerPath(), "{", "utf-8");
+		await expect(createGovernor(opts())).rejects.toThrow(/spend-ledger\.json/);
+		await expect(createGovernor(opts())).rejects.toThrow(/delete it to reset/i);
+	});
+});
+
+describe("spend ledger — trust() enforces the same contract as createGovernor()", () => {
+	// The two governors carry byte-identical copies of the loader; a one-sided
+	// edit would leave `trust()` re-granting the budget while `createGovernor()`
+	// refused. Drive BOTH.
+	it("trust() also refuses a corrupt ledger", async () => {
+		writeFileSync(ledgerPath(), '{"budgetSpent": ', "utf-8");
+		await expect(
+			trust({} as never, { budget: 100_000, dryRun: true, vaultBase: root } as never),
+		).rejects.toThrow(SpendLedgerUnreadableError);
+	});
+
+	it("trust() gets PAST the ledger read when none is present", async () => {
+		// `trust()` loads the ledger before it detects the client kind, so a stub
+		// client fails detection LATER. Asserting the failure is not the ledger's is
+		// what proves the absent-ledger path still returns zero rather than throwing
+		// — without coupling this test to client-detection internals.
+		const err = await trust(
+			{} as never,
+			{ budget: 100_000, dryRun: true, vaultBase: root } as never,
+		).catch((e: unknown) => e);
+		expect(err).not.toBeInstanceOf(SpendLedgerUnreadableError);
+		expect(String(err)).toMatch(/Unsupported LLM client/);
+	});
+});


### PR DESCRIPTION
`spend-ledger.json` carries cumulative spend across restarts. Its value seeds two things at startup: the in-process `budgetSpent`, and — via `max(0, budget - budgetSpent)` — the TigerBeetle enforcing wallet (`govern.ts:996 → :1007 → :3466`, and the matching path in `headless.ts`). **So the answer "0" is load-bearing in two places at once.**

`loadSpendLedger` returned `0` for every failure: missing file, unreadable file, malformed JSON, wrong shape, negative or non-finite value. Only the first of those is a fact we know.

| Ledger state | Before | Now |
|---|---|---|
| absent (first run) | `0` | `0` — the one honest zero |
| unreadable (EACCES/EIO) | `0` | `SpendLedgerUnreadableError` |
| truncated / zero-length / all-NUL | `0` | `SpendLedgerUnreadableError` |
| valid JSON, wrong shape | `0` | `SpendLedgerUnreadableError` |
| negative or non-finite | `0` | `SpendLedgerUnreadableError` |

The error names the file and the reason. The operator can restore it, fix its permissions, or delete it to deliberately reset cumulative spend — each a choice made knowingly.

### On the write path — what did *not* need fixing

The rename was **already atomic** and the tmp path already unique per writer, so no ordinary crash or restart could tear the target. That part was correct and is unchanged.

What was missing is **durability ordering**: without an fsync before the rename, a power loss can leave the rename durable while the bytes it points at are not, producing a zero-length or partially-zeroed file. The tmp file is now fsynced before the rename, and the directory after it (the latter best-effort — some filesystems refuse a read-only directory fsync, and failing a write over that would be worse than the residual risk).

The read change and the write change ship together on purpose: the read now refuses a file it cannot interpret, and the write makes producing one much less likely, so the refusal stays rare rather than becoming routine.

### Both governors

`trust()` and `createGovernor()` carry byte-identical copies of this loader. A one-sided edit would leave one re-granting the budget while the other refused, so the tests drive **both** public entry points.

### ⚠️ Behaviour change

A deployment whose ledger is currently corrupt starts failing instead of starting with a full budget. That is the point of the change. One of four activations landing in a single release — see #97 for the bundled decision.

### A measured cost, and a test that was hiding behind it

The fsync adds **~5.4ms per settle** (measured APFS/SSD: 0.20ms → 5.61ms; 2.9ms file, 2.5ms directory). Negligible beside an LLM round-trip.

But it exposed a latent problem in `govern/anthropic-surfaces.test.ts`: its `flush()` helper is a **40ms wall-clock** budget, and those cases run `dryRun: false` against a real temp vault, so the settle path does real disk I/O *before* the `postPendingSpend` call they assert on. 40ms cleared the old write by a hair when idle. It does not reliably clear an fsync under parallel load. Raised to 400ms with the measurement recorded in the comment — these are timing floors, not timing assertions. Verified 3× clean at 30/30.

### Gates

- full suite **3166 passed / 14 skipped**
- coverage **93.86 / 87.50 / 95.17 / 95.29** (exit 0)
- biome **0**, `tsc -b packages/core` **0**

### Tests

`packages/core/tests/harden/spend-ledger-integrity.test.ts` — 15 cases driven through the public entry points rather than the module-private loader, because the property that matters is that a governor **refuses to start**, not that a helper returns the right number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ouQi5z58VPHxwAMAWtGsr