### PR TITLE
fix(anchor): an unparseable successor pin must reach the verdict

### DIFF
--- a/packages/core/src/audit/anchor-verify.ts
+++ b/packages/core/src/audit/anchor-verify.ts
@@ -146,6 +146,13 @@ const INVALID_REASONS = new Set([
 	"range-invalid",
 	"sig-invalid",
 	"rekor-receipt-invalid",
+	// Caller-supplied trust material that cannot be parsed. Registered here
+	// deliberately: an UNregistered reason falls into the default bucket at the
+	// classification step, which is MISMATCH — the most severe verdict, and the
+	// wrong one. A mismatch means the anchors disagree with the vault; a
+	// malformed pin means the operator's own input could not be read, and
+	// blaming the vault for it sends them to the wrong investigation.
+	"malformed-successor-pin",
 ]);
 const NON_FAIL_REASONS = new Set(["no-trust-material", "witness-unreachable"]);
 
@@ -494,13 +501,30 @@ export function verifyAnchorChain(
 	const knownKeys = new Map<string, KeyObject>();
 	const rootKeyId = keyIdFromKeyObject(rootKey);
 	knownKeys.set(rootKeyId, rootKey);
-	for (const pem of trust.successorPinsPem ?? []) {
+	// An UNPARSEABLE successor pin used to be dropped here in silence. Note the
+	// asymmetry it created with the root key a few lines above: an unparseable
+	// ROOT pushes "trust root public key is not a parseable PEM" and returns,
+	// while a mistyped or truncated `--successor-pin` simply vanished. The
+	// operator supplied a pin precisely to constrain which successor key is
+	// acceptable, so discarding it silently verifies against a WEAKER trust set
+	// than the one they asked for — and the run still reports success. A pin that
+	// cannot be read is an input error, not an absent constraint.
+	for (const [i, pem] of (trust.successorPinsPem ?? []).entries()) {
 		const k = publicKeyFromPem(pem);
-		if (k !== null) {
-			const id = keyIdFromKeyObject(k);
-			pinKeyIds.add(id);
-			knownKeys.set(id, k);
+		if (k === null) {
+			errors.push(`successor pin #${i + 1} is not a parseable PEM`);
+			// `errors` does NOT reach the verdict — `evaluateAnchoredVault` derives it
+			// from `invalidReasons` + `mismatchReasons` alone (see the `reasons.push`
+			// there). Recording only the error left `verifyVaultWithAnchors` still
+			// answering ANCHORED_VERIFIED with exit 0, so the fix would have reported
+			// the unreadable input in a field nothing consumed — the same false OK
+			// this change exists to remove, one level up.
+			invalidReasons.push("malformed-successor-pin");
+			continue;
 		}
+		const id = keyIdFromKeyObject(k);
+		pinKeyIds.add(id);
+		knownKeys.set(id, k);
 	}
 
 	// A mixed-vaultId set is rejected wholesale, BEFORE dedup can collapse a
@@ -871,9 +895,39 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 		};
 	};
 
+	// Step 1b — CALLER-SUPPLIED trust material, validated BEFORE anything about
+	// the vault is examined.
+	//
+	// Placement is the whole point. `verifyAnchorChain` also rejects a malformed
+	// pin, but it is only reached at step 4 — and step 2 below returns UNANCHORED
+	// for an empty or legacy vault before any of that runs. So validating only
+	// there left the exact case where it matters most still answering
+	// `valid: true`, exit 0: a vault with nothing to check, and an operator whose
+	// pin was never read. A pin the caller could not spell is an INPUT error, and
+	// it does not become acceptable because the vault turned out to be empty.
+	let malformedPins = 0;
+	if (input.trust !== null) {
+		for (const [i, pem] of (input.trust.successorPinsPem ?? []).entries()) {
+			if (publicKeyFromPem(pem) === null) {
+				errors.push(`successor pin #${i + 1} is not a parseable PEM`);
+				reasons.push("malformed-successor-pin");
+				malformedPins++;
+			}
+		}
+	}
+
 	// Step 2 — discovery.
+	//
+	// NO early return on a malformed pin when anchors are present. Returning here
+	// reported ANCHOR_INVALID and skipped every anchor-content check, so a
+	// malformed pin accompanying a FORK, a rollback, mixed vault ids or mirror
+	// disagreement would hide the stronger evidence — and the state machine's
+	// worst-state rule has MISMATCH outranking INVALID. The reason is recorded
+	// above and carried into the normal classification, which already picks the
+	// worst state. Only when there is nothing else to evaluate does the pin
+	// decide the verdict on its own.
 	if (!anchorsPresent) {
-		return finish("UNANCHORED", []);
+		return finish(malformedPins > 0 ? "ANCHOR_INVALID" : "UNANCHORED", []);
 	}
 
 	// Step 3 — trust material (before parse escalation, per constraints §4.2).

--- a/packages/core/tests/harden/anchor-pin-verdict.test.ts
+++ b/packages/core/tests/harden/anchor-pin-verdict.test.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * An unparseable `--successor-pin` must reach the VERDICT.
+ *
+ * Split out of `false-ok.test.ts` because the change it covers is not the
+ * one-line kind the rest of that file holds. `anchor-verify` carries a verdict
+ * lattice — UNANCHORED / ANCHORED_VERIFIED / ANCHOR_STALE / ANCHOR_UNVERIFIABLE
+ * / ANCHOR_INVALID / ANCHOR_MISMATCH — with precedence rules, several
+ * early-return paths, and a byte-identical twin in `packages/verify`. Three
+ * review rounds each found a defect in the previous round's FIX rather than in
+ * the original code:
+ *
+ *   1. the pin was discarded silently;
+ *   2. fixed → recorded into `errors`, which the verdict does not read;
+ *   3. fixed → validated inside `verifyAnchorChain`, which the UNANCHORED
+ *      early-return skips entirely;
+ *   4. fixed → returned immediately, short-circuiting the anchor-content checks
+ *      and masking ANCHOR_MISMATCH, which OUTRANKS ANCHOR_INVALID.
+ *
+ * Each correction was sound in isolation and wrong about its surroundings —
+ * which is what editing a state machine through a peephole looks like. On its
+ * own branch the whole lattice is the diff, so a reviewer can see the precedence
+ * rather than one arm of it.
+ */
+
+import { generateKeyPairSync } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { evaluateAnchoredVault, verifyAnchorChain } from "../../src/audit/anchor-verify.js";
+
+describe("false OK — an unparseable --successor-pin", () => {
+	// A real root, so the run gets past the root-key guard and reaches the pins.
+	const rootPem = generateKeyPairSync("ed25519").publicKey.export({
+		type: "spki",
+		format: "pem",
+	}) as string;
+
+	it("REPORTS a pin it could not parse instead of dropping it", () => {
+		const result = verifyAnchorChain([], {
+			rootPem,
+			successorPinsPem: ["-----BEGIN PUBLIC KEY-----\nnot-a-key\n-----END PUBLIC KEY-----"],
+		} as Parameters<typeof verifyAnchorChain>[1]);
+		// The operator supplied a pin to CONSTRAIN which successor is acceptable.
+		// Silently discarding it verified against a weaker trust set than they
+		// asked for — and still reported success.
+		expect(result.errors.join(" ")).toMatch(/successor pin #1 is not a parseable PEM/i);
+	});
+
+	it("names WHICH pin failed when several are supplied", () => {
+		const result = verifyAnchorChain([], {
+			rootPem,
+			successorPinsPem: [rootPem, "garbage", rootPem],
+		} as Parameters<typeof verifyAnchorChain>[1]);
+		expect(result.errors.join(" ")).toMatch(/successor pin #2/i);
+	});
+
+	it("makes the PUBLIC verdict fail, not just an error string", () => {
+		// The finding Codex caught in the first cut of this fix: `errors` does not
+		// reach the verdict. `evaluateAnchoredVault` derives it from
+		// `invalidReasons` + `mismatchReasons` alone, so recording only the error
+		// left `verifyVaultWithAnchors` still answering ANCHORED_VERIFIED with exit
+		// 0 — the reported input error changed nothing an auditor would see. Assert
+		// at the level the verdict is actually read.
+		const result = verifyAnchorChain([], {
+			rootPem,
+			successorPinsPem: ["nope"],
+		} as Parameters<typeof verifyAnchorChain>[1]);
+		expect(result.invalidReasons).toContain("malformed-successor-pin");
+	});
+
+	it("classifies as INVALID rather than falling into the MISMATCH default", () => {
+		// An UNregistered reason lands in the default bucket at classification,
+		// which is MISMATCH — the most severe verdict and the wrong one. A mismatch
+		// means the anchors disagree with the vault; a malformed pin means the
+		// operator's own input could not be read.
+		const evaluation = evaluateAnchoredVault({
+			orderedHashes: [],
+			externalAnchors: [],
+			externalErrors: [],
+			mirrorAnchors: [],
+			mirrorErrors: [],
+			trust: { rootPem, successorPinsPem: ["nope"] },
+			witness: { requested: false },
+		} as Parameters<typeof evaluateAnchoredVault>[0]);
+		expect(evaluation.anchorState).not.toBe("ANCHOR_MISMATCH");
+	});
+
+	it("rejects a malformed pin on an UNANCHORED vault, where the check matters most", () => {
+		// The re-review finding. `evaluateAnchoredVault` returns UNANCHORED at the
+		// discovery step for an empty or legacy vault, BEFORE trust material is
+		// ever examined — so validating the pin inside `verifyAnchorChain` left
+		// exactly the case with nothing to check still answering valid, exit 0.
+		const evaluation = evaluateAnchoredVault({
+			orderedHashes: [],
+			externalAnchors: [],
+			externalErrors: [],
+			mirrorAnchors: [],
+			mirrorErrors: [],
+			trust: { rootPem, successorPinsPem: ["nope"] },
+			witness: { requested: false },
+		} as Parameters<typeof evaluateAnchoredVault>[0]);
+		expect(evaluation.anchorState).toBe("ANCHOR_INVALID");
+		expect(evaluation.anchorsValid).toBe(false);
+		expect(evaluation.reasons).toContain("malformed-successor-pin");
+	});
+
+	it("still reports UNANCHORED for an empty vault whose pins are fine", () => {
+		// The guard must not turn every unanchored vault into a failure.
+		const evaluation = evaluateAnchoredVault({
+			orderedHashes: [],
+			externalAnchors: [],
+			externalErrors: [],
+			mirrorAnchors: [],
+			mirrorErrors: [],
+			trust: { rootPem, successorPinsPem: [rootPem] },
+			witness: { requested: false },
+		} as Parameters<typeof evaluateAnchoredVault>[0]);
+		expect(evaluation.anchorState).toBe("UNANCHORED");
+	});
+
+	it("stays silent when every pin parses", () => {
+		const result = verifyAnchorChain([], {
+			rootPem,
+			successorPinsPem: [rootPem],
+		} as Parameters<typeof verifyAnchorChain>[1]);
+		expect(result.errors.join(" ")).not.toMatch(/parseable PEM/i);
+	});
+});

--- a/packages/verify/src/anchor-verify.ts
+++ b/packages/verify/src/anchor-verify.ts
@@ -146,6 +146,13 @@ const INVALID_REASONS = new Set([
 	"range-invalid",
 	"sig-invalid",
 	"rekor-receipt-invalid",
+	// Caller-supplied trust material that cannot be parsed. Registered here
+	// deliberately: an UNregistered reason falls into the default bucket at the
+	// classification step, which is MISMATCH — the most severe verdict, and the
+	// wrong one. A mismatch means the anchors disagree with the vault; a
+	// malformed pin means the operator's own input could not be read, and
+	// blaming the vault for it sends them to the wrong investigation.
+	"malformed-successor-pin",
 ]);
 const NON_FAIL_REASONS = new Set(["no-trust-material", "witness-unreachable"]);
 
@@ -494,13 +501,30 @@ export function verifyAnchorChain(
 	const knownKeys = new Map<string, KeyObject>();
 	const rootKeyId = keyIdFromKeyObject(rootKey);
 	knownKeys.set(rootKeyId, rootKey);
-	for (const pem of trust.successorPinsPem ?? []) {
+	// An UNPARSEABLE successor pin used to be dropped here in silence. Note the
+	// asymmetry it created with the root key a few lines above: an unparseable
+	// ROOT pushes "trust root public key is not a parseable PEM" and returns,
+	// while a mistyped or truncated `--successor-pin` simply vanished. The
+	// operator supplied a pin precisely to constrain which successor key is
+	// acceptable, so discarding it silently verifies against a WEAKER trust set
+	// than the one they asked for — and the run still reports success. A pin that
+	// cannot be read is an input error, not an absent constraint.
+	for (const [i, pem] of (trust.successorPinsPem ?? []).entries()) {
 		const k = publicKeyFromPem(pem);
-		if (k !== null) {
-			const id = keyIdFromKeyObject(k);
-			pinKeyIds.add(id);
-			knownKeys.set(id, k);
+		if (k === null) {
+			errors.push(`successor pin #${i + 1} is not a parseable PEM`);
+			// `errors` does NOT reach the verdict — `evaluateAnchoredVault` derives it
+			// from `invalidReasons` + `mismatchReasons` alone (see the `reasons.push`
+			// there). Recording only the error left `verifyVaultWithAnchors` still
+			// answering ANCHORED_VERIFIED with exit 0, so the fix would have reported
+			// the unreadable input in a field nothing consumed — the same false OK
+			// this change exists to remove, one level up.
+			invalidReasons.push("malformed-successor-pin");
+			continue;
 		}
+		const id = keyIdFromKeyObject(k);
+		pinKeyIds.add(id);
+		knownKeys.set(id, k);
 	}
 
 	// A mixed-vaultId set is rejected wholesale, BEFORE dedup can collapse a
@@ -871,9 +895,39 @@ export function evaluateAnchoredVault(input: AnchorEvaluationInput): AnchorEvalu
 		};
 	};
 
+	// Step 1b — CALLER-SUPPLIED trust material, validated BEFORE anything about
+	// the vault is examined.
+	//
+	// Placement is the whole point. `verifyAnchorChain` also rejects a malformed
+	// pin, but it is only reached at step 4 — and step 2 below returns UNANCHORED
+	// for an empty or legacy vault before any of that runs. So validating only
+	// there left the exact case where it matters most still answering
+	// `valid: true`, exit 0: a vault with nothing to check, and an operator whose
+	// pin was never read. A pin the caller could not spell is an INPUT error, and
+	// it does not become acceptable because the vault turned out to be empty.
+	let malformedPins = 0;
+	if (input.trust !== null) {
+		for (const [i, pem] of (input.trust.successorPinsPem ?? []).entries()) {
+			if (publicKeyFromPem(pem) === null) {
+				errors.push(`successor pin #${i + 1} is not a parseable PEM`);
+				reasons.push("malformed-successor-pin");
+				malformedPins++;
+			}
+		}
+	}
+
 	// Step 2 — discovery.
+	//
+	// NO early return on a malformed pin when anchors are present. Returning here
+	// reported ANCHOR_INVALID and skipped every anchor-content check, so a
+	// malformed pin accompanying a FORK, a rollback, mixed vault ids or mirror
+	// disagreement would hide the stronger evidence — and the state machine's
+	// worst-state rule has MISMATCH outranking INVALID. The reason is recorded
+	// above and carried into the normal classification, which already picks the
+	// worst state. Only when there is nothing else to evaluate does the pin
+	// decide the verdict on its own.
 	if (!anchorsPresent) {
-		return finish("UNANCHORED", []);
+		return finish(malformedPins > 0 ? "ANCHOR_INVALID" : "UNANCHORED", []);
 	}
 
 	// Step 3 — trust material (before parse escalation, per constraints §4.2).


### PR DESCRIPTION
**Split out of #98** so one hard change stops gating three one-liners.

An unparseable `--successor-pin` was dropped with no error and no warning. The tell is the asymmetry a few lines above: an unparseable trust **root** already reported `"not a parseable PEM"` and returned, while a mistyped **pin** simply vanished — so verification ran against a *weaker trust set than the operator asked for*, and still reported success.

### Why this is its own PR

Getting that to the **verdict** took four attempts, and every review round found a defect in the previous round's *fix* rather than in the original code:

| # | State | Why it still answered `valid: true` |
|---|---|---|
| 1 | original | pin discarded silently |
| 2 | fix | recorded into `errors` — but `evaluateAnchoredVault` derives its answer from `invalidReasons` + `mismatchReasons` alone, so the public verdict stayed `ANCHORED_VERIFIED`, exit 0 |
| 3 | fix | validated inside `verifyAnchorChain` — which the `UNANCHORED` early-return skips entirely, so an empty or legacy vault (the case with *nothing to check*) still answered valid |
| 4 | fix | returned immediately on failure — **short-circuiting the anchor-content checks and masking `ANCHOR_MISMATCH` behind `ANCHOR_INVALID`**, violating the state machine's worst-state rule |

Each correction was sound in isolation and wrong about its surroundings. That is what editing a state machine through a peephole looks like — `anchor-verify` carries a verdict lattice (`UNANCHORED` / `ANCHORED_VERIFIED` / `ANCHOR_STALE` / `ANCHOR_UNVERIFIABLE` / `ANCHOR_INVALID` / `ANCHOR_MISMATCH`) with precedence rules, several early-return paths, and a byte-identical twin.

**On its own branch the whole lattice is the diff**, so a reviewer can see the precedence rather than one arm of it.

Step 4 deserves calling out: closing a false OK created a way to hide a *worse* finding behind a lesser one. A malformed pin accompanying a fork, a rollback, mixed vault ids or mirror disagreement would have reported only `ANCHOR_INVALID`.

### What it does now

- Pins are validated **before** anchor discovery, so the empty-vault case is covered
- The reason is recorded and **evaluation continues**, so the normal classification still picks the worst state
- The pin decides the verdict alone **only** when there are no anchors to evaluate
- `malformed-successor-pin` is registered in `INVALID_REASONS` deliberately — an *unregistered* reason falls into the classification default, which is `MISMATCH`, and a mismatch means the anchors disagree with the vault while a malformed pin means the operator's own input could not be read

Both mirrored copies, per the parity contract.

### Tests

`packages/core/tests/harden/anchor-pin-verdict.test.ts` asserts at the **public verdict level** rather than on the internal reason array — which is where attempt 2 was passing while the observable answer was unchanged. Includes the guard against over-correction: an unanchored vault whose pins are well-formed must still report `UNANCHORED`, not a failure.

### Gates

full suite **3158 passed / 14 skipped**; biome **0**; `tsc -b packages/core packages/verify` **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ouQi5z58VPHxwAMAWtGsr