### PR TITLE
feat(cli): usertrust policy validate, and a health line that reports rule count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -706,6 +706,14 @@ for an identity comparison — is refused rather than accepted as a rule that ca
 *Prevents:* the pre-fix behaviour, where unparseable or unrecognised input resolved to an empty rule
 set with no throw and no log.
 
+**`usertrust policy validate` is the pre-flight, and `health` reports rule COUNT.** The loader
+refusing to start is only survivable if an operator can find out why before deploying, so
+`validatePolicyFile` reports every problem in one pass behind that command. It resolves its target
+exactly as the governor does — the configured value verbatim, no `existsSync` preflight — because a
+diagnostic that resolves a different file than the thing it diagnoses can pass while the deployment
+fails. `health` reports loaded AND ACTIVE counts, since `enabled: false` rules load and never fire:
+a violation count alone cannot distinguish an enforced policy from an unloaded one.
+
 **Host-owned policy-context fields are STRIPPED BEFORE the request-body spread.** Every
 `evaluatePolicy` call site builds context as `{ ...sanitizePolicyContext(callerParams),
 ...trustedFields }`. The explicit assignments after the spread still say what each trusted field is,
@@ -847,7 +855,7 @@ first, clip second.
 repaint the terminal of the auditor running the command — forging a passing verdict, which is the
 entire product for a verification tool.
 
-There are **eleven** sanitizers, in two variants. Do not consolidate them onto the weaker one.
+There are **thirteen** sanitizers, in two variants. Do not consolidate them onto the weaker one.
 
 The entries below are deliberately NOT numbered. They used to be ("a seventh", "an eighth"), and
 adding one meant renumbering every later entry — so a new copy was added and the ordinals silently
@@ -879,6 +887,17 @@ stopped matching the count. Adding a sanitizer means: add a bullet, and update t
 - Independent and deliberately **stronger**: `forDisplay` in `core/src/cli/budget.ts`. It
   also covers `0x80–0x9f`, the C1 range holding the 8-bit CSI/OSC introducers that the regex above
   does not match; it substitutes `?` rather than stripping; and it clips at 120.
+
+- Two more of the stronger variant, `scrubForTerminal` in `core/src/cli/policy.ts` and
+  `core/src/cli/health.ts`. Both quote operator-authored text back at a terminal: a policy file's
+  key names arrive inside zod issue messages, and the `policies` config value arrives as the path.
+  Each clips at 200 rather than 80 — a validation message cut to 80 loses the field path that makes
+  it actionable. **Neither applies to `--json`:** those paths escape C1 as `\uXXXX` at
+  serialization instead, via a local `toSafeJson`, because substituting or clipping would corrupt a
+  machine-readable field a consumer has to parse back. Escaping and scrubbing are not
+  interchangeable, and the choice belongs at the render site, not at the value's source — applying
+  the terminal scrubber inside the loader corrupted the JSON diagnostic in exactly that way before
+  it was moved.
 
 That C1 coverage is not an accident of style. `budget.ts` quotes attacker-controlled argv back to
 the operator in every invalid-value message, and its own comment names the attack

--- a/packages/core/src/cli/completions.ts
+++ b/packages/core/src/cli/completions.ts
@@ -29,10 +29,14 @@ _usertrust() {
     cur="\${COMP_WORDS[COMP_CWORD]}"
     prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
-    commands="init inspect health verify snapshot tb completions"
+    commands="init inspect health policy verify snapshot tb completions"
     global_flags="--json --help"
 
     case "\${prev}" in
+        policy)
+            COMPREPLY=( $(compgen -W "validate" -- "\${cur}") )
+            return 0
+            ;;
         snapshot)
             COMPREPLY=( $(compgen -W "create restore list" -- "\${cur}") )
             return 0
@@ -76,6 +80,7 @@ _usertrust() {
         'init:Initialize trust vault'
         'inspect:Show trust bank statement'
         'health:Show entropy diagnostics'
+        'policy:Validate the policy file'
         'verify:Verify audit chain integrity'
         'snapshot:Create/restore vault snapshots'
         'tb:Manage TigerBeetle process'
@@ -99,6 +104,11 @@ _usertrust() {
             ;;
         args)
             case "\${words[1]}" in
+                policy)
+                    local -a policy_cmds
+                    policy_cmds=('validate:Check the policy file loads and would enforce')
+                    _describe 'policy subcommand' policy_cmds
+                    ;;
                 snapshot)
                     local -a snapshot_cmds
                     snapshot_cmds=('create:Create a snapshot' 'restore:Restore a snapshot' 'list:List snapshots')
@@ -134,6 +144,7 @@ complete -c usertrust -f
 complete -c usertrust -n '__fish_use_subcommand' -a init -d 'Initialize trust vault'
 complete -c usertrust -n '__fish_use_subcommand' -a inspect -d 'Show trust bank statement'
 complete -c usertrust -n '__fish_use_subcommand' -a health -d 'Show entropy diagnostics'
+complete -c usertrust -n '__fish_use_subcommand' -a policy -d 'Validate the policy file'
 complete -c usertrust -n '__fish_use_subcommand' -a verify -d 'Verify audit chain integrity'
 complete -c usertrust -n '__fish_use_subcommand' -a snapshot -d 'Create/restore vault snapshots'
 complete -c usertrust -n '__fish_use_subcommand' -a tb -d 'Manage TigerBeetle process'
@@ -142,6 +153,9 @@ complete -c usertrust -n '__fish_use_subcommand' -a completions -d 'Output shell
 # Global flags
 complete -c usertrust -l json -d 'Output machine-readable JSON'
 complete -c usertrust -l help -d 'Show help'
+
+# policy subcommands
+complete -c usertrust -n '__fish_seen_subcommand_from policy' -a validate -d 'Check the policy file loads and would enforce'
 
 # snapshot subcommands
 complete -c usertrust -n '__fish_seen_subcommand_from snapshot' -a create -d 'Create a snapshot'

--- a/packages/core/src/cli/health.ts
+++ b/packages/core/src/cli/health.ts
@@ -79,7 +79,10 @@ function scrubForTerminal(text: string, max = 200): string {
  * distinguishes "nothing was violated" from "nothing was enforced".
  */
 function loadPolicyStatus(vaultPath: string): {
-	path: string;
+	/** null when the config could not be resolved — there is no target to name. */
+	path: string | null;
+	/** Set only when the failure is the CONFIG rather than the policy file. */
+	configError?: string;
 	present: boolean;
 	rules: number;
 	active: number;
@@ -92,9 +95,15 @@ function loadPolicyStatus(vaultPath: string): {
 	// governor rejects is a green light for a vault that cannot start.
 	const resolved = resolvePolicyPath(vaultPath);
 	if ("error" in resolved) {
+		// No policy target was resolved, so there is no path to report and nothing
+		// whose presence could be asserted. Naming the DEFAULT here attributed the
+		// failure to `policies/default.yml` — a file that may be perfectly fine and
+		// that the governor will never reach — and `present: true` claimed it had
+		// been looked at. The config is the subject of this failure; say so.
 		return {
-			path: join(vaultPath, DEFAULT_POLICIES_PATH),
-			present: true,
+			path: null,
+			configError: resolved.error,
+			present: false,
 			rules: 0,
 			active: 0,
 			issues: 1,
@@ -263,6 +272,9 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 					level: levelLabel(report.level),
 					policy: {
 						path: policyStatus.path,
+						...(policyStatus.configError !== undefined
+							? { configError: policyStatus.configError }
+							: {}),
 						present: policyStatus.present,
 						rulesLoaded: policyStatus.rules,
 						rulesActive: policyStatus.active,
@@ -292,12 +304,21 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 	// here and used for every human-rendered branch below, rather than scrubbed at
 	// each print site — the JSON payload above keeps the raw value, since escaping
 	// is a rendering concern and truncating there would corrupt the field.
-	const safePath = scrubForTerminal(policyStatus.path);
+	const safePath = policyStatus.path === null ? null : scrubForTerminal(policyStatus.path);
 
 	// Signal 0: what the policy file actually contributes. This line comes FIRST
 	// on purpose — a violation count is only meaningful once you know how many
 	// rules were in a position to be violated.
-	if (!policyStatus.present) {
+	if (policyStatus.configError !== undefined) {
+		// The CONFIG failed, so no policy file was ever identified. Naming one here
+		// would point the operator at a file that is probably fine.
+		console.log(
+			`  Policy rules loaded:      0    ${pc.red("[CONFIG]")} ${scrubForTerminal(policyStatus.configError)}`,
+		);
+		console.log(
+			`${pc.red("      The governor resolves its policy path from this file, so it will not start.")}`,
+		);
+	} else if (!policyStatus.present) {
 		console.log(
 			`  Policy rules loaded:      0    ${pc.yellow("[none]")} no policy file at ${safePath} — built-in budget rules only`,
 		);

--- a/packages/core/src/cli/health.ts
+++ b/packages/core/src/cli/health.ts
@@ -21,6 +21,7 @@ import { validatePolicyFile } from "../policy/gate.js";
 import { VAULT_DIR } from "../shared/constants.js";
 import type { AuditEvent } from "../shared/types.js";
 import type { CliOptions } from "./init.js";
+import { DEFAULT_POLICIES_PATH, resolvePolicyPath } from "./policy-path.js";
 
 function loadEvents(vaultPath: string): AuditEvent[] {
 	const logPath = join(vaultPath, "audit", "events.jsonl");
@@ -68,9 +69,6 @@ function scrubForTerminal(text: string, max = 200): string {
 	return out.length > max ? `${out.slice(0, max)}...` : out;
 }
 
-/** Default from `TrustConfigSchema.policies`, resolved relative to the vault dir. */
-const DEFAULT_POLICIES_PATH = "./policies/default.yml";
-
 /**
  * What the policy file would actually contribute to a governed call.
  *
@@ -88,19 +86,22 @@ function loadPolicyStatus(vaultPath: string): {
 	issues: number;
 	firstIssue: string | undefined;
 } {
-	let rel = DEFAULT_POLICIES_PATH;
-	try {
-		const cfgPath = join(vaultPath, "usertrust.config.json");
-		if (existsSync(cfgPath)) {
-			const cfg = JSON.parse(readFileSync(cfgPath, "utf-8")) as { policies?: string };
-			// Verbatim, including "" — see cli/policy.ts: substituting the default
-			// would report on a different file than the governor loads.
-			if (typeof cfg.policies === "string") rel = cfg.policies;
-		}
-	} catch {
-		// Unreadable config — fall back to the schema default rather than failing
-		// the whole health report; the policy line below still reports honestly.
+	// Shared with `cli/policy.ts` — see policy-path.ts. A config that cannot be
+	// read is reported, not replaced with the default: validating
+	// ./policies/default.yml and printing [ok] for a deployment whose config the
+	// governor rejects is a green light for a vault that cannot start.
+	const resolved = resolvePolicyPath(vaultPath);
+	if ("error" in resolved) {
+		return {
+			path: join(vaultPath, DEFAULT_POLICIES_PATH),
+			present: true,
+			rules: 0,
+			active: 0,
+			issues: 1,
+			firstIssue: resolved.error,
+		};
 	}
+	const rel = resolved.path;
 	const path = join(vaultPath, rel);
 	// No `existsSync` preflight — see validatePolicyFile. An absent file yields no
 	// issues and no rules, which is what `present: false` means here; anything

--- a/packages/core/src/cli/health.ts
+++ b/packages/core/src/cli/health.ts
@@ -17,6 +17,7 @@ import {
 	type EntropyLevel,
 } from "../audit/entropy.js";
 import { verifyChain } from "../audit/verify.js";
+import { validatePolicyFile } from "../policy/gate.js";
 import { VAULT_DIR } from "../shared/constants.js";
 import type { AuditEvent } from "../shared/types.js";
 import type { CliOptions } from "./init.js";
@@ -36,6 +37,111 @@ function loadEvents(vaultPath: string): AuditEvent[] {
 	} catch {
 		return [];
 	}
+}
+
+/**
+ * Strip control characters from untrusted text before it reaches a terminal.
+ *
+ * Policy-file content is operator-authored but not necessarily trusted — an
+ * issue message can quote a key name straight out of the document. AGENTS.md
+ * requires sanitising BEFORE clipping, since a half-clipped escape is still an
+ * escape. Mirrors `CONTROL_CHARS`/`clipKey` in `cli/verify.ts`.
+ */
+/**
+ * Make untrusted text safe to echo to a terminal.
+ *
+ * Covers C0 AND C1 (0x80-0x9f), the range holding the 8-bit CSI/OSC introducers
+ * — a terminal honouring those can be repainted by a string the common
+ * C0-only regex passes through untouched. AGENTS.md records why `budget.ts`'s
+ * `forDisplay` is deliberately stronger than the other copies and must not be
+ * unified down onto them; this path has the same property (it echoes argv and
+ * config-supplied text), so it takes the strong form rather than adding another
+ * weak one. Substitutes rather than strips, so removing a byte cannot close two
+ * fragments into a plausible whole, and clips AFTER substituting.
+ */
+function scrubForTerminal(text: string, max = 200): string {
+	let out = "";
+	for (const ch of text) {
+		const code = ch.codePointAt(0) as number;
+		out += code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? "?" : ch;
+	}
+	return out.length > max ? `${out.slice(0, max)}...` : out;
+}
+
+/** Default from `TrustConfigSchema.policies`, resolved relative to the vault dir. */
+const DEFAULT_POLICIES_PATH = "./policies/default.yml";
+
+/**
+ * What the policy file would actually contribute to a governed call.
+ *
+ * `health` reported policy VIOLATIONS and nothing else, and `coloredTag()`
+ * renders zero hits as a green `[ok]`. A vault with no loaded rules and a vault
+ * with a fully satisfied policy were therefore indistinguishable on that line.
+ * Reporting how many rules actually LOAD — and how many are enabled — is what
+ * distinguishes "nothing was violated" from "nothing was enforced".
+ */
+function loadPolicyStatus(vaultPath: string): {
+	path: string;
+	present: boolean;
+	rules: number;
+	active: number;
+	issues: number;
+	firstIssue: string | undefined;
+} {
+	let rel = DEFAULT_POLICIES_PATH;
+	try {
+		const cfgPath = join(vaultPath, "usertrust.config.json");
+		if (existsSync(cfgPath)) {
+			const cfg = JSON.parse(readFileSync(cfgPath, "utf-8")) as { policies?: string };
+			// Verbatim, including "" — see cli/policy.ts: substituting the default
+			// would report on a different file than the governor loads.
+			if (typeof cfg.policies === "string") rel = cfg.policies;
+		}
+	} catch {
+		// Unreadable config — fall back to the schema default rather than failing
+		// the whole health report; the policy line below still reports honestly.
+	}
+	const path = join(vaultPath, rel);
+	// No `existsSync` preflight — see validatePolicyFile. An absent file yields no
+	// issues and no rules, which is what `present: false` means here; anything
+	// else is a real problem and must not read as "no policy file".
+	const { rules, issues, present } = validatePolicyFile(path);
+	if (!present) {
+		return { path, present: false, rules: 0, active: 0, issues: 0, firstIssue: undefined };
+	}
+	// `enabled: false` rules load and are then skipped by `ruleMatches`, so a file
+	// of nothing but disabled rules is loaded-but-inert. Counting those as live
+	// would reproduce, one level along, exactly the confusion this line exists to
+	// remove: a green count next to no enforcement.
+	const active = rules.filter((r) => r.enabled !== false).length;
+	return {
+		path,
+		present: true,
+		rules: rules.length,
+		active,
+		issues: issues.length,
+		// RAW on purpose. Scrubbing here would substitute and clip BEFORE the output
+		// mode is chosen, so `--json` would report a corrupted diagnostic that
+		// `toSafeJson` cannot restore. The human branch scrubs where it prints;
+		// escaping and scrubbing are not interchangeable.
+		firstIssue: issues[0] === undefined ? undefined : `${issues[0].at}: ${issues[0].message}`,
+	};
+}
+
+/**
+ * Serialise with C1 escaped.
+ *
+ * The scrubber above is for HUMAN output: it substitutes and clips, which is
+ * right for a terminal and wrong for a machine-readable field — a consumer needs
+ * the real value back. So JSON escapes rather than substitutes, and nothing on
+ * the `--json` path is clipped.
+ */
+function toSafeJson(value: unknown): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: escaping them is the intent
+	return JSON.stringify(value).replace(/[\u007f-\u009f]/g, (c) => {
+		const hex = c.charCodeAt(0).toString(16).padStart(4, "0");
+		return `\\u${hex}`;
+	});
 }
 
 function loadConfig(vaultPath: string): { budget: number } {
@@ -95,7 +201,7 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 	if (!existsSync(vaultPath)) {
 		if (json) {
 			console.log(
-				JSON.stringify({
+				toSafeJson({
 					command: "health",
 					success: false,
 					data: { message: "No trust vault found. Run `usertrust init` first." },
@@ -109,6 +215,7 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 
 	const events = loadEvents(vaultPath);
 	const config = loadConfig(vaultPath);
+	const policyStatus = loadPolicyStatus(vaultPath);
 
 	// Convert audit events to entropy event inputs
 	const entropyEvents: EntropyEventInput[] = events.map((e) => ({
@@ -147,12 +254,22 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 
 	if (json) {
 		console.log(
-			JSON.stringify({
+			toSafeJson({
 				command: "health",
 				success: true,
 				data: {
 					score: report.score,
 					level: levelLabel(report.level),
+					policy: {
+						path: policyStatus.path,
+						present: policyStatus.present,
+						rulesLoaded: policyStatus.rules,
+						rulesActive: policyStatus.active,
+						issues: policyStatus.issues,
+						...(policyStatus.firstIssue !== undefined
+							? { firstIssue: policyStatus.firstIssue }
+							: {}),
+					},
 					signals: {
 						policyViolations: policyHits,
 						budgetUtilization: Number.parseFloat(budgetPct),
@@ -169,9 +286,49 @@ export async function run(rootDir?: string, opts?: CliOptions): Promise<void> {
 
 	console.log(`Entropy score: ${report.score}/100 (${coloredLevel(report.level)})`);
 
+	// The policy PATH is config-supplied (`policies` in usertrust.config.json), so
+	// it is untrusted text on a terminal exactly like an issue message. Bound once
+	// here and used for every human-rendered branch below, rather than scrubbed at
+	// each print site — the JSON payload above keeps the raw value, since escaping
+	// is a rendering concern and truncating there would corrupt the field.
+	const safePath = scrubForTerminal(policyStatus.path);
+
+	// Signal 0: what the policy file actually contributes. This line comes FIRST
+	// on purpose — a violation count is only meaningful once you know how many
+	// rules were in a position to be violated.
+	if (!policyStatus.present) {
+		console.log(
+			`  Policy rules loaded:      0    ${pc.yellow("[none]")} no policy file at ${safePath} — built-in budget rules only`,
+		);
+	} else if (policyStatus.issues > 0) {
+		console.log(
+			`  Policy rules loaded:      0    ${pc.red("[INVALID]")} ${policyStatus.issues} problem(s) in ${safePath}`,
+		);
+		if (policyStatus.firstIssue !== undefined) {
+			console.log(`${pc.red(`      first: ${scrubForTerminal(policyStatus.firstIssue)}`)}`);
+		}
+		console.log(
+			`${pc.red("      NONE of this file's rules are enforced. Run `usertrust policy validate`.")}`,
+		);
+	} else if (policyStatus.rules === 0) {
+		console.log(
+			`  Policy rules loaded:      0    ${pc.yellow("[empty]")} file is valid but declares no rules`,
+		);
+	} else if (policyStatus.active === 0) {
+		console.log(
+			`  Policy rules loaded:      ${policyStatus.rules}    ${pc.yellow("[inert]")} all ${policyStatus.rules} are \`enabled: false\` — none can fire`,
+		);
+	} else if (policyStatus.active < policyStatus.rules) {
+		console.log(
+			`  Policy rules loaded:      ${policyStatus.active}/${policyStatus.rules} active    ${pc.green("[ok]")}`,
+		);
+	} else {
+		console.log(`  Policy rules loaded:      ${policyStatus.rules}    ${pc.green("[ok]")}`);
+	}
+
 	// Signal 1: Policy violations
-	const policyStatus = coloredTag(policySignal?.value ?? 0, policyHits);
-	console.log(`  Policy violations (30d):  ${policyHits}   ${policyStatus}`);
+	const policyTag = coloredTag(policySignal?.value ?? 0, policyHits);
+	console.log(`  Policy violations (30d):  ${policyHits}   ${policyTag}`);
 
 	// Signal 2: Budget utilization
 	const budgetStatus =

--- a/packages/core/src/cli/main.ts
+++ b/packages/core/src/cli/main.ts
@@ -6,6 +6,7 @@ const COMMANDS = [
 	"init",
 	"inspect",
 	"health",
+	"policy",
 	"verify",
 	"export",
 	"anchor",
@@ -81,6 +82,11 @@ switch (command) {
 	case "health":
 		await import("./health.js").then((m) => m.run(undefined, { json: jsonFlag }));
 		break;
+	case "policy": {
+		const rest = argv.slice(argv.indexOf("policy") + 1).filter((a) => a !== "--json");
+		await import("./policy.js").then((m) => m.run(undefined, { json: jsonFlag }, rest));
+		break;
+	}
 	case "verify":
 		await import("./verify.js").then((m) => m.run(undefined, { json: jsonFlag }));
 		break;
@@ -136,6 +142,7 @@ Commands:
   init          Initialize trust vault
   inspect       Show trust bank statement
   health        Show entropy diagnostics
+  policy        Validate the policy file before it has to matter
   verify        Verify audit chain integrity
   export        Export receipts as markdown (Obsidian-ready)
   anchor        External audit anchoring (signed checkpoints)

--- a/packages/core/src/cli/policy-path.ts
+++ b/packages/core/src/cli/policy-path.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * Where the policy file IS, decided once for every diagnostic that reports on it.
+ *
+ * `cli/policy.ts` and `cli/health.ts` both need this and both had their own copy.
+ * The copies diverged the moment one was fixed: a review found that an unreadable
+ * config made `policy validate` check `./policies/default.yml` instead of failing,
+ * that was repaired, and the identical bug sat in `health.ts` until the next round
+ * found it there. Two copies of a rule is two places to fix it and one place to
+ * forget.
+ *
+ * The rule itself: a diagnostic must resolve its target exactly as the governor
+ * does, and refuse when it cannot. A diagnostic that answers confidently about a
+ * file the governor would never load is worse than one that declines — it reports
+ * `[ok]` for a deployment that cannot start.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Default from `TrustConfigSchema.policies`, relative to the vault dir. */
+export const DEFAULT_POLICIES_PATH = "./policies/default.yml";
+
+export type PolicyPathResolution = { path: string } | { error: string };
+
+/**
+ * Read the `policies` key out of `usertrust.config.json`.
+ *
+ * Tolerates a config that is unusable in OTHER respects — a broken budget must
+ * not stop an operator diagnosing their policy — but not one that cannot be read,
+ * parsed, or whose `policies` is not a string. The value is taken VERBATIM,
+ * including `""`: `TrustConfigSchema` accepts an empty string and both governors
+ * resolve it to the vault directory, where the load fails, so substituting the
+ * default would report on a different file than the one that runs.
+ */
+export function resolvePolicyPath(vaultDir: string): PolicyPathResolution {
+	const configPath = join(vaultDir, "usertrust.config.json");
+	if (!existsSync(configPath)) return { path: DEFAULT_POLICIES_PATH };
+
+	let raw: string;
+	try {
+		raw = readFileSync(configPath, "utf-8");
+	} catch (err) {
+		return { error: `config cannot be read: ${(err as Error).message}` };
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch (err) {
+		return { error: `config is not valid JSON: ${(err as Error).message}` };
+	}
+
+	// `JSON.parse("null")` SUCCEEDS and returns null, so a property read here threw
+	// a raw TypeError outside every catch — the command emitted no diagnostic at
+	// all, in either output mode, for a config that a bad generation step can
+	// easily produce. A valid JSON document is not necessarily a usable one.
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return {
+			error: `config must be a JSON object, got ${parsed === null ? "null" : Array.isArray(parsed) ? "an array" : typeof parsed}`,
+		};
+	}
+
+	const policies = (parsed as { policies?: unknown }).policies;
+	if (policies !== undefined && typeof policies !== "string") {
+		return { error: `config "policies" must be a string, got ${typeof policies}` };
+	}
+	return { path: typeof policies === "string" ? policies : DEFAULT_POLICIES_PATH };
+}

--- a/packages/core/src/cli/policy.ts
+++ b/packages/core/src/cli/policy.ts
@@ -23,6 +23,7 @@ import pc from "picocolors";
 import { validatePolicyFile } from "../policy/gate.js";
 import { VAULT_DIR } from "../shared/constants.js";
 import type { CliOptions } from "./init.js";
+import { resolvePolicyPath } from "./policy-path.js";
 
 /**
  * Strip control characters from untrusted text before it reaches a terminal.
@@ -51,46 +52,6 @@ function scrubForTerminal(text: string, max = 200): string {
 		out += code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? "?" : ch;
 	}
 	return out.length > max ? `${out.slice(0, max)}...` : out;
-}
-
-/** Default from `TrustConfigSchema.policies`. */
-const DEFAULT_POLICIES_PATH = "./policies/default.yml";
-
-/**
- * Read just the `policies` key. Tolerates a config that is otherwise unusable —
- * a broken budget must not stop an operator diagnosing their policy — but NOT a
- * config that cannot be read or parsed at all.
- *
- * Falling back to the default in that case validated a DIFFERENT file than the
- * governor would load, so the command could exit 0 having checked something
- * unrelated while startup failed. A diagnostic answering confidently about the
- * wrong file is worse than one that refuses.
- *
- * The value is taken VERBATIM, including "". `TrustConfigSchema` accepts an empty
- * string and both governors resolve it to the vault directory, where the load
- * fails — so substituting the default there would report ok for a deployment that
- * cannot start. A diagnostic must resolve its target the way the thing it
- * diagnoses does.
- */
-function readPoliciesPath(vaultDir: string): { path: string } | { error: string } {
-	const p = join(vaultDir, "usertrust.config.json");
-	if (!existsSync(p)) return { path: DEFAULT_POLICIES_PATH };
-	let raw: string;
-	try {
-		raw = readFileSync(p, "utf-8");
-	} catch (err) {
-		return { error: `config cannot be read: ${(err as Error).message}` };
-	}
-	let cfg: { policies?: unknown };
-	try {
-		cfg = JSON.parse(raw) as { policies?: unknown };
-	} catch (err) {
-		return { error: `config is not valid JSON: ${(err as Error).message}` };
-	}
-	if (cfg.policies !== undefined && typeof cfg.policies !== "string") {
-		return { error: `config "policies" must be a string, got ${typeof cfg.policies}` };
-	}
-	return { path: typeof cfg.policies === "string" ? cfg.policies : DEFAULT_POLICIES_PATH };
 }
 
 /**
@@ -146,7 +107,14 @@ export async function run(
 	// a missing budget, which would make an operator fix their config before they
 	// could find out why their policy stopped enforcing. Linting the policy file
 	// must not depend on anything else being right.
-	const resolved = readPoliciesPath(join(vaultPath, VAULT_DIR));
+	// The EXPLICIT path is chosen first, and the config is only consulted when
+	// there isn't one. Resolving config first meant `policy validate ./candidate.yml`
+	// refused on an unrelated config problem and never looked at the named file —
+	// killing the check-before-install mode this command advertises, in exactly the
+	// situation an operator reaches for it.
+	const explicit = argv.find((a, i) => i > 0 && !a.startsWith("-"));
+	const resolved =
+		explicit !== undefined ? { path: explicit } : resolvePolicyPath(join(vaultPath, VAULT_DIR));
 	if ("error" in resolved) {
 		if (options.json) {
 			console.log(
@@ -163,10 +131,8 @@ export async function run(
 		process.exitCode = 1;
 		return;
 	}
-	const policiesRel = resolved.path;
-	// An explicit path wins, so an operator can check a file before installing it.
-	const explicit = argv.find((a, i) => i > 0 && !a.startsWith("-"));
-	const policiesPath = explicit ?? join(vaultPath, VAULT_DIR, policiesRel);
+	const policiesPath =
+		explicit !== undefined ? explicit : join(vaultPath, VAULT_DIR, resolved.path);
 
 	const safePath = scrubForTerminal(policiesPath);
 	// Validate FIRST. An `existsSync` preflight answers false for a file inside a

--- a/packages/core/src/cli/policy.ts
+++ b/packages/core/src/cli/policy.ts
@@ -98,10 +98,23 @@ export async function run(
 ): Promise<void> {
 	const sub = argv[0];
 	if (sub !== undefined && sub !== "validate") {
-		const reason = `Unknown policy subcommand: "${scrubForTerminal(sub, 40)}". Expected: validate`;
-		// A caller passing --json parses every outcome, including this one.
-		if (options.json) console.log(toSafeJson({ ok: false, error: "unknown_subcommand", reason }));
-		else console.error(reason);
+		// RAW for JSON, scrubbed for the terminal. `toSafeJson` escapes controls so
+		// a consumer parses back the real value; scrubbing first would substitute
+		// and clip it beyond recovery. Same split as `health --json`.
+		if (options.json) {
+			console.log(
+				toSafeJson({
+					ok: false,
+					error: "unknown_subcommand",
+					subcommand: sub,
+					reason: `Unknown policy subcommand. Expected: validate`,
+				}),
+			);
+		} else {
+			console.error(
+				`Unknown policy subcommand: "${scrubForTerminal(sub, 40)}". Expected: validate`,
+			);
+		}
 		process.exitCode = 2;
 		return;
 	}
@@ -130,7 +143,7 @@ export async function run(
 		// a CI step validate nothing and pass. Same distinction the loader draws
 		// between absent and unreadable.
 		if (explicit !== undefined) {
-			const reason = `No such policy file: ${safePath}`;
+			const reason = `No such policy file: ${safePath}`; // terminal only
 			if (options.json)
 				console.log(
 					toSafeJson({
@@ -144,9 +157,19 @@ export async function run(
 			process.exitCode = 1;
 			return;
 		}
+		// Terminal-only string; the JSON branch builds its own from raw values.
 		const msg = `No policy file at ${safePath} — only the built-in budget rules apply.`;
 		if (options.json)
-			console.log(toSafeJson({ ok: true, path: policiesPath, rules: 0, issues: [], note: msg }));
+			console.log(
+				toSafeJson({
+					ok: true,
+					path: policiesPath,
+					rules: 0,
+					active: 0,
+					issues: [],
+					note: `No policy file — only the built-in budget rules apply.`,
+				}),
+			);
 		else console.log(`${pc.yellow("[none]")} ${msg}`);
 		return;
 	}
@@ -159,6 +182,12 @@ export async function run(
 				ok: issues.length === 0,
 				path: policiesPath,
 				rules: rules.length,
+				// A file of `enabled: false` rules is indistinguishable from an active
+				// one of the same size without this: the human branch says `[inert]`
+				// and CI, which reads the JSON, saw only a total. `inert` is derived
+				// rather than left to the consumer, so the judgement lives in one place.
+				active: rules.filter((r) => r.enabled !== false).length,
+				inert: rules.length > 0 && rules.every((r) => r.enabled === false),
 				issues,
 			}),
 		);

--- a/packages/core/src/cli/policy.ts
+++ b/packages/core/src/cli/policy.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * CLI: usertrust policy validate — check the policy file before it matters.
+ *
+ * This command exists because its absence was the reason a whole class of
+ * failure was uncatchable locally. `loadPolicies` used to answer a tab
+ * character, a wrong indent, a trailing comma, or a top-level key of
+ * `policies:` with an empty rule set and no error, so a policy file could stop
+ * enforcing anything and the only observable difference was that calls the
+ * operator expected to be denied quietly succeeded.
+ *
+ * The loader now refuses such a file outright, which turns that silence into a
+ * startup failure. This command is the other half: a way to find out BEFORE
+ * deploying, with every problem in the file reported in one pass rather than
+ * one exception at a time.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import pc from "picocolors";
+import { validatePolicyFile } from "../policy/gate.js";
+import { VAULT_DIR } from "../shared/constants.js";
+import type { CliOptions } from "./init.js";
+
+/**
+ * Strip control characters from untrusted text before it reaches a terminal.
+ *
+ * A policy file can name a key containing an ANSI escape, and zod quotes the key
+ * back inside its issue message. Printing that raw lets the file repaint the
+ * terminal of the operator running the diagnostic — including painting a passing
+ * verdict over a failing one. AGENTS.md requires sanitising BEFORE clipping.
+ */
+/**
+ * Make untrusted text safe to echo to a terminal.
+ *
+ * Covers C0 AND C1 (0x80-0x9f), the range holding the 8-bit CSI/OSC introducers
+ * — a terminal honouring those can be repainted by a string the common
+ * C0-only regex passes through untouched. AGENTS.md records why `budget.ts`'s
+ * `forDisplay` is deliberately stronger than the other copies and must not be
+ * unified down onto them; this path has the same property (it echoes argv and
+ * config-supplied text), so it takes the strong form rather than adding another
+ * weak one. Substitutes rather than strips, so removing a byte cannot close two
+ * fragments into a plausible whole, and clips AFTER substituting.
+ */
+function scrubForTerminal(text: string, max = 200): string {
+	let out = "";
+	for (const ch of text) {
+		const code = ch.codePointAt(0) as number;
+		out += code <= 0x1f || (code >= 0x7f && code <= 0x9f) ? "?" : ch;
+	}
+	return out.length > max ? `${out.slice(0, max)}...` : out;
+}
+
+/** Default from `TrustConfigSchema.policies`. */
+const DEFAULT_POLICIES_PATH = "./policies/default.yml";
+
+/** Read just the `policies` key, tolerating a config that is otherwise unusable. */
+function readPoliciesPath(vaultDir: string): string {
+	try {
+		const p = join(vaultDir, "usertrust.config.json");
+		if (!existsSync(p)) return DEFAULT_POLICIES_PATH;
+		const cfg = JSON.parse(readFileSync(p, "utf-8")) as { policies?: string };
+		// The configured value VERBATIM, including "". `TrustConfigSchema` accepts
+		// an empty string and both governors resolve it to the vault directory,
+		// where the load fails — so substituting the default here would validate a
+		// different file than the one that runs, and report ok for a deployment
+		// that cannot start. A diagnostic must resolve its target the same way the
+		// thing it diagnoses does.
+		return typeof cfg.policies === "string" ? cfg.policies : DEFAULT_POLICIES_PATH;
+	} catch {
+		return DEFAULT_POLICIES_PATH;
+	}
+}
+
+/**
+ * Serialise with C1 escaped.
+ *
+ * `JSON.stringify` escapes C0 but leaves U+0080–U+009F literal, and U+009B is
+ * the 8-bit CSI introducer — so `--json` piped straight to a terminal carries
+ * the same repaint risk the human output is scrubbed for. Escaping rather than
+ * substituting here, because JSON must stay round-trippable: a consumer gets the
+ * real value back, a terminal never sees the raw byte.
+ */
+function toSafeJson(value: unknown): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: escaping them is the intent
+	return JSON.stringify(value).replace(/[\u007f-\u009f]/g, (c) => {
+		const hex = c.charCodeAt(0).toString(16).padStart(4, "0");
+		return `\\u${hex}`;
+	});
+}
+
+export async function run(
+	rootDir?: string,
+	options: CliOptions = {},
+	argv: string[] = [],
+): Promise<void> {
+	const sub = argv[0];
+	if (sub !== undefined && sub !== "validate") {
+		const reason = `Unknown policy subcommand: "${scrubForTerminal(sub, 40)}". Expected: validate`;
+		// A caller passing --json parses every outcome, including this one.
+		if (options.json) console.log(toSafeJson({ ok: false, error: "unknown_subcommand", reason }));
+		else console.error(reason);
+		process.exitCode = 2;
+		return;
+	}
+
+	const vaultPath = rootDir ?? process.cwd();
+	// Deliberately NOT `loadConfig`: that validates the whole config and throws on
+	// a missing budget, which would make an operator fix their config before they
+	// could find out why their policy stopped enforcing. Linting the policy file
+	// must not depend on anything else being right.
+	const policiesRel = readPoliciesPath(join(vaultPath, VAULT_DIR));
+	// An explicit path wins, so an operator can check a file before installing it.
+	const explicit = argv.find((a, i) => i > 0 && !a.startsWith("-"));
+	const policiesPath = explicit ?? join(vaultPath, VAULT_DIR, policiesRel);
+
+	const safePath = scrubForTerminal(policiesPath);
+	// Validate FIRST. An `existsSync` preflight answers false for a file inside a
+	// directory it cannot traverse, so this command would report `[none]` and exit
+	// 0 for the very file the governor refuses to start against — a CI check that
+	// passes while the deploy fails. Absence is whatever ENOENT says it is.
+	const result = validatePolicyFile(policiesPath);
+	if (!result.present) {
+		// An ABSENT file at the CONFIGURED path is a legitimate deployment — no
+		// policy file means the built-in budget rules apply, and that is a real
+		// answer. A path the operator NAMED is different: they asked about a
+		// specific file, and answering "ok" for a file that is not there would let
+		// a CI step validate nothing and pass. Same distinction the loader draws
+		// between absent and unreadable.
+		if (explicit !== undefined) {
+			const reason = `No such policy file: ${safePath}`;
+			if (options.json)
+				console.log(
+					toSafeJson({
+						ok: false,
+						path: policiesPath,
+						rules: 0,
+						issues: [{ at: "file", message: "does not exist" }],
+					}),
+				);
+			else console.log(`${pc.red("[missing]")} ${reason}`);
+			process.exitCode = 1;
+			return;
+		}
+		const msg = `No policy file at ${safePath} — only the built-in budget rules apply.`;
+		if (options.json)
+			console.log(toSafeJson({ ok: true, path: policiesPath, rules: 0, issues: [], note: msg }));
+		else console.log(`${pc.yellow("[none]")} ${msg}`);
+		return;
+	}
+
+	const { rules, issues } = result;
+
+	if (options.json) {
+		console.log(
+			toSafeJson({
+				ok: issues.length === 0,
+				path: policiesPath,
+				rules: rules.length,
+				issues,
+			}),
+		);
+		process.exitCode = issues.length === 0 ? 0 : 1;
+		return;
+	}
+
+	console.log(`Policy file: ${safePath}`);
+	if (issues.length > 0) {
+		console.log(
+			`${pc.red("[invalid]")} ${issues.length} problem(s) — NONE of this file's rules will load:`,
+		);
+		for (const issue of issues) {
+			console.log(`  ${pc.red("×")} ${scrubForTerminal(`${issue.at}: ${issue.message}`)}`);
+		}
+		console.log("");
+		console.log("A governor started against this file refuses to start rather than");
+		console.log("enforcing an empty policy. Fix the above and re-run.");
+		process.exitCode = 1;
+		return;
+	}
+
+	if (rules.length === 0) {
+		console.log(
+			`${pc.yellow("[empty]")} valid, but declares 0 rules — only the built-in budget rules apply.`,
+		);
+		return;
+	}
+
+	const active = rules.filter((r) => r.enabled !== false).length;
+	if (active === 0) {
+		// Loaded is not the same as live: `ruleMatches` skips a disabled rule, so a
+		// green "would enforce" over a file of disabled rules is the same false
+		// reassurance the health line was fixed for.
+		console.log(
+			`${pc.yellow("[inert]")} ${rules.length} rule(s) load, but all are \`enabled: false\` — none can fire:`,
+		);
+	} else if (active < rules.length) {
+		console.log(`${pc.green("[ok]")} ${active} of ${rules.length} rule(s) active:`);
+	} else {
+		console.log(`${pc.green("[ok]")} ${rules.length} rule(s) load and would enforce:`);
+	}
+	for (const r of rules) {
+		const label = scrubForTerminal(r.id !== undefined ? `${r.id} — ${r.name}` : r.name, 120);
+		const enf = r.enforcement === "hard" ? pc.red("hard") : pc.yellow("soft");
+		const enabled = r.enabled === false ? pc.dim(" (disabled)") : "";
+		console.log(`  ${pc.green("✓")} ${label}  [${r.effect}/${enf}]${enabled}`);
+		// A scopePatterns rule only ever matches a context that carries a matching
+		// `scope`, and no governed call path populates one. Saying so here is the
+		// difference between a rule an operator believes is live and one that is.
+		if (r.scopePatterns !== undefined && r.scopePatterns.length > 0) {
+			console.log(
+				pc.yellow(
+					`      note: scoped to ${scrubForTerminal(r.scopePatterns.join(", "), 120)} — only matches calls that supply a matching context scope`,
+				),
+			);
+		}
+	}
+}

--- a/packages/core/src/cli/policy.ts
+++ b/packages/core/src/cli/policy.ts
@@ -112,7 +112,37 @@ export async function run(
 	// refused on an unrelated config problem and never looked at the named file —
 	// killing the check-before-install mode this command advertises, in exactly the
 	// situation an operator reaches for it.
-	const explicit = argv.find((a, i) => i > 0 && !a.startsWith("-"));
+	// EVERY remaining argument must be consumed. Taking the first non-flag and
+	// ignoring the rest meant `policy validate a.yml b.yml` checked only `a.yml`
+	// and exited 0 — a pre-flight that validates a different target than the one
+	// asked about and reports success. An unrecognised dashed option was worse: it
+	// was skipped as a flag and the command silently fell back to the CONFIGURED
+	// policy, answering about a file the operator never named.
+	const rest = argv.slice(1);
+	const paths = rest.filter((a) => !a.startsWith("-"));
+	const flags = rest.filter((a) => a.startsWith("-"));
+	const unknownFlags = flags.filter((a) => a !== "--json");
+	if (unknownFlags.length > 0 || paths.length > 1) {
+		const reason =
+			unknownFlags.length > 0
+				? `unknown option${unknownFlags.length > 1 ? "s" : ""}: ${unknownFlags.join(", ")}`
+				: `expected at most one policy file, got ${paths.length}`;
+		if (options.json) {
+			console.log(
+				toSafeJson({
+					command: "policy",
+					success: false,
+					data: { error: "bad_arguments", reason, arguments: rest },
+				}),
+			);
+		} else {
+			console.error(`${pc.red("[usage]")} ${scrubForTerminal(reason)}`);
+			console.error("Usage: usertrust policy validate [path] [--json]");
+		}
+		process.exitCode = 2;
+		return;
+	}
+	const explicit = paths[0];
 	const resolved =
 		explicit !== undefined ? { path: explicit } : resolvePolicyPath(join(vaultPath, VAULT_DIR));
 	if ("error" in resolved) {

--- a/packages/core/src/cli/policy.ts
+++ b/packages/core/src/cli/policy.ts
@@ -56,22 +56,41 @@ function scrubForTerminal(text: string, max = 200): string {
 /** Default from `TrustConfigSchema.policies`. */
 const DEFAULT_POLICIES_PATH = "./policies/default.yml";
 
-/** Read just the `policies` key, tolerating a config that is otherwise unusable. */
-function readPoliciesPath(vaultDir: string): string {
+/**
+ * Read just the `policies` key. Tolerates a config that is otherwise unusable —
+ * a broken budget must not stop an operator diagnosing their policy — but NOT a
+ * config that cannot be read or parsed at all.
+ *
+ * Falling back to the default in that case validated a DIFFERENT file than the
+ * governor would load, so the command could exit 0 having checked something
+ * unrelated while startup failed. A diagnostic answering confidently about the
+ * wrong file is worse than one that refuses.
+ *
+ * The value is taken VERBATIM, including "". `TrustConfigSchema` accepts an empty
+ * string and both governors resolve it to the vault directory, where the load
+ * fails — so substituting the default there would report ok for a deployment that
+ * cannot start. A diagnostic must resolve its target the way the thing it
+ * diagnoses does.
+ */
+function readPoliciesPath(vaultDir: string): { path: string } | { error: string } {
+	const p = join(vaultDir, "usertrust.config.json");
+	if (!existsSync(p)) return { path: DEFAULT_POLICIES_PATH };
+	let raw: string;
 	try {
-		const p = join(vaultDir, "usertrust.config.json");
-		if (!existsSync(p)) return DEFAULT_POLICIES_PATH;
-		const cfg = JSON.parse(readFileSync(p, "utf-8")) as { policies?: string };
-		// The configured value VERBATIM, including "". `TrustConfigSchema` accepts
-		// an empty string and both governors resolve it to the vault directory,
-		// where the load fails — so substituting the default here would validate a
-		// different file than the one that runs, and report ok for a deployment
-		// that cannot start. A diagnostic must resolve its target the same way the
-		// thing it diagnoses does.
-		return typeof cfg.policies === "string" ? cfg.policies : DEFAULT_POLICIES_PATH;
-	} catch {
-		return DEFAULT_POLICIES_PATH;
+		raw = readFileSync(p, "utf-8");
+	} catch (err) {
+		return { error: `config cannot be read: ${(err as Error).message}` };
 	}
+	let cfg: { policies?: unknown };
+	try {
+		cfg = JSON.parse(raw) as { policies?: unknown };
+	} catch (err) {
+		return { error: `config is not valid JSON: ${(err as Error).message}` };
+	}
+	if (cfg.policies !== undefined && typeof cfg.policies !== "string") {
+		return { error: `config "policies" must be a string, got ${typeof cfg.policies}` };
+	}
+	return { path: typeof cfg.policies === "string" ? cfg.policies : DEFAULT_POLICIES_PATH };
 }
 
 /**
@@ -104,10 +123,13 @@ export async function run(
 		if (options.json) {
 			console.log(
 				toSafeJson({
-					ok: false,
-					error: "unknown_subcommand",
-					subcommand: sub,
-					reason: `Unknown policy subcommand. Expected: validate`,
+					command: "policy",
+					success: false,
+					data: {
+						error: "unknown_subcommand",
+						subcommand: sub,
+						reason: `Unknown policy subcommand. Expected: validate`,
+					},
 				}),
 			);
 		} else {
@@ -124,7 +146,24 @@ export async function run(
 	// a missing budget, which would make an operator fix their config before they
 	// could find out why their policy stopped enforcing. Linting the policy file
 	// must not depend on anything else being right.
-	const policiesRel = readPoliciesPath(join(vaultPath, VAULT_DIR));
+	const resolved = readPoliciesPath(join(vaultPath, VAULT_DIR));
+	if ("error" in resolved) {
+		if (options.json) {
+			console.log(
+				toSafeJson({
+					command: "policy",
+					success: false,
+					data: { error: "config_unreadable", reason: resolved.error },
+				}),
+			);
+		} else {
+			console.error(`${pc.red("[config]")} ${scrubForTerminal(resolved.error)}`);
+			console.error("The governor resolves its policy path from this file; fix it first.");
+		}
+		process.exitCode = 1;
+		return;
+	}
+	const policiesRel = resolved.path;
 	// An explicit path wins, so an operator can check a file before installing it.
 	const explicit = argv.find((a, i) => i > 0 && !a.startsWith("-"));
 	const policiesPath = explicit ?? join(vaultPath, VAULT_DIR, policiesRel);
@@ -147,10 +186,14 @@ export async function run(
 			if (options.json)
 				console.log(
 					toSafeJson({
-						ok: false,
-						path: policiesPath,
-						rules: 0,
-						issues: [{ at: "file", message: "does not exist" }],
+						command: "policy",
+						success: false,
+						data: {
+							path: policiesPath,
+							rules: 0,
+							active: 0,
+							issues: [{ at: "file", message: "does not exist" }],
+						},
 					}),
 				);
 			else console.log(`${pc.red("[missing]")} ${reason}`);
@@ -162,12 +205,15 @@ export async function run(
 		if (options.json)
 			console.log(
 				toSafeJson({
-					ok: true,
-					path: policiesPath,
-					rules: 0,
-					active: 0,
-					issues: [],
-					note: `No policy file — only the built-in budget rules apply.`,
+					command: "policy",
+					success: true,
+					data: {
+						path: policiesPath,
+						rules: 0,
+						active: 0,
+						issues: [],
+						note: `No policy file — only the built-in budget rules apply.`,
+					},
 				}),
 			);
 		else console.log(`${pc.yellow("[none]")} ${msg}`);
@@ -179,16 +225,19 @@ export async function run(
 	if (options.json) {
 		console.log(
 			toSafeJson({
-				ok: issues.length === 0,
-				path: policiesPath,
-				rules: rules.length,
-				// A file of `enabled: false` rules is indistinguishable from an active
-				// one of the same size without this: the human branch says `[inert]`
-				// and CI, which reads the JSON, saw only a total. `inert` is derived
-				// rather than left to the consumer, so the judgement lives in one place.
-				active: rules.filter((r) => r.enabled !== false).length,
-				inert: rules.length > 0 && rules.every((r) => r.enabled === false),
-				issues,
+				command: "policy",
+				success: issues.length === 0,
+				data: {
+					path: policiesPath,
+					rules: rules.length,
+					// A file of `enabled: false` rules is indistinguishable from an active
+					// one of the same size without this: the human branch says `[inert]`
+					// and CI, which reads the JSON, saw only a total. `inert` is derived
+					// rather than left to the consumer, so the judgement lives in one place.
+					active: rules.filter((r) => r.enabled !== false).length,
+					inert: rules.length > 0 && rules.every((r) => r.enabled === false),
+					issues,
+				},
 			}),
 		);
 		process.exitCode = issues.length === 0 ? 0 : 1;

--- a/packages/core/tests/cli/health.test.ts
+++ b/packages/core/tests/cli/health.test.ts
@@ -145,3 +145,88 @@ describe("usertrust health", () => {
 		expect(okCount).toBeGreaterThanOrEqual(5);
 	});
 });
+
+describe("usertrust health — policy line", () => {
+	let tempDir: string;
+	let logOutput: string[];
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "trust-health-policy-"));
+		logOutput = [];
+		vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+			logOutput.push(args.map(String).join(" "));
+		});
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	function vault(config: Record<string, unknown>): void {
+		const v = join(tempDir, ".usertrust");
+		mkdirSync(join(v, "policies"), { recursive: true });
+		writeFileSync(join(v, "usertrust.config.json"), JSON.stringify(config), "utf-8");
+	}
+	const out = (): string => logOutput.join("\n");
+
+	it("does not echo terminal control sequences from a config-supplied path", async () => {
+		// `policies` is read from the vault's config, so it is untrusted text
+		// reaching a terminal: a tampered vault could otherwise repaint or forge
+		// the human-readable verdict. The file already defines a scrubber; the
+		// missing-file and invalid-file branches now use it.
+		vault({ budget: 1000, policies: "./\u001b[2J\u001b[1;1Hall clear.yml" });
+		await run(tempDir, { json: false });
+		// Assert on the INJECTED payload specifically, not on "any escape byte".
+		// picocolors emits real ANSI colour on a TTY and under CI's FORCE_COLOR, so
+		// a blanket escape-free assertion passes locally and fails on a runner —
+		// it would be testing the environment, not the scrubber.
+		expect(out()).not.toContain("\u001b[2J"); // clear screen
+		expect(out()).not.toContain("\u001b[1;1H"); // cursor home
+		expect(out()).toContain("Policy rules loaded");
+		// The path is still reported, just inert — the operator must still be told
+		// WHICH file, or the diagnostic is useless.
+		expect(out()).toContain("all clear.yml");
+	});
+
+	it("reports rules as inert when every rule is disabled", async () => {
+		vault({ budget: 1000, policies: "./policies/default.yml" });
+		writeFileSync(
+			join(tempDir, ".usertrust", "policies", "default.yml"),
+			`rules:
+  - name: off-rule
+    effect: deny
+    enforcement: hard
+    enabled: false
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+`,
+			"utf-8",
+		);
+		await run(tempDir, { json: false });
+		// A loaded-but-disabled rule cannot fire; reporting it as live would put a
+		// green count next to no enforcement.
+		expect(out()).toContain("[inert]");
+	});
+
+	it("--json escapes C1 but preserves the real path value", async () => {
+		// The human scrubber substitutes and clips, which is right for a terminal
+		// and wrong for a machine-readable field: a consumer needs the value back.
+		// JSON therefore escapes at serialisation and clips nothing.
+		const CSI = String.fromCharCode(0x9b);
+		vault({ budget: 1000, policies: `./${CSI}[2Jx.yml` });
+		await run(tempDir, { json: true });
+		const raw = out();
+		expect(raw).not.toContain(CSI);
+		const parsed = JSON.parse(raw) as { data: { policy: { path: string } } };
+		expect(parsed.data.policy.path).toContain(CSI);
+	});
+
+	it("distinguishes no policy file from a loaded policy", async () => {
+		vault({ budget: 1000, policies: "./policies/default.yml" });
+		await run(tempDir, { json: false });
+		expect(out()).toContain("[none]");
+		expect(out()).toContain("built-in budget rules only");
+	});
+});

--- a/packages/core/tests/cli/health.test.ts
+++ b/packages/core/tests/cli/health.test.ts
@@ -223,6 +223,20 @@ describe("usertrust health — policy line", () => {
 		expect(parsed.data.policy.path).toContain(CSI);
 	});
 
+	it("reports a broken config as invalid instead of validating the default", async () => {
+		// health shared this bug with `policy validate` by copy: a malformed config
+		// left the path at the default, so it validated ./policies/default.yml and
+		// printed [ok] for a deployment whose config the governor rejects outright.
+		// Both now use the one resolver in cli/policy-path.ts.
+		const v = join(tempDir, ".usertrust");
+		mkdirSync(join(v, "policies"), { recursive: true });
+		writeFileSync(join(v, "policies", "default.yml"), "rules: []\n", "utf-8");
+		writeFileSync(join(v, "usertrust.config.json"), "{ broken", "utf-8");
+		await run(tempDir, { json: false });
+		expect(out()).toContain("[INVALID]");
+		expect(out()).not.toContain("Policy rules loaded:      0    [none]");
+	});
+
 	it("distinguishes no policy file from a loaded policy", async () => {
 		vault({ budget: 1000, policies: "./policies/default.yml" });
 		await run(tempDir, { json: false });

--- a/packages/core/tests/cli/health.test.ts
+++ b/packages/core/tests/cli/health.test.ts
@@ -233,8 +233,25 @@ describe("usertrust health — policy line", () => {
 		writeFileSync(join(v, "policies", "default.yml"), "rules: []\n", "utf-8");
 		writeFileSync(join(v, "usertrust.config.json"), "{ broken", "utf-8");
 		await run(tempDir, { json: false });
-		expect(out()).toContain("[INVALID]");
-		expect(out()).not.toContain("Policy rules loaded:      0    [none]");
+		// [CONFIG], not [INVALID]: the config is the subject of the failure, and
+		// naming policies/default.yml would point the operator at a file that is
+		// probably fine and that the governor never reaches.
+		expect(out()).toContain("[CONFIG]");
+		expect(out()).not.toContain("default.yml");
+	});
+
+	it("--json reports the config failure without claiming a policy file is present", async () => {
+		const v = join(tempDir, ".usertrust");
+		mkdirSync(join(v, "policies"), { recursive: true });
+		writeFileSync(join(v, "policies", "default.yml"), "rules: []\n", "utf-8");
+		writeFileSync(join(v, "usertrust.config.json"), "{ broken", "utf-8");
+		await run(tempDir, { json: true });
+		const p = JSON.parse(out()) as {
+			data: { policy: { path: string | null; present: boolean; configError?: string } };
+		};
+		expect(p.data.policy.path).toBeNull();
+		expect(p.data.policy.present).toBe(false);
+		expect(p.data.policy.configError).toMatch(/not valid JSON/);
 	});
 
 	it("distinguishes no policy file from a loaded policy", async () => {

--- a/packages/core/tests/cli/policy.test.ts
+++ b/packages/core/tests/cli/policy.test.ts
@@ -231,6 +231,34 @@ describe("usertrust policy validate", () => {
 		expect(process.exitCode).toBe(1);
 	});
 
+	it("does not crash on a config whose JSON root is null", async () => {
+		// `JSON.parse("null")` succeeds, so a property read threw a raw TypeError
+		// outside every catch — the command emitted NO diagnostic in either output
+		// mode, which is the one thing a pre-flight must never do.
+		mkdirSync(join(tempDir, ".usertrust"), { recursive: true });
+		writeFileSync(join(tempDir, ".usertrust", "usertrust.config.json"), "null", "utf-8");
+		await run(tempDir, { json: true }, ["validate"]);
+		const p = JSON.parse(out()) as { success: boolean; data: { error: string; reason: string } };
+		expect(p.success).toBe(false);
+		expect(p.data.error).toBe("config_unreadable");
+		expect(p.data.reason).toMatch(/must be a JSON object, got null/);
+	});
+
+	it("checks an EXPLICIT file even when the config is broken", async () => {
+		// Resolving the config first meant `policy validate ./candidate.yml` refused
+		// on an unrelated config problem and never looked at the named file — in
+		// exactly the situation an operator reaches for check-before-install.
+		mkdirSync(join(tempDir, ".usertrust"), { recursive: true });
+		writeFileSync(join(tempDir, ".usertrust", "usertrust.config.json"), "{ broken", "utf-8");
+		const candidate = join(tempDir, "candidate.yml");
+		writeFileSync(candidate, GOOD_YAML, "utf-8");
+		await run(tempDir, { json: true }, ["validate", candidate]);
+		const p = JSON.parse(out()) as { success: boolean; data: { path: string; rules: number } };
+		expect(p.success).toBe(true);
+		expect(p.data.path).toBe(candidate);
+		expect(p.data.rules).toBe(1);
+	});
+
 	it("rejects an unknown subcommand rather than silently validating", async () => {
 		writePolicy(GOOD_YAML);
 		await run(tempDir, { json: false }, ["lint"]);

--- a/packages/core/tests/cli/policy.test.ts
+++ b/packages/core/tests/cli/policy.test.ts
@@ -107,13 +107,14 @@ describe("usertrust policy validate", () => {
 		writePolicy(GOOD_YAML.replace("operator: contains", "operator: contain"));
 		await run(tempDir, { json: true }, ["validate"]);
 		const payload = JSON.parse(out()) as {
-			ok: boolean;
-			rules: number;
-			issues: { at: string; message: string }[];
+			command: string;
+			success: boolean;
+			data: { rules: number; issues: { at: string; message: string }[] };
 		};
-		expect(payload.ok).toBe(false);
-		expect(payload.rules).toBe(0);
-		expect(payload.issues.length).toBeGreaterThan(0);
+		expect(payload.command).toBe("policy");
+		expect(payload.success).toBe(false);
+		expect(payload.data.rules).toBe(0);
+		expect(payload.data.issues.length).toBeGreaterThan(0);
 		expect(process.exitCode).toBe(1);
 	});
 
@@ -154,8 +155,8 @@ describe("usertrust policy validate", () => {
 		expect(out()).not.toContain(CSI);
 		expect(out()).toContain("\\u009b");
 		// Still valid JSON, and still round-trips to the real value.
-		const parsed = JSON.parse(out()) as { path: string };
-		expect(parsed.path).toContain(CSI);
+		const parsed = JSON.parse(out()) as { data: { path: string } };
+		expect(parsed.data.path).toContain(CSI);
 	});
 
 	it("validates the CONFIGURED path verbatim, including an empty one", async () => {
@@ -181,10 +182,12 @@ describe("usertrust policy validate", () => {
 			GOOD_YAML.replace("    enforcement: hard", "    enforcement: hard\n    enabled: false"),
 		);
 		await run(tempDir, { json: true }, ["validate"]);
-		const p = JSON.parse(out()) as { rules: number; active: number; inert: boolean };
-		expect(p.rules).toBe(1);
-		expect(p.active).toBe(0);
-		expect(p.inert).toBe(true);
+		const p = JSON.parse(out()) as {
+			data: { rules: number; active: number; inert: boolean };
+		};
+		expect(p.data.rules).toBe(1);
+		expect(p.data.active).toBe(0);
+		expect(p.data.inert).toBe(true);
 	});
 
 	it("--json carries RAW diagnostic values, not terminal-scrubbed ones", async () => {
@@ -196,9 +199,36 @@ describe("usertrust policy validate", () => {
 		await run(tempDir, { json: true }, [longSub]);
 		const raw = out();
 		expect(raw).not.toContain(CSI);
-		const p = JSON.parse(raw) as { subcommand: string };
+		const p = JSON.parse(raw) as { data: { subcommand: string } };
 		// Round-trips to the original, in full — neither substituted nor clipped.
-		expect(p.subcommand).toBe(longSub);
+		expect(p.data.subcommand).toBe(longSub);
+	});
+
+	it("follows the repo's {command, success, data} JSON envelope on every outcome", async () => {
+		// Every sibling command emits this shape and json-flag.test.ts asserts it.
+		// Emitting a bespoke top-level `{ok}` meant generic CLI automation read
+		// `success` as undefined for this command specifically — including on
+		// failures, where it matters most.
+		writePolicy(GOOD_YAML);
+		await run(tempDir, { json: true }, ["validate"]);
+		const ok = JSON.parse(out()) as { command: string; success: boolean; data: unknown };
+		expect(ok.command).toBe("policy");
+		expect(ok.success).toBe(true);
+		expect(ok.data).toBeDefined();
+	});
+
+	it("refuses an unreadable config instead of validating the default file", async () => {
+		// Falling back to ./policies/default.yml validated a DIFFERENT file than the
+		// governor would load, so the command could exit 0 having checked something
+		// unrelated while startup failed.
+		mkdirSync(join(tempDir, ".usertrust", "policies"), { recursive: true });
+		writeFileSync(join(tempDir, ".usertrust", "policies", "default.yml"), GOOD_YAML, "utf-8");
+		writeFileSync(join(tempDir, ".usertrust", "usertrust.config.json"), "{ broken", "utf-8");
+		await run(tempDir, { json: true }, ["validate"]);
+		const p = JSON.parse(out()) as { success: boolean; data: { error: string } };
+		expect(p.success).toBe(false);
+		expect(p.data.error).toBe("config_unreadable");
+		expect(process.exitCode).toBe(1);
 	});
 
 	it("rejects an unknown subcommand rather than silently validating", async () => {

--- a/packages/core/tests/cli/policy.test.ts
+++ b/packages/core/tests/cli/policy.test.ts
@@ -259,6 +259,30 @@ describe("usertrust policy validate", () => {
 		expect(p.data.rules).toBe(1);
 	});
 
+	it("refuses extra paths rather than checking only the first", async () => {
+		// `policy validate a.yml b.yml` used to check a.yml and exit 0 — a pre-flight
+		// validating a different target than the one asked about, and passing.
+		writePolicy(GOOD_YAML);
+		const a = join(tempDir, "a.yml");
+		const b = join(tempDir, "b.yml");
+		writeFileSync(a, GOOD_YAML, "utf-8");
+		writeFileSync(b, "rules: [", "utf-8");
+		await run(tempDir, { json: true }, ["validate", a, b]);
+		const p = JSON.parse(out()) as { success: boolean; data: { error: string } };
+		expect(p.success).toBe(false);
+		expect(p.data.error).toBe("bad_arguments");
+		expect(process.exitCode).toBe(2);
+	});
+
+	it("refuses an unknown option rather than falling back to the configured policy", async () => {
+		writePolicy(GOOD_YAML);
+		await run(tempDir, { json: true }, ["validate", "--strict"]);
+		const p = JSON.parse(out()) as { success: boolean; data: { reason: string } };
+		expect(p.success).toBe(false);
+		expect(p.data.reason).toMatch(/unknown option/);
+		expect(process.exitCode).toBe(2);
+	});
+
 	it("rejects an unknown subcommand rather than silently validating", async () => {
 		writePolicy(GOOD_YAML);
 		await run(tempDir, { json: false }, ["lint"]);

--- a/packages/core/tests/cli/policy.test.ts
+++ b/packages/core/tests/cli/policy.test.ts
@@ -174,6 +174,33 @@ describe("usertrust policy validate", () => {
 		expect(process.exitCode).toBe(1);
 	});
 
+	it("--json distinguishes an all-disabled file from an active one", async () => {
+		// The human branch said `[inert]` while --json emitted only a total, so CI
+		// could not tell a file of disabled rules from an equally sized live one.
+		writePolicy(
+			GOOD_YAML.replace("    enforcement: hard", "    enforcement: hard\n    enabled: false"),
+		);
+		await run(tempDir, { json: true }, ["validate"]);
+		const p = JSON.parse(out()) as { rules: number; active: number; inert: boolean };
+		expect(p.rules).toBe(1);
+		expect(p.active).toBe(0);
+		expect(p.inert).toBe(true);
+	});
+
+	it("--json carries RAW diagnostic values, not terminal-scrubbed ones", async () => {
+		// Scrubbing substitutes and clips, which is right for a terminal and
+		// unrecoverable for a consumer. Escaping happens at serialization instead.
+		const CSI = String.fromCharCode(0x9b);
+		const longSub = `bogus${CSI}${"x".repeat(60)}`;
+		writePolicy(GOOD_YAML);
+		await run(tempDir, { json: true }, [longSub]);
+		const raw = out();
+		expect(raw).not.toContain(CSI);
+		const p = JSON.parse(raw) as { subcommand: string };
+		// Round-trips to the original, in full — neither substituted nor clipped.
+		expect(p.subcommand).toBe(longSub);
+	});
+
 	it("rejects an unknown subcommand rather than silently validating", async () => {
 		writePolicy(GOOD_YAML);
 		await run(tempDir, { json: false }, ["lint"]);

--- a/packages/core/tests/cli/policy.test.ts
+++ b/packages/core/tests/cli/policy.test.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Usertools, Inc.
+
+/**
+ * `usertrust policy validate` — the operator-facing half of the loader fix.
+ *
+ * The loader now refuses a policy file it cannot honour, which turns a silent
+ * non-enforcement into a startup failure. This command is how an operator finds
+ * out BEFORE deploying, and its absence was the reason the original defect was
+ * uncatchable locally: there was no way to ask "will these rules actually load?"
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { run } from "../../src/cli/policy.js";
+
+const GOOD_YAML = `rules:
+  - id: no-frontier
+    name: Block frontier models
+    effect: deny
+    enforcement: hard
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+`;
+
+describe("usertrust policy validate", () => {
+	let tempDir: string;
+	let logged: string[];
+
+	function writePolicy(content: string): void {
+		const dir = join(tempDir, ".usertrust", "policies");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "default.yml"), content, "utf-8");
+	}
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "trust-policy-cli-"));
+		logged = [];
+		vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+			logged.push(a.join(" "));
+		});
+		vi.spyOn(console, "error").mockImplementation((...a: unknown[]) => {
+			logged.push(a.join(" "));
+		});
+		process.exitCode = undefined;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		rmSync(tempDir, { recursive: true, force: true });
+		process.exitCode = undefined;
+	});
+
+	const out = (): string => logged.join("\n");
+
+	it("reports a valid policy and lists what would enforce", async () => {
+		writePolicy(GOOD_YAML);
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).toContain("1 rule(s) load");
+		expect(out()).toContain("no-frontier");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("EXITS NON-ZERO and names the problem for an unparseable file", async () => {
+		writePolicy(GOOD_YAML.replace("  - id: no-frontier", "\t- id: no-frontier"));
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).toContain("NONE of this file's rules will load");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("locates a misspelled operator down to the condition", async () => {
+		writePolicy(GOOD_YAML.replace("operator: contains", "operator: contain"));
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).toContain("rules[0].conditions[0].operator");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("distinguishes 'no policy file' from 'policy loaded'", async () => {
+		// The distinction the health line existed to make: an operator must never
+		// read "fine" and conclude their rules are live.
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).toContain("only the built-in budget rules apply");
+		expect(process.exitCode).toBeUndefined();
+	});
+
+	it("flags a scopePatterns rule as conditional on a caller-supplied scope", async () => {
+		writePolicy(`rules:
+  - id: prod-only
+    name: Prod only
+    effect: deny
+    enforcement: hard
+    scopePatterns: ["production/*"]
+    conditions:
+      - field: model
+        operator: contains
+        value: opus
+`);
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).toContain("only matches calls that supply a matching context scope");
+	});
+
+	it("--json reports ok/rules/issues machine-readably", async () => {
+		writePolicy(GOOD_YAML.replace("operator: contains", "operator: contain"));
+		await run(tempDir, { json: true }, ["validate"]);
+		const payload = JSON.parse(out()) as {
+			ok: boolean;
+			rules: number;
+			issues: { at: string; message: string }[];
+		};
+		expect(payload.ok).toBe(false);
+		expect(payload.rules).toBe(0);
+		expect(payload.issues.length).toBeGreaterThan(0);
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("reports an all-disabled file as inert, not as enforcing", async () => {
+		writePolicy(
+			GOOD_YAML.replace("    enforcement: hard", "    enforcement: hard\n    enabled: false"),
+		);
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).toContain("[inert]");
+		expect(out()).toContain("none can fire");
+	});
+
+	it("does not echo control sequences from a config-supplied path", async () => {
+		mkdirSync(join(tempDir, ".usertrust"), { recursive: true });
+		writeFileSync(
+			join(tempDir, ".usertrust", "usertrust.config.json"),
+			JSON.stringify({ budget: 1000, policies: "./\u001b[2J\u001b[1;1Hall clear.yml" }),
+			"utf-8",
+		);
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).not.toContain("\u001b[2J");
+		expect(out()).not.toContain("\u001b[1;1H");
+		expect(out()).toContain("all clear.yml");
+	});
+
+	it("escapes C1 controls in --json output", async () => {
+		// JSON.stringify escapes C0 and leaves C1 literal, and U+009B is the 8-bit
+		// CSI introducer — so --json piped to a terminal carried the repaint risk
+		// the human output is scrubbed for.
+		const CSI = String.fromCharCode(0x9b);
+		mkdirSync(join(tempDir, ".usertrust"), { recursive: true });
+		writeFileSync(
+			join(tempDir, ".usertrust", "usertrust.config.json"),
+			JSON.stringify({ budget: 1000, policies: `./${CSI}[2Jx.yml` }),
+			"utf-8",
+		);
+		await run(tempDir, { json: true }, ["validate"]);
+		expect(out()).not.toContain(CSI);
+		expect(out()).toContain("\\u009b");
+		// Still valid JSON, and still round-trips to the real value.
+		const parsed = JSON.parse(out()) as { path: string };
+		expect(parsed.path).toContain(CSI);
+	});
+
+	it("validates the CONFIGURED path verbatim, including an empty one", async () => {
+		// TrustConfigSchema accepts `policies: ""` and both governors resolve it to
+		// the vault directory, where the load fails. Substituting the default here
+		// would report ok for a deployment that cannot start.
+		mkdirSync(join(tempDir, ".usertrust", "policies"), { recursive: true });
+		writeFileSync(join(tempDir, ".usertrust", "policies", "default.yml"), GOOD_YAML, "utf-8");
+		writeFileSync(
+			join(tempDir, ".usertrust", "usertrust.config.json"),
+			JSON.stringify({ budget: 1000, policies: "" }),
+			"utf-8",
+		);
+		await run(tempDir, { json: false }, ["validate"]);
+		expect(out()).not.toContain("[ok]");
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("rejects an unknown subcommand rather than silently validating", async () => {
+		writePolicy(GOOD_YAML);
+		await run(tempDir, { json: false }, ["lint"]);
+		expect(out()).toContain("Unknown policy subcommand");
+		expect(process.exitCode).toBe(2);
+	});
+});

--- a/packages/core/tests/harden/false-ok.test.ts
+++ b/packages/core/tests/harden/false-ok.test.ts
@@ -233,7 +233,12 @@ describe("false OK — a documented count that stops matching reality", () => {
 		const actual =
 			count("CONTROL_CHARS = /\\[") +
 			count("function forDisplay") +
-			count("function scrubForError");
+			count("function scrubForError") +
+			// `scrubForTerminal` is the same strong variant under a third name, in
+			// cli/policy.ts and cli/health.ts. A counter that only knows the names it
+			// was written with reports a smaller inventory than exists — which is the
+			// false-OK this test is named for, one level up.
+			count("function scrubForTerminal");
 
 		expect(actual).toBe(declaredCount);
 	});


### PR DESCRIPTION
Diagnostics half of the policy-integrity work, split from #97.

**Must land before any release carrying #97.** That change makes a deployment refuse to start on an unparseable policy; this is how an operator finds out which line is wrong. Fail-closed without a diagnostic is an outage with no error message.

- `usertrust policy validate` — every problem in one pass, resolving its target exactly as the governor does (configured value verbatim, no `existsSync` preflight, refuses an unreadable config rather than checking a different file)
- `usertrust health` — reports loaded AND active rule counts, so a vault with no rules loaded is distinguishable from one with a satisfied policy
- Two C1-aware sanitizers for terminal output; `--json` escapes at serialization instead so values stay parseable
- Standard `{command, success, data}` envelope on every outcome
- Shell completions for `policy validate` in all three generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZCkyMkaEi2hRwhkVLa6TS