### PR TITLE
test(harden): count sanitizers by shape, not by name

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -858,10 +858,11 @@ owns it: the count guard derives its root from its own file location, so it comp
 sanitizers against that tree's AGENTS.md, never one against the other.
 
 The total is pinned by `core/tests/harden/false-ok.test.ts`, which counts what a sanitizer DOES —
-the C1 comparison for the stronger variant, the `CONTROL_CHARS` class for the weaker — rather than
-matching known function names. An earlier version matched names and reported a smaller inventory
-than existed the moment one landed under a new name. So a new copy is counted whatever it is
-called: add a bullet here and update the total.
+the C1 comparison for the stronger variant, the control-character class for the weaker — rather
+than matching known function or constant names. Two earlier versions matched names — first the function names, then the
+`CONTROL_CHARS` binding — and each reported a smaller inventory than existed the moment a copy
+landed under a different name. So a new copy is counted whatever it is called, and whatever its
+constant is called: add a bullet here and update the total.
 
 The entries below are deliberately NOT numbered. They used to be ("a seventh", "an eighth"), and
 adding one meant renumbering every later entry — so a new copy was added and the ordinals silently

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -849,6 +849,14 @@ entire product for a verification tool.
 
 There are **eleven** sanitizers, in two variants. Do not consolidate them onto the weaker one.
 
+**A whole-repo command asserts over A TREE, not THE REPO.** This repo is worked in through several
+git worktrees at once, so `packages/*/src` means something different depending on where the command
+ran. The sanitizer count is 11 on one branch and 13 on another and BOTH are correct — they are
+counting different trees. The same class produced a false "master is red" alarm from a `biome check`
+run at a root that swept in sibling worktrees' configs. Scope a global assertion to the tree that
+owns it: the count guard derives its root from its own file location, so it compares a tree's
+sanitizers against that tree's AGENTS.md, never one against the other.
+
 The total is pinned by `core/tests/harden/false-ok.test.ts`, which counts what a sanitizer DOES —
 the C1 comparison for the stronger variant, the `CONTROL_CHARS` class for the weaker — rather than
 matching known function names. An earlier version matched names and reported a smaller inventory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -849,6 +849,12 @@ entire product for a verification tool.
 
 There are **eleven** sanitizers, in two variants. Do not consolidate them onto the weaker one.
 
+The total is pinned by `core/tests/harden/false-ok.test.ts`, which counts what a sanitizer DOES —
+the C1 comparison for the stronger variant, the `CONTROL_CHARS` class for the weaker — rather than
+matching known function names. An earlier version matched names and reported a smaller inventory
+than existed the moment one landed under a new name. So a new copy is counted whatever it is
+called: add a bullet here and update the total.
+
 The entries below are deliberately NOT numbered. They used to be ("a seventh", "an eighth"), and
 adding one meant renumbering every later entry — so a new copy was added and the ordinals silently
 stopped matching the count. Adding a sanitizer means: add a bullet, and update the total above.

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -288,7 +288,15 @@ describe("false OK — a documented count that stops matching reality", () => {
 		// could then inflate the count, or offset a genuinely removed sanitizer so
 		// the total still agreed. A shape matcher has to match the shape, and two
 		// different variables is a different shape.
-		const STRONG = /([A-Za-z_$][A-Za-z0-9_$]*) *>= *0x7f *&& *\1 *<= *0x9f/g;
+		// ANCHORED AT BOTH ENDS of the identifier. An unanchored capture could start
+		// mid-token: in `start >= 0x7f && t <= 0x9f` the engine captures the final
+		// `t` of `start`, the backreference then matches the real `t`, and a
+		// two-variable interval check counts as a sanitizer. Which matters because
+		// a false POSITIVE can offset a genuinely REMOVED sanitizer and leave the
+		// stale total agreeing — two errors cancelling into a passing guard is the
+		// hardest failure here to notice, since nothing looks wrong at all.
+		const STRONG =
+			/(?<![A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*) *>= *0x7f *&& *\1(?![A-Za-z0-9_$]) *<= *0x9f/g;
 		const WEAK = /= *\/\[\\x00-\\x1f\\x7f\]\/g/g;
 		for (const dir of srcDirs) {
 			let files: string[];

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -282,14 +282,26 @@ describe("false OK — a documented count that stops matching reality", () => {
 		let weak = 0;
 		// Identifiers are wildcards: the range bounds and operators are the
 		// behaviour, the names around them are incidental.
-		const STRONG = />= *0x7f *&& *[A-Za-z_$][A-Za-z0-9_$]* *<= *0x9f/g;
+		// BOTH BOUNDS BIND ONE IDENTIFIER, via a back-reference. Without it this
+		// also matched `start >= 0x7f && end <= 0x9f` — an INTERVAL check over two
+		// variables, not a sanitizer testing a single code point. Unrelated code
+		// could then inflate the count, or offset a genuinely removed sanitizer so
+		// the total still agreed. A shape matcher has to match the shape, and two
+		// different variables is a different shape.
+		const STRONG = /([A-Za-z_$][A-Za-z0-9_$]*) *>= *0x7f *&& *\1 *<= *0x9f/g;
 		const WEAK = /= *\/\[\\x00-\\x1f\\x7f\]\/g/g;
 		for (const dir of srcDirs) {
 			let files: string[];
 			try {
 				files = await tsFiles(dir);
-			} catch {
-				continue; // package has no src/
+			} catch (err) {
+				// ONLY a genuinely absent directory is "no source". A blanket catch
+				// here read EACCES or an I/O error as an empty package, so a new
+				// sanitizer in an unreadable tree went uncounted and the stale total
+				// passed — the guard failing exactly the way the file it lives in is
+				// named for, in the guard written to catch that.
+				if ((err as NodeJS.ErrnoException)?.code === "ENOENT") continue;
+				throw err;
 			}
 			for (const f of files) {
 				const code = codeOnly(await readFile(f, "utf-8"));

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -190,13 +190,29 @@ describe("false OK — the fail-closed error must still be machine-readable", ()
 describe("false OK — a documented count that stops matching reality", () => {
 	/**
 	 * AGENTS.md asserts an EXACT number of sanitizers and enumerates them. That
-	 * number went stale twice in this branch alone: once when the mirrored
-	 * `scrubForError` pair was added, and again when the count was corrected for
-	 * the snapshot copy while those two were still uncounted.
+	 * number went stale twice while this guard was being written: once when a
+	 * mirrored pair was added, and again when the count was corrected for a
+	 * different copy while that pair stayed uncounted.
 	 *
 	 * A prose invariant nobody executes is the same shape as a health signal
-	 * nobody wired: it reads as authoritative and measures nothing. This test is
-	 * the seam — the count is now checked against the source rather than asserted.
+	 * nobody wired: it reads as authoritative and measures nothing.
+	 *
+	 * ── WHY THIS MATCHES ON SHAPE, NOT ON NAMES ──
+	 *
+	 * The first version of this guard counted three known function NAMES. It
+	 * worked — it caught a stale count within a minute of the next AGENTS.md edit
+	 * — and it was wrong in the direction it exists to catch: a fourth sanitizer
+	 * landed under a fourth name (`scrubForTerminal`) and the counter reported
+	 * ELEVEN where THIRTEEN existed, failing a correct update. A counter that only
+	 * knows the names it was written with reports a smaller inventory than exists,
+	 * which is the same false OK this file is named for, one level up.
+	 *
+	 * So it counts what a sanitizer DOES. Both variants have an unmistakable
+	 * signature: the stronger one covers the C1 range and therefore names `0x9f`;
+	 * the weaker one is the `CONTROL_CHARS` character-class regex. Any future copy
+	 * under any name is counted, because the thing being counted is the behaviour
+	 * rather than the label — the same move as deriving fixtures from real
+	 * producer call sites instead of inventing them.
 	 */
 	it("AGENTS.md's sanitizer count matches the sanitizers in src/", async () => {
 		const { readFile } = await import("node:fs/promises");
@@ -205,7 +221,7 @@ describe("false OK — a documented count that stops matching reality", () => {
 
 		const agents = await readFile(join(repoRoot, "AGENTS.md"), "utf-8");
 		const declared = agents.match(/There are \*\*(\w+)\*\* sanitizers/)?.[1];
-		expect(declared).toBeDefined();
+		expect(declared, "AGENTS.md no longer states a sanitizer count").toBeDefined();
 
 		const WORDS: Record<string, number> = {
 			six: 6,
@@ -217,24 +233,33 @@ describe("false OK — a documented count that stops matching reality", () => {
 			twelve: 12,
 			thirteen: 13,
 			fourteen: 14,
+			fifteen: 15,
+			sixteen: 16,
 		};
 		const declaredCount = WORDS[declared as string];
 		expect(declaredCount, `unrecognised number word "${declared}"`).toBeDefined();
 
-		// Count the real thing: each weak-variant file holds one copy, and each
-		// strong-variant definition is one copy.
-		const count = (pattern: string): number => {
+		// Count OCCURRENCES of each variant's signature, not files and not names.
+		const occurrences = (pattern: string): number => {
 			const out = execSync(
-				`grep -rl '${pattern}' ${join(repoRoot, "packages")}/*/src --include='*.ts' || true`,
+				`grep -rho '${pattern}' ${join(repoRoot, "packages")}/*/src --include='*.ts' || true`,
 				{ encoding: "utf-8" },
 			).trim();
 			return out === "" ? 0 : out.split("\n").length;
 		};
-		const actual =
-			count("CONTROL_CHARS = /\\[") +
-			count("function forDisplay") +
-			count("function scrubForError");
+		// Stronger variant: match its BODY, not a mention of the range. The first
+		// cut of this matched bare `0x9f` and counted 7 where 5 exist, because two
+		// of the copies also name the range in their doc comment — a matcher that
+		// counted descriptions alongside implementations. The comparison itself is
+		// the signature and appears exactly once per sanitizer.
+		const strong = occurrences("code >= 0x7f && code <= 0x9f");
+		// Weaker variant: the shared control-character character class.
+		const weak = occurrences("CONTROL_CHARS = /\\[");
 
-		expect(actual).toBe(declaredCount);
+		expect(
+			strong + weak,
+			`AGENTS.md says ${declaredCount}; src/ contains ${strong} C1-covering + ${weak} CONTROL_CHARS = ${strong + weak}. ` +
+				"Add a bullet to the inventory and update the total — the entries are deliberately unnumbered so nothing needs renumbering.",
+		).toBe(declaredCount);
 	});
 });

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -253,12 +253,17 @@ describe("false OK — a documented count that stops matching reality", () => {
 		// counted descriptions alongside implementations. The comparison itself is
 		// the signature and appears exactly once per sanitizer.
 		const strong = occurrences("code >= 0x7f && code <= 0x9f");
-		// Weaker variant: the shared control-character character class.
-		const weak = occurrences("CONTROL_CHARS = /\\[");
+		// Weaker variant: the character class ITSELF, bound to any name. Matching
+		// `CONTROL_CHARS` left half the guard name-based — a weak sanitizer under
+		// another constant name would have gone uncounted and a stale total would
+		// still have passed. The `= ` anchor keeps it to DEFINITIONS: the bare
+		// class also appears in two doc comments describing it, the same
+		// prose-counts-as-code trap the strong matcher fell into first.
+		const weak = occurrences("= /\\[\\\\x00-\\\\x1f\\\\x7f\\]/g");
 
 		expect(
 			strong + weak,
-			`AGENTS.md says ${declaredCount}; src/ contains ${strong} C1-covering + ${weak} CONTROL_CHARS = ${strong + weak}. ` +
+			`AGENTS.md says ${declaredCount}; src/ contains ${strong} C1-covering + ${weak} control-class = ${strong + weak}. ` +
 				"Add a bullet to the inventory and update the total — the entries are deliberately unnumbered so nothing needs renumbering.",
 		).toBe(declaredCount);
 	});

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -240,26 +240,34 @@ describe("false OK — a documented count that stops matching reality", () => {
 		expect(declaredCount, `unrecognised number word "${declared}"`).toBeDefined();
 
 		// Count OCCURRENCES of each variant's signature, not files and not names.
+		// EXTENDED-REGEX, so the patterns can admit any identifier spelling.
 		const occurrences = (pattern: string): number => {
 			const out = execSync(
-				`grep -rho '${pattern}' ${join(repoRoot, "packages")}/*/src --include='*.ts' || true`,
+				`grep -rhoE '${pattern}' ${join(repoRoot, "packages")}/*/src --include='*.ts' || true`,
 				{ encoding: "utf-8" },
 			).trim();
 			return out === "" ? 0 : out.split("\n").length;
 		};
-		// Stronger variant: match its BODY, not a mention of the range. The first
-		// cut of this matched bare `0x9f` and counted 7 where 5 exist, because two
-		// of the copies also name the range in their doc comment — a matcher that
-		// counted descriptions alongside implementations. The comparison itself is
-		// the signature and appears exactly once per sanitizer.
-		const strong = occurrences("code >= 0x7f && code <= 0x9f");
+		// Stronger variant: the C1 comparison, with the local's NAME left open.
+		//
+		// Four rounds of correction landed here, each generalizing the part that had
+		// just failed and leaving the part that had not yet been tested:
+		//   1. matched three function NAMES        — missed a fourth name;
+		//   2. matched bare `0x9f`                 — counted two doc comments as code;
+		//   3. matched the constant `CONTROL_CHARS`— missed any other binding;
+		//   4. matched the literal `code >= ...`   — missed a local named `codePoint`.
+		//
+		// A matcher gets audited where it was last wrong. What survives all four is
+		// the SHAPE: the two range bounds and the operators between them, with every
+		// identifier a wildcard. The bounds are the behaviour; the names are not.
+		const strong = occurrences(">= *0x7f *&& *[A-Za-z_$][A-Za-z0-9_$]* *<= *0x9f");
 		// Weaker variant: the character class ITSELF, bound to any name. Matching
 		// `CONTROL_CHARS` left half the guard name-based — a weak sanitizer under
 		// another constant name would have gone uncounted and a stale total would
 		// still have passed. The `= ` anchor keeps it to DEFINITIONS: the bare
 		// class also appears in two doc comments describing it, the same
 		// prose-counts-as-code trap the strong matcher fell into first.
-		const weak = occurrences("= /\\[\\\\x00-\\\\x1f\\\\x7f\\]/g");
+		const weak = occurrences("= */\\[\\\\x00-\\\\x1f\\\\x7f\\]/g");
 
 		expect(
 			strong + weak,

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -215,8 +215,7 @@ describe("false OK — a documented count that stops matching reality", () => {
 	 * producer call sites instead of inventing them.
 	 */
 	it("AGENTS.md's sanitizer count matches the sanitizers in src/", async () => {
-		const { readFile } = await import("node:fs/promises");
-		const { execSync } = await import("node:child_process");
+		const { readFile, readdir } = await import("node:fs/promises");
 		const repoRoot = join(import.meta.dirname, "..", "..", "..", "..");
 
 		const agents = await readFile(join(repoRoot, "AGENTS.md"), "utf-8");
@@ -239,35 +238,65 @@ describe("false OK — a documented count that stops matching reality", () => {
 		const declaredCount = WORDS[declared as string];
 		expect(declaredCount, `unrecognised number word "${declared}"`).toBeDefined();
 
-		// Count OCCURRENCES of each variant's signature, not files and not names.
-		// EXTENDED-REGEX, so the patterns can admit any identifier spelling.
-		const occurrences = (pattern: string): number => {
-			const out = execSync(
-				`grep -rhoE '${pattern}' ${join(repoRoot, "packages")}/*/src --include='*.ts' || true`,
-				{ encoding: "utf-8" },
-			).trim();
-			return out === "" ? 0 : out.split("\n").length;
+		/**
+		 * Strip comments and string literals, then collapse whitespace.
+		 *
+		 * This replaces a `grep -o` sweep, which was wrong at BOTH ends: it could
+		 * not see a signature that Biome had wrapped across lines (undercounting a
+		 * real copy), and it counted the same signature appearing inside a doc
+		 * comment or a string (overcounting prose as implementation). Line-oriented
+		 * text matching cannot distinguish code from writing about code.
+		 *
+		 * HONEST LIMIT: this is a lexical approximation, not a parse. It does not
+		 * model template literals with embedded expressions, regex literals
+		 * containing quote characters, or nested comment edge cases. It is enough
+		 * for the question asked — does a control-range comparison exist in code —
+		 * and if that ever stops being true, this comment is the place to escalate
+		 * to the TypeScript AST rather than adding another special case.
+		 */
+		const codeOnly = (src: string): string =>
+			src
+				.replace(/\/\*[\s\S]*?\*\//g, " ")
+				.replace(/\/\/[^\n]*/g, " ")
+				.replace(/"(?:[^"\\\n]|\\.)*"/g, '""')
+				.replace(/'(?:[^'\\\n]|\\.)*'/g, "''")
+				.replace(/`(?:[^`\\]|\\.)*`/g, "``")
+				.replace(/\s+/g, " ");
+
+		const tsFiles = async (dir: string): Promise<string[]> => {
+			const out: string[] = [];
+			for (const e of await readdir(dir, { withFileTypes: true })) {
+				const full = join(dir, e.name);
+				if (e.isDirectory()) out.push(...(await tsFiles(full)));
+				else if (e.name.endsWith(".ts")) out.push(full);
+			}
+			return out;
 		};
-		// Stronger variant: the C1 comparison, with the local's NAME left open.
-		//
-		// Four rounds of correction landed here, each generalizing the part that had
-		// just failed and leaving the part that had not yet been tested:
-		//   1. matched three function NAMES        — missed a fourth name;
-		//   2. matched bare `0x9f`                 — counted two doc comments as code;
-		//   3. matched the constant `CONTROL_CHARS`— missed any other binding;
-		//   4. matched the literal `code >= ...`   — missed a local named `codePoint`.
-		//
-		// A matcher gets audited where it was last wrong. What survives all four is
-		// the SHAPE: the two range bounds and the operators between them, with every
-		// identifier a wildcard. The bounds are the behaviour; the names are not.
-		const strong = occurrences(">= *0x7f *&& *[A-Za-z_$][A-Za-z0-9_$]* *<= *0x9f");
-		// Weaker variant: the character class ITSELF, bound to any name. Matching
-		// `CONTROL_CHARS` left half the guard name-based — a weak sanitizer under
-		// another constant name would have gone uncounted and a stale total would
-		// still have passed. The `= ` anchor keeps it to DEFINITIONS: the bare
-		// class also appears in two doc comments describing it, the same
-		// prose-counts-as-code trap the strong matcher fell into first.
-		const weak = occurrences("= */\\[\\\\x00-\\\\x1f\\\\x7f\\]/g");
+
+		const pkgs = join(repoRoot, "packages");
+		const srcDirs = (await readdir(pkgs, { withFileTypes: true }))
+			.filter((e) => e.isDirectory())
+			.map((e) => join(pkgs, e.name, "src"));
+
+		let strong = 0;
+		let weak = 0;
+		// Identifiers are wildcards: the range bounds and operators are the
+		// behaviour, the names around them are incidental.
+		const STRONG = />= *0x7f *&& *[A-Za-z_$][A-Za-z0-9_$]* *<= *0x9f/g;
+		const WEAK = /= *\/\[\\x00-\\x1f\\x7f\]\/g/g;
+		for (const dir of srcDirs) {
+			let files: string[];
+			try {
+				files = await tsFiles(dir);
+			} catch {
+				continue; // package has no src/
+			}
+			for (const f of files) {
+				const code = codeOnly(await readFile(f, "utf-8"));
+				strong += code.match(STRONG)?.length ?? 0;
+				weak += code.match(WEAK)?.length ?? 0;
+			}
+		}
 
 		expect(
 			strong + weak,

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -295,8 +295,15 @@ describe("false OK — a documented count that stops matching reality", () => {
 		// a false POSITIVE can offset a genuinely REMOVED sanitizer and leave the
 		// stale total agreeing — two errors cancelling into a passing guard is the
 		// hardest failure here to notice, since nothing looks wrong at all.
+		// The HEX LITERALS are anchored too. `0x9f` is a prefix of `0x9fff`, so
+		// `cp >= 0x7f && cp <= 0x9fff` — a wide range check, not a C1 test —
+		// matched. Every token in this pattern now has to be a whole token: the
+		// identifier on both sides, and both bounds. That is the eighth round on
+		// this guard and the eighth token I had left unbounded, which is the
+		// lesson: "match the shape" is not one property, it is a property of every
+		// element, and I kept checking the one I had just been shown.
 		const STRONG =
-			/(?<![A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*) *>= *0x7f *&& *\1(?![A-Za-z0-9_$]) *<= *0x9f/g;
+			/(?<![A-Za-z0-9_$])([A-Za-z_$][A-Za-z0-9_$]*) *>= *0x7f(?![0-9a-fA-F]) *&& *\1(?![A-Za-z0-9_$]) *<= *0x9f(?![0-9a-fA-F])/g;
 		const WEAK = /= *\/\[\\x00-\\x1f\\x7f\]\/g/g;
 		for (const dir of srcDirs) {
 			let files: string[];


### PR DESCRIPTION
The guard added in #98 for AGENTS.md's sanitizer inventory **had the defect it is named for**, and two sessions found it independently within minutes.

It counted three known function **names**. It worked — it caught a stale count immediately on the next AGENTS.md edit — and it was wrong in exactly the direction it exists to catch: a fourth sanitizer landed under a fourth name (`scrubForTerminal`) and the counter reported **eleven where thirteen existed**, failing a *correct* update.

> A counter that only knows the names it was written with reports a smaller inventory than exists.

Same false OK this file is named for, one level up — and the same remedy as everywhere else in this series: **derive the enumeration from what the code does, never hand-maintain a list of what it is called.**

### What it matches now

| Variant | Signature |
|---|---|
| stronger | `code >= 0x7f && code <= 0x9f` — the C1 comparison, one per sanitizer |
| weaker | `CONTROL_CHARS = /[` — the shared character class |

Any future copy is counted whatever it is named, with no change to the test.

### One correction inside the fix — the same mistake a third time

The first shape matcher counted bare `0x9f` and reported **seven where five exist**: two copies also name the range in their *doc comment*, so it was counting descriptions alongside implementations. Narrowed to the comparison itself.

*A shape matcher that matches prose is a name matcher wearing a costume.*

### Mutation-verified in both directions

- a sanitizer under a name the test has never seen (`totallyDifferentName`) **is counted**, and the guard fails until the inventory is updated
- a declared count that no longer matches the source **fails**

AGENTS.md now records how the total is derived, so the next person to add a sanitizer knows the guard finds it regardless of naming.

### Credit

usertrust-4 hit this within a minute of its own AGENTS.md edit, extended the name list with its two names and mutation-verified that — but deliberately left the detection strategy to me rather than changing it mid-flight. That was the right call; this is the follow-through. The orchestrator independently reached the same recommendation.

### Gates

full suite **3284 passed / 14 skipped** · biome **0** · `tsc -b packages/core packages/verify` **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ouQi5z58VPHxwAMAWtGsr